### PR TITLE
feat: presentDocument に path を追加（既存ドキュメントを再保存せず表示・その場編集）

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Highlights
 
+#### `presentDocument` can open a document you already wrote
+
+Until now the tool only ever created: it took `markdown` inline, saved a fresh file under `artifacts/documents/<YYYY>/<MM>/`, and showed that. Re-displaying an existing document meant reading it and writing a second copy.
+
+It now accepts a `path` instead — the workspace-relative path of an existing `artifacts/documents/**.md` — and presents that file in place, with nothing written. `markdown` and `path` are mutually exclusive, exactly as `html` and `path` already are on `presentHtml`. Edits the user makes in the document view (Apply, or an inline task-list checkbox) write back to that same file, so the agent and the user are editing one document rather than diverging copies.
+
 #### Start MulmoClaude from an icon, without a terminal (#2613, PRs #2615 / #2623)
 
 For anyone who does not open a terminal, `npx mulmoclaude@latest` was the whole barrier to entry. One command creates a clickable app:

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -43,7 +43,7 @@
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.0",
     "@mulmoclaude/html-plugin": "^1.1.0",
-    "@mulmoclaude/markdown-plugin": "^1.1.0",
+    "@mulmoclaude/markdown-plugin": "^1.2.0",
     "@mulmoclaude/markdown-utils": "^1.3.1",
     "@mulmoclaude/mulmoscript-plugin": "^1.1.2",
     "@mulmoclaude/spotify-plugin": "^1.0.2",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/markdown-plugin",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Full-fidelity markdown document plugin (presentDocument) — Marp slides, PDF export, AI image-fill — shared gui-chat-protocol plugin for MulmoClaude and MulmoTerminal.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/markdown-plugin/src/core/plugin.ts
+++ b/packages/plugins/markdown-plugin/src/core/plugin.ts
@@ -1,22 +1,70 @@
 import type { ToolContext, ToolResult, ToolPluginCore } from "gui-chat-protocol";
-import { TOOL_NAME, TOOL_DEFINITION, type MarkdownToolData, type MarkdownArgs } from "../plugins/markdown/definition";
+import { TOOL_NAME, TOOL_DEFINITION, isFilePath, type MarkdownToolData, type MarkdownArgs } from "../plugins/markdown/definition";
 import { executeMarkdown, type MarkdownExecuteContext } from "../plugins/markdown/core";
-import type { MarkdownDispatchArgs } from "../plugins/markdown/contract";
+import type { MarkdownDispatchArgs, MarkdownHostApp } from "../plugins/markdown/contract";
 
