### PR TITLE
docs: 実装と食い違う記述8件を修正し、サンドボックスのパスと2インスタンス起動を追記

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -70,7 +70,9 @@ All env vars are **optional unless flagged "required"**. The server reads them a
 
 | Variable                               | Default                        | Effect                                                                                                                                                                                                                                                                                            |
 | -------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PORT`                                 | `3001`                         | Express listen port (`server/index.ts:47`).                                                                                                                                                                                                                                                       |
+| `PORT`                                 | `3001`                         | Express listen port (`server/system/env.ts` — `env.port`). Left unset, a busy port walks forward so a stale `yarn dev` doesn't crash the launch; set **explicitly** and a busy port exits instead, matching `npx mulmoclaude --port`. Note the Vite dev client does **not** follow this — its proxy targets are literal `localhost:3001` (see [Running two instances](#running-two-instances)). |
+| `MULMOCLAUDE_WORKSPACE_PATH`           | `<homedir>/mulmoclaude`        | Absolute path to the workspace (`server/workspace/paths.ts` — `workspacePath`). **Evaluated once at module load**, so it is a start-time choice: there is no API, UI, or CLI flag that switches workspaces on a running server. A path that does not exist yet is created on boot, `git init` included. Under a test runner with an un-overridden `HOME` the default becomes `<tmpdir>/mulmoclaude-test` instead. Point it elsewhere to run a second, fully isolated instance — see [Running two instances](#running-two-instances). |
+| `MULMOCLAUDE_CLIENT_DIR`               | `<serverDir>/../client`        | Absolute path to the built client Express serves when `NODE_ENV=production` (`server/index.ts`, `server/utils/clientDir.ts`). The default is the layout `packages/mulmoclaude/bin/prepare-dist.js` produces when packaging the tarball; set it when the bundle lives elsewhere — e.g. running from a source clone, where it points at `<repo-root>/dist/client`. Empty string falls back to the default. |
 | `NODE_ENV`                             | unset / `production`           | When `production`, Express serves the built client from `dist/client` and falls back to `index.html` for SPA history-mode routing. Auto-set by tooling — you rarely set this manually.                                                                                                            |
 | `DISABLE_SANDBOX`                      | unset                          | Set to `1` to bypass the Docker sandbox even when Docker is available. The agent runs `claude` directly on the host. Useful for debugging without container rebuild overhead (`server/system/docker.ts:49`, `server/index.ts:147`).                                                               |
 | `SANDBOX_SSH_AGENT_FORWARD`            | unset                          | Set to `1` to forward the host's `$SSH_AUTH_SOCK` into the sandbox. Private keys stay on the host; the agent signs on the container's behalf. Full contract: [docs/sandbox-credentials.md](sandbox-credentials.md).                                                                               |
@@ -148,7 +150,7 @@ You never set these by hand; the server constructs them when spawning Claude ins
 | `HOME`                           | container only | `/home/node` so Claude CLI finds its credentials at `~/.claude`.                                                                                                                                                                                                              |
 | Sentinel `X_BEARER_TOKEN=1` etc. | container only | `isMcpToolEnabled()` re-evaluates inside the container; the actual API call still happens on the host, so we only signal "enabled" with `1`.                                                                                                                                  |
 
-> **There is no `WORKSPACE_PATH` env var.** The workspace path is hard-coded to `~/mulmoclaude` in `server/workspace/workspace.ts:11`. To experiment with multiple workspaces you currently need a code change or a symlink swap.
+> **Paths inside the sandbox are not host paths.** The container sees the workspace at `/home/node/mulmoclaude` (`server/agent/config.ts` — `CONTAINER_WORKSPACE_PATH`), and each configured reference directory at `/mnt/readonly/<basename>-<hash8>` (`server/workspace/reference-dirs.ts` — `containerPath`), never at its host location. Anything that hands the agent a **literal host path** — a custom role's `prompt`, a collection action template, a skill — therefore reads nothing in Docker mode, and does so silently. Refer to a reference directory by its **label**: the host injects a label→mount-path table into the system prompt (`buildReferenceDirsPrompt`), and the built-in roles keep every path workspace-relative for the same reason.
 
 ---
 
@@ -208,11 +210,28 @@ Three independent Node processes cooperate at runtime:
 2. **Vite dev client** — listens on `localhost:5173`, proxies `/api/*` to `:3001`. Production builds skip Vite and let Express serve the static `dist/client`.
 3. **MCP stdio bridge** (`server/agent/mcp-server.ts`) — spawned by the Claude CLI subprocess via `--mcp-config`. No HTTP listener: speaks JSON-RPC over stdin/stdout, forwards Claude's tool calls back to the Express server (`MCP_HOST:PORT/api/*`).
 
+### Running two instances
+
+`yarn dev` twice does **not** give you two independent stacks. The server half honours `PORT`, but Vite's proxy targets are literal `localhost:3001` / `ws://localhost:3001` in `vite.config.ts`, with no env override — so the second dev client talks to the *first* server whatever you set, and nothing errors to tell you.
+
+To get a genuinely isolated second instance today, bypass Vite and let Express serve a prebuilt client:
+
+```bash
+yarn build   # once, produces dist/client
+MULMOCLAUDE_WORKSPACE_PATH=~/mulmoclaude-scratch \
+PORT=3100 \
+NODE_ENV=production \
+MULMOCLAUDE_CLIENT_DIR="$PWD/dist/client" \
+  yarn server
+```
+
+Workspace, port, and served client are then all independent. `e2e-live/fixtures/isolated-dev-server.ts` uses this same combination (plus `HOME`) to give each live test its own stack — which is also why live tests exercise the production serving path rather than the Vite one.
+
 ---
 
 ## Workspace layout (`~/mulmoclaude/`)
 
-`initWorkspace()` creates / refreshes this on every server start (`server/workspace/workspace.ts`). Everything is plain files tracked in a private git repo, grouped into four top-level buckets by purpose (issue #284):
+`initWorkspace()` creates / refreshes this on every server start (`server/workspace/workspace.ts`). The location defaults to `~/mulmoclaude` and is overridden with [`MULMOCLAUDE_WORKSPACE_PATH`](#runtime), read once at module load. Everything is plain files tracked in a private git repo, grouped into four top-level buckets by purpose (issue #284):
 
 ```text
 ~/mulmoclaude/

--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -317,18 +317,20 @@ const skills = await discoverSkills({ workspaceRoot: workspacePath });
 
 **例 (built-in)**: `general`, `office`, `guide`, `artist`, `tutor`, `storyteller`, `settings`, `accounting`, `cookingCoach`, `debug`
 
-**追加 (user-defined)**: MulmoClaude の Settings → Roles から `manageRoles` 経由、または `<workspace>/config/roles/<id>.md` を直接置く
+**追加 (user-defined)**: MulmoClaude の Settings → Roles から `manageRoles` 経由、または `<workspace>/config/roles/<id>.json` を直接置く
+
+ローダ (`server/workspace/roles.ts` — `loadCustomRoles`) が読むのは **`.json` のみ**。`.md` など他の拡張子は読み込み対象にすら入らない。加えて JSON 構文エラーとスキーマ検証失敗は現状無言で握り潰されるため、置いた role が一覧に出ない場合はまず拡張子と JSON の妥当性を疑うこと (#2649)。
 
 **ソース実装**:
 
-- Schema: `src/config/roles.ts:25-32` — `RoleSchema`
-- Built-in: `src/config/roles.ts:36` — `export const ROLES: Role[]`
+- Schema: `src/config/roles.ts` — `RoleSchema`
+- Built-in: `src/config/roles.ts` — `export const ROLES: Role[]` (`BUILTIN_ROLES` として再エクスポート)
 - Persona prompt 注入: `server/agent/prompt.ts:683` — `buildSystemPrompt`
 - Plugin gate: `server/agent/activeTools.ts:78` — `role.availablePlugins`
 
 ```ts
-// src/config/roles.ts:25
-const RoleSchema = z.object({
+// src/config/roles.ts
+export const RoleSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string(),

--- a/docs/migrating-from-claude-code.md
+++ b/docs/migrating-from-claude-code.md
@@ -312,8 +312,9 @@ cp -r ~/projects/my-project/docs/*.md ~/mulmoclaude/data/wiki/pages/
 - 非 Docker mode ではプロンプト指示ベースの read-only (緩い)
 - AI は内容を読めるが書き込めない
 - 機密ディレクトリ (`.ssh`, `.aws`, `/etc` 等) は自動でブロック
+- **Docker mode ではコンテナ内のパスが変わる** — `/mnt/readonly/<basename>-<hash8>` にマウントされ、ホストの絶対パスはコンテナ内に存在しない (`server/workspace/reference-dirs.ts` — `containerPath`)。システムプロンプトにはラベルとマウント先の対応表が入るので、**チャットやカスタム role の `prompt` では絶対パスではなくラベルで指す**こと。ホストパスを直書きすると Docker mode では何も読めず、しかもエラーが出ない
 
-**最大エントリ数**: 20 (`server/workspace/reference-dirs.ts:30`)
+**最大エントリ数**: 20 (`server/workspace/reference-dirs.ts` — `MAX_ENTRIES`)
 
 ### 4.4 どれを選ぶか
 

--- a/docs/migrating-from-claude-code.md
+++ b/docs/migrating-from-claude-code.md
@@ -75,7 +75,7 @@ MulmoClaude は **「`~/mulmoclaude/`」を中心とする独立したアプリ*
 ```
 
 ポイント:
-- **`~/mulmoclaude/` の場所はハードコード**で env override なし (`server/workspace/paths.ts:74`)。別の場所に置きたい場合は symlink で対応
+- **`~/mulmoclaude/` の場所は `MULMOCLAUDE_WORKSPACE_PATH` で変更できる** (`server/workspace/paths.ts` — `workspacePath`)。`~/mulmoclaude` は env 未設定時のフォールバック。モジュール読み込み時に一度だけ評価されるので、起動時に指定して再起動する
 - **MulmoClaude は `~/.claude/skills/` を再利用** ([後述](#3-skill-の移行))
 - それ以外の Claude Code 設定は読み込まれない
 
@@ -186,7 +186,7 @@ cp ~/.claude/.mcp.json ~/mulmoclaude/config/mcp.json
 
 ### Step 5: CLAUDE.md の指示を MulmoClaude 流に書き直す (任意)
 
-[§5 CLAUDE.md の扱い](#5-claude-md-の扱い) を参照。
+[§5 CLAUDE.md の扱い](#5-claudemd-の扱い) を参照。
 
 ### Step 6: Role を選ぶ / 必要なら作る
 
@@ -413,13 +413,14 @@ sandbox なしで動かすなら `DISABLE_SANDBOX=1 npx mulmoclaude`。
 
 ### 7.5 「~/mulmoclaude を別の場所に置きたい」
 
-→ env override なし (`server/workspace/paths.ts:74`)。
-**symlink** で対応:
+→ `MULMOCLAUDE_WORKSPACE_PATH` で指定する (`server/workspace/paths.ts` — `workspacePath`)。`~/mulmoclaude` は env 未設定時のフォールバック:
 
 ```bash
 mv ~/mulmoclaude /Volumes/External/mulmoclaude
-ln -s /Volumes/External/mulmoclaude ~/mulmoclaude
+MULMOCLAUDE_WORKSPACE_PATH=/Volumes/External/mulmoclaude npx mulmoclaude
 ```
+
+モジュール読み込み時に一度だけ評価されるので、**起動前**に設定する。動作中のサーバーを切り替える API / UI / CLI フラグは無い。指定先が存在しなければ起動時に作られる (`git init` も含む)。
 
 ### 7.6 「Claude Code の sub-agent (Agent tool) は使える?」
 
@@ -446,4 +447,4 @@ ln -s /Volumes/External/mulmoclaude ~/mulmoclaude
 - [ ] 必要なドキュメントが §4 のいずれかの戦略で AI から見えている
 - [ ] 普段使う role を 1 つ決めた / カスタム role が必要なら作った
 - [ ] Docker sandbox が動いている (`docker info` 成功)
-- [ ] reference dirs マウントが反映されている (chat で「ホームディレクトリの `~/projects/foo/README.md` を見せて」で確認)
+- [ ] reference dirs マウントが反映されている (chat で「参照ディレクトリ **My Project** の `README.md` を見せて」のように **ラベルで** 確認。ホストの絶対パスで頼むと Docker mode では読めない → [§4.3](#43-戦略-c-reference-dirs-として外部からマウントする-read-only))

--- a/docs/wiki-html-render-surfaces.md
+++ b/docs/wiki-html-render-surfaces.md
@@ -187,7 +187,7 @@ mulmoclaude は **ネイティブ実行**(developer machine)と **Docker サン�
 |---|---|
 | URL 形式 | `@ref/<label>/<remainder>` |
 | 配信ルート | `/api/files/raw?path=@ref/<label>/<remainder>`(static mount は使わない) |
-| Docker での扱い | ホストの絶対パスを read-only で bind mount(コンテナ内 `/workspace/refs/<label>` 等)。書き込みは弾かれる |
+| Docker での扱い | ホストの絶対パスを read-only で bind mount(コンテナ内 `/mnt/readonly/<basename>-<hash8>`。`server/workspace/reference-dirs.ts` — `containerPath`)。書き込みは弾かれる |
 | センシティブ・パス遮断 | `.git` / `.ssh` / `.env` / `.aws` などサーバー側で `isSensitivePath` 検査 |
 | 画像表示 | `/api/files/raw?path=@ref/...` 経由で `<img>` が表示可。**`/artifacts/images/` mount からは届かない**(別ファイルシステム・別 prefix) |
 

--- a/docs/wiki-html-render-surfaces.md
+++ b/docs/wiki-html-render-surfaces.md
@@ -168,16 +168,20 @@ mulmoclaude は **ネイティブ実行**(developer machine)と **Docker サン�
 
 ### モード差
 
-| 項目 | ネイティブ | Docker サンドボックス |
+「Docker サンドボックス」列は **コンテナ内のエージェントから見えるパス**。Express サーバー自身は
+どちらのモードでもホスト側プロセスなので、配信時に読むのは常にホストのパス
+(→ [discussion-image-path-routing.md](discussion-image-path-routing.md))。
+
+| 項目 | ネイティブ | Docker サンドボックス(エージェントから見た値) |
 |---|---|---|
-| Workspace の場所 | `~/mulmoclaude/` | コンテナ内 `/workspace/`(host の `~/mulmoclaude/` を bind mount) |
-| `/artifacts/images/` の実体 | `~/mulmoclaude/artifacts/images/` | `/workspace/artifacts/images/` |
-| `/artifacts/html/` の実体 | `~/mulmoclaude/artifacts/html/` | `/workspace/artifacts/html/` |
-| `WORKSPACE_PATHS` 定数 | OS native パス | コンテナ内パス |
+| Workspace の場所 | `~/mulmoclaude/` | コンテナ内 `/home/node/mulmoclaude/`(host の `~/mulmoclaude/` を bind mount。`server/agent/config.ts` — `CONTAINER_WORKSPACE_PATH`) |
+| `/artifacts/images/` の実体 | `~/mulmoclaude/artifacts/images/` | `/home/node/mulmoclaude/artifacts/images/` |
+| `/artifacts/html/` の実体 | `~/mulmoclaude/artifacts/html/` | `/home/node/mulmoclaude/artifacts/html/` |
+| エージェントに渡す workspace パス | OS native パス | `CONTAINER_WORKSPACE_PATH`(`server/agent/index.ts` が切り替える) |
 | 書き込み(画像保存・HTML 保存) | アプリプロセスが直接 write | コンテナ内のアプリが write、host にも反映 |
 | 副作用 | ホスト全体に届きうる | bind mount された範囲のみ |
 
-`/artifacts/images/` と `/artifacts/html/` の URL 経路 → 配信元のロジックは同一実装で、モード判定は `WORKSPACE_PATHS` の値だけで吸収されています。`<img src="/artifacts/images/foo.png">` を書く LLM 出力もアプリ側のレンダラも両モードで違いを意識しなくていい設計。
+`/artifacts/images/` と `/artifacts/html/` の URL 経路 → 配信元のロジックは両モードで同一実装。配信するのは常にホスト側の Express なので、`<img src="/artifacts/images/foo.png">` を書く LLM 出力もアプリ側のレンダラも両モードで違いを意識しなくていい設計。パスの差が出るのは、コンテナ内でファイルを直接読み書きするエージェント側だけ。
 
 ### リファレンス・ディレクトリ(`@ref/<label>/...`)
 


### PR DESCRIPTION
## Summary

`docs/` の記述を最新 `origin/main` (7ba5f4d51) の実装と1件ずつ突き合わせ、**食い違っていた8件を修正**し、実装上そうなっているのに未記載だった2件を追記した。**docs のみ**でコードは触っていない。

CLOSED になった #2648 の指摘を再検証したもの。#2648 の指摘6件はすべて正しかったが、base が99コミット古かったため、最新 main に対して検証し直したうえで作り直している。検証中にコード側の問題として切り出したものは別 issue: **#2649 / #2650 / #2651**。

## Items to Confirm / Review

人間に見てほしい点:

1. **行番号参照を落とした判断** — 今回見つかった誤りのうち4件 (D5–D8) は `file.ts:NN` 形式の参照が実装の変化に追随できず腐ったもの。**同じ形式で番号だけ直すと同じ罠を再生産する**と判断し、シンボル名が既に併記されている箇所は行番号を落として `file.ts` — `SymbolName` 形式に変えた。リポジトリ全体は `file.ts:NN` 形式が主流なので、慣行から外れる変更として明示的に確認してほしい。今回触っていない箇所の同形式参照はそのままにしてある。
2. **`### Running two instances` の手順** — `e2e-live/fixtures/isolated-dev-server.ts` が使っている組み合わせをそのまま書いたが、`yarn build` → `yarn server` の手順は**実際に2本起動して確認まではしていない**。手順の妥当性を確認してほしい。
3. **`MULMOCLAUDE_CLIENT_DIR` を公開ドキュメントに載せてよいか** — 元々は e2e-live の test seam として入ったもの (`plans/feat-e2e-live.md`)。Runtime env 表に載せると一般向けの設定に見えるので、意図と合っているか確認してほしい。
4. **sandbox パスの注意書きの置き場所** — `### Container-only env` 節末の誤った blockquote を差し替える形にした。内容は container に関係するので位置は妥当だと考えているが、より目立つ場所が良ければ移す。

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/2648 このPRを確認して、バグが有るものは直したいし、documentも間違いは更新したい。１つ１つ確認してバグは１つ１つissue化して。

追加で決めたこと:

- コードバグは1件ずつ個別 issue にする。ドキュメント誤りは issue を立てず、まとめて1本の docs 修正 PR にする
- コードバグ自体の修正は今回やらず、issue に残す
- #2648 は reopen せず、最新 main から新しいブランチで作り直す

## 検証結果

すべて `origin/main` (7ba5f4d51) の実物に対して確認した。

| # | 場所 | 誤った記述 | 実装 |
|---|---|---|---|
| D1 | `docs/developer.md` | 「`WORKSPACE_PATH` env var は無い / `~/mulmoclaude` にハードコード / `server/workspace/workspace.ts:11` / コード変更か symlink が必要」 | `MULMOCLAUDE_WORKSPACE_PATH` が実在 (`server/workspace/paths.ts` — `workspacePath`)。`~/mulmoclaude` は env 未設定時のフォールバックで、テストランナー下 (かつ `HOME` 非上書き) では `<tmpdir>/mulmoclaude-test`。`workspace.ts:11` は空行 |
| D2 | `docs/wiki-html-render-surfaces.md` | コンテナ内 `/workspace/refs/<label>` | `/mnt/readonly/<basename>-<hash8>` (`reference-dirs.ts` — `CONTAINER_MOUNT_ROOT` + `containerPath`)。`/workspace/refs` はリポジトリ全体でこの docs にしか存在しない文字列だった |
| D3 | `docs/extension-mechanisms.md` | `<workspace>/config/roles/<id>.md` | ローダは `.endsWith(".json")` のみ (`server/workspace/roles.ts`)、書き込みも `${roleId}.json` (`server/utils/files/roles-io.ts`) |
| D4 | `docs/developer.md` `### Runtime` 表 | `MULMOCLAUDE_WORKSPACE_PATH` / `MULMOCLAUDE_CLIENT_DIR` が欠落 | 両方実在 (`paths.ts`, `server/index.ts` + `server/utils/clientDir.ts`) |
| D5 | `docs/extension-mechanisms.md` | `src/config/roles.ts:25-32` に `RoleSchema` | 実際は `:33-42`。`:25-32` は `availablePluginsSchema` |
| D6 | `docs/extension-mechanisms.md` | `src/config/roles.ts:36` に `export const ROLES` | 実際は `:45`。`:36` は `icon: z.string()` |
| D7 | `docs/migrating-from-claude-code.md` | 最大エントリ数 20 = `reference-dirs.ts:30` | `MAX_ENTRIES` は `:28`。`:30` は `CONTAINER_MOUNT_ROOT` |
| D8 | `docs/developer.md` `### Runtime` 表 | `PORT` = `server/index.ts:47` | `:47` は import 行。port は `server/system/env.ts` — `env.port`、bind は `resolvePort()` |

D5–D8 は #2648 が拾えていなかったぶん。

### 未記載だったので追記した2件

**1. サンドボックス内ではホストの絶対パスが使えない**

`containerPath()` の設計上の帰結だが、どこにも書かれていなかった。カスタム role の `prompt` にホスト絶対パスを直書きすると、エージェントは Docker サンドボックス内で動くためそのパスが存在せず、**ファイルを一切読めないうえエラーも出ない**。正しくはラベルで指す — ホストが `buildReferenceDirsPrompt` でラベルとマウント先の対応表をシステムプロンプトに入れる。ビルトインの role はすべてワークスペース相対パスで書かれていて暗黙にこの慣行を守っているが、明文化されていなかった。

`docs/developer.md` の誤った blockquote をこの注意書きに置き換え、`docs/migrating-from-claude-code.md` の参照ディレクトリ節にも同趣旨を追記した。

**2. `yarn dev` を2本並走できない理由と分離手順**

サーバ側は `PORT` で動かせるが、`vite.config.ts` の proxy target が `localhost:3001` / `ws://localhost:3001` のリテラル固定で env 上書きが無いため、2本目の dev client は1本目のサーバに繋がる (→ #2650)。Vite をバイパスして分離する手順を `## Process map` 直下に `### Running two instances` として追加した。

## 別 issue に切り出したコード側の問題

| issue | 内容 |
|---|---|
| #2649 | `loadCustomRoles` が role の JSON パース / スキーマ検証失敗を `catch { return [] }` で無言で握り潰す。ログも出ないので、置いた role が出ない理由を利用者が切り分けられない |
| #2650 | `vite.config.ts` の proxy target が `localhost:3001` 固定で `PORT` を無視する。サーバ側は `PORT` を尊重するため、`PORT=3100 yarn dev` はサーバだけ移動しクライアントは3001に繋がる |
| #2651 | `e2e-live/fixtures/isolated-dev-server.ts` のコメントが陳腐化。「Vite の token file path は `~/mulmoclaude/.session-token` にハードコード」は #1570 で修正済み。「(added in this PR)」もマージ済 PR を指したまま |

## 確認したこと

- `yarn format` は `{src,server,test,e2e,e2e-live,packages}/**/*.{ts,json,yaml,vue}`、`yarn lint` は `src server test e2e e2e-live packages` が対象で、**どちらも `docs/` を含まない**。よって静的チェックは本 PR の対象外
- `.github/workflows/pull_request.yaml` は `docs/**` / `plans/**` / `**/*.md` を `paths-ignore` しており、docs のみの PR では lint_test + e2e が走らない (`lint_test_windows.yaml` / `duplication-scan.yaml` も同様)。一方 `codex_review.yaml` は docs-only diff でも意図的に発火し、`secret-scan.yml` は path フィルタ無しで常時走る
- 差分が `docs/` 配下の4ファイルに閉じていること
- 新設したアンカーリンク (`#running-two-instances` / `#runtime`) の見出しが実在すること
- `### Runtime` 表の全行で列数が揃っていること
- 修正後の docs に、置き換え対象だった誤り文字列がひとつも残っていないこと

