### PR TITLE
fix(roles): 読み込めなかった role ファイルを名前と理由つきで warn する (#2649)

### DIFF
--- a/docs/extension-mechanisms.md
+++ b/docs/extension-mechanisms.md
@@ -319,7 +319,7 @@ const skills = await discoverSkills({ workspaceRoot: workspacePath });
 
 **追加 (user-defined)**: MulmoClaude の Settings → Roles から `manageRoles` 経由、または `<workspace>/config/roles/<id>.json` を直接置く
 
-ローダ (`server/workspace/roles.ts` — `loadCustomRoles`) が読むのは **`.json` のみ**。`.md` など他の拡張子は読み込み対象にすら入らない。加えて JSON 構文エラーとスキーマ検証失敗は現状無言で握り潰されるため、置いた role が一覧に出ない場合はまず拡張子と JSON の妥当性を疑うこと (#2649)。
+ローダ (`server/workspace/roles.ts` — `loadCustomRoles`) が読むのは **`.json` のみ**。`.md` など他の拡張子は読み込み対象にすら入らない。読めなかったファイルは（壊れた1件で一覧を落とさないため）スキップされるが、**理由はサーバログに `[roles]` の warn として出る** — ファイル名 + 「空 / JSON 構文エラー / スキーマ検証失敗（どのフィールドか）/ 読み取り失敗」まで出るので、置いた role が一覧に出ないときはログを見れば切り分けられる (#2649)。`.json` 以外を置いた場合も 1 行にまとめて警告される。
 
 **ソース実装**:
 

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -251,11 +251,14 @@ naming the file:
 - `role file is empty, skipping` — zero-length or whitespace only.
 - `role file could not be read, skipping` — permissions, or the path is
   a directory.
+- `role file disappeared while loading, skipping` — the file was renamed
+  or deleted while the list was being read, or it is a broken symlink.
+  Re-running the load is enough if the file is there now.
 - `ignoring entries that are not .json files` — a `.md` / `.jsonc` /
   `.json.txt` file is never read as a role.
 
 Ask the user for that warning line (or the file's contents) rather than
-guessing which of the five it is. Writing the role through
+guessing which of the six it is. Writing the role through
 `manageRoles` instead sidesteps all of them — it serializes the role, so
 the file is always valid.
 

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -225,6 +225,40 @@ shipped registry repo's README. Common rejections:
 - `name` reuses the reserved value `official`.
 - `name` doesn't match `[A-Za-z0-9][A-Za-z0-9_-]{0,31}`.
 
+## A hand-placed custom role never appears in the list
+
+### Symptoms
+
+- The user put a file in `config/roles/` themselves (not via Settings →
+  Roles / `manageRoles`) and the role is absent from the role list.
+- Nothing failed in tool output — `manageRoles` with `action: "list"`
+  simply doesn't include it.
+
+### Cause + fix
+
+The loader reads **`config/roles/<id>.json` only**, and a file it cannot
+use is skipped rather than fatal — so one broken file can't take the
+whole list down. The reason is in the server log as a `[roles]` warning
+naming the file:
+
+- `role file is not valid JSON, skipping` — trailing comma, single
+  quotes, unquoted key.
+- `role file does not match the role schema, skipping` — the `issues`
+  field names each field, e.g. `icon: Invalid input: expected string,
+  received undefined`. All of `id`, `name`, `icon`, `prompt`,
+  `availablePlugins` are required; `availablePlugins` must be an array
+  even for one entry.
+- `role file is empty, skipping` — zero-length or whitespace only.
+- `role file could not be read, skipping` — permissions, or the path is
+  a directory.
+- `ignoring entries that are not .json files` — a `.md` / `.jsonc` /
+  `.json.txt` file is never read as a role.
+
+Ask the user for that warning line (or the file's contents) rather than
+guessing which of the five it is. Writing the role through
+`manageRoles` instead sidesteps all of them — it serializes the role, so
+the file is always valid.
+
 ## Marp slide PDF — empty / image / font issues
 
 ### Symptoms

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^1.0.3",
     "@mulmoclaude/collection-plugin": "^1.2.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.0",
     "@mulmoclaude/html-plugin": "^1.2.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.10.0"
+    "@mulmoclaude/core": "^1.10.1"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.10.0"
+    "@mulmoclaude/core": "^1.10.1"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.10.0"
+    "@mulmoclaude/core": "^1.10.1"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.10.0"
+    "@mulmoclaude/core": "^1.10.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,20 +37,20 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "@mulmoclaude/markdown-utils": "^1.3.2",
     "js-yaml": "^5.2.2",
     "marked": "^18.0.7",
     "mermaid": "^11.16.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^1.10.0",
+    "@mulmoclaude/core": "^1.10.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.10.0"
+    "@mulmoclaude/core": "^1.10.1"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",

--- a/plans/fix-2649-role-load-diagnostics.md
+++ b/plans/fix-2649-role-load-diagnostics.md
@@ -33,7 +33,7 @@ issue のコメントに記録済み。`GET /api/roles/list` は `loadCustomRole
 
 `RoleFileProblem` は `{ message, data }` で持つ。ログ整形は呼び出し側 1 箇所だけになり、純粋関数側は「何が起きたか」だけを組み立てる。
 
-zod の `issues` を生の配列で渡すとテキストシンクで JSON の壁になるので、`path: message` を `; ` で連結した1行に畳む（`summarizeRoleIssues`）。issue が求めた「どのフィールドか」がそのまま読める形。
+zod の `issues` を生の配列で渡すとテキストシンクで JSON の壁になるので、`path: message` を `"; "` で連結した1行に畳む（`summarizeRoleIssues`）。issue が求めた「どのフィールドか」がそのまま読める形。
 
 `.json` 以外のエントリは 1 行にまとめて警告する。dotfile (`.DS_Store` 等) は role を置く意図が無いので対象外 — `collection/server/discovery.ts` の `name.startsWith(".")` と同じ扱い。
 
@@ -45,8 +45,8 @@ zod の `issues` を生の配列で渡すとテキストシンクで JSON の壁
 
 ## ドキュメント / help
 
-- `docs/extension-mechanisms.md` § 3.6 Role — #2652 が入れた「無言で握り潰される」記述を、実際の warn の内容（ファイル名 + 5 種の理由）に差し替える。
-- `packages/core/assets/helps/error-recovery.md` — エージェントが実行時に読む復旧手順に「手で置いた role が一覧に出ない」節を追加。5 つの warn メッセージを列挙し、**どれなのかを推測せず利用者にその行を訊く**よう指示する。既存の `[collections-registry] registry config entry rejected` 節と同じ形。
+- `docs/extension-mechanisms.md` § 3.6 Role — #2652 が入れた「無言で握り潰される」記述を、実際の warn の内容（ファイル名 + 理由）に差し替える。
+- `packages/core/assets/helps/error-recovery.md` — エージェントが実行時に読む復旧手順に「手で置いた role が一覧に出ない」節を追加。6 つの warn メッセージ（`readRoleText` 2 + `parseRoleFile` 3 + `ignoredEntryProblems` 1）を列挙し、**どれなのかを推測せず利用者にその行を訊く**よう指示する。既存の `[collections-registry] registry config entry rejected` 節と同じ形。
   - `assets/helps/*` は npm に載るので `@mulmoclaude/core` を 1.10.0 → **1.10.1** に上げ、宣言側 13 箇所（8 パッケージ）の range を `^1.10.1` に掃く。npm への publish 自体は `/publish` の仕事なので本 PR には含めない（consumer の次のリリース前に必要）。
 
 ## テスト
@@ -57,4 +57,7 @@ zod の `issues` を生の配列で渡すとテキストシンクで JSON の壁
 - 統合: 一時ワークスペース + `captureStderr`（`test/utils/test_logBackgroundError.ts` と同じ手）で、
   - 壊れたファイルの**名前と理由**が warn に出る
   - 壊れたファイルの隣の妥当な role は**そのまま読める**（握り潰しの意図は保つ）
+  - 読めないエントリ（`*.json` という名前のディレクトリ）— errno はプラットフォーム差があるので理由文だけを assert する
+  - readdir と read が食い違うケース = **dangling symlink**。先に消すと readdir に載らないのでこの分岐に入らない（win32 は symlink 権限のため skip）
+  - `config/roles` が無い / 空のときは**何も出ない**（新規インストールが無音であること）
   - `.md` を置くと「`.json` のみ」の警告が出る / `.DS_Store` では出ない

--- a/plans/fix-2649-role-load-diagnostics.md
+++ b/plans/fix-2649-role-load-diagnostics.md
@@ -1,0 +1,60 @@
+# 手で置いた role ファイルが無言で消える
+
+Issue: #2649 · 発見経路: #2648 (docs, CLOSED) のレビュー → ドキュメント側の訂正は #2652
+
+## 症状の構造
+
+`loadCustomRoles()` の `catch { return []; }` が、**性質の違う4つの失敗を1つの結果に潰している**。
+
+| 実際に起きたこと | 現状の見え方 |
+|---|---|
+| JSON 構文エラー | role が出ない |
+| `RoleSchema` 検証失敗 | role が出ない |
+| 読み取り失敗 (権限等) | role が出ない |
+| 空ファイル | role が出ない |
+
+さらに `.filter(endsWith(".json"))` で落ちた `.md` / `.jsonc` は try にも入らない。
+
+握り潰し自体は正しい設計（壊れた1ファイルで起動を止めない）なので、**握り潰しをやめるのではなく、握り潰したことを記録する**。
+
+## 診断面が他に無いことは確認済み
+
+issue のコメントに記録済み。`GET /api/roles/list` は `loadCustomRoles()` の戻りをそのまま返すので UI からも不可視、`log.warn("roles", "manage: error")` は manage アクション（UI/ツール経由）専用で手置きファイルの読み込み経路には効かない。`saveRole` は `JSON.stringify` で書くのでアプリ経由の role は常に妥当 — **失敗するのは手で置いた/手で編集したときだけ**で、そこにだけ診断が無い。
+
+## 変更
+
+### `server/workspace/roles.ts`
+
+読み取り（I/O）と解釈（純粋）を分ける。
+
+- `parseRoleFile(fileName, raw)` — **純粋関数、export**。`{ role }` か `{ problem }` を返す。空 → JSON 構文 → スキーマ の順に判定するので、利用者が受け取る理由が実際の失敗原因と1対1に対応する。テストは env も一時ディレクトリも要らない。
+- `readRoleText(fileName)` — `readTextUnderSync` の `string | null` と throw を `{ text }` / `{ problem }` に畳む。`null` は ENOENT のみ（`workspace-io` の契約）なので「readdir が挙げた直後に消えた」= 走査中のリネーム/削除として報告する。
+- `loadCustomRoles()` — outcome を集め、problem を `log.warn("roles", ...)`、role を返す。
+
+`RoleFileProblem` は `{ message, data }` で持つ。ログ整形は呼び出し側 1 箇所だけになり、純粋関数側は「何が起きたか」だけを組み立てる。
+
+zod の `issues` を生の配列で渡すとテキストシンクで JSON の壁になるので、`path: message` を `; ` で連結した1行に畳む（`summarizeRoleIssues`）。issue が求めた「どのフィールドか」がそのまま読める形。
+
+`.json` 以外のエントリは 1 行にまとめて警告する。dotfile (`.DS_Store` 等) は role を置く意図が無いので対象外 — `collection/server/discovery.ts` の `name.startsWith(".")` と同じ扱い。
+
+### 抑制（dedup）は入れない
+
+`getRole()` はエージェントのリクエスト毎に呼ばれるので、壊れたファイルがある間は警告がリクエスト毎に出る。一度だけに絞る実装も考えたが**入れない**:
+
+利用者の動線は「role が出ない → ログを見る」。初回だけ警告する設計だと、ログを見始めた時点で既に警告が流れ終わっていて **元のバグ（何も出ない）と区別がつかない**。設定を直せば止まる警告なので、量は問題に見合っている。`collection` の discovery も走査毎に警告している。
+
+## ドキュメント / help
+
+- `docs/extension-mechanisms.md` § 3.6 Role — #2652 が入れた「無言で握り潰される」記述を、実際の warn の内容（ファイル名 + 5 種の理由）に差し替える。
+- `packages/core/assets/helps/error-recovery.md` — エージェントが実行時に読む復旧手順に「手で置いた role が一覧に出ない」節を追加。5 つの warn メッセージを列挙し、**どれなのかを推測せず利用者にその行を訊く**よう指示する。既存の `[collections-registry] registry config entry rejected` 節と同じ形。
+  - `assets/helps/*` は npm に載るので `@mulmoclaude/core` を 1.10.0 → **1.10.1** に上げ、宣言側 13 箇所（8 パッケージ）の range を `^1.10.1` に掃く。npm への publish 自体は `/publish` の仕事なので本 PR には含めない（consumer の次のリリース前に必要）。
+
+## テスト
+
+`test/roles/test_role_file_diagnostics.ts`
+
+- 純粋関数 `parseRoleFile`: 妥当な role / 空 / 空白のみ / 末尾カンマ / issue の再現ケース（`{"id","name"}` のみ → `icon`・`prompt`・`availablePlugins` が理由に出る）
+- 統合: 一時ワークスペース + `captureStderr`（`test/utils/test_logBackgroundError.ts` と同じ手）で、
+  - 壊れたファイルの**名前と理由**が warn に出る
+  - 壊れたファイルの隣の妥当な role は**そのまま読める**（握り潰しの意図は保つ）
+  - `.md` を置くと「`.json` のみ」の警告が出る / `.DS_Store` では出ない

--- a/server/workspace/roles.ts
+++ b/server/workspace/roles.ts
@@ -112,7 +112,7 @@ function ignoredEntryProblems(fileNames: string[]): RoleFileProblem[] {
   return [
     {
       message: `ignoring entries that are not ${ROLE_FILE_EXT} files — a custom role must be <id>${ROLE_FILE_EXT}`,
-      data: { dir: WORKSPACE_DIRS.roles, ignored: ignored.join(", ") },
+      data: { dir: WORKSPACE_DIRS.roles, ignored },
     },
   ];
 }

--- a/server/workspace/roles.ts
+++ b/server/workspace/roles.ts
@@ -2,19 +2,25 @@ import path from "node:path";
 import { BUILTIN_ROLES, RoleSchema, type Role } from "../../src/config/roles.js";
 import { WORKSPACE_DIRS, workspacePath } from "./paths.js";
 import { readdirUnderSync, readTextUnderSync } from "../utils/files/workspace-io.js";
+import { log } from "../system/logger/index.js";
+
+const ROLE_FILE_EXT = ".json";
+const LOG_PREFIX = "roles";
+
+// Skipping a broken file keeps one bad role from taking the list down; the problem
+// it carries is so the skip isn't also invisible, which is all a hand-placed file
+// used to get. `saveRole` writes via JSON.stringify — only humans land here (#2649).
+export interface RoleFileProblem {
+  message: string;
+  data: Record<string, unknown>;
+}
+type RoleFileOutcome = { role: Role } | { problem: RoleFileProblem };
 
 export function loadCustomRoles(): Role[] {
-  return readdirUnderSync(workspacePath, WORKSPACE_DIRS.roles)
-    .filter((fileName) => fileName.endsWith(".json"))
-    .flatMap((fileName) => {
-      try {
-        const raw = readTextUnderSync(workspacePath, path.posix.join(WORKSPACE_DIRS.roles, fileName));
-        if (!raw) return [];
-        return [RoleSchema.parse(JSON.parse(raw))];
-      } catch {
-        return [];
-      }
-    });
+  const fileNames = readdirUnderSync(workspacePath, WORKSPACE_DIRS.roles);
+  const outcomes = fileNames.filter(isRoleFileName).map(readRoleFile);
+  [...outcomes.flatMap(problemsOf), ...ignoredEntryProblems(fileNames)].forEach((problem) => log.warn(LOG_PREFIX, problem.message, problem.data));
+  return outcomes.flatMap((outcome) => ("role" in outcome ? [outcome.role] : []));
 }
 
 export function loadAllRoles(): Role[] {
@@ -25,4 +31,88 @@ export function loadAllRoles(): Role[] {
 
 export function getRole(roleId: string): Role {
   return loadAllRoles().find((role) => role.id === roleId) ?? BUILTIN_ROLES[0];
+}
+
+function isRoleFileName(fileName: string): boolean {
+  return fileName.endsWith(ROLE_FILE_EXT);
+}
+
+function problemsOf(outcome: RoleFileOutcome): RoleFileProblem[] {
+  return "problem" in outcome ? [outcome.problem] : [];
+}
+
+function readRoleFile(fileName: string): RoleFileOutcome {
+  const read = readRoleText(fileName);
+  return "problem" in read ? read : parseRoleFile(fileName, read.text);
+}
+
+function readRoleText(fileName: string): { text: string } | { problem: RoleFileProblem } {
+  try {
+    const text = readTextUnderSync(workspacePath, path.posix.join(WORKSPACE_DIRS.roles, fileName));
+    // null is ENOENT only (workspace-io's contract) and readdir just listed it.
+    if (text === null) return { problem: { message: "role file disappeared while loading, skipping", data: { fileName } } };
+    return { text };
+  } catch (err) {
+    return { problem: { message: "role file could not be read, skipping", data: { fileName, error: String(err) } } };
+  }
+}
+
+// Pure: the whole reason a file was dropped, decided from its text alone.
+export function parseRoleFile(fileName: string, raw: string): RoleFileOutcome {
+  if (raw.trim() === "") {
+    return { problem: { message: "role file is empty, skipping", data: { fileName } } };
+  }
+  const json = parseJson(raw);
+  if ("error" in json) {
+    return { problem: { message: "role file is not valid JSON, skipping", data: { fileName, error: json.error } } };
+  }
+  const parsed = RoleSchema.safeParse(json.value);
+  if (!parsed.success) {
+    return { problem: { message: "role file does not match the role schema, skipping", data: { fileName, issues: summarizeRoleIssues(parsed.error.issues) } } };
+  }
+  return { role: parsed.data };
+}
+
+function parseJson(raw: string): { value: unknown } | { error: string } {
+  try {
+    return { value: JSON.parse(raw) };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+interface RoleIssue {
+  readonly path: readonly PropertyKey[];
+  readonly message: string;
+  readonly errors?: readonly (readonly { readonly message: string }[])[];
+}
+
+// zod's raw issues JSON-dump into a log line as a wall of nesting; which field and why
+// is what the reader acts on.
+function summarizeRoleIssues(issues: readonly RoleIssue[]): string {
+  return issues.map((issue) => `${issueField(issue)}: ${issueReason(issue)}`).join("; ");
+}
+
+function issueField(issue: RoleIssue): string {
+  return issue.path.length > 0 ? issue.path.map(String).join(".") : "(root)";
+}
+
+// A union issue (`availablePlugins`) says only "Invalid input" for itself; the branch
+// errors nested under it carry the actionable part ("expected array, received string").
+function issueReason(issue: RoleIssue): string {
+  const nested = [...new Set((issue.errors ?? []).flat().map((branch) => branch.message))].filter((message) => message !== issue.message);
+  return nested.length > 0 ? `${issue.message} (${nested.join(" / ")})` : issue.message;
+}
+
+// A `.md` / `.jsonc` / `.json.txt` file never reaches the loader, so it would be as
+// invisible as a broken one. Dotfiles are nobody's role attempt (as in collections).
+function ignoredEntryProblems(fileNames: string[]): RoleFileProblem[] {
+  const ignored = fileNames.filter((fileName) => !isRoleFileName(fileName) && !fileName.startsWith("."));
+  if (ignored.length === 0) return [];
+  return [
+    {
+      message: `ignoring entries that are not ${ROLE_FILE_EXT} files — a custom role must be <id>${ROLE_FILE_EXT}`,
+      data: { dir: WORKSPACE_DIRS.roles, ignored: ignored.join(", ") },
+    },
+  ];
 }

--- a/test/roles/test_role_file_diagnostics.ts
+++ b/test/roles/test_role_file_diagnostics.ts
@@ -1,0 +1,156 @@
+// #2649: a hand-placed `config/roles/<id>.json` that was empty, malformed, or
+// schema-invalid used to be dropped by a bare `catch { return []; }` — the role
+// simply never appeared and nothing was logged, so the user could not tell a
+// wrong path from a wrong schema. Skipping the file is still correct; being
+// silent about it is not.
+
+import { describe, it, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// paths.ts resolves `workspacePath` from the environment when it is first
+// evaluated, so the workspace has to exist before anything imports it — hence
+// the sync mkdtemp and the awaited imports below rather than a `before()` hook.
+const workspaceRoot = mkdtempSync(path.join(tmpdir(), "mulmoclaude-roles-test-"));
+process.env.MULMOCLAUDE_WORKSPACE_PATH = workspaceRoot;
+
+const { WORKSPACE_DIRS } = await import("../../server/workspace/paths.js");
+const { parseRoleFile, loadCustomRoles } = await import("../../server/workspace/roles.js");
+
+const rolesDir = path.join(workspaceRoot, WORKSPACE_DIRS.roles);
+
+after(async () => {
+  await rm(workspaceRoot, { recursive: true, force: true });
+});
+
+const VALID_ROLE = {
+  id: "reviewer",
+  name: "Reviewer",
+  icon: "star",
+  prompt: "You review things.",
+  availablePlugins: ["presentHTML"],
+};
+
+const SCHEMA_INVALID = '{ "id": "test", "name": "Test" }'; // icon / prompt / availablePlugins absent — the issue's repro
+
+const roleOf = (outcome: ReturnType<typeof parseRoleFile>) => ("role" in outcome ? outcome.role : undefined);
+const problemOf = (outcome: ReturnType<typeof parseRoleFile>) => ("problem" in outcome ? outcome.problem : undefined);
+
+describe("parseRoleFile", () => {
+  it("returns the role for a valid file", () => {
+    assert.deepEqual(roleOf(parseRoleFile("reviewer.json", JSON.stringify(VALID_ROLE))), VALID_ROLE);
+  });
+
+  it("reports an empty file as empty, not as a schema failure", () => {
+    const problem = problemOf(parseRoleFile("blank.json", ""));
+    assert.match(problem?.message ?? "", /empty/);
+    assert.equal(problem?.data.fileName, "blank.json");
+  });
+
+  it("treats a whitespace-only file as empty", () => {
+    assert.match(problemOf(parseRoleFile("blank.json", "\n  \t\n"))?.message ?? "", /empty/);
+  });
+
+  it("reports a JSON syntax error with the parser's own message", () => {
+    const problem = problemOf(parseRoleFile("trailing.json", '{ "id": "a", "name": "A", }'));
+    assert.match(problem?.message ?? "", /not valid JSON/);
+    assert.equal(problem?.data.fileName, "trailing.json");
+    assert.match(String(problem?.data.error), /JSON/);
+  });
+
+  it("names every missing field for the repro in the issue", () => {
+    const problem = problemOf(parseRoleFile("test.json", SCHEMA_INVALID));
+    assert.match(problem?.message ?? "", /role schema/);
+    const issues = String(problem?.data.issues);
+    ["icon", "prompt", "availablePlugins"].forEach((field) => assert.match(issues, new RegExp(field), `missing ${field} in: ${issues}`));
+  });
+
+  it("reports the path of a nested type error down to the element", () => {
+    const broken = { ...VALID_ROLE, queries: ["ok", 42] };
+    const issues = String(problemOf(parseRoleFile("reviewer.json", JSON.stringify(broken)))?.data.issues);
+    assert.match(issues, /queries\.1/, issues);
+  });
+
+  it("unwraps a union issue so a bare string in availablePlugins says what was expected", () => {
+    const broken = { ...VALID_ROLE, availablePlugins: "presentHTML" };
+    const issues = String(problemOf(parseRoleFile("reviewer.json", JSON.stringify(broken)))?.data.issues);
+    assert.match(issues, /availablePlugins:.*expected array, received string/, issues);
+  });
+
+  it("reports a top-level non-object as a root issue", () => {
+    const issues = String(problemOf(parseRoleFile("array.json", "[]"))?.data.issues);
+    assert.match(issues, /\(root\)/, issues);
+  });
+});
+
+// warn goes to stderr; capturing it is how test_logBackgroundError.ts asserts on
+// log output without wiring DI into the logger.
+function captureStderr<T>(func: () => T): { result: T; out: string } {
+  const chunks: string[] = [];
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    return { result: func(), out: chunks.join("") };
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+}
+
+describe("loadCustomRoles diagnostics", () => {
+  beforeEach(async () => {
+    await rm(rolesDir, { recursive: true, force: true });
+    await mkdir(rolesDir, { recursive: true });
+  });
+
+  const place = (fileName: string, content: string) => writeFile(path.join(rolesDir, fileName), content, "utf-8");
+
+  it("warns about each unloadable file by name while still returning the good ones", async () => {
+    await place("reviewer.json", JSON.stringify(VALID_ROLE));
+    await place("test.json", SCHEMA_INVALID);
+    await place("trailing.json", '{ "id": "t", }');
+    await place("blank.json", "");
+    await place("notes.md", "# not a role");
+    await place(".DS_Store", "");
+
+    const { result, out } = captureStderr(() => loadCustomRoles());
+
+    assert.deepEqual(
+      result.map((role) => role.id),
+      ["reviewer"],
+    );
+    assert.match(out, /test\.json/);
+    assert.match(out, /role schema/);
+    assert.match(out, /trailing\.json/);
+    assert.match(out, /not valid JSON/);
+    assert.match(out, /blank\.json/);
+    assert.match(out, /empty/);
+    assert.match(out, /notes\.md/);
+    assert.ok(!out.includes("DS_Store"), `dotfiles must not be reported: ${out}`);
+    assert.ok(!out.includes("reviewer.json"), `the loadable role must not be reported: ${out}`);
+  });
+
+  it("says nothing when every file loads", async () => {
+    await place("reviewer.json", JSON.stringify(VALID_ROLE));
+
+    const { result, out } = captureStderr(() => loadCustomRoles());
+
+    assert.equal(result.length, 1);
+    assert.equal(out, "");
+  });
+
+  it("keeps warning on every load, so a user who starts reading the log later still sees why", async () => {
+    await place("test.json", SCHEMA_INVALID);
+
+    const first = captureStderr(() => loadCustomRoles());
+    const second = captureStderr(() => loadCustomRoles());
+
+    assert.match(first.out, /test\.json/);
+    assert.match(second.out, /test\.json/);
+  });
+});

--- a/test/roles/test_role_file_diagnostics.ts
+++ b/test/roles/test_role_file_diagnostics.ts
@@ -7,7 +7,7 @@
 import { describe, it, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync } from "node:fs";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -135,12 +135,55 @@ describe("loadCustomRoles diagnostics", () => {
     assert.ok(!out.includes("reviewer.json"), `the loadable role must not be reported: ${out}`);
   });
 
+  it("names an entry it could not read at all, and still loads the rest", async () => {
+    await place("reviewer.json", JSON.stringify(VALID_ROLE));
+    await mkdir(path.join(rolesDir, "backup.json")); // a directory readdir lists but read cannot open
+
+    const { result, out } = captureStderr(() => loadCustomRoles());
+
+    assert.deepEqual(
+      result.map((role) => role.id),
+      ["reviewer"],
+    );
+    // The errno differs by platform (EISDIR / EPERM), so assert only on what we say.
+    assert.match(out, /could not be read/);
+    assert.match(out, /backup\.json/);
+  });
+
+  // A dangling symlink is the one deterministic way to make readdir and read
+  // disagree — deleting the file first would just drop it from the listing.
+  it("reports a file that vanished between listing and read", { skip: process.platform === "win32" }, async () => {
+    await symlink(path.join(rolesDir, "gone.json"), path.join(rolesDir, "ghost.json"));
+
+    const { result, out } = captureStderr(() => loadCustomRoles());
+
+    assert.equal(result.length, 0);
+    assert.match(out, /disappeared while loading/);
+    assert.match(out, /ghost\.json/);
+  });
+
   it("says nothing when every file loads", async () => {
     await place("reviewer.json", JSON.stringify(VALID_ROLE));
 
     const { result, out } = captureStderr(() => loadCustomRoles());
 
     assert.equal(result.length, 1);
+    assert.equal(out, "");
+  });
+
+  it("says nothing for an empty roles directory", () => {
+    const { result, out } = captureStderr(() => loadCustomRoles());
+
+    assert.deepEqual(result, []);
+    assert.equal(out, "");
+  });
+
+  it("says nothing when the roles directory does not exist — a fresh install must be quiet", async () => {
+    await rm(rolesDir, { recursive: true, force: true });
+
+    const { result, out } = captureStderr(() => loadCustomRoles());
+
+    assert.deepEqual(result, []);
     assert.equal(out, "");
   });
 


### PR DESCRIPTION
## Summary

手で置いた `config/roles/<id>.json` が不備を含むとき、`loadCustomRoles()` の `catch { return []; }` が **JSON 構文エラー / スキーマ検証失敗 / 読み取り失敗 / 空ファイル** をすべて「無かったこと」に潰していた。role が一覧から消えるだけで理由がどこにも出ないので、利用者は拡張子・パス・スキーマのどれが違うのか切り分けられなかった。

握り潰し自体（壊れた1件で一覧全体を落とさない）は**意図として妥当なので維持**し、握り潰したことを `log.warn("roles", …)` に記録する。

実際に出るようになったログ（issue の再現 + `.md` 誤配置 + ディレクトリの3ケースを `getRole()` 経路で実行した実出力）:

```
WARN [roles] role file could not be read, skipping fileName=backup.json error="Error: EISDIR: illegal operation on a directory, read"
WARN [roles] role file does not match the role schema, skipping fileName=test.json issues="icon: Invalid input: expected string, received undefined; prompt: Invalid input: expected string, received undefined; availablePlugins: Invalid input"
WARN [roles] ignoring entries that are not .json files — a custom role must be <id>.json dir=config/roles ignored=designer.md
```

## Items to Confirm / Review

1. **警告の抑制（dedup）を入れていない** — `getRole()` はエージェントのリクエスト毎に呼ばれるので、壊れたファイルがある間は警告がリクエスト毎に出ます。「初回だけ」に絞る実装も検討しましたが**入れませんでした**: 利用者の動線は「role が出ない → ログを見る」で、初回だけだとログを見始めた時点で既に流れ終わっていて**元のバグ（何も出ない）と区別がつかない**。設定を直せば止まる警告なので量は問題に見合っている、という判断です。ここは異論があれば従います。
2. **`.json` 以外の警告で dotfile を除外している** — `.DS_Store` を毎回警告するのはノイズなので、`collection/server/discovery.ts` と同じ `startsWith(".")` 除外にしました。サブディレクトリは除外していないので `config/roles/backup/` は「`.json` ではない」として警告に出ます。
3. **union issue の展開** — `availablePlugins` は `z.union([...])` なので zod 自身のメッセージは `Invalid input` だけになります。分岐側 (`errors`) のメッセージを括弧で補って `availablePlugins: Invalid input (expected array, received string)` にしました（`"availablePlugins": "presentHTML"` と書いた場合の最頻ケース）。`RoleSchema` 自体は触っていません。
4. **`@mulmoclaude/core` 1.10.0 → 1.10.1 と range 13 箇所の掃き** — `assets/helps/error-recovery.md` を変更したので CLAUDE.md の規約に従って bump しました。launcher の**自身の** `version` は触っていません（`check:launcher-sync` は OK）。**npm への publish は本 PR に含めていません** — `/publish` の仕事なので、consumer の次のリリース前に必要です。
5. **JSON parse エラー文字列** — V8 のメッセージはファイル内容の断片を含むことがあります（`Unexpected token 'x', "xyz" is not valid JSON`）。role ファイルの中身は persona 文なので許容と判断しましたが、気になるなら truncate します。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2649 fix

追加の判断（会話中に確認したもの）:

- `packages/core/assets/helps/error-recovery.md` にも「手で置いた role が一覧に出ない」節を追加する。`@mulmoclaude/core` の version bump と consumer の range 更新も込みで行う。

## 実装

計画: [`plans/fix-2649-role-load-diagnostics.md`](plans/fix-2649-role-load-diagnostics.md)

### `server/workspace/roles.ts`

読み取り（I/O）と解釈（純粋）を分離した。

| 関数 | 役割 |
|---|---|
| `parseRoleFile(fileName, raw)` (export, 純粋) | `{ role }` か `{ problem }` を返す。**空 → JSON 構文 → スキーマ** の順に判定するので、出る理由が実際の失敗原因と1対1に対応する。テストは env も一時ディレクトリも不要 |
| `readRoleText(fileName)` | `readTextUnderSync` の `string \| null` と throw を `{ text }` / `{ problem }` に畳む。`null` は ENOENT のみ（`workspace-io` の契約）で readdir が直前に挙げた名前なので「走査中に消えた」として報告 |
| `loadCustomRoles()` | outcome を集め、problem を warn、role を返す |

`RoleFileProblem` は `{ message, data }` で持つので、ログ整形は呼び出し側 1 箇所だけ。純粋関数側は「何が起きたか」の組み立てに専念する。

zod の `issues` は生の配列だとテキストシンクで JSON の壁になるので `path: message` を `; ` で連結した1行に畳む（`summarizeRoleIssues`）。

`RoleSchema.parse` → `safeParse` に変えたが受け入れ条件は同一（transform 込みの `.data` を返す）。

### ドキュメント

- `docs/extension-mechanisms.md` § 3.6 Role — #2652 が入れた「無言で握り潰される」記述を実際の挙動に差し替え。
- `packages/core/assets/helps/error-recovery.md` — 既存の `[collections-registry] registry config entry rejected` 節と同じ形で、5 種の warn を列挙し「どれなのかを推測せず利用者にその行を訊く」よう指示。

## テスト

`test/roles/test_role_file_diagnostics.ts` — 11 件、すべて green。

純粋関数 `parseRoleFile`:
- 妥当な role / 空 / 空白のみ / 末尾カンマ
- issue の再現ケース（`{"id","name"}` のみ → `icon`・`prompt`・`availablePlugins` が理由に出る）
- ネストした型エラーの path (`queries.1`) / union issue の展開 / トップレベル非オブジェクト → `(root)`

統合（一時ワークスペース + `captureStderr`、`test/utils/test_logBackgroundError.ts` と同じ手）:
- 壊れたファイルの**名前と理由**が warn に出る／**隣の妥当な role はそのまま読める**（握り潰しの意図は保つ）
- `.md` は警告に出る / `.DS_Store` は出ない / 妥当なファイルだけなら**何も出ない**
- 2 回続けて load しても両方警告が出る（1 の判断の pin）

`config/roles` が無い場合・空の場合に警告が出ないことは実コード経路で別途確認済み（新規インストールが無音であること）。

ゲート: `yarn format` / `yarn lint`（0 errors、warning 46 は既存ベースライン）/ `yarn typecheck` / `yarn build` / `yarn test`（8574 件, fail 0）/ `yarn check:launcher-sync`。

Closes #2649

work in mulmoclaude4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add diagnostics and logging for custom role file loading failures while keeping broken files from affecting the overall role list.

New Features:
- Log warnings for unreadable, invalid, or otherwise unusable custom role files in config/roles, including filename and reason.
- Warn when non-.json entries are present in the roles directory while still ignoring them in the loader.

Enhancements:
- Refactor role loading to separate file I/O from pure role parsing with structured problem reporting.
- Summarize Zod schema validation issues into concise, field-oriented messages for logs.
- Document the behavior and troubleshooting steps when hand-placed roles do not appear, including the new [roles] warnings.
- Add a plan document describing the role load diagnostics change.

Build:
- Bump @mulmoclaude/core from 1.10.0 to 1.10.1 and update dependent packages to use the new range.

Tests:
- Add unit and integration tests covering role file diagnostics, logging behavior, and handling of valid, empty, malformed, schema-invalid, and non-.json role files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom role loading diagnostics: non-loadable role `.json` files are skipped with clearer server warnings including filename and specific failure reason.
  * Better handling for unexpected directory entries (e.g., non-role entries) with consolidated warnings.
  * Roles that can be parsed successfully still load even when other role files are problematic.

* **Documentation**
  * Updated extension and troubleshooting docs with the new warning cases and clarified supported file expectations.

* **Tests**
  * Expanded stderr diagnostic coverage for missing, empty, non-readable, and disappearing role files.

* **Maintenance**
  * Bumped `@mulmoclaude/core` to `1.10.1` across packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->