-async function createDocument(context: MarkdownExecuteContext, args: MarkdownArgs): Promise<ToolResult<MarkdownToolData>> {
-  const { app } = context;
-  if (!app) {
-    throw new Error("markdown plugin: context.app (MarkdownHostApp) was not provided by the host");
+const PRESENT_ACK = "The document has been presented to the user in a rendered markdown view.";
+
+const nonEmptyString = (value: unknown): value is string => typeof value === "string" && value.length > 0;
+
+/** Present a document already on disk under `artifacts/documents/**` without
+ *  re-saving. `loadDoc` doubles as the existence check — the host app has no
+ *  separate `exists`, and a read is what the View does next anyway. Edits the
+ *  user applies in the View dispatch `saveDoc` against this same path, so they
+ *  land on the original file. */
+async function presentExistingDocument(app: MarkdownHostApp, path: string, title: string): Promise<ToolResult<MarkdownToolData>> {
+  if (!isFilePath(path)) {
+    return {
+      message: "path must be an existing .md file under artifacts/documents/",
+      instructions: "Acknowledge the error and retry with a valid artifacts/documents/… path or inline `markdown`.",
+    };
   }
+  try {
+    await app.loadDoc(path);
+  } catch {
+    return {
+      message: `No document exists at ${path}`,
+      instructions: "Acknowledge that the file was not found and retry with a path that exists or inline `markdown`.",
+    };
+  }
+  return { message: `Presented existing document${title ? `: ${title}` : ""}`, data: { markdown: path }, instructions: PRESENT_ACK };
+}
+
+/** Persist new markdown under a fresh artifact path, then present it. */
+async function saveAndPresentDocument(app: MarkdownHostApp, args: MarkdownArgs): Promise<ToolResult<MarkdownToolData>> {
   const { title, markdown, filenamePrefix } = args;
-  const filled = (await app.fillImages(markdown)).markdown;
+  const filled = (await app.fillImages(markdown ?? "")).markdown;
   const { path } = await app.saveNewDoc(filenamePrefix ?? "document", filled);
   return {
     message: `Document created${title ? `: ${title}` : ""}`,
     // `data` is the host's render-gate signal + the view's source.
     data: { markdown: path, filenamePrefix },
-    instructions: "The document has been presented to the user in a rendered markdown view.",
+    instructions: PRESENT_ACK,
   };
+}
+
+/** `markdown` and `path` are mutually exclusive: inline markdown is written to
+ *  a fresh `artifacts/documents/**` path, `path` presents an existing document
+ *  in place. Same contract as presentHtml's `html` / `path`. */
+async function createDocument(context: MarkdownExecuteContext, args: MarkdownArgs): Promise<ToolResult<MarkdownToolData>> {
+  const { app } = context;
+  if (!app) {
+    throw new Error("markdown plugin: context.app (MarkdownHostApp) was not provided by the host");
+  }
+  const { title, markdown, path } = args;
+  if (nonEmptyString(path) && nonEmptyString(markdown)) {
+    return {
+      message: "provide either `markdown` or `path`, not both",
+      instructions: "Acknowledge the error and retry with exactly one of `markdown` or `path`.",
+    };
+  }
+  if (nonEmptyString(path)) {
+    return presentExistingDocument(app, path, title);
+  }
+  if (nonEmptyString(markdown)) {
+    return saveAndPresentDocument(app, args);
+  }
+  return { message: "provide either `markdown` or `path`", instructions: "Acknowledge the error and retry with inline `markdown` or an existing `path`." };
 }
 
 const DISPATCH_KINDS: ReadonlySet<string> = new Set(["loadDoc", "saveDoc", "marpThemes", "exportPdf", "fillImages"]);

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
@@ -21,12 +21,23 @@ export interface MarkdownArgs {
   path?: string;
 }
 
-/** True when the `markdown` field is a workspace-relative file path
- *  rather than inline content. Accepts the canonical
- *  `artifacts/documents/*.md` prefix. */
+const DOCUMENTS_PREFIX = "artifacts/documents/";
+
+/** True when the value is a workspace-relative document path rather than
+ *  inline content — the `markdown` field's two shapes, and the gate on the
+ *  tool's `path` argument.
+ *
+ *  Canonical form is enforced, not just prefix + extension: this also runs in
+ *  hosts that pass the value straight to their file layer, so a prefixed
+ *  traversal (`artifacts/documents/../../secrets.md`) must not pass here just
+ *  because MulmoClaude happens to re-validate with `isMarkdownPath`. Same
+ *  constraints as the host's `makePathValidator`, expressed without node's
+ *  `path` because this module is also bundled for the browser. */
 export function isFilePath(value: string): boolean {
   if (!value.endsWith(".md")) return false;
-  return value.startsWith("artifacts/documents/");
+  if (!value.startsWith(DOCUMENTS_PREFIX)) return false;
+  if (value.includes("..") || value.includes("\0") || value.includes("\\")) return false;
+  return value.split("/").every((segment) => segment.length > 0 && segment !== ".");
 }
 
 export const TOOL_DEFINITION: ToolDefinition = {
@@ -76,7 +87,7 @@ export const TOOL_DEFINITION: ToolDefinition = {
       filenamePrefix: {
         type: "string",
         description:
-          "Short English filename prefix (without extension), required with `markdown`. Use lowercase with hyphens, e.g. 'project-summary'. The server sanitizes the value and appends a random id to prevent collisions.",
+          "Short English filename prefix (without extension). Always send it with `markdown` — it is what makes the saved file findable; omitting it falls back to 'document'. Ignored with `path`. Use lowercase with hyphens, e.g. 'project-summary'. The server sanitizes the value and appends a random id to prevent collisions.",
       },
       path: {
         type: "string",

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
@@ -8,13 +8,17 @@ export interface MarkdownToolData {
   filenamePrefix?: string;
 }
 
-/** Args the LLM passes when invoking the tool (the create path). All
- *  three are `required` in TOOL_DEFINITION.parameters, so they're
- *  non-optional here too. */
+/** Args the LLM passes when invoking the tool. Two shapes share this
+ *  type: the create path (`markdown` + `filenamePrefix`, saved to a
+ *  fresh artifact path) and the present-existing path (`path`, rendered
+ *  in place). Only `title` is `required` in TOOL_DEFINITION.parameters
+ *  because JSON Schema can't express that either-or; the executor
+ *  enforces the mutual exclusion. */
 export interface MarkdownArgs {
   title: string;
-  markdown: string;
-  filenamePrefix: string;
+  markdown?: string;
+  filenamePrefix?: string;
+  path?: string;
 }
 
 /** True when the `markdown` field is a workspace-relative file path
@@ -28,10 +32,12 @@ export function isFilePath(value: string): boolean {
 export const TOOL_DEFINITION: ToolDefinition = {
   type: "function",
   name: TOOL_NAME,
-  description: "Display a document in markdown format.",
+  description: "Display a document in markdown format — either new markdown (saved) or an existing saved document (by path).",
   prompt:
     `Use the ${TOOL_NAME} tool when the user asks for a document that combines text with embedded images — guides, reports, tutorials, articles, or any structured content with visuals. ` +
     `Prefer this over standalone image generation when the user wants informational content with supporting visuals.\n\n` +
+    "Provide EITHER `markdown` + `filenamePrefix` (new content, saved under `artifacts/documents/<YYYY>/<MM>/…`) OR `path` (the workspace-relative path of a document you already wrote under `artifacts/documents/`), not both. " +
+    "`path` presents that existing document without re-saving a copy, and edits the user makes in the view write back to that same file.\n\n" +
     "Format embedded images as: ![Detailed image prompt](__too_be_replaced_image_path__)\n\n" +
     "── Slide-deck (Marp) mode ──\n" +
     "When the user asks for a slide deck / presentation / スライド, opt into Marp by writing this YAML frontmatter at the very top of the markdown:\n" +
@@ -65,15 +71,22 @@ export const TOOL_DEFINITION: ToolDefinition = {
       markdown: {
         type: "string",
         description:
-          "The markdown content to display. Describe embedded images in the following format: ![Detailed image prompt](__too_be_replaced_image_path__). IMPORTANT: For embedded images, you MUST use the EXACT placeholder path '__too_be_replaced_image_path__'.",
+          "The markdown content to display. Provide this (with `filenamePrefix`) OR `path`. Describe embedded images in the following format: ![Detailed image prompt](__too_be_replaced_image_path__). IMPORTANT: For embedded images, you MUST use the EXACT placeholder path '__too_be_replaced_image_path__'.",
       },
       filenamePrefix: {
         type: "string",
         description:
-          "Short English filename prefix (without extension). Use lowercase with hyphens, e.g. 'project-summary'. The server sanitizes the value and appends a random id to prevent collisions.",
+          "Short English filename prefix (without extension), required with `markdown`. Use lowercase with hyphens, e.g. 'project-summary'. The server sanitizes the value and appends a random id to prevent collisions.",
+      },
+      path: {
+        type: "string",
+        description:
+          "Workspace-relative path to an existing markdown file under `artifacts/documents/` to present without re-saving (e.g. `artifacts/documents/2026/07/report-abc123.md`). Provide this OR `markdown`.",
       },
     },
-    required: ["title", "markdown", "filenamePrefix"],
+    // `markdown` + `filenamePrefix` and `path` are mutually exclusive, which
+    // JSON Schema can't express — the executor validates the pairing.
+    required: ["title"],
   },
 };
 

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -117,13 +117,13 @@ async function saveAndPresentDocument(res: Response<PresentDocumentSuccess | Pre
     badRequest(res, "provide either `markdown` or `path`");
     return;
   }
-  if (!isNonEmpty(filenamePrefix)) {
-    log.warn("plugins", "presentDocument: missing filenamePrefix");
-    badRequest(res, "filenamePrefix is required");
-    return;
-  }
+  // A missing prefix is no longer a 400: `path` made `filenamePrefix`
+  // conditional, and JSON Schema can't say "required only with `markdown`", so
+  // a caller reading `required` can legitimately omit it. `saveMarkdown`
+  // slugifies to "document" on empty — the same default the shared plugin core
+  // applies (`filenamePrefix ?? "document"`), so both hosts behave alike.
   const filledMarkdown = await fillMarkdownImagePlaceholders(markdown);
-  const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix);
+  const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix ?? "");
   log.info("plugins", "presentDocument: ok", { markdownPath, bytes: filledMarkdown.length });
   res.json({ message: `Saved markdown to ${markdownPath}`, instructions: PRESENT_DOCUMENT_ACK, title, data: { markdown: markdownPath, filenamePrefix } });
 }

--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -14,7 +14,7 @@ import { errorMessage } from "../../utils/errors.js";
 import { badRequest, serverError } from "../../utils/httpError.js";
 import { saveImage } from "../../utils/files/image-store.js";
 import { fillMarkdownImagePlaceholders } from "../../utils/files/markdown-image-fill.js";
-import { saveMarkdown, overwriteMarkdown, isMarkdownPath } from "../../utils/files/markdown-store.js";
+import { saveMarkdown, overwriteMarkdown, isMarkdownPath, markdownExists } from "../../utils/files/markdown-store.js";
 import { saveSpreadsheet, overwriteSpreadsheet, isSpreadsheetPath } from "../../utils/files/spreadsheet-store.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { bindRoute } from "../../utils/router.js";
@@ -69,45 +69,88 @@ function wrapPluginExecute<TBody = any, TResult = unknown>(
 // presentDocument — fills image placeholders via Gemini if API key is available
 interface PresentDocumentBody {
   title: string;
-  markdown: string;
-  filenamePrefix: string;
+  markdown?: string;
+  filenamePrefix?: string;
+  path?: string;
 }
 
 interface PresentDocumentSuccess {
   message: string;
   instructions: string;
   title: string;
-  data: { markdown: string; filenamePrefix: string };
+  data: { markdown: string; filenamePrefix?: string };
 }
 
 interface PresentDocumentError {
   error: string;
 }
 
+const PRESENT_DOCUMENT_ACK = "Acknowledge that the document has been presented to the user.";
+
+const isNonEmpty = (value: unknown): value is string => typeof value === "string" && value.trim().length > 0;
+
+/** `path` form — present an existing `artifacts/documents/**.md` in place.
+ *  Nothing is written: `data.markdown` carries the caller's path verbatim, so
+ *  the View loads THAT file and its Apply / task-checkbox saves (PUT
+ *  /api/markdown/update) overwrite it rather than a fresh copy. */
+async function presentExistingDocument(res: Response<PresentDocumentSuccess | PresentDocumentError>, path: string, title: string): Promise<void> {
+  if (!isMarkdownPath(path)) {
+    log.warn("plugins", "presentDocument: invalid path", { pathPreview: previewSnippet(path) });
+    badRequest(res, "path must be a .md file under artifacts/documents/");
+    return;
+  }
+  if (!(await markdownExists(path))) {
+    log.warn("plugins", "presentDocument: path not found", { path });
+    badRequest(res, `No document exists at ${path}`);
+    return;
+  }
+  log.info("plugins", "presentDocument: presented existing", { path });
+  res.json({ message: `Presented existing document at ${path}`, instructions: PRESENT_DOCUMENT_ACK, title, data: { markdown: path } });
+}
+
+/** `markdown` form — fill image placeholders, then save under a fresh
+ *  `artifacts/documents/<YYYY>/<MM>/…` path. */
+async function saveAndPresentDocument(res: Response<PresentDocumentSuccess | PresentDocumentError>, body: PresentDocumentBody): Promise<void> {
+  const { title, markdown, filenamePrefix } = body;
+  if (!isNonEmpty(markdown)) {
+    log.warn("plugins", "presentDocument: missing markdown and path");
+    badRequest(res, "provide either `markdown` or `path`");
+    return;
+  }
+  if (!isNonEmpty(filenamePrefix)) {
+    log.warn("plugins", "presentDocument: missing filenamePrefix");
+    badRequest(res, "filenamePrefix is required");
+    return;
+  }
+  const filledMarkdown = await fillMarkdownImagePlaceholders(markdown);
+  const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix);
+  log.info("plugins", "presentDocument: ok", { markdownPath, bytes: filledMarkdown.length });
+  res.json({ message: `Saved markdown to ${markdownPath}`, instructions: PRESENT_DOCUMENT_ACK, title, data: { markdown: markdownPath, filenamePrefix } });
+}
+
 bindRoute(
   router,
   API_ROUTES.markdown.create,
   async (req: Request<object, unknown, PresentDocumentBody>, res: Response<PresentDocumentSuccess | PresentDocumentError>) => {
-    const { title, markdown, filenamePrefix } = req.body;
+    const { title, markdown, filenamePrefix, path: documentPath } = req.body;
     log.info("plugins", "presentDocument: start", {
       titlePreview: typeof title === "string" ? previewSnippet(title) : undefined,
       prefixPreview: typeof filenamePrefix === "string" ? previewSnippet(filenamePrefix) : undefined,
       markdownBytes: typeof markdown === "string" ? markdown.length : undefined,
+      pathPreview: typeof documentPath === "string" ? previewSnippet(documentPath) : undefined,
     });
-    if (typeof filenamePrefix !== "string" || filenamePrefix.trim().length === 0) {
-      log.warn("plugins", "presentDocument: missing filenamePrefix");
-      badRequest(res, "filenamePrefix is required");
+    // `markdown` and `path` are mutually exclusive — same contract as
+    // presentHtml's `html` / `path`. Reject both-set rather than letting
+    // one silently win.
+    if (isNonEmpty(documentPath) && isNonEmpty(markdown)) {
+      badRequest(res, "provide either `markdown` or `path`, not both");
       return;
     }
-    const filledMarkdown = await fillMarkdownImagePlaceholders(markdown);
-    const markdownPath = await saveMarkdown(filledMarkdown, filenamePrefix);
-    log.info("plugins", "presentDocument: ok", { markdownPath, bytes: filledMarkdown.length });
-    res.json({
-      message: `Saved markdown to ${markdownPath}`,
-      instructions: "Acknowledge that the document has been presented to the user.",
-      title,
-      data: { markdown: markdownPath, filenamePrefix },
-    });
+    if (isNonEmpty(documentPath)) {
+      await presentExistingDocument(res, documentPath, title);
+      return;
+    }
+    await saveAndPresentDocument(res, req.body);
   },
 );
 

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from "fs/promises";
+import { readFile, stat } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -22,13 +22,23 @@ export async function loadMarkdown(relativePath: string): Promise<string> {
 // Strict — overwriteMarkdown's path.join doesn't normalize traversal, so this gate is the primary defence.
 export const isMarkdownPath = makePathValidator({ prefix: WORKSPACE_DIRS.markdowns, ext: ".md" });
 
-// Existence probe for presentDocument's `path` form. Gated on isMarkdownPath
-// first for the same traversal reason as overwriteMarkdown.
+// Readable-regular-file probe for presentDocument's `path` form. Gated on
+// isMarkdownPath first for the same traversal reason as overwriteMarkdown,
+// then re-checked with the `path.relative` containment pattern — redundant
+// at runtime, but it is what CodeQL's js/path-injection data flow recognizes
+// as a sanitizer (same reasoning as `escapesRoot` in ./safe.ts).
+//
+// `isFile()` rather than a bare existence check: a DIRECTORY named
+// `…/report.md` satisfies access(), so the route would report a presented
+// document whose subsequent loadDoc (readFile) fails with EISDIR.
 export async function markdownExists(relativePath: string): Promise<boolean> {
   if (!isMarkdownPath(relativePath)) return false;
+  const absPath = path.resolve(workspacePath, relativePath);
+  const relative = path.relative(workspacePath, absPath);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return false;
   try {
-    await access(path.join(workspacePath, relativePath));
-    return true;
+    const stats = await stat(absPath);
+    return stats.isFile();
   } catch {
     return false;
   }

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises";
+import { access, readFile } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -21,6 +21,18 @@ export async function loadMarkdown(relativePath: string): Promise<string> {
 
 // Strict — overwriteMarkdown's path.join doesn't normalize traversal, so this gate is the primary defence.
 export const isMarkdownPath = makePathValidator({ prefix: WORKSPACE_DIRS.markdowns, ext: ".md" });
+
+// Existence probe for presentDocument's `path` form. Gated on isMarkdownPath
+// first for the same traversal reason as overwriteMarkdown.
+export async function markdownExists(relativePath: string): Promise<boolean> {
+  if (!isMarkdownPath(relativePath)) return false;
+  try {
+    await access(path.join(workspacePath, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // Defense in depth (matches `overwriteSvg`): if a caller forgets to
 // pre-check via `isMarkdownPath`, `path.join(workspacePath, relativePath)`

--- a/server/utils/files/markdown-store.ts
+++ b/server/utils/files/markdown-store.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from "fs/promises";
+import { readFile, realpath, stat } from "fs/promises";
 import path from "path";
 import { workspacePath } from "../../workspace/workspace.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -22,23 +22,35 @@ export async function loadMarkdown(relativePath: string): Promise<string> {
 // Strict — overwriteMarkdown's path.join doesn't normalize traversal, so this gate is the primary defence.
 export const isMarkdownPath = makePathValidator({ prefix: WORKSPACE_DIRS.markdowns, ext: ".md" });
 
+// `path.relative(root, candidate)` starts with `..` when `candidate` escapes
+// `root`. Lexically redundant after `isMarkdownPath`, but it is the sanitizer
+// pattern CodeQL's js/path-injection data flow recognizes — and applied to a
+// REALPATH it is also the symlink check (same shape as `escapesRoot` in
+// ./safe.ts).
+function escapesWorkspace(rootReal: string, candidate: string): boolean {
+  const relative = path.relative(rootReal, candidate);
+  return relative.startsWith("..") || path.isAbsolute(relative);
+}
+
 // Readable-regular-file probe for presentDocument's `path` form. Gated on
-// isMarkdownPath first for the same traversal reason as overwriteMarkdown,
-// then re-checked with the `path.relative` containment pattern — redundant
-// at runtime, but it is what CodeQL's js/path-injection data flow recognizes
-// as a sanitizer (same reasoning as `escapesRoot` in ./safe.ts).
+// isMarkdownPath first, for the same traversal reason as overwriteMarkdown.
 //
 // `isFile()` rather than a bare existence check: a DIRECTORY named
 // `…/report.md` satisfies access(), so the route would report a presented
-// document whose subsequent loadDoc (readFile) fails with EISDIR.
+// document whose subsequent read fails with EISDIR.
+//
+// Realpath rather than the lexical path alone: `stat` follows symlinks, so
+// `artifacts/documents/report.md -> /etc/secret` would otherwise present as a
+// workspace document.
 export async function markdownExists(relativePath: string): Promise<boolean> {
   if (!isMarkdownPath(relativePath)) return false;
-  const absPath = path.resolve(workspacePath, relativePath);
-  const relative = path.relative(workspacePath, absPath);
-  if (relative.startsWith("..") || path.isAbsolute(relative)) return false;
   try {
-    const stats = await stat(absPath);
-    return stats.isFile();
+    const rootReal = await realpath(workspacePath);
+    const absPath = path.resolve(rootReal, relativePath);
+    if (escapesWorkspace(rootReal, absPath)) return false;
+    const absReal = await realpath(absPath);
+    if (escapesWorkspace(rootReal, absReal)) return false;
+    return (await stat(absReal)).isFile();
   } catch {
     return false;
   }

--- a/test/plugins/markdown/test_isFilePath.ts
+++ b/test/plugins/markdown/test_isFilePath.ts
@@ -46,4 +46,26 @@ describe("markdown isFilePath", () => {
     assert.equal(isFilePath("markdowns/abc.md"), false);
     assert.equal(isFilePath("markdowns/sub/nested.md"), false);
   });
+
+  // The prefix + extension pair alone let a traversal through
+  // (`artifacts/documents/../../secrets.md`). It also gates the
+  // `path` argument of presentDocument in the host-agnostic core, where
+  // no second validator stands behind it — so canonical form is checked
+  // here, matching the host's `makePathValidator`.
+  it("rejects traversal segments under the documents prefix", () => {
+    assert.equal(isFilePath("artifacts/documents/../../secrets.md"), false);
+    assert.equal(isFilePath("artifacts/documents/sub/../../../etc/passwd.md"), false);
+    assert.equal(isFilePath("artifacts/documents/..md"), false);
+  });
+
+  it("rejects non-canonical segments", () => {
+    assert.equal(isFilePath("artifacts/documents/./foo.md"), false);
+    assert.equal(isFilePath("artifacts/documents//foo.md"), false);
+    assert.equal(isFilePath("artifacts/documents/sub//deep.md"), false);
+  });
+
+  it("rejects backslashes and NUL bytes", () => {
+    assert.equal(isFilePath("artifacts/documents/sub\\foo.md"), false);
+    assert.equal(isFilePath("artifacts/documents/foo\0.md"), false);
+  });
 });

--- a/test/plugins/markdown/test_presentDocumentCore.ts
+++ b/test/plugins/markdown/test_presentDocumentCore.ts
@@ -1,0 +1,140 @@
+// Branch coverage for the shared `presentDocument` executor — the
+// host-agnostic create path in `@mulmoclaude/markdown-plugin`
+// (`src/core/plugin.ts`), which MulmoTerminal and any other host reach
+// through `pluginCore.execute`.
+//
+// `markdown` and `path` are mutually exclusive (same contract as
+// presentHtml's `html` / `path`), so the cases that matter are the
+// pairings the LLM can produce: both, neither, a bad path, a path whose
+// file is missing, and each valid form. The host app is a stub — these
+// assertions are about the dispatcher's decisions, not about any host's
+// storage.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { executeDocument, type MarkdownHostApp } from "@mulmoclaude/markdown-plugin";
+import type { ToolContext } from "gui-chat-protocol";
+
+const EXISTING = "artifacts/documents/2026/07/existing-abc123.md";
+
+interface StubCalls {
+  loadDoc: string[];
+  saveNewDoc: { prefix: string; markdown: string }[];
+  fillImages: string[];
+}
+
+/** `missing` is the set of paths whose `loadDoc` rejects, standing in for
+ *  a file that is not on disk. */
+function stubApp(missing: ReadonlySet<string> = new Set()): { app: MarkdownHostApp; calls: StubCalls } {
+  const calls: StubCalls = { loadDoc: [], saveNewDoc: [], fillImages: [] };
+  const app: MarkdownHostApp = {
+    async loadDoc(path) {
+      calls.loadDoc.push(path);
+      if (missing.has(path)) throw new Error(`ENOENT: ${path}`);
+      return { content: "# existing\n" };
+    },
+    async saveDoc(path) {
+      return { path };
+    },
+    async saveNewDoc(prefix, markdown) {
+      calls.saveNewDoc.push({ prefix, markdown });
+      return { path: `artifacts/documents/2026/07/${prefix}-new123.md` };
+    },
+    async marpThemes() {
+      return { themes: [] };
+    },
+    async exportPdf() {
+      return { pdfBase64: "" };
+    },
+    async fillImages(markdown) {
+      calls.fillImages.push(markdown);
+      return { markdown };
+    },
+  };
+  return { app, calls };
+}
+
+function contextFor(app: MarkdownHostApp): ToolContext {
+  return { app } as unknown as ToolContext;
+}
+
+describe("presentDocument core — markdown / path mutual exclusion", () => {
+  it("rejects both `markdown` and `path`", async () => {
+    const { app, calls } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "T", markdown: "# hi", path: EXISTING });
+
+    assert.equal(result.data, undefined, "a rejected call must not present anything");
+    assert.match(result.message, /not both/);
+    assert.deepEqual(calls.saveNewDoc, [], "nothing should be saved");
+    assert.deepEqual(calls.loadDoc, [], "nothing should be loaded");
+  });
+
+  it("rejects neither `markdown` nor `path`", async () => {
+    const { app, calls } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "T" });
+
+    assert.equal(result.data, undefined);
+    assert.match(result.message, /either `markdown` or `path`/);
+    assert.deepEqual(calls.saveNewDoc, []);
+  });
+});
+
+describe("presentDocument core — `path` form", () => {
+  it("presents an existing document without re-saving it", async () => {
+    const { app, calls } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "Report", path: EXISTING });
+
+    assert.equal(result.data?.markdown, EXISTING, "data.markdown carries the caller's path verbatim");
+    assert.deepEqual(calls.saveNewDoc, [], "the `path` form must not write a copy");
+    assert.deepEqual(calls.loadDoc, [EXISTING], "existence is probed through loadDoc");
+  });
+
+  it("rejects a traversal path before touching the host", async () => {
+    const { app, calls } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "T", path: "artifacts/documents/../../secrets.md" });
+
+    assert.equal(result.data, undefined);
+    assert.match(result.message, /artifacts\/documents\//);
+    assert.deepEqual(calls.loadDoc, [], "a bad path must not reach the host's file layer");
+  });
+
+  it("rejects a path outside artifacts/documents/", async () => {
+    const { app } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "T", path: "wiki/notes.md" });
+
+    assert.equal(result.data, undefined);
+  });
+
+  it("reports a missing file rather than presenting it", async () => {
+    const missing = "artifacts/documents/2026/07/gone-zzz999.md";
+    const { app, calls } = stubApp(new Set([missing]));
+    const result = await executeDocument(contextFor(app), { title: "T", path: missing });
+
+    assert.equal(result.data, undefined, "a missing file must not render as a presented document");
+    assert.match(result.message, /No document exists/);
+    assert.deepEqual(calls.loadDoc, [missing]);
+  });
+});
+
+describe("presentDocument core — `markdown` form", () => {
+  it("fills images and saves under the given prefix", async () => {
+    const { app, calls } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "T", markdown: "# hi", filenamePrefix: "my-report" });
+
+    assert.equal(result.data?.markdown, "artifacts/documents/2026/07/my-report-new123.md");
+    assert.deepEqual(calls.fillImages, ["# hi"]);
+    assert.deepEqual(calls.saveNewDoc, [{ prefix: "my-report", markdown: "# hi" }]);
+  });
+
+  // `filenamePrefix` became conditional when `path` arrived — JSON Schema
+  // cannot say "required only with `markdown`", so a caller reading
+  // `required` may legitimately omit it. Both hosts default rather than
+  // fail; this pins that the two agree.
+  it("defaults the prefix when it is omitted", async () => {
+    const { app, calls } = stubApp();
+    const result = await executeDocument(contextFor(app), { title: "T", markdown: "# hi" });
+
+    assert.ok(result.data?.markdown, "a missing prefix must still produce a document");
+    assert.equal(calls.saveNewDoc[0]?.prefix, "document");
+  });
+});

--- a/test/routes/test_presentDocumentRoute.ts
+++ b/test/routes/test_presentDocumentRoute.ts
@@ -1,0 +1,213 @@
+// Route-level checks for presentDocument's two forms on
+// POST /api/markdown.
+//
+//   - `markdown` → fills image placeholders, saves a NEW file under
+//     `artifacts/documents/YYYY/MM/`, returns that path.
+//   - `path`     → presents an EXISTING file in place; nothing is
+//     written, and `data.markdown` carries the caller's path verbatim so
+//     the View's edits (PUT /api/markdown/update) land on that file.
+//
+// Driven with plain Request / Response mocks rather than an Express +
+// supertest harness, matching `test_canvasImageRoutes.ts`. HOME is
+// redirected to a tmp dir BEFORE the route module is imported so
+// `workspacePath` resolves inside the sandbox.
+
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync } from "fs";
+import { mkdtemp, readdir, rm, symlink, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import path from "path";
+import type { Request, Response } from "express";
+
+type PluginsModule = typeof import("../../server/api/routes/plugins.js");
+
+type Handler = (req: Request, res: Response) => Promise<void> | void;
+
+interface StackFrame {
+  route?: {
+    path: string;
+    stack: { method: string; handle: Handler }[];
+  };
+}
+interface RouterInternals {
+  stack: StackFrame[];
+}
+
+function extractRouteHandler(mod: { default: unknown }, routePath: string, method: string): Handler {
+  const router = mod.default as unknown as RouterInternals;
+  for (const frame of router.stack) {
+    if (frame.route?.path !== routePath) continue;
+    const layer = frame.route.stack.find((stackLayer) => stackLayer.method === method);
+    if (layer) return layer.handle;
+  }
+  throw new Error(`route ${method.toUpperCase()} ${routePath} not registered`);
+}
+
+interface ResBody {
+  message?: string;
+  instructions?: string;
+  title?: string;
+  data?: { markdown: string; filenamePrefix?: string };
+  error?: string;
+}
+
+function mockRes() {
+  const state: { status: number; body: ResBody | undefined } = { status: 200, body: undefined };
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return res;
+    },
+    json(payload: ResBody) {
+      state.body = payload;
+      return res;
+    },
+  };
+  return { state, res: res as unknown as Response };
+}
+
+function req(body: unknown): Request {
+  return { body, params: {} } as unknown as Request;
+}
+
+const EXISTING_REL = "artifacts/documents/2026/07/existing-test123.md";
+const EXISTING_BODY = "# Existing\n\nAlready on disk.\n";
+// A DIRECTORY whose name ends in `.md` — passes a bare existence check but
+// makes the View's subsequent read fail with EISDIR.
+const DIR_REL = "artifacts/documents/2026/07/directory-test123.md";
+// A well-named entry inside the workspace that resolves OUTSIDE it.
+const SYMLINK_REL = "artifacts/documents/2026/07/symlink-test123.md";
+
+let tmpRoot: string;
+let workspaceDir: string;
+let documentsDir: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let createHandler: Handler;
+
+before(async () => {
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "mulmo-present-document-route-"));
+  originalHome = process.env.HOME;
+  originalUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tmpRoot;
+  process.env.USERPROFILE = tmpRoot;
+
+  const { workspacePath } = await import("../../server/workspace/workspace.js");
+  const { WORKSPACE_DIRS } = await import("../../server/workspace/paths.js");
+  workspaceDir = workspacePath;
+  documentsDir = path.join(workspaceDir, WORKSPACE_DIRS.markdowns);
+  mkdirSync(path.join(workspaceDir, path.dirname(EXISTING_REL)), { recursive: true });
+  await writeFile(path.join(workspaceDir, EXISTING_REL), EXISTING_BODY, "utf-8");
+  mkdirSync(path.join(workspaceDir, DIR_REL), { recursive: true });
+  const outsideFile = path.join(tmpRoot, "outside-secret.md");
+  await writeFile(outsideFile, "# secret\n", "utf-8");
+  await symlink(outsideFile, path.join(workspaceDir, SYMLINK_REL));
+
+  const pluginsMod: PluginsModule = await import("../../server/api/routes/plugins.js");
+  createHandler = extractRouteHandler(pluginsMod, "/api/markdown", "post");
+});
+
+after(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+/** Every `.md` currently under `artifacts/documents/YYYY/MM/`. Used to prove
+ *  the `path` form writes nothing. */
+async function documentFiles(): Promise<string[]> {
+  const dir = path.join(documentsDir, "2026", "07");
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+describe("POST /api/markdown — `path` form", () => {
+  it("presents the existing file in place, writing nothing", async () => {
+    const filesBefore = await documentFiles();
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "Report", path: EXISTING_REL }), res);
+
+    assert.equal(state.status, 200);
+    assert.equal(state.body?.data?.markdown, EXISTING_REL, "data.markdown must carry the caller's path verbatim");
+    assert.deepEqual(await documentFiles(), filesBefore, "the `path` form must not create a copy");
+  });
+
+  it("rejects a path together with markdown", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", markdown: "# hi", path: EXISTING_REL }), res);
+
+    assert.equal(state.status, 400);
+    assert.match(state.body?.error ?? "", /not both/);
+  });
+
+  it("rejects neither markdown nor path", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T" }), res);
+
+    assert.equal(state.status, 400);
+    assert.match(state.body?.error ?? "", /either `markdown` or `path`/);
+  });
+
+  it("rejects a traversal path", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", path: "artifacts/documents/../../secrets.md" }), res);
+
+    assert.equal(state.status, 400);
+  });
+
+  it("rejects a path outside artifacts/documents/", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", path: "wiki/notes.md" }), res);
+
+    assert.equal(state.status, 400);
+  });
+
+  it("rejects a path whose file does not exist", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", path: "artifacts/documents/2026/07/gone-zzz999.md" }), res);
+
+    assert.equal(state.status, 400);
+    assert.match(state.body?.error ?? "", /No document exists/);
+  });
+
+  it("rejects a directory that merely ends in .md", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", path: DIR_REL }), res);
+
+    assert.equal(state.status, 400, "a directory would fail the View's read — reject it at present time");
+  });
+
+  it("rejects a symlink pointing outside the workspace", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", path: SYMLINK_REL }), res);
+
+    assert.equal(state.status, 400, "stat() follows symlinks — containment is checked on the realpath");
+  });
+});
+
+describe("POST /api/markdown — `markdown` form", () => {
+  it("saves a new document under the given prefix", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", markdown: "# New\n", filenamePrefix: "my-report" }), res);
+
+    assert.equal(state.status, 200);
+    assert.match(state.body?.data?.markdown ?? "", /^artifacts\/documents\/\d{4}\/\d{2}\/my-report-[0-9a-z]+\.md$/);
+  });
+
+  // `filenamePrefix` became conditional when `path` arrived, so a caller
+  // reading `required` may omit it. The route defaults instead of 400-ing,
+  // matching the shared plugin core.
+  it("defaults the prefix when it is omitted", async () => {
+    const { state, res } = mockRes();
+    await createHandler(req({ title: "T", markdown: "# New\n" }), res);
+
+    assert.equal(state.status, 200);
+    assert.match(state.body?.data?.markdown ?? "", /^artifacts\/documents\/\d{4}\/\d{2}\/document-[0-9a-z]+\.md$/);
+  });
+});


