### PR TITLE
fix(remote-host): 循環参照した返信で再帰が止まらない (#2634 追加分)

### DIFF
--- a/packages/core/src/remote-host/server/firestoreSafeResult.ts
+++ b/packages/core/src/remote-host/server/firestoreSafeResult.ts
@@ -35,42 +35,42 @@ const isPlainObject = (value: object): boolean => {
 
 const isWalkable = (value: unknown): value is object => typeof value === "object" && value !== null && (Array.isArray(value) || isPlainObject(value));
 
-// A reply that points back at itself has no bottom, so both walks below would
-// recurse until the stack gives out. `RangeError: Maximum call stack size exceeded`
-// is caught by the runner and written back as the command's error, so nothing
-// crashes — but it names neither the cause nor the field, which is the one thing
-// this module exists to provide. Ancestors only: a value referenced twice from
-// different branches is ordinary JSON, so each branch removes itself on the way out.
-const guardCycle = (value: object, ancestors: WeakSet<object>, path: string): void => {
+const childPath = (prefix: string, key: string | number): string => (prefix ? `${prefix}.${key}` : String(key));
+
+// A reply that points back at itself has no bottom, so the walks below would recurse
+// until the stack gives out. `RangeError: Maximum call stack size exceeded` is caught
+// by the runner and written back as the command's error, so nothing crashes — but it
+// names neither the cause nor the field, which is the one thing this module exists to
+// provide. Ancestors only: a value referenced twice from different branches is
+// ordinary JSON, so each branch removes itself on the way out. One home for the rule
+// because the two walks are structurally twins — applied separately, a later edit to
+// the safety logic would land in only one of them.
+const withCycleGuard = <T>(value: object, ancestors: WeakSet<object>, path: string, walk: () => T): T => {
   if (ancestors.has(value)) throw new Error(`circular reference at ${path || ROOT_PATH} — Firestore cannot serialise it`);
+  ancestors.add(value);
+  try {
+    return walk();
+  } finally {
+    ancestors.delete(value);
+  }
 };
 
 const pathsIn = (value: unknown, prefix: string, ancestors: WeakSet<object>): string[] => {
   if (value === undefined) return [prefix || ROOT_PATH];
   if (!isWalkable(value)) return [];
-  guardCycle(value, ancestors, prefix);
-  ancestors.add(value);
-  const child = (key: string | number) => (prefix ? `${prefix}.${key}` : String(key));
-  try {
+  return withCycleGuard(value, ancestors, prefix, () =>
     // Array.from, not flatMap: a SPARSE array's holes are skipped by flatMap/map, so
     // `[1, , 3]` would be reported clean and then written with a hole Firestore rejects.
-    if (Array.isArray(value)) return Array.from(value).flatMap((item, index) => pathsIn(item, child(index), ancestors));
-    return Object.entries(value).flatMap(([key, item]) => pathsIn(item, child(key), ancestors));
-  } finally {
-    ancestors.delete(value);
-  }
+    Array.isArray(value)
+      ? Array.from(value).flatMap((item, index) => pathsIn(item, childPath(prefix, index), ancestors))
+      : Object.entries(value).flatMap(([key, item]) => pathsIn(item, childPath(prefix, key), ancestors)),
+  );
 };
 
 /** Every path holding `undefined`, in `a.b.0.c` form. Empty when the value is safe to write.
  *  Throws on a circular reply, naming the path it closed the loop at. */
 export const undefinedPaths = (value: unknown, prefix = ""): string[] => pathsIn(value, prefix, new WeakSet());
 
-/**
- * The same value with every `undefined` removed — object keys dropped, array holes
- * turned into `null` so the surrounding indexes still line up with what the sender
- * meant. Returns `unknown` because a stripped object is no longer the input type.
- * Throws on a circular reply, same as `undefinedPaths`.
- */
 const strippedIn = (value: unknown, prefix: string, ancestors: WeakSet<object>): unknown => {
   // The whole reply can be undefined (a handler with no explicit return); `null` is
   // what the runner already substitutes for a missing result.
@@ -78,17 +78,21 @@ const strippedIn = (value: unknown, prefix: string, ancestors: WeakSet<object>):
   // Anything that is not an array or a plain object is handed back untouched — see
   // isPlainObject: a Date rebuilt from its entries is an empty object.
   if (!isWalkable(value)) return value;
-  guardCycle(value, ancestors, prefix);
-  ancestors.add(value);
-  const child = (key: string | number) => (prefix ? `${prefix}.${key}` : String(key));
-  try {
-    if (Array.isArray(value)) return Array.from(value, (item, index) => strippedIn(item, child(index), ancestors));
-    return Object.fromEntries(Object.entries(value).flatMap(([key, item]) => (item === undefined ? [] : [[key, strippedIn(item, child(key), ancestors)]])));
-  } finally {
-    ancestors.delete(value);
-  }
+  return withCycleGuard(value, ancestors, prefix, () =>
+    Array.isArray(value)
+      ? Array.from(value, (item, index) => strippedIn(item, childPath(prefix, index), ancestors))
+      : Object.fromEntries(
+          Object.entries(value).flatMap(([key, item]) => (item === undefined ? [] : [[key, strippedIn(item, childPath(prefix, key), ancestors)]])),
+        ),
+  );
 };
 
+/**
+ * The same value with every `undefined` removed — object keys dropped, array holes
+ * turned into `null` so the surrounding indexes still line up with what the sender
+ * meant. Returns `unknown` because a stripped object is no longer the input type.
+ * Throws on a circular reply, same as `undefinedPaths`.
+ */
 export const stripUndefined = (value: unknown): unknown => strippedIn(value, "", new WeakSet());
 
 /** Does `path` match `pattern`, where `*` stands for exactly one segment?

--- a/packages/core/src/remote-host/server/firestoreSafeResult.ts
+++ b/packages/core/src/remote-host/server/firestoreSafeResult.ts
@@ -35,32 +35,61 @@ const isPlainObject = (value: object): boolean => {
 
 const isWalkable = (value: unknown): value is object => typeof value === "object" && value !== null && (Array.isArray(value) || isPlainObject(value));
 
-/** Every path holding `undefined`, in `a.b.0.c` form. Empty when the value is safe to write. */
-export const undefinedPaths = (value: unknown, prefix = ""): string[] => {
+// A reply that points back at itself has no bottom, so both walks below would
+// recurse until the stack gives out. `RangeError: Maximum call stack size exceeded`
+// is caught by the runner and written back as the command's error, so nothing
+// crashes — but it names neither the cause nor the field, which is the one thing
+// this module exists to provide. Ancestors only: a value referenced twice from
+// different branches is ordinary JSON, so each branch removes itself on the way out.
+const guardCycle = (value: object, ancestors: WeakSet<object>, path: string): void => {
+  if (ancestors.has(value)) throw new Error(`circular reference at ${path || ROOT_PATH} — Firestore cannot serialise it`);
+};
+
+const pathsIn = (value: unknown, prefix: string, ancestors: WeakSet<object>): string[] => {
   if (value === undefined) return [prefix || ROOT_PATH];
   if (!isWalkable(value)) return [];
+  guardCycle(value, ancestors, prefix);
+  ancestors.add(value);
   const child = (key: string | number) => (prefix ? `${prefix}.${key}` : String(key));
-  // Array.from, not flatMap: a SPARSE array's holes are skipped by flatMap/map, so
-  // `[1, , 3]` would be reported clean and then written with a hole Firestore rejects.
-  if (Array.isArray(value)) return Array.from(value).flatMap((item, index) => undefinedPaths(item, child(index)));
-  return Object.entries(value).flatMap(([key, item]) => undefinedPaths(item, child(key)));
+  try {
+    // Array.from, not flatMap: a SPARSE array's holes are skipped by flatMap/map, so
+    // `[1, , 3]` would be reported clean and then written with a hole Firestore rejects.
+    if (Array.isArray(value)) return Array.from(value).flatMap((item, index) => pathsIn(item, child(index), ancestors));
+    return Object.entries(value).flatMap(([key, item]) => pathsIn(item, child(key), ancestors));
+  } finally {
+    ancestors.delete(value);
+  }
 };
+
+/** Every path holding `undefined`, in `a.b.0.c` form. Empty when the value is safe to write.
+ *  Throws on a circular reply, naming the path it closed the loop at. */
+export const undefinedPaths = (value: unknown, prefix = ""): string[] => pathsIn(value, prefix, new WeakSet());
 
 /**
  * The same value with every `undefined` removed — object keys dropped, array holes
  * turned into `null` so the surrounding indexes still line up with what the sender
  * meant. Returns `unknown` because a stripped object is no longer the input type.
+ * Throws on a circular reply, same as `undefinedPaths`.
  */
-export const stripUndefined = (value: unknown): unknown => {
+const strippedIn = (value: unknown, prefix: string, ancestors: WeakSet<object>): unknown => {
   // The whole reply can be undefined (a handler with no explicit return); `null` is
   // what the runner already substitutes for a missing result.
   if (value === undefined) return null;
   // Anything that is not an array or a plain object is handed back untouched — see
   // isPlainObject: a Date rebuilt from its entries is an empty object.
   if (!isWalkable(value)) return value;
-  if (Array.isArray(value)) return Array.from(value, (item) => stripUndefined(item));
-  return Object.fromEntries(Object.entries(value).flatMap(([key, item]) => (item === undefined ? [] : [[key, stripUndefined(item)]])));
+  guardCycle(value, ancestors, prefix);
+  ancestors.add(value);
+  const child = (key: string | number) => (prefix ? `${prefix}.${key}` : String(key));
+  try {
+    if (Array.isArray(value)) return Array.from(value, (item, index) => strippedIn(item, child(index), ancestors));
+    return Object.fromEntries(Object.entries(value).flatMap(([key, item]) => (item === undefined ? [] : [[key, strippedIn(item, child(key), ancestors)]])));
+  } finally {
+    ancestors.delete(value);
+  }
 };
+
+export const stripUndefined = (value: unknown): unknown => strippedIn(value, "", new WeakSet());
 
 /** Does `path` match `pattern`, where `*` stands for exactly one segment?
  *  Segment-wise rather than by regex: no escaping of user-supplied dots, and no

--- a/packages/core/test/remote-host/test_firestoreSafeResult.ts
+++ b/packages/core/test/remote-host/test_firestoreSafeResult.ts
@@ -118,6 +118,60 @@ describe("stripUndefined", () => {
   });
 });
 
+// A reply that points back at itself has no bottom. The walk used to recurse until
+// the stack gave out: the runner caught the RangeError, so nothing crashed, but the
+// command failed with `Maximum call stack size exceeded` — naming neither the cause
+// nor the field, which is the one thing this module exists to provide (CodeRabbit,
+// #2637 thread).
+describe("circular replies", () => {
+  // Built by mutation: a cycle cannot be written as a literal.
+  const selfReferential = () => {
+    const node: Record<string, unknown> = { title: "a" };
+    node.self = node;
+    return node;
+  };
+
+  const mutuallyRecursive = () => {
+    const left: Record<string, unknown> = { name: "left" };
+    const right: Record<string, unknown> = { name: "right", left };
+    left.right = right;
+    return { left };
+  };
+
+  it("names the path where undefinedPaths closed the loop", () => {
+    assert.throws(() => undefinedPaths(selfReferential()), /circular reference at self/);
+  });
+
+  it("catches a mutual cycle, not just a direct self-reference", () => {
+    assert.throws(() => undefinedPaths(mutuallyRecursive()), /circular reference at left\.right\.left/);
+  });
+
+  it("catches a cycle through an array", () => {
+    const items: unknown[] = [1];
+    items.push(items);
+    assert.throws(() => undefinedPaths({ items }), /circular reference at items\.1/);
+  });
+
+  it("stripUndefined refuses a cycle too, rather than recursing", () => {
+    assert.throws(() => stripUndefined(selfReferential()), /circular reference/);
+  });
+
+  it("reports the root when the reply is its own container", () => {
+    const items: unknown[] = [];
+    items.push(items);
+    assert.throws(() => undefinedPaths(items), /circular reference at 0/);
+  });
+
+  // The guard tracks ANCESTORS only. The same object reached twice from different
+  // branches is ordinary JSON — treating it as a cycle would reject valid replies.
+  it("allows a value referenced twice from different branches", () => {
+    const shared = { label: "shared", missing: undefined };
+    const reply = { first: shared, second: shared };
+    assert.deepEqual(undefinedPaths(reply), ["first.missing", "second.missing"]);
+    assert.deepEqual(stripUndefined(reply), { first: { label: "shared" }, second: { label: "shared" } });
+  });
+});
+
 describe("matchesPathPattern", () => {
   it("matches a literal path", () => {
     assert.equal(matchesPathPattern("sessions.1.work", "sessions.1.work"), true);

--- a/packages/core/test/remote-host/test_firestoreSafeResult.ts
+++ b/packages/core/test/remote-host/test_firestoreSafeResult.ts
@@ -152,8 +152,20 @@ describe("circular replies", () => {
     assert.throws(() => undefinedPaths({ items }), /circular reference at items\.1/);
   });
 
+  // The same three shapes against stripUndefined: the two walks share a guard but
+  // stay separate functions, so each cycle kind is pinned on both sides.
   it("stripUndefined refuses a cycle too, rather than recursing", () => {
-    assert.throws(() => stripUndefined(selfReferential()), /circular reference/);
+    assert.throws(() => stripUndefined(selfReferential()), /circular reference at self/);
+  });
+
+  it("stripUndefined catches a mutual cycle", () => {
+    assert.throws(() => stripUndefined(mutuallyRecursive()), /circular reference at left\.right\.left/);
+  });
+
+  it("stripUndefined catches a cycle through an array", () => {
+    const items: unknown[] = [1];
+    items.push(items);
+    assert.throws(() => stripUndefined({ items }), /circular reference at items\.1/);
   });
 
   it("reports the root when the reply is its own container", () => {


### PR DESCRIPTION
## Summary

循環参照した返信で `undefinedPaths` / `stripUndefined` の再帰が止まらない問題を塞ぎます。#2638（#2634）に対する CodeRabbit の指摘で、**PR #2637 のスレッドでレビュー単位を分けるため意図的に先送りした分**です（[該当コメント](https://github.com/receptron/mulmoclaude/pull/2637#issuecomment-5112653260)）。

`WeakSet` で**祖先パス**を追跡し、循環を検知したらパス付きのエラーを投げます。

```
circular reference at left.right.left — Firestore cannot serialise it
```

## Items to Confirm / Review

1. **深刻度は Major ではなく Minor だと判断しています** — 現状でも `undefinedPaths` は `runHandler` の `try` の中で呼ばれるので、`RangeError: Maximum call stack size exceeded` は catch されて `writeError(ref, "handler_error", …)` に落ちます。**プロセスは死にません**し、そもそも Firestore 自身のシリアライザも同じ循環を歩くので書き込みは元から失敗していました。直す価値は「失敗メッセージが原因を名指しすること」— このモジュールの存在理由そのもの — にあります。
2. **祖先だけを追跡しています**。別の枝から同じオブジェクトを 2 回参照するのは**ごく普通の JSON** なので、これを循環扱いすると正当な返信を拒否してしまいます。枝を抜けるときに `finally` で集合から外しており、テストで固定しています（`first` / `second` が同じオブジェクトを指すケース）。
3. **エラーにする（除去しない）判断** — 循環は「Firestore が値として受け付けない」ものなので、除去して書いても向こうで落ちます。ここで説明的に落とすのが一番早く原因に辿り着けます。
4. **未検証**: 実際の Firestore への書き込みでは確認していません（ユニットテストのみ）。

## User Prompt

> receptron/mulmoclaude#2640 — @mulmoclaude/core の publish いく？
>
> （順番の確認に対して）手元に未コミットの循環参照ガードを先に進めよう

## テスト

`packages/core/test/remote-host/test_firestoreSafeResult.ts` に 6 ケース追加（計 29）:

- 自己参照 → `circular reference at self`
- 相互再帰 → `circular reference at left.right.left`
- 配列経由の循環 → `circular reference at items.1`
- `stripUndefined` も同様に落ちる
- 返信そのものが自分を含むコンテナ
- **別の枝からの重複参照は通る**（+ 除去も従来どおり効く）

`yarn format` / `yarn lint`（0 errors・warning 46 = main と同数）/ `yarn typecheck` / `yarn build` / `yarn test` 全通過。

## この後

#2640（`@mulmoclaude/core` 1.9.0 の publish）のチェックリスト先頭がこれです。マージ後に version bump + 全 consumer の dep range 一斉更新 + publish + タグ + GH release へ進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Guard Firestore-safe result processing against circular reply structures and ensure they fail with descriptive errors instead of unbounded recursion.

Bug Fixes:
- Detect circular references when walking replies in undefinedPaths and stripUndefined to prevent unbounded recursion and stack overflows.

Enhancements:
- Include the path of the detected circular reference in error messages to better pinpoint invalid reply fields.
- Allow shared sub-objects referenced from multiple branches while still rejecting true cycles in reply structures.

Tests:
- Add test cases covering self-referential, mutually recursive, array-based, and container-level cycles, plus non-cyclic shared references, for undefinedPaths and stripUndefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Circular data structures are now detected when processing Firestore results.
  * Errors clearly identify the path where a circular reference occurs.
  * Shared objects referenced from multiple branches continue to be handled correctly.
  * Array-based circular references are detected reliably, including root-level cycles.
* **Tests**
  * Added coverage for direct, nested, mutual, and array-based circular references.
  * Added validation for undefined-path reporting and for correct undefined-to-null stripping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->