### PR TITLE
docs: 実装と食い違う記述4件を修正し、サンドボックス内のパスと2インスタンス起動を追記

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -71,6 +71,8 @@ All env vars are **optional unless flagged "required"**. The server reads them a
 | Variable                               | Default                        | Effect                                                                                                                                                                                                                                                                                            |
 | -------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                                 | `3001`                         | Express listen port (`server/index.ts:47`).                                                                                                                                                                                                                                                       |
+| `MULMOCLAUDE_WORKSPACE_PATH`           | `<homedir>/mulmoclaude`        | Absolute path to the workspace (`server/workspace/paths.ts`). **Evaluated once at module load**, so it is a start-time choice — there is no API, UI, or CLI flag to switch workspaces on a running server. A path that does not exist yet is created on boot (`server/workspace/workspace.ts`), including `git init`. Under `node:test` with an un-overridden `HOME` the default becomes `<tmpdir>/mulmoclaude-test` instead. Point it somewhere else to run a second, fully isolated instance — see [Running two instances](#running-two-instances). |
+| `MULMOCLAUDE_CLIENT_DIR`               | `<serverDir>/../client`        | Absolute path to the built client Express serves when `NODE_ENV=production` (`server/index.ts`). Set it when the client bundle lives outside the standard dist layout — e.g. running a second instance straight from a source clone (`e2e-live/fixtures/isolated-dev-server.ts` does exactly this). |
 | `NODE_ENV`                             | unset / `production`           | When `production`, Express serves the built client from `dist/client` and falls back to `index.html` for SPA history-mode routing. Auto-set by tooling — you rarely set this manually.                                                                                                            |
 | `DISABLE_SANDBOX`                      | unset                          | Set to `1` to bypass the Docker sandbox even when Docker is available. The agent runs `claude` directly on the host. Useful for debugging without container rebuild overhead (`server/system/docker.ts:49`, `server/index.ts:147`).                                                               |
 | `SANDBOX_SSH_AGENT_FORWARD`            | unset                          | Set to `1` to forward the host's `$SSH_AUTH_SOCK` into the sandbox. Private keys stay on the host; the agent signs on the container's behalf. Full contract: [docs/sandbox-credentials.md](sandbox-credentials.md).                                                                               |
@@ -147,7 +149,7 @@ You never set these by hand; the server constructs them when spawning Claude ins
 | `HOME`                           | container only | `/home/node` so Claude CLI finds its credentials at `~/.claude`.                                                                                                                                                                                                              |
 | Sentinel `X_BEARER_TOKEN=1` etc. | container only | `isMcpToolEnabled()` re-evaluates inside the container; the actual API call still happens on the host, so we only signal "enabled" with `1`.                                                                                                                                  |
 
-> **There is no `WORKSPACE_PATH` env var.** The workspace path is hard-coded to `~/mulmoclaude` in `server/workspace/workspace.ts:11`. To experiment with multiple workspaces you currently need a code change or a symlink swap.
+> **Paths inside the sandbox are not host paths.** The container sees the workspace at `/home/node/mulmoclaude` and each configured reference directory at `/mnt/readonly/<basename>-<hash8>` (`server/workspace/reference-dirs.ts`) — never at its host location. Anything that hands the agent a **literal host path** (a custom role's `prompt`, a collection action template, a skill) silently fails in Docker mode, because that path does not exist in the container. Refer to a reference directory by its **label**: the host already injects a label→mount-path table into the system prompt, and the built-in roles keep every path workspace-relative for the same reason.
 
 ---
 
@@ -207,11 +209,28 @@ Three independent Node processes cooperate at runtime:
 2. **Vite dev client** — listens on `localhost:5173`, proxies `/api/*` to `:3001`. Production builds skip Vite and let Express serve the static `dist/client`.
 3. **MCP stdio bridge** (`server/agent/mcp-server.ts`) — spawned by the Claude CLI subprocess via `--mcp-config`. No HTTP listener: speaks JSON-RPC over stdin/stdout, forwards Claude's tool calls back to the Express server (`MCP_HOST:PORT/api/*`).
 
+### Running two instances
+
+`yarn dev` twice does **not** give you two independent stacks. The server half honours `PORT`, but Vite's proxy targets are literal `localhost:3001` / `ws://localhost:3001` in `vite.config.ts`, with no env override — so the second dev client talks to the *first* server no matter what you set.
+
+To run a genuinely isolated second instance, bypass Vite and let Express serve a prebuilt client:
+
+```bash
+yarn build   # once, produces dist/client
+MULMOCLAUDE_WORKSPACE_PATH=~/mulmoclaude-scratch \
+PORT=3100 \
+NODE_ENV=production \
+MULMOCLAUDE_CLIENT_DIR="$PWD/dist/client" \
+  yarn server
+```
+
+The workspace, port, and served client are then all independent. `e2e-live/fixtures/isolated-dev-server.ts` uses this exact combination (plus `HOME`) to give each live test its own stack.
+
 ---
 
 ## Workspace layout (`~/mulmoclaude/`)
 
-`initWorkspace()` creates / refreshes this on every server start (`server/workspace/workspace.ts`). Everything is plain files tracked in a private git repo, grouped into four top-level buckets by purpose (issue #284):
+`initWorkspace()` creates / refreshes this on every server start (`server/workspace/workspace.ts`). The location defaults to `~/mulmoclaude` and is overridden with [`MULMOCLAUDE_WORKSPACE_PATH`](#runtime), read once at module load. Everything is plain files tracked in a private git repo, grouped into four top-level buckets by purpose (issue #284):
 
 ```text
 ~/mulmoclaude/

--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -317,7 +317,7 @@ const skills = await discoverSkills({ workspaceRoot: workspacePath });
 
 **例 (built-in)**: `general`, `office`, `guide`, `artist`, `tutor`, `storyteller`, `settings`, `accounting`, `cookingCoach`, `debug`
 
-**追加 (user-defined)**: MulmoClaude の Settings → Roles から `manageRoles` 経由、または `<workspace>/config/roles/<id>.md` を直接置く
+**追加 (user-defined)**: MulmoClaude の Settings → Roles から `manageRoles` 経由、または `<workspace>/config/roles/<id>.json` を直接置く (ローダは `.json` のみ読む — `server/workspace/roles.ts`)
 
 **ソース実装**:
 

--- a/docs/migrating-from-claude-code.md
+++ b/docs/migrating-from-claude-code.md
@@ -312,6 +312,7 @@ cp -r ~/projects/my-project/docs/*.md ~/mulmoclaude/data/wiki/pages/
 - 非 Docker mode ではプロンプト指示ベースの read-only (緩い)
 - AI は内容を読めるが書き込めない
 - 機密ディレクトリ (`.ssh`, `.aws`, `/etc` 等) は自動でブロック
+- **Docker mode ではコンテナ内のパスが変わる** — `/mnt/readonly/<basename>-<hash8>` にマウントされ、ホストの絶対パスはコンテナ内に存在しない (`server/workspace/reference-dirs.ts`)。システムプロンプトにはラベルとマウント先の対応表が入るので、**チャットやカスタム role の `prompt` では絶対パスではなくラベルで指す**こと。ホストパスを直書きすると Docker mode で読めない
 
 **最大エントリ数**: 20 (`server/workspace/reference-dirs.ts:30`)
 

--- a/docs/wiki-html-render-surfaces.md
+++ b/docs/wiki-html-render-surfaces.md
@@ -187,7 +187,7 @@ mulmoclaude は **ネイティブ実行**(developer machine)と **Docker サン�
 |---|---|
 | URL 形式 | `@ref/<label>/<remainder>` |
 | 配信ルート | `/api/files/raw?path=@ref/<label>/<remainder>`(static mount は使わない) |
-| Docker での扱い | ホストの絶対パスを read-only で bind mount(コンテナ内 `/workspace/refs/<label>` 等)。書き込みは弾かれる |
+| Docker での扱い | ホストの絶対パスを read-only で bind mount(コンテナ内 `/mnt/readonly/<basename>-<hash8>`。`server/workspace/reference-dirs.ts`)。書き込みは弾かれる |
 | センシティブ・パス遮断 | `.git` / `.ssh` / `.env` / `.aws` などサーバー側で `isSensitivePath` 検査 |
 | 画像表示 | `/api/files/raw?path=@ref/...` 経由で `<img>` が表示可。**`/artifacts/images/` mount からは届かない**(別ファイルシステム・別 prefix) |
 


### PR DESCRIPTION
## 何を直したか

ドキュメントを実装と突き合わせたところ、**実装と食い違う記述が4件**見つかったので直しました。あわせて、実際にハマった落とし穴を2つ追記しています。docs のみの変更で、コードには一切触れていません。

### 1. `docs/developer.md` — `WORKSPACE_PATH` に関する記述が4点とも誤り

```
> **There is no `WORKSPACE_PATH` env var.** The workspace path is hard-coded to
> `~/mulmoclaude` in `server/workspace/workspace.ts:11`. To experiment with multiple
> workspaces you currently need a code change or a symlink swap.
```

| 主張 | 実際 |
|---|---|
| env var は存在しない | `MULMOCLAUDE_WORKSPACE_PATH` が存在する（`server/workspace/paths.ts`） |
| `~/mulmoclaude` にハードコード | env 未設定時のフォールバック。テスト環境ではさらに `<tmpdir>/mulmoclaude-test` に分岐する |
| `server/workspace/workspace.ts:11` にある | 同ファイルは `paths.js` を import して re-export しているだけ（`:11` は空行） |
| コード変更か symlink が必要 | 環境変数を設定して再起動するだけ。`e2e-live/fixtures/isolated-dev-server.ts` が実運用例 |

`docs/troubleshooting.md` と `docs/e2e-live-testing.md` は既に `MULMOCLAUDE_WORKSPACE_PATH` を前提に書かれていて、リファレンス側だけが取り残されていました。

### 2. `docs/wiki-html-render-surfaces.md` — 参照ディレクトリのコンテナ内パスが実装に存在しない

`/workspace/refs/<label>` と書かれていましたが、この文字列はコードのどこにもありません。実装は `/mnt/readonly/<basename>-<hash8>`（`server/workspace/reference-dirs.ts`）です。

### 3. `docs/extension-mechanisms.md` — カスタム role の拡張子が違う

`<workspace>/config/roles/<id>.md` とありますが、ローダは `.json` しか読みません（`server/workspace/roles.ts`）。`.md` を置いても読み込まれず、しかもパース失敗は握り潰されるので無言で無視されます。

### 4. サンドボックス内ではホストの絶対パスが使えないこと（未記載だった）

**実際にこれで詰まりました。** カスタム role の `prompt` に参照ディレクトリのホスト絶対パスを直書きしたところ、エージェントは Docker サンドボックス内で動くためそのパスが存在せず、ファイルを一切読めませんでした。エラーも出ないので原因が分かりません。

正しくは**ラベルで指す**ことです。ホストが `buildReferenceDirsPrompt` でラベルとマウント先の対応表をシステムプロンプトに入れてくれます。ビルトインの role はすべてワークスペース相対パスで書かれていて暗黙にこの慣行を守っていますが、明文化されていませんでした。

`docs/developer.md` の `### Container-only env` 節末（内容は container 無関係だったので位置も不適切でした）を、この注意書きに置き換えています。`docs/migrating-from-claude-code.md` の参照ディレクトリの節にも同趣旨を追記しました。

### 5. `yarn dev` を2本並走できない理由と、分離する手順（未記載だった）

サーバ側は `PORT` で動かせますが、`vite.config.ts` の proxy target が `localhost:3001` / `ws://localhost:3001` のリテラル固定で env 上書きが無いため、**2本目の dev client は1本目のサーバに繋がります**。

Vite をバイパスして分離する手順を `## Process map` の直下に `### Running two instances` として追加しました。`e2e-live/fixtures/isolated-dev-server.ts` が使っている組み合わせと同じです。

### 6. env 表の欠落2件

`MULMOCLAUDE_WORKSPACE_PATH` と `MULMOCLAUDE_CLIENT_DIR` は実在するのに `### Runtime` の表にありませんでした。後者は上記の2インスタンス起動に必要です。

## 変更範囲

```
docs/developer.md                  | 23 +++++++++++++++++++++--
docs/extension-mechanisms.md       |  2 +-
docs/migrating-from-claude-code.md |  1 +
docs/wiki-html-render-surfaces.md  |  2 +-
```

## 確認したこと

- `format` は `{src,server,test,e2e,e2e-live,packages}/**/*.{ts,json,yaml,vue}`、`lint` は `src server test e2e e2e-live packages` が対象で、**どちらも `docs/` を含みません**。CI も `docs/**` と `**/*.md` を `paths-ignore` で除外しています。したがって静的チェックは対象外です
- 差分が `docs/` 配下の4ファイルに閉じていること
- 新設したアンカーリンク（`#running-two-instances` / `#runtime`）の見出しが実在すること
- `### Runtime` の表の全行で列数が揃っていること

## 触っていないもの

`packages/core/assets/helps/` 側にも同種の追記価値がありますが（`sandbox.md` のマウント表に参照ディレクトリの行が無い、`error-recovery.md` にパス解決の失敗の節が無い、`collection-skills.md` の「hidden worker / チャット一覧に出ない」が手動 Refresh には当てはまらない）、`@mulmoclaude/core` のバージョン更新と依存範囲の掃き出しを伴うため、この PR には含めていません。別途出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align documentation with current workspace, sandbox, and dev-server behavior, and document how to run isolated instances.

New Features:
- Document how to run two isolated MulmoClaude instances using separate workspaces and client builds.
- Describe Docker sandbox path behavior for workspaces and reference directories so users know to refer to labels instead of host paths.

Documentation:
- Update env var reference to describe `MULMOCLAUDE_WORKSPACE_PATH` and `MULMOCLAUDE_CLIENT_DIR` and how they control workspace location and served client assets.
- Clarify that custom roles must be defined as JSON files under `<workspace>/config/roles/` rather than Markdown.
- Correct reference directory container paths and behavior in the wiki HTML render surfaces docs.
- Add migration docs note explaining Docker-mode path remapping for reference directories and the need to use labels instead of absolute host paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded setup guidance for workspace configuration and running multiple instances.
  * Clarified Docker sandbox and reference-directory path behavior, including read-only mounts and container-only paths.
  * Documented how to reference mounted directories using labels instead of host absolute paths.
  * Updated custom role documentation to specify JSON file format and loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->