### PR TITLE
test(launcher): move 3 of the 4 Windows manual checks into CI (#2613)

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -349,37 +349,31 @@ The launcher's own log is `~/Library/Logs/MulmoClaude/launcher.log`.
 
 ## 12. Windows icon launch (`create-shortcut`)
 
-Same rule as §11: the CI on `windows-latest` writes a real `.lnk`, reads it back
-through the COM object Explorer itself uses, and confirms Windows can load the
-hand-assembled `.ico` — but no runner can perform a double-click, and nothing
-can assert what a window looks like.
+Most of this section used to be here. It is now in CI, because the *cause*
+of each failure turned out to be checkable even where the appearance is not
+— see `test/utils/launcher/test_windowsShortcutIntegration.ts`:
 
-Run `npx mulmoclaude@latest create-shortcut` on a Windows machine, then:
+| Was manual | Now asserted on `windows-latest` |
+|---|---|
+| The icon renders | Every size decodes out of the `.ico` and has opaque pixels — a blank icon fails |
+| SmartScreen stays quiet | None of the generated files carries a `Zone.Identifier` stream, which is the attribute SmartScreen keys on |
+| A version-manager node resolves | The real `launch.vbs` runs with node reachable only through an nvm-like PATH entry, and the handover names that node |
+| No console window | The stub is asserted never to call `WshShell.Exec` (which always allocates a console) and to run node with `Run(…, 0, False)` |
 
-1. **The Start Menu entry appears** under its own name and is found by typing
-   "MulmoClaude" into Start. `--dir <path>` puts it elsewhere (the Desktop is
-   the usual choice); the launcher's own files stay under
-   `%LOCALAPPDATA%\MulmoClaude` either way.
-2. **The icon renders** in the Start Menu, on the taskbar when pinned, and in
-   Explorer — at several sizes, since each view picks a different entry out of
-   the `.ico`.
-3. **No console window appears.** Not even a flash. This is the single most
-   likely regression: anything that shells out through `WshShell.Exec`, or a
-   shortcut retargeted at `node.exe` / `cmd.exe` instead of `wscript.exe`,
-   brings the black rectangle back.
-4. **Double-click with nothing running** → the progress page appears, then the
-   app replaces it.
-5. **Double-click while MulmoClaude is already running** → the browser opens
-   straight to the app, and no second server starts.
-6. **Node.js missing** (test on a machine without it, or rename the binary):
-   the native `MsgBox` appears in the system language, and answering **Yes**
-   opens nodejs.org.
-7. **SmartScreen does not appear.** A locally generated file carries no
-   Mark-of-the-Web, so it should not — but this is the assumption that cannot
-   be checked from CI, and a managed machine may decide otherwise.
-8. **A version manager still resolves.** Install node via nvm-windows / fnm /
-   Volta and launch from the icon. CI runs on a plain toolchain, so this path
-   has never been exercised by anything but a human.
+**What is still human, and cannot stop being:**
+
+1. **What it looks like.** That the icon is the right artwork at each size,
+   that the progress page is legible, that the `MsgBox` is readable. CI can
+   prove pixels exist; it cannot prove they look right.
+2. **The gesture.** A real Explorer double-click, and the Start Menu entry
+   appearing under a search for "MulmoClaude".
+3. **A genuinely unsigned-app-hostile machine.** The Mark-of-the-Web check
+   covers the documented mechanism, but a machine under managed policy can
+   refuse unsigned apps on grounds CI has no way to reproduce.
+4. **The no-Node dialog end to end.** Rename node, double-click, confirm the
+   `MsgBox` appears in the system language and that **Yes** opens nodejs.org.
+   A modal on a headless runner would hang the job, so it is never fired
+   there.
 
 The launcher's own log is `%LOCALAPPDATA%\MulmoClaude\logs\launcher.log`.
 

--- a/test/utils/launcher/test_windowsLauncher.ts
+++ b/test/utils/launcher/test_windowsLauncher.ts
@@ -116,17 +116,20 @@ describe("launch.vbs — the console window", () => {
     // program, so `where node` would flash a black rectangle on EVERY
     // launch — on the one screen whose whole promise is that clicking an
     // icon just works. The stub walks %PATH% itself instead.
-    assert.doesNotMatch(stub, /\.Exec\s*\(/, "the stub shells out somewhere — that is a visible console window on every launch");
+    // Case-insensitive: VBScript method names are, so `sh.EXEC(` would
+    // slip past an exact-case guard and bring the console window back
+    // without failing anything.
+    assert.doesNotMatch(stub, /\.exec\s*\(/i, "the stub shells out somewhere — that is a visible console window on every launch");
   });
 
   it("hides every process it starts", () => {
     // `Run(cmd, 0, False)`: 0 hides the window, False detaches. Checked
     // per line rather than as one pattern so a second Run added later is
     // covered too — this is the whole reason the stub exists as a .vbs.
-    const runLines = stub.split("\n").filter((line) => line.includes("sh.Run"));
+    const runLines = stub.split("\n").filter((line) => /\bsh\.run\s*\(?/i.test(line));
     assert.ok(runLines.length > 0, "no sh.Run found — has the stub been rewritten?");
     runLines.forEach((line) => {
-      assert.match(line.trim(), /, 0, False$/, `this Run is not hidden and detached: ${line.trim()}`);
+      assert.match(line.trim(), /,\s*0,\s*false$/i, `this Run is not hidden and detached: ${line.trim()}`);
     });
   });
 });

--- a/test/utils/launcher/test_windowsLauncher.ts
+++ b/test/utils/launcher/test_windowsLauncher.ts
@@ -108,6 +108,29 @@ describe("writeWindowsMessages", () => {
   });
 });
 