### PR DESCRIPTION
## 何をしたか

`presentDocument` が `presentHtml` と同じく **既存ファイルのパス** を受け取れるようにしました。

これまで `presentDocument` は常に「作る」だけで、`markdown` をインラインで受け取り `artifacts/documents/<YYYY>/<MM>/` に新規保存したものを表示していました。既存ドキュメントを再表示するには読み直してコピーを書くしかありませんでした。

今回、`markdown` の代わりに `path`（`artifacts/documents/**.md` のワークスペース相対パス）を渡せます。存在確認だけ行い、**何も書き込まずに**そのファイルをそのまま表示します。`markdown` と `path` は排他で、`presentHtml` の `html` / `path` と同じ契約です。

View 側は既に path ベースで動いている（`data.markdown` が `isFilePath` なら `loadDoc` で読み、Apply とインラインのタスクチェックボックスは `saveDoc` で書く）ので、**ユーザーの編集は渡したその同じファイルに書き戻ります**。エージェントとユーザーが 1 つのドキュメントを共有し、コピーが分岐しません。

## 変更点

- **`markdown-plugin/.../definition.ts`** — `path` パラメータ追加。排他は JSON Schema で表現できないため `required` は `["title"]` のみに緩め、`MarkdownArgs` の `markdown` / `filenamePrefix` を optional に。prompt に排他と in-place 編集の挙動を明記
- **`server/api/routes/plugins.ts`**（アプリが実際に使う POST /api/markdown）— 両方指定は 400、`path` は `isMarkdownPath` の封じ込め + `markdownExists` の存在確認を経て in-place 提示。ハンドラを `presentExistingDocument` / `saveAndPresentDocument` に分割
- **`markdown-plugin/src/core/plugin.ts`**（MulmoTerminal 等が `pluginCore` 経由で使う共有 core）— 同じ分岐。存在確認は `MarkdownHostApp` に `exists` がないため `loadDoc` の成否で代用し、contract は変更なし（ホスト側のポート不要）
- **`server/utils/files/markdown-store.ts`** — `markdownExists()` 追加
- **バージョン** — `@mulmoclaude/markdown-plugin` 1.1.0 → 1.2.0、`packages/mulmoclaude` の依存レンジも `^1.2.0` に同期
- **`docs/CHANGELOG.md`** — Unreleased に追記

