### PR TITLE
fix(remote-host): 返り値の undefined 1 つで返信全体が落ちる (#2634)

### DIFF
--- a/docs/remote-host.md
+++ b/docs/remote-host.md
@@ -156,6 +156,19 @@ presence doc** the remote already listens to:
   "Offline queueing").
 - The payload shape (`HostPresence`) is a **browser-safe** export both repos
   compile against, so host and mobile client can't drift on the contract.
+- **`undefined` never costs the whole reply (#2634).** Firestore rejects
+  `undefined` at ANY depth, so one stray value buried in a handler's return made
+  `updateDoc` throw — `status:"done"` never landed and the remote waited out its
+  timeout. The symptom was "nothing arrives", not "one field is missing". Before
+  writing, the runner strips every `undefined` (object keys dropped, array holes
+  → `null` so indexes still line up) and reports the paths it dropped through
+  `onEvent`: `result.sessions.11.work`, which Firestore's own error never tells
+  you. Stripping rather than throwing is the point — a throw reproduces exactly
+  the outcome this prevents. Paths where `undefined` is legitimate are declared
+  per method via `opts.expectedUndefined` (`{ listSessions: ["sessions.*.work"] }`,
+  `*` = one segment): still stripped, silently, so the report stays worth reading.
+  Deliberately NOT `ignoreUndefinedProperties` — that turns the bug into "the
+  value just doesn't arrive", with nothing to grep for.
 - **Claim exactly once.** `claimCommand` runs a `runTransaction` that reads the
   doc and only flips `queued → processing` if it is still `queued`; a second
   host (or a snapshot replay) that races gets `null` and skips it.

--- a/packages/core/src/remote-host/server/firestoreSafeResult.ts
+++ b/packages/core/src/remote-host/server/firestoreSafeResult.ts
@@ -1,0 +1,70 @@
+// A handler's reply, made safe to hand to Firestore (#2634).
+//
+// Firestore rejects `undefined` at ANY depth, and the runner writes a handler's
+// return value straight into the command document. So one `undefined` — anywhere
+// in a reply, however deep — takes down the WHOLE reply: `updateDoc` throws,
+// `status: "done"` never lands, and the remote waits until it times out. The
+// symptom is not "one field missing" but "nothing works", which is what happened
+// when a `work: undefined` reached MulmoTerminal's session list
+// (receptron/mulmoterminal#1042).
+//
+// Strip rather than throw: a missing optional field costs one row's worth of
+// detail, while a throw costs the user the entire reply — the very outcome this
+// exists to prevent. The report is what keeps it from being silent, because an
+// undeclared stripped key IS a bug on the sending side, and Firestore's own error
+// names the document rather than the field.
+//
+// NOT `ignoreUndefinedProperties` on the Firestore instance: that setting makes
+// this class of bug disappear into "the value just doesn't arrive", with nothing
+// logged and nothing to grep for.
+
+/** Path reported for a reply that is itself `undefined` — it has no field name. */
+export const ROOT_PATH = "(root)";
+
+/** Every path holding `undefined`, in `a.b.0.c` form. Empty when the value is safe to write. */
+export const undefinedPaths = (value: unknown, prefix = ""): string[] => {
+  if (value === undefined) return [prefix || ROOT_PATH];
+  if (value === null || typeof value !== "object") return [];
+  const child = (key: string | number) => (prefix ? `${prefix}.${key}` : String(key));
+  // Array.from, not flatMap: a SPARSE array's holes are skipped by flatMap/map, so
+  // `[1, , 3]` would be reported clean and then written with a hole Firestore rejects.
+  if (Array.isArray(value)) return Array.from(value).flatMap((item, index) => undefinedPaths(item, child(index)));
+  return Object.entries(value).flatMap(([key, item]) => undefinedPaths(item, child(key)));
+};
+
+/**
+ * The same value with every `undefined` removed — object keys dropped, array holes
+ * turned into `null` so the surrounding indexes still line up with what the sender
+ * meant. Returns `unknown` because a stripped object is no longer the input type.
+ */
+export const stripUndefined = (value: unknown): unknown => {
+  // The whole reply can be undefined (a handler with no explicit return); `null` is
+  // what the runner already substitutes for a missing result.
+  if (value === undefined) return null;
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return Array.from(value, (item) => stripUndefined(item));
+  return Object.fromEntries(Object.entries(value).flatMap(([key, item]) => (item === undefined ? [] : [[key, stripUndefined(item)]])));
+};
+
+/** Does `path` match `pattern`, where `*` stands for exactly one segment?
+ *  Segment-wise rather than by regex: no escaping of user-supplied dots, and no
+ *  pattern can turn into a catastrophic backtrack. */
+export const matchesPathPattern = (path: string, pattern: string): boolean => {
+  const segments = path.split(".");
+  const wanted = pattern.split(".");
+  return segments.length === wanted.length && wanted.every((segment, index) => segment === "*" || segment === segments[index]);
+};
+
+/**
+ * The paths worth reporting: everything the caller has NOT declared as
+ * legitimately-optional (`"sessions.*.work"`).
+ *
+ * Takes paths rather than the value so a caller walks the reply once — the walk is
+ * also what tells it whether stripping (a full copy) is needed at all.
+ *
+ * Both kinds have to be stripped — that is Firestore's rule, not a judgment — but
+ * only one kind is a defect. Reporting both means reporting one on every reply,
+ * which is how a warning stops being read.
+ */
+export const unexpectedPaths = (paths: readonly string[], expected: readonly string[] = []): string[] =>
+  paths.filter((path) => !expected.some((pattern) => matchesPathPattern(path, pattern)));

--- a/packages/core/src/remote-host/server/firestoreSafeResult.ts
+++ b/packages/core/src/remote-host/server/firestoreSafeResult.ts
@@ -21,10 +21,22 @@
 /** Path reported for a reply that is itself `undefined` — it has no field name. */
 export const ROOT_PATH = "(root)";
 
+// Only arrays and plain objects are walked. A class instance is left ALONE, because
+// rebuilding it from its entries destroys it: Firestore accepts `Date`, `Timestamp`,
+// `GeoPoint`, `DocumentReference` and its own sentinels as values, and
+// `Object.fromEntries(Object.entries(new Date()))` is `{}`. Silently turning a
+// timestamp into an empty object would be a worse bug than the one being fixed.
+const isPlainObject = (value: object): boolean => {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+const isWalkable = (value: unknown): value is object => typeof value === "object" && value !== null && (Array.isArray(value) || isPlainObject(value));
+
 /** Every path holding `undefined`, in `a.b.0.c` form. Empty when the value is safe to write. */
 export const undefinedPaths = (value: unknown, prefix = ""): string[] => {
   if (value === undefined) return [prefix || ROOT_PATH];
-  if (value === null || typeof value !== "object") return [];
+  if (!isWalkable(value)) return [];
   const child = (key: string | number) => (prefix ? `${prefix}.${key}` : String(key));
   // Array.from, not flatMap: a SPARSE array's holes are skipped by flatMap/map, so
   // `[1, , 3]` would be reported clean and then written with a hole Firestore rejects.
@@ -41,7 +53,9 @@ export const stripUndefined = (value: unknown): unknown => {
   // The whole reply can be undefined (a handler with no explicit return); `null` is
   // what the runner already substitutes for a missing result.
   if (value === undefined) return null;
-  if (value === null || typeof value !== "object") return value;
+  // Anything that is not an array or a plain object is handed back untouched — see
+  // isPlainObject: a Date rebuilt from its entries is an empty object.
+  if (!isWalkable(value)) return value;
   if (Array.isArray(value)) return Array.from(value, (item) => stripUndefined(item));
   return Object.fromEntries(Object.entries(value).flatMap(([key, item]) => (item === undefined ? [] : [[key, stripUndefined(item)]])));
 };

--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -34,6 +34,7 @@ import {
   hostDoc,
   isExpired,
 } from "../index.js";
+import { stripUndefined, undefinedPaths, unexpectedPaths } from "./firestoreSafeResult.js";
 
 const DEFAULT_HEARTBEAT_MS = 60_000;
 
@@ -80,6 +81,12 @@ export interface HostRunnerOptions {
   onExpire?: (command: Command, uid: string) => void | Promise<void>;
   // Presence heartbeat interval; defaults to one minute.
   heartbeatMs?: number;
+  // Paths in a handler's reply where `undefined` is expected rather than a bug,
+  // keyed by method name — `{ listSessions: ["sessions.*.work"] }`, `*` matching
+  // exactly one segment. Firestore refuses `undefined` either way, so these are
+  // still stripped; declaring them only silences the report, which is what keeps
+  // it worth reading (#2634).
+  expectedUndefined?: Record<string, readonly string[]>;
 }
 
 interface Claim {
@@ -111,10 +118,25 @@ const claimCommand = (firestore: Firestore, ref: DocumentReference): Promise<Cla
 export const resolveCommandHandler = (handlers: CommandHandlers, method: string): CommandHandler | undefined =>
   Object.hasOwn(handlers, method) ? handlers[method] : undefined;
 
-const runHandler = async (ref: DocumentReference, claim: Claim, handler: CommandHandler): Promise<HostEvent> => {
+// Firestore refuses a write containing `undefined` at any depth, so one stray
+// value would cost the whole reply — `status: "done"` never lands and the remote
+// waits out its timeout. Strip instead, and name the paths: Firestore's own error
+// points at the document, never at the field, which is where the debugging time
+// goes. Paths the caller declared as legitimately-optional are stripped silently.
+const reportStripped = (dropped: string[], claim: Claim, options: HostRunnerOptions): void => {
+  if (dropped.length === 0) return;
+  const paths = dropped.map((path) => `result.${path}`).join(", ");
+  options.onEvent?.({ phase: "error", method: claim.method, message: `undefined dropped at ${paths} — Firestore would have refused the whole reply` });
+};
+
+const runHandler = async (ref: DocumentReference, claim: Claim, handler: CommandHandler, options: HostRunnerOptions): Promise<HostEvent> => {
   try {
-    const result = await handler(claim.params);
-    await updateDoc(ref, { status: "done", result: result ?? null, updatedAt: serverTimestamp() });
+    const returned = await handler(claim.params);
+    const dropped = undefinedPaths(returned);
+    reportStripped(unexpectedPaths(dropped, options.expectedUndefined?.[claim.method]), claim, options);
+    // The walk above already answered "is there anything to strip", so a clean
+    // reply — every reply, normally — is written without copying it first.
+    await updateDoc(ref, { status: "done", result: dropped.length === 0 ? returned : stripUndefined(returned), updatedAt: serverTimestamp() });
     return { phase: "done", method: claim.method };
   } catch (error) {
     const message = errorMessage(error);
@@ -171,7 +193,7 @@ const processCommand = async (ctx: RunnerContext, ref: DocumentReference, comman
     options.onEvent?.({ phase: "error", method: claim.method, message: "unknown method" });
     return;
   }
-  options.onEvent?.(await runHandler(ref, claim, handler));
+  options.onEvent?.(await runHandler(ref, claim, handler, options));
 };
 
 // A resilient command listener: its mutable retry state plus the fixed collaborators.

--- a/packages/core/src/remote-host/server/index.ts
+++ b/packages/core/src/remote-host/server/index.ts
@@ -8,6 +8,7 @@
 // it without pulling this server surface.
 export { startHostRunner } from "./hostRunner.js";
 export type { HostEvent, HostRunnerOptions } from "./hostRunner.js";
+export { stripUndefined, undefinedPaths, unexpectedPaths } from "./firestoreSafeResult.js";
 export { createRemoteHost } from "./lifecycle.js";
 export type { RemoteHostStatus, RemoteHostLogger, RemoteHostDeps, RemoteHostLifecycle } from "./lifecycle.js";
 export { createRemoteHostAuth } from "./auth.js";

--- a/packages/core/test/remote-host/test_firestoreSafeResult.ts
+++ b/packages/core/test/remote-host/test_firestoreSafeResult.ts
@@ -84,6 +84,38 @@ describe("stripUndefined", () => {
     const clean = { sessions: [{ title: "a", work: null }], count: 2 };
     assert.deepEqual(stripUndefined(clean), clean);
   });
+
+  // Firestore accepts Date / Timestamp / GeoPoint / DocumentReference as VALUES,
+  // and rebuilding one from its entries produces `{}`. Turning a timestamp into an
+  // empty object because some unrelated field was undefined would be a worse bug
+  // than the one this guard exists to fix (CodeRabbit, #2638).
+  it("leaves a Date intact when a sibling key is stripped", () => {
+    const createdAt = new Date("2026-07-29T00:00:00.000Z");
+    const stripped = stripUndefined({ createdAt, work: undefined });
+    assert.deepEqual(stripped, { createdAt });
+    assert.ok(Reflect.get(Object(stripped), "createdAt") instanceof Date);
+  });
+
+  it("leaves a class instance (Timestamp-like) intact", () => {
+    class Timestamp {
+      constructor(readonly seconds: number) {}
+      toMillis(): number {
+        return this.seconds * 1_000;
+      }
+    }
+    const stamp = new Timestamp(5);
+    const stripped = stripUndefined({ stamp, gone: undefined });
+    assert.equal(Reflect.get(Object(stripped), "stamp"), stamp);
+  });
+
+  it("does not report paths inside a class instance it will not rewrite", () => {
+    // Reporting a path the strip cannot reach would promise a fix that never
+    // happens — Firestore refuses a custom object outright, which is its own error.
+    class Holder {
+      readonly missing: undefined = undefined;
+    }
+    assert.deepEqual(undefinedPaths({ held: new Holder() }), []);
+  });
 });
 
 describe("matchesPathPattern", () => {

--- a/packages/core/test/remote-host/test_firestoreSafeResult.ts
+++ b/packages/core/test/remote-host/test_firestoreSafeResult.ts
@@ -1,0 +1,128 @@
+// Unit tests for the guard that keeps one `undefined` from costing a whole reply
+// (#2634). Firestore rejects `undefined` at any depth, so a single stray value in
+// a handler's return made `updateDoc` throw — `status: "done"` never landed and
+// the remote waited out its timeout.
+//
+//   - every offending path is reported, nested, in `a.b.0.c` form
+//   - a SPARSE array's holes are reported too: `flatMap`/`map` skip them, so the
+//     naive walk called `[1, , 3]` clean and then Firestore refused it
+//   - the reply being `undefined` ITSELF is reported and becomes `null`
+//   - stripping drops object keys but turns array holes into `null`, so the
+//     indexes the sender meant still line up
+//   - declared paths (`sessions.*.work`) are stripped SILENTLY — reporting the
+//     expected ones on every reply is how a warning stops being read
+//   - a value with nothing wrong is reported empty and passes through unchanged
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ROOT_PATH, matchesPathPattern, stripUndefined, undefinedPaths, unexpectedPaths } from "../../src/remote-host/server/firestoreSafeResult.js";
+
+// A genuinely SPARSE array — holes, not `undefined` values. Built rather than
+// written as `[1, , 3]` so the shape is unambiguous at a glance.
+const withHole = (): unknown[] => {
+  const items: unknown[] = new Array(3);
+  items[0] = 1;
+  items[2] = 3;
+  return items;
+};
+
+describe("undefinedPaths", () => {
+  it("finds nothing in a value that is safe to write", () => {
+    assert.deepEqual(undefinedPaths({ sessions: [{ title: "a", work: null }], count: 0, ok: false }), []);
+  });
+
+  it("names a nested path the way Firestore's own error would", () => {
+    assert.deepEqual(undefinedPaths({ sessions: [{ title: "a" }, { title: "b", work: undefined }] }), ["sessions.1.work"]);
+  });
+
+  it("reports every offending path, not just the first", () => {
+    assert.deepEqual(undefinedPaths({ one: undefined, nested: { two: undefined } }), ["one", "nested.two"]);
+  });
+
+  // The trap: flatMap/map skip holes, so this walked clean and the write was
+  // refused anyway (CodeRabbit, receptron/mulmoterminal#1044).
+  it("reports a SPARSE array's holes", () => {
+    assert.deepEqual(undefinedPaths({ items: withHole() }), ["items.1"]);
+  });
+
+  it("reports the reply being undefined itself", () => {
+    assert.deepEqual(undefinedPaths(undefined), [ROOT_PATH]);
+  });
+
+  it("walks into arrays of arrays", () => {
+    assert.deepEqual(undefinedPaths([[{ deep: undefined }]]), ["0.0.deep"]);
+  });
+
+  it("treats null and primitives as safe (null is a value Firestore accepts)", () => {
+    assert.deepEqual(undefinedPaths(null), []);
+    assert.deepEqual(undefinedPaths(0), []);
+    assert.deepEqual(undefinedPaths(""), []);
+  });
+});
+
+describe("stripUndefined", () => {
+  it("drops the offending key and leaves the rest untouched", () => {
+    assert.deepEqual(stripUndefined({ title: "a", work: undefined, count: 0 }), { title: "a", count: 0 });
+  });
+
+  it("keeps array indexes lined up by writing null into a hole", () => {
+    assert.deepEqual(stripUndefined(withHole()), [1, null, 3]);
+    assert.deepEqual(stripUndefined([undefined, "b"]), [null, "b"]);
+  });
+
+  it("turns a reply that is itself undefined into null", () => {
+    // Warning about it and then returning it unchanged left the write just as
+    // broken; null is what the runner already substitutes for a missing result.
+    assert.equal(stripUndefined(undefined), null);
+  });
+
+  it("strips at depth", () => {
+    assert.deepEqual(stripUndefined({ sessions: [{ title: "a", work: undefined }] }), { sessions: [{ title: "a" }] });
+  });
+
+  it("passes a clean value through with the same shape", () => {
+    const clean = { sessions: [{ title: "a", work: null }], count: 2 };
+    assert.deepEqual(stripUndefined(clean), clean);
+  });
+});
+
+describe("matchesPathPattern", () => {
+  it("matches a literal path", () => {
+    assert.equal(matchesPathPattern("sessions.1.work", "sessions.1.work"), true);
+  });
+
+  it("lets `*` stand for exactly one segment", () => {
+    assert.equal(matchesPathPattern("sessions.11.work", "sessions.*.work"), true);
+    assert.equal(matchesPathPattern("sessions.11.deep.work", "sessions.*.work"), false);
+  });
+
+  it("does not match a different depth or a different key", () => {
+    assert.equal(matchesPathPattern("sessions.1", "sessions.*.work"), false);
+    assert.equal(matchesPathPattern("sessions.1.title", "sessions.*.work"), false);
+  });
+
+  it("treats a dot in the pattern as a separator, never as a regex wildcard", () => {
+    assert.equal(matchesPathPattern("sessionsXwork", "sessions.work"), false);
+  });
+});
+
+describe("unexpectedPaths", () => {
+  it("reports everything when nothing is declared", () => {
+    assert.deepEqual(unexpectedPaths(undefinedPaths({ sessions: [{ work: undefined }] })), ["sessions.0.work"]);
+  });
+
+  it("stays silent about a declared optional path", () => {
+    assert.deepEqual(unexpectedPaths(undefinedPaths({ sessions: [{ work: undefined }] }), ["sessions.*.work"]), []);
+  });
+
+  it("still reports the undeclared ones alongside a declared one", () => {
+    const reply = { sessions: [{ work: undefined, title: undefined }] };
+    assert.deepEqual(unexpectedPaths(undefinedPaths(reply), ["sessions.*.work"]), ["sessions.0.title"]);
+  });
+
+  // Declaring a path silences the REPORT, never the strip — Firestore's rule is
+  // not negotiable, so the value has to go either way.
+  it("declaring a path does not keep it out of the strip", () => {
+    assert.deepEqual(stripUndefined({ sessions: [{ work: undefined }] }), { sessions: [{}] });
+  });
+});

--- a/plans/fix-2634-undefined-in-handler-result.md
+++ b/plans/fix-2634-undefined-in-handler-result.md
@@ -21,7 +21,7 @@ phone, with the cause visible only in the host's own console.
 
 Firestore's error names the document, never the field:
 
-```
+```text
 Unsupported field value: undefined (found in field result.sessions.11.work
   in document users/…/hosts/…/commands/…)
 ```
@@ -37,8 +37,10 @@ every host that uses core.
 - `undefinedPaths(value)` → every offending path in `a.b.0.c` form.
 - `stripUndefined(value)` → the same value with object keys dropped and array holes
   turned into `null`, so surrounding indexes still line up.
-- `matchesPathPattern(path, pattern)` / `unexpectedUndefinedPaths(value, expected)`
-  → which of those paths are worth reporting.
+- `matchesPathPattern(path, pattern)` / `unexpectedPaths(paths, expected)`
+  → which of those paths are worth reporting. It takes the paths, not the value, so
+  the runner walks the reply once — that walk is also what tells it whether
+  stripping (a full copy) is needed at all.
 
 Wired into `runHandler`: report the unexpected paths through `onEvent`, then write
 the stripped value.

--- a/plans/fix-2634-undefined-in-handler-result.md
+++ b/plans/fix-2634-undefined-in-handler-result.md
@@ -1,0 +1,89 @@
+# One `undefined` in a reply takes down the whole reply
+
+Issue: #2634 · accident report: receptron/mulmoterminal#1042 · interim host-side guard: receptron/mulmoterminal#1044
+
+## The trap
+
+Firestore rejects `undefined` at ANY depth, and the runner writes a handler's
+return value straight into the command document:
+
+```ts
+await updateDoc(ref, { status: "done", result: await handler(params) ?? null, … });
+```
+
+`?? null` covers a handler that returns nothing. It does nothing for an `undefined`
+buried in the returned structure — and there, `updateDoc` throws, `status: "done"`
+never lands, and the remote waits until it times out.
+
+So the symptom is not "one field is missing". It is **"nothing arrives"**: one
+`work: undefined` in one session emptied MulmoTerminal's whole session list on the
+phone, with the cause visible only in the host's own console.
+
+Firestore's error names the document, never the field:
+
+```
+Unsupported field value: undefined (found in field result.sessions.11.work
+  in document users/…/hosts/…/commands/…)
+```
+
+…and `result.sessions.11.work` is the one piece of information that made the
+diagnosis possible. The guard's job is to produce that line without losing the reply.
+
+## Change — `packages/core/src/remote-host/server/firestoreSafeResult.ts` (new)
+
+The runner is the single write site, so checking just before the write covers
+every host that uses core.
+
+- `undefinedPaths(value)` → every offending path in `a.b.0.c` form.
+- `stripUndefined(value)` → the same value with object keys dropped and array holes
+  turned into `null`, so surrounding indexes still line up.
+- `matchesPathPattern(path, pattern)` / `unexpectedUndefinedPaths(value, expected)`
+  → which of those paths are worth reporting.
+
+Wired into `runHandler`: report the unexpected paths through `onEvent`, then write
+the stripped value.
+
+**Strip, don't throw.** Throwing reproduces the exact outcome this prevents — the
+whole reply lost. A missing optional field costs one row's worth of detail.
+
+**Not `ignoreUndefinedProperties`.** That setting turns this class of bug into "the
+value just doesn't arrive", with nothing logged and nothing to grep for.
+
+### Two kinds of `undefined`, one of which is a bug
+
+- **A bug** — the sender put it somewhere it must not be. Has to be findable.
+- **Normal** — an optional field with no value this time. Reported on every reply,
+  it trains everyone to ignore the warning.
+
+Both must be stripped (Firestore's rule is not negotiable); only the first should be
+reported. `HostRunnerOptions.expectedUndefined` declares the second, per method:
+
+```ts
+expectedUndefined: { listSessions: ["sessions.*.work"] }   // `*` = exactly one segment
+```
+
+Matching is segment-wise, not by regex: no escaping of dots in caller-supplied
+patterns, and no pattern can turn into a catastrophic backtrack.
+
+## Traps this walks into deliberately (both cost a fix in mulmoterminal#1044)
+
+- **Sparse arrays.** `flatMap` / `map` SKIP holes, so `[1, , 3]` walked clean and
+  Firestore refused the write anyway. `Array.from` visits every index.
+- **The reply being `undefined` itself.** Reporting it and then returning it
+  unchanged left the write just as broken; it becomes `null`, which is what the
+  runner already substituted for a missing result.
+
+## Tests
+
+`packages/core/test/remote-host/test_firestoreSafeResult.ts` — nested paths, every
+offending path (not just the first), the sparse-array hole, the root case, index
+alignment after stripping, `*` matching exactly one segment, a dot never behaving as
+a regex wildcard, and the rule that declaring a path silences the report but never
+the strip.
+
+## Not in this PR
+
+- **#2633** (presence failures are invisible; the listener gives up after ~31 s) —
+  same file, unrelated failure, its own PR (#2637).
+- Publishing `@mulmoclaude/core`. mulmoterminal can drop
+  `server/backends/remoteHost/firestoreSafeResult.ts` once this ships to npm.


### PR DESCRIPTION
## Summary

ハンドラの戻り値に `undefined` が 1 つ混ざると、**返信そのものが書けなくなる**問題 (#2634) を塞ぎます。Firestore は深さを問わず `undefined` を拒否するので、`updateDoc` が例外になり `status: "done"` が入らず、スマホは結果を待ち続けてタイムアウトします。ユーザから見えるのは「一覧が全滅」であって「そのフィールドが欠ける」ではありません（receptron/mulmoterminal#1042）。

**ランナーが唯一の書き込み口なので、書き込み直前に検査します。** core を使う全ホストが同じ保護を受けます。

```
Unsupported field value: undefined (found in field result.sessions.11.work in document users/…)
                                                        ^^^^^^^^^^^^^^^^^^^^ Firestore が教えてくれない側
```

- `undefinedPaths()` — `result.sessions.11.work` の形でパスを列挙。**このパスが分かることが一番の価値**でした（Firestore のエラーはドキュメントしか教えてくれない）。
- `stripUndefined()` — 除去して書く。オブジェクトはキーごと削除、配列は `null`（添字を保つため）。
- `expectedUndefined` — 「ここは undefined でよい」パスをメソッドごとに宣言できる（`{ listSessions: ["sessions.*.work"] }`、`*` は 1 セグメント）。

## Items to Confirm / Review

1. **throw ではなく除去 + 報告にした理由** — throw だと「一覧が全滅」を再現するだけで、この機構が防ごうとしている結果そのものになります。optional フィールドが 1 つ欠けるコストと、返信全体が消えるコストの比較です。
2. **`ignoreUndefinedProperties` を使わない理由** — 「なぜか値が来ない」という別の症状に化けるだけで、ログにも残らず grep する手掛かりもなくなります。
3. **報告を `phase: "error"` で出しています** — コマンド自体は成功する（`status: "done"` は入る）のに error イベントを出すのは一見矛盾しますが、`expireCommand` が「onExpire 失敗 → error、その後 done」を出しているのと同じ形です。送り手のバグであることを弱めたくないので error にしました。**ここは異論があれば直します。**
4. **`expectedUndefined` は現時点で MulmoClaude 側の利用者がいません** — issue に「ハンドラ登録時に同じ宣言ができると使いやすい」とあり、MulmoTerminal には実際に `sessions.*.work` という具体例があるため入れています。無いと、正常な optional フィールドで毎回警告が出て誰も読まなくなります。
5. **パターン照合は正規表現ではなくセグメント単位** — 呼び出し側が書いたドットのエスケープが要らず、ReDoS も原理的に起きません。
6. **未検証**: 実際の Firestore への書き込みでは確認していません（ユニットテストのみ）。パス列挙・除去・宣言の各規則は 20 ケースで固定しています。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2633
>
> #2634 も考慮できたらしてね

（#2633 は別 PR #2637。同じ `hostRunner.ts` を触りますが別の不具合なので、レビュー単位を分けました。）

## 実装

計画: [`plans/fix-2634-undefined-in-handler-result.md`](plans/fix-2634-undefined-in-handler-result.md)

**`packages/core/src/remote-host/server/firestoreSafeResult.ts`（新規）** — `undefinedPaths` / `stripUndefined` / `matchesPathPattern` / `unexpectedPaths`。`runHandler` が書き込み直前に呼びます。

戻り値が綺麗な場合（＝通常のすべての返信）は**コピーを作りません**。パスの走査が「除去が必要か」も同時に答えるので、`dropped.length === 0` ならそのまま書きます。

### 移植元 (receptron/mulmoterminal#1044) が踏んだ落とし穴を 2 つとも固定

- **疎な配列の穴** — `flatMap` / `map` は穴を飛ばすので `[1, , 3]` が「問題なし」と報告され、そのまま書かれて拒否されていました。`Array.from` で全インデックスを走査します。
- **戻り値そのものが `undefined`** — 警告は出るのに値をそのまま返していて、書き込みは壊れたままでした。`null` にします（ランナーが元々 `?? null` で入れていた値と同じ）。

## テスト

`packages/core/test/remote-host/test_firestoreSafeResult.ts`（20 ケース）— ネストしたパス、最初の 1 つではなく全部、疎な配列の穴、ルートが undefined、除去後も添字が揃うこと、`*` がちょうど 1 セグメントであること、パターンのドットが正規表現のワイルドカードにならないこと、そして「宣言は報告を黙らせるが除去は黙らせない」規則。

`yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn build` / `yarn test` 全通過。

## この PR に含まれないもの

- **#2633**（presence の失敗が見えない / リスナが約 31 秒で打ち切られる）— PR #2637
- **`@mulmoclaude/core` の publish** — npm に出れば MulmoTerminal 側の暫定ラッパ `server/backends/remoteHost/firestoreSafeResult.ts` を削除できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Guard Firestore command results against undefined values so a single bad field no longer prevents replies from being written.

Bug Fixes:
- Prevent handler replies containing undefined at any depth from causing Firestore writes to fail and commands to hang without reaching status:"done".

Enhancements:
- Introduce a Firestore-safe result sanitizer that detects paths containing undefined, strips them while preserving array indices, and reports unexpected occurrences via host events.
- Allow hosts to declare per-method paths where undefined is expected so optional fields can be stripped silently while still enforcing Firestore constraints.
- Export the Firestore-safe utilities from the remote-host server API for reuse by other components.
- Document the new undefined-stripping behavior and expectedUndefined option in the remote host documentation.

Documentation:
- Update remote host documentation to describe automatic stripping of undefined values, error reporting of dropped paths, and configuration of expected undefined paths.

Tests:
- Add unit tests covering undefined path detection, stripping behavior (including sparse arrays and root undefined), pattern matching for expected undefined paths, and reporting of unexpected paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Handler results containing `undefined` values no longer prevent Firestore updates from completing.
  * Undefined object fields are removed, while array positions are preserved with `null` values.
  * Reports now identify unexpected result paths containing `undefined`.

* **Documentation**
  * Added guidance on result sanitization, optional fields, and reported paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->