## 触っていないもの

`packages/core/assets/helps/` 側にも同種の追記価値があるが (`sandbox.md` のマウント表に参照ディレクトリの行が無い等)、`@mulmoclaude/core` のバージョン更新を伴うため本 PR には含めていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2

## Summary by Sourcery

Align documentation with current workspace, sandbox, and runtime behavior, and document how to run multiple isolated instances.

Documentation:
- Update runtime environment variable table to describe PORT behavior accurately and document MULMOCLAUDE_WORKSPACE_PATH and MULMOCLAUDE_CLIENT_DIR.
- Clarify that sandbox-visible paths differ from host paths and instruct users to reference directories by label rather than host absolute paths.
- Correct and generalize references to role schema definitions and built-in roles, and state that custom roles must be provided as JSON with silent failure on invalid files.
- Document Docker reference directory mount paths consistently across developer and migration guides and the wiki HTML rendering guide.
- Add a "Running two instances" section describing how to start a second fully isolated instance using a prebuilt client instead of Vite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified runtime configuration details, including port handling, workspace/client directory evaluation timing, and fallback behavior.
  * Updated guidance for running isolated instances, explaining why duplicate dev runs don’t isolate stacks and providing the correct environment-variable setup.
  * Expanded Docker sandbox documentation: sandbox-visible paths differ from host paths, and reference-directory labels should be used instead of host paths.
  * Refined role-loading rules: only valid JSON role definitions are recognized; invalid JSON is ignored without listing.
  * Updated migration and wiki HTML rendering docs with the revised reference-directory mount behavior and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->