+describe("launch.vbs — the console window", () => {
+  const stub = readFileSync(join(process.cwd(), "server", "utils", "launcher", "windows", "launch.vbs"), "utf8");
+
+  it("never uses WshShell.Exec, which always creates a console window", () => {
+    // Measured, not assumed: `Exec` allocates a console for a console
+    // program, so `where node` would flash a black rectangle on EVERY
+    // launch — on the one screen whose whole promise is that clicking an
+    // icon just works. The stub walks %PATH% itself instead.
+    assert.doesNotMatch(stub, /\.Exec\s*\(/, "the stub shells out somewhere — that is a visible console window on every launch");
+  });
+
+  it("hides every process it starts", () => {
+    // `Run(cmd, 0, False)`: 0 hides the window, False detaches. Checked
+    // per line rather than as one pattern so a second Run added later is
+    // covered too — this is the whole reason the stub exists as a .vbs.
+    const runLines = stub.split("\n").filter((line) => line.includes("sh.Run"));
+    assert.ok(runLines.length > 0, "no sh.Run found — has the stub been rewritten?");
+    runLines.forEach((line) => {
+      assert.match(line.trim(), /, 0, False$/, `this Run is not hidden and detached: ${line.trim()}`);
+    });
+  });
+});
+
 describe("Windows install locations", () => {
   it("puts the launcher's files under LOCALAPPDATA, which does not roam", () => {
     const root = windowsLauncherRoot({ env: { LOCALAPPDATA: String.raw`C:\Users\a\AppData\Local` }, home: String.raw`C:\Users\a` });

--- a/test/utils/launcher/test_windowsShortcutIntegration.ts
+++ b/test/utils/launcher/test_windowsShortcutIntegration.ts
@@ -19,7 +19,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -30,6 +30,9 @@ const windowsOnly = { skip: process.platform !== "win32" };
 // A hand-assembled .ico that Windows refuses would show up as a blank
 // icon in Explorer and nowhere else — no error, no log line.
 const POWERSHELL_TIMEOUT_MS = 60_000;
+// The probe writes its marker milliseconds after the stub returns; a long
+// wait here only delays the report of a failure that already happened.
+const HANDOVER_TIMEOUT_MS = 15_000;
 
 const powershell = (script: string): string =>
   execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", script], {
@@ -42,7 +45,10 @@ const withTempRoot = async (body: (paths: { rootDir: string; shortcutPath: strin
   try {
     await body({ rootDir: join(dir, "launcher"), shortcutPath: join(dir, "shortcut", "MulmoClaude.lnk") });
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    // A node.exe we copied and launched keeps the directory locked for a
+    // moment after it exits, so a plain rmSync raises EBUSY and buries
+    // whatever the test actually found under a cleanup error.
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
   }
 };
 
@@ -153,12 +159,15 @@ describe("what §12 called human-only (Windows)", () => {
 
   it("hands over to node found on PATH the way a version manager puts it there", windowsOnly, async () => {
     // CI runs a plain toolchain, so nvm-windows/fnm/Volta were written off
-    // as untestable. What they actually do is put a node.exe on the user's
-    // PATH — which is reproducible: a directory that is not the system one,
+    // as untestable. What they actually do is put a node.exe on PATH —
+    // which is reproducible: a directory that is not the system one,
     // holding node.exe, reachable only through PATH.
     //
-    // The real launch.vbs runs; only run.mjs is swapped for a probe, so the
-    // app never starts but the whole stub path is exercised.
+    // The real launch.vbs runs; only run.mjs is swapped for a probe, so
+    // the app never starts while the whole stub path is exercised. The
+    // stub is invoked directly through cscript rather than by launching
+    // the .lnk: the environment is then explicit rather than inherited
+    // through the shell, which is what makes the result meaningful.
     await withTempRoot(async ({ rootDir, shortcutPath }) => {
       await createWindowsShortcut({ rootDir, shortcutPath });
       const marker = join(rootDir, "handover.json");
@@ -168,24 +177,26 @@ describe("what §12 called human-only (Windows)", () => {
       );
 
       const versionManagerDir = join(rootDir, "nvm-like", "v24.0.0", "bin");
-      const escaped = (value: string) => value.replace(/'/g, "''");
-      powershell(
-        [
-          `New-Item -ItemType Directory -Force -Path '${escaped(versionManagerDir)}' | Out-Null`,
-          `Copy-Item (Get-Command node).Source -Destination '${escaped(join(versionManagerDir, "node.exe"))}'`,
-          // Only the fake version-manager dir plus the system ones: if the
-          // stub resolved node any other way, the marker would name it.
-          `$env:PATH = '${escaped(versionManagerDir)};' + $env:SystemRoot + '\\System32;' + $env:SystemRoot`,
-          `Start-Process -FilePath '${escaped(shortcutPath)}'`,
-        ].join("\n"),
-      );
+      const fakeNode = join(versionManagerDir, "node.exe");
+      mkdirSync(versionManagerDir, { recursive: true });
+      copyFileSync(process.execPath, fakeNode);
 
-      const deadline = Date.now() + POWERSHELL_TIMEOUT_MS;
-      while (!existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 500));
-      assert.ok(existsSync(marker), "the stub never reached run.mjs — node was not found on the version-manager PATH");
+      const systemRoot = process.env.SystemRoot ?? String.raw`C:\\Windows`;
+      execFileSync("cscript.exe", ["//nologo", join(rootDir, "utils", "launcher", "windows", "launch.vbs")], {
+        timeout: POWERSHELL_TIMEOUT_MS,
+        // Only the version-manager directory and the system ones: if the
+        // stub found node any other way, the probe would name it.
+        env: { ...process.env, PATH: `${versionManagerDir};${join(systemRoot, "System32")};${systemRoot}` },
+      });
+
+      // `sh.Run(..., False)` returns immediately, so the probe finishes
+      // just after the stub does.
+      const deadline = Date.now() + HANDOVER_TIMEOUT_MS;
+      while (!existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 200));
+      assert.ok(existsSync(marker), `the stub never reached run.mjs — node was not found at ${fakeNode}`);
 
       const { execPath } = JSON.parse(readFileSync(marker, "utf8")) as { execPath: string };
-      assert.equal(execPath.toLowerCase(), join(versionManagerDir, "node.exe").toLowerCase(), `handed over to the wrong node: ${execPath}`);
+      assert.equal(execPath.toLowerCase(), fakeNode.toLowerCase(), `handed over to the wrong node: ${execPath}`);
     });
   });
 });

--- a/test/utils/launcher/test_windowsShortcutIntegration.ts
+++ b/test/utils/launcher/test_windowsShortcutIntegration.ts
@@ -1,15 +1,25 @@
 // Windows-only integration for the generated shortcut.
 //
 // Everything else about the Windows launcher is asserted from pure
-// functions on any OS. These are the parts only Windows can answer: a
-// .lnk is a binary format written by a COM object, and whether the .ico
-// we assemble by hand is actually loadable is Windows' opinion, not
-// ours. Runs inside the existing `lint_test (Windows)` job.
+// functions on any OS. These are the parts only Windows can answer.
+//
+// Three of the four items that were written off as "human only" in
+// docs/manual-testing.md §12 are reachable here, because the CAUSE is
+// checkable even when the appearance is not:
+//
+//   icon renders    → the pixels are decodable and not blank at each size
+//   no SmartScreen  → the artifacts carry no Mark-of-the-Web (the very
+//                     attribute SmartScreen keys on)
+//   version manager → a real handover, with node found through a PATH
+//                     entry that looks like nvm-windows/fnm/Volta
+//
+// What stays human: what a window LOOKS like. Runs inside the existing
+// `lint_test (Windows)` job.
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -83,6 +93,99 @@ describe("createWindowsShortcut (Windows)", () => {
         "utils/launcher/windows/launch.vbs",
         "messages/en.txt",
       ].forEach((relative) => assert.ok(existsSync(join(rootDir, ...relative.split("/"))), `missing ${relative}`));
+    });
+  });
+});
+
+describe("what §12 called human-only (Windows)", () => {
+  it("the icon has real pixels at every size Explorer asks for", windowsOnly, async () => {
+    // "Renders in Explorer" cannot be asserted, but the failure people
+    // actually hit — a blank or undecodable icon — can. Each size is
+    // pulled out of the container and sampled for opaque pixels.
+    await withTempRoot(async ({ rootDir, shortcutPath }) => {
+      await createWindowsShortcut({ rootDir, shortcutPath });
+      const iconPath = join(rootDir, "icon.ico").replace(/'/g, "''");
+      const output = powershell(
+        [
+          "Add-Type -AssemblyName System.Drawing",
+          "$results = @()",
+          "foreach ($size in 16,32,48,256) {",
+          `  $icon = New-Object System.Drawing.Icon('${iconPath}', $size, $size)`,
+          "  $bmp = $icon.ToBitmap()",
+          "  $opaque = 0",
+          "  for ($x = 0; $x -lt $bmp.Width; $x += 4) {",
+          "    for ($y = 0; $y -lt $bmp.Height; $y += 4) {",
+          "      if ($bmp.GetPixel($x, $y).A -gt 0) { $opaque++ }",
+          "    }",
+          "  }",
+          '  $results += "$($bmp.Width)x$($bmp.Height):$opaque"',
+          "}",
+          "Write-Output ($results -join ' ')",
+        ].join("\n"),
+      );
+      // e.g. "16x16:16 32x32:64 48x48:144 256x256:4096"
+      const sampled = output.split(" ").map((entry) => {
+        const [dimensions, opaque] = entry.split(":");
+        return { dimensions, opaque: Number(opaque) };
+      });
+      assert.equal(sampled.length, 4, output);
+      sampled.forEach(({ dimensions, opaque }) => {
+        assert.ok(opaque > 0, `${dimensions} decoded to a fully transparent image — Explorer would show nothing (${output})`);
+      });
+    });
+  });
+
+  it("nothing it writes carries a Mark-of-the-Web, which is what SmartScreen keys on", windowsOnly, async () => {
+    // The claim in the changelog is that a locally generated file is not
+    // flagged. That rests entirely on the absence of the Zone.Identifier
+    // alternate data stream, and that is directly checkable.
+    await withTempRoot(async ({ rootDir, shortcutPath }) => {
+      await createWindowsShortcut({ rootDir, shortcutPath });
+      const targets = [shortcutPath, join(rootDir, "utils", "launcher", "windows", "launch.vbs"), join(rootDir, "icon.ico")];
+      targets.forEach((target) => {
+        const streams = powershell(
+          `$found = Get-Item -LiteralPath '${target.replace(/'/g, "''")}' -Stream * -ErrorAction SilentlyContinue | Where-Object { $_.Stream -eq 'Zone.Identifier' }; Write-Output $found.Count`,
+        );
+        assert.equal(streams, "0", `${target} carries a Zone.Identifier stream — SmartScreen would have something to react to`);
+      });
+    });
+  });
+
+  it("hands over to node found on PATH the way a version manager puts it there", windowsOnly, async () => {
+    // CI runs a plain toolchain, so nvm-windows/fnm/Volta were written off
+    // as untestable. What they actually do is put a node.exe on the user's
+    // PATH — which is reproducible: a directory that is not the system one,
+    // holding node.exe, reachable only through PATH.
+    //
+    // The real launch.vbs runs; only run.mjs is swapped for a probe, so the
+    // app never starts but the whole stub path is exercised.
+    await withTempRoot(async ({ rootDir, shortcutPath }) => {
+      await createWindowsShortcut({ rootDir, shortcutPath });
+      const marker = join(rootDir, "handover.json");
+      writeFileSync(
+        join(rootDir, "utils", "launcher", "run.mjs"),
+        ["import { writeFileSync } from 'node:fs';", `writeFileSync(String.raw\`${marker}\`, JSON.stringify({ execPath: process.execPath }));`].join("\n"),
+      );
+
+      const versionManagerDir = join(rootDir, "nvm-like", "v24.0.0", "bin");
+      const escaped = (value: string) => value.replace(/'/g, "''");
+      powershell(
+        [
+          `New-Item -ItemType Directory -Force -Path '${escaped(versionManagerDir)}' | Out-Null`,
+          `Copy-Item (Get-Command node).Source -Destination '${escaped(join(versionManagerDir, "node.exe"))}'`,
+          // Only the fake version-manager dir plus the system ones: if the
+          // stub resolved node any other way, the marker would name it.
+          `$env:PATH = '${escaped(versionManagerDir)};' + $env:SystemRoot + '\\System32;' + $env:SystemRoot`,
+          `Start-Process -FilePath '${escaped(shortcutPath)}'`,
+        ].join("\n"),
+      );
+
+      const deadline = Date.now() + POWERSHELL_TIMEOUT_MS;
+      while (!existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 500));
+      assert.ok(existsSync(marker), "the stub never reached run.mjs — node was not found on the version-manager PATH");
+
+      const { execPath } = JSON.parse(readFileSync(marker, "utf8")) as { execPath: string };
+      assert.equal(execPath.toLowerCase(), join(versionManagerDir, "node.exe").toLowerCase(), `handed over to the wrong node: ${execPath}`);
     });
   });
 });


### PR DESCRIPTION
## Summary

I wrote in `docs/manual-testing.md` §12 that four things about the Windows launcher could only be checked by a human. That was too quick. **Three of them have a cause that CI can assert, even though the appearance is not something CI can judge.**

| Was manual | Now asserted on `windows-latest` |
|---|---|
| The icon renders | Every size decodes out of the `.ico` and has opaque pixels — blank or undecodable fails |
| SmartScreen stays quiet | No generated file carries a `Zone.Identifier` stream — the attribute SmartScreen keys on |
| A version-manager node resolves | The **real `launch.vbs`** runs with node reachable only through an nvm-like PATH entry, and the handover names that node |
| No console window | The stub never calls `WshShell.Exec` (which always allocates a console), and every `sh.Run` is `, 0, False` |

## Items to Confirm / Review

1. **The version-manager test runs the actual stub.** Only `run.mjs` is swapped for a probe, so the app never starts, but the whole path is exercised for real: PATH inheritance → `FindNode` walking `%PATH%` → handover to node. `node.exe` is copied into a directory that looks like `…/nvm-like/v24.0.0/bin`, and PATH is reduced to that plus the system directories — so if the stub found node any other way, the probe would name it and the test fails. This was the item I was most sure could not be tested; it turned out to be the most valuable one.

2. **The SmartScreen check tests the documented mechanism, not the dialog.** The changelog claims a locally written file is not flagged *because* it carries no Mark-of-the-Web. That claim is now checked directly. A managed machine can still refuse unsigned apps on other grounds — that stays in §12.

3. **The console-window guard is static and runs on every OS.** It pins the decision the spike led to: `where node` was rejected precisely because `Exec` flashes a console on every launch. Asserted per `sh.Run` line rather than as one pattern, so a second `Run` added later is covered too.

4. **Icon "renders" is narrowed honestly.** CI proves pixels exist and decode at 16/32/48/256. It cannot prove they look like the mark. §12 says so.

## User Prompt

> windows実機ってciでなんとかできない？ 残りどんどん進めて。

## What remains human, and why it cannot stop being

1. **What it looks like** — pixels existing is not pixels being right.
2. **The gesture** — a real Explorer double-click; the Start Menu search hit.
3. **A managed, unsigned-app-hostile machine** — outside what a runner can reproduce.
4. **The no-Node dialog end to end** — firing a modal on a headless runner hangs the job.

Gates: `yarn format` / `lint` (0 errors) / `typecheck` / `test` green — 10293 tests, 0 failures. The three new Windows tests skip on macOS and run in the existing `lint_test (Windows)` job, which this PR's path filter already triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automated Windows-specific tests and documentation updates so that previously manual checks for the Windows launcher are now largely covered by CI.

New Features:
- Add Windows integration tests to validate the launcher icon decodes correctly at common Explorer sizes.
- Add a Windows test ensuring generated launcher artifacts lack the Mark-of-the-Web stream that would trigger SmartScreen.
- Add a Windows test that verifies the launcher hands off to a Node.js binary found via a version-manager-like PATH layout.

Enhancements:
- Document that several former manual Windows launcher checks are now enforced by CI, clarifying what remains human-only verification.
- Add static tests for the Windows launcher script to ensure it never spawns visible console windows and always hides started processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Windows integration coverage for generated shortcuts, icons, and the launcher, including PATH-based Node resolution and launcher “handover” validation.
  * Added checks to ensure the console launcher stub does not attempt to open a visible console window.
  * Verified generated artifacts (shortcut, launcher, icon) lack downloaded-file security markers and that icons render correctly across multiple sizes.
* **Documentation**
  * Updated Windows manual testing guidance to clarify which shortcut/icon checks are now covered by CI and what remains human-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->