View / Preview には変更なしです。

## 確認

`yarn format` / `yarn lint`（error 0）/ `yarn typecheck` / `yarn build` / `yarn test`（27 ファイル、fail 0）すべて通過。

新しい `path` 分岐に対する単体テストは追加していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Allow presentDocument to display existing markdown documents by path without creating new copies, aligning its behavior with presentHtml and in-place view editing.

New Features:
- Add support for a workspace-relative `path` parameter in presentDocument so existing markdown files under artifacts/documents can be presented and edited in place.

Enhancements:
- Enforce mutual exclusivity between inline markdown content and file path for presentDocument in both the server route and markdown plugin core.
- Add a markdownExists helper to safely check for existing markdown files before presenting them.
- Clarify markdown plugin tooling definitions and prompts to document the new path-based usage and relax JSON Schema requirements accordingly.

Build:
- Bump @mulmoclaude/markdown-plugin to version 1.2.0 and update mulmoclaude package dependencies to reference the new version.

Documentation:
- Update the changelog to describe the new ability for presentDocument to open existing documents by path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `presentDocument` can now present an existing Markdown document by supplying a `path` to `artifacts/documents/**.md`.
  * You can also create a new document using inline `markdown` plus an optional `filenamePrefix` (defaults when omitted).
  * `markdown` and `path` are mutually exclusive, with clearer validation and error messages.
  * Edits in the document view write back to the same underlying file.
* **Documentation**
  * Updated the Unreleased changelog entry to reflect the new document workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->