### PR TITLE
docs: 実装と食い違うコメント3件を修正 (#2651)

### DIFF
--- a/e2e-live/fixtures/isolated-dev-server.ts
+++ b/e2e-live/fixtures/isolated-dev-server.ts
@@ -18,12 +18,12 @@
 // `NODE_ENV=production` switches the express server into static-host
 // mode so it serves `index.html` itself (with the `<meta
 // name="mulmoclaude-auth">` token substituted). The Vite dev server
-// is bypassed entirely — Vite's proxy is hardcoded to 3001 and its
-// token file path is hardcoded to `~/mulmoclaude/.session-token`,
-// neither of which respects the per-test overrides this helper sets.
+// is bypassed entirely: each test then owns a single process it fully
+// controls, and live tests exercise the same static serving path the
+// published package uses.
 //
-// `MULMOCLAUDE_CLIENT_DIR` (added in this PR) tells the production
-// path where to read `index.html` from. Without it, the server reads
+// `MULMOCLAUDE_CLIENT_DIR` tells the production path where to read
+// `index.html` from. Without it, the server reads
 // `<__dirname>/../client/`, which only exists in the published
 // package layout (`prepare-dist.js` copies `dist/client/` there).
 // From a source checkout we point at `<repo-root>/dist/client/`.

--- a/plans/docs-2651-fix-stale-comments.md
+++ b/plans/docs-2651-fix-stale-comments.md
@@ -1,12 +1,12 @@
 # 実装に追随していないコメント 3 件を直す
 
-Issue: #2651 · 関連: #1570 (token path を env 対応にした PR), #2653 (proxy port 固定を解消する open PR)
+Issue: #2651 · 関連: #1570 (token path を env 対応にした PR), #2653 (proxy port 固定を解消した PR, `d1f126900` でマージ済み)
 
 ## 直すもの
 
 ### 1. `e2e-live/fixtures/isolated-dev-server.ts:21-23` — バイパスの理由が 2 件とも古い
 
-```
+```text
 // is bypassed entirely — Vite's proxy is hardcoded to 3001 and its
 // token file path is hardcoded to `~/mulmoclaude/.session-token`,
 ```
@@ -15,11 +15,13 @@ Issue: #2651 · 関連: #1570 (token path を env 対応にした PR), #2653 (pr
   `MULMOCLAUDE_WORKSPACE_PATH` を process.env と `.env` の両方から読む。
   `e2e-live/tests/fresh-boot.spec.ts:71` が「`.session-token` は temp workspace 側に書かれる」を
   実際に assert している。
-- **proxy 3001 固定**: 現時点では事実だが、**#2653 (open, MERGEABLE, CI 全緑) が解消する**。
-  同 PR は `isolated-dev-server.ts` を触らないので、issue の言うとおり「理由 = proxy port 固定」に
-  絞ると、#2653 マージ時に**この issue と同じ陳腐化が再発する**。
+- **proxy 3001 固定**: **#2653 (`d1f126900`) で既に解消済み** — `vite.config.ts` は
+  `scripts/lib/devServerPort.ts` の `resolveServerPort()` からポートを取る。この plan を書いた
+  時点では #2653 は open だったが、本 PR を開く前にマージされたので、コメントを
+  「理由 = proxy port 固定」に絞る書き方は**もう事実ではない**。
 
-→ 理由を「Vite の現在の実装上の制約」ではなく、**#2653 の前後どちらでも真な事実**で書く:
+→ 理由を「Vite の現在の実装上の制約」ではなく、**#2653 の前後どちらでも真な事実**で書く
+   (陳腐化しない理由を選ぶ):
    テストごとに単一プロセスで完結すること、live test が published package と同じ
    static serving path を通ること。これは #2653 が `docs/developer.md` に書いた説明と同じ立場。
 

--- a/plans/docs-2651-fix-stale-comments.md
+++ b/plans/docs-2651-fix-stale-comments.md
@@ -1,0 +1,56 @@
+# 実装に追随していないコメント 3 件を直す
+
+Issue: #2651 · 関連: #1570 (token path を env 対応にした PR), #2653 (proxy port 固定を解消する open PR)
+
+## 直すもの
+
+### 1. `e2e-live/fixtures/isolated-dev-server.ts:21-23` — バイパスの理由が 2 件とも古い
+
+```
+// is bypassed entirely — Vite's proxy is hardcoded to 3001 and its
+// token file path is hardcoded to `~/mulmoclaude/.session-token`,
+```
+
+- **token path**: #1570 で解消済み。`vite.config.ts:19-30` の `resolveWorkspacePath()` が
+  `MULMOCLAUDE_WORKSPACE_PATH` を process.env と `.env` の両方から読む。
+  `e2e-live/tests/fresh-boot.spec.ts:71` が「`.session-token` は temp workspace 側に書かれる」を
+  実際に assert している。
+- **proxy 3001 固定**: 現時点では事実だが、**#2653 (open, MERGEABLE, CI 全緑) が解消する**。
+  同 PR は `isolated-dev-server.ts` を触らないので、issue の言うとおり「理由 = proxy port 固定」に
+  絞ると、#2653 マージ時に**この issue と同じ陳腐化が再発する**。
+
+→ 理由を「Vite の現在の実装上の制約」ではなく、**#2653 の前後どちらでも真な事実**で書く:
+   テストごとに単一プロセスで完結すること、live test が published package と同じ
+   static serving path を通ること。これは #2653 が `docs/developer.md` に書いた説明と同じ立場。
+
+### 2. `e2e-live/fixtures/isolated-dev-server.ts:25` — `(added in this PR)`
+
+指している PR は既にマージ済み (L-FRESH-BOOT)。読んだ人に「未導入の機能」と誤解させる。
+CLAUDE.md の「コメントに現在のタスク・修正・呼び出し元を書かない」にも反する。
+→ 削除し、env var が何をするかの説明だけ残す。
+
+### 3. `server/agent/prompt.ts:105` — `workspacePath="/workspace"` が誤り (issue コメントの追加分)
+
+コンテナ内の workspace は `/home/node/mulmoclaude`:
+
+- `server/agent/config.ts:20` — `export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";`
+- `server/agent/index.ts:132` — `workspacePath: useDocker ? CONTAINER_WORKSPACE_PATH : workspacePath`
+
+`/workspace` はリポジトリ内でこのコメントにしか存在しない (同じ誤りが `docs/wiki-html-render-surfaces.md`
+にもあったが #2652 で修正済み)。コメントの**主張自体**は正しく、誤っているのは例示したパスだけ。
+→ 定数名を指す形に直す。
+
+## やらないこと
+
+- **e2e-live を Vite 経路に戻す**。#2653 後は技術的に可能になるが、live test の配線変更は別リスク
+  (#2653 自身も対象外としている)。今回はコメントを事実に合わせるだけ。
+- コメント内の他の issue 番号 (`#1070` / `#1029` / `#1432` / `#1280`) の整理。既存の履歴マーカーで、
+  本 issue の範囲外。
+
+## 検証
+
+コード変更なし (コメントのみ) なので、根拠は grep と既存 test の assert に置く:
+
+- `.session-token` が override 側に書かれること → `e2e-live/tests/fresh-boot.spec.ts:71` の既存 assert
+- `/workspace` が他に無いこと → `grep -rn '"/workspace"'` が prompt.ts の 1 件のみ
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`

--- a/server/agent/prompt.ts
+++ b/server/agent/prompt.ts
@@ -102,8 +102,9 @@ export function buildMemoryContext(snapshot: MemorySnapshot, workspacePath: stri
 // #1029 PR-B (one fact per `<type>_<slug>.md`). Both this section
 // and `buildMemoryContext` derive format from the same `snapshot`
 // so write rules and read context stay consistent — including in
-// Docker runs where `workspacePath="/workspace"` doesn't match the
-// host path the snapshot was loaded from (Codex review on #1280).
+// Docker runs where `workspacePath` is `CONTAINER_WORKSPACE_PATH`,
+// which doesn't match the host path the snapshot was loaded from
+// (Codex review on #1280).
 export function buildMemoryManagementSection(snapshot: MemorySnapshot): string {
   return snapshot.format === "topic" ? TOPIC_MEMORY_MANAGEMENT : ATOMIC_MEMORY_MANAGEMENT;
 }


### PR DESCRIPTION
## Summary

実装に追随していないコメント **3 件**を修正します。コードは 1 行も変えていません。

| 箇所 | 何が誤りだったか |
|---|---|
| `e2e-live/fixtures/isolated-dev-server.ts:21-23` | 「Vite の token file path が `~/mulmoclaude/.session-token` 固定」— **#1570 で解消済み** |
| `e2e-live/fixtures/isolated-dev-server.ts:25` | `MULMOCLAUDE_CLIENT_DIR` を `(added in this PR)` と書いたまま — その PR は既にマージ済み |
| `server/agent/prompt.ts:105` | `workspacePath="/workspace"` — コンテナ内の workspace は `/home/node/mulmoclaude` |

いずれも実害はありませんが、`isolated-dev-server.ts` は「なぜ Vite をバイパスするのか」を説明する唯一の場所なので、この制約を見直そうとする人が最初に読んで誤った前提を持ちます。

## Items to Confirm / Review

1. **「proxy が 3001 固定」を理由として書きませんでした（本 PR で一番の判断）。** issue の「期待する修正」は *バイパスの理由を proxy port 固定の1点に絞る* ですが、**その 1 点は #2653 (`d1f126900`) で既に解消されています** — マージは 01:10:58Z で、本 PR の最初の commit (01:15:19Z) の 5 分前でした。#2653 は `isolated-dev-server.ts` を触らないので、issue の文言どおりに「理由 = proxy port 固定」に絞ると、**絞った先が既に偽**になります。そこで #2653 の前後どちらでも真な事実 — 単一プロセスで完結すること、live test が published package と同じ static serving path を通ること — に書き換えました。これは #2653 が `docs/developer.md` に書いた立場（バイパスは制約ではなく意図的な選択）と同じです。**当初は「#2653 マージ後も陳腐化しない書き方」として選びましたが、実際には #2653 が先にマージされていたため、この書き方が現在の main の事実そのものです — 落とした事実はありません。** (`vite.config.ts` は `scripts/lib/devServerPort.ts` の `resolveServerPort()` / `serverOrigins()` から port を取り、残る `3001` の言及は過去形の履歴コメントと既定値のみ。)
2. **`prompt.ts` はパスだけ直し、主張は残しました。** 「host パスと一致しないので snapshot 由来の format を使う」というコメントの主張自体は正しく、誤っていたのは例示したパスだけなので、定数名 `CONTAINER_WORKSPACE_PATH` を指す形にとどめています。
3. **既存コメント内の issue 番号は整理していません。** `(Codex review on #1280)` / `#1070` / `#1029` / `#1432` は CLAUDE.md 的には削除対象ですが、既存の履歴マーカーであり本 issue の範囲外と判断しました。**まとめて掃くべきなら別 PR で。**
4. **issue の URL は `#26511` でしたが、そのような issue は存在しません**（`Could not resolve to an issue`）。桁が 1 つ多いだけと見て **#2651** として扱っています。

## User Prompt

> つぎ。 https://github.com/receptron/mulmoclaude/issues/26511

方式の確認に対する選択:

> #2653 後も真な理由で書く

## 根拠（3 件すべて実装を読んで確認）

**1. token path は #1570 で解消済み** — `vite.config.ts:19-30` の `resolveWorkspacePath()` が `MULMOCLAUDE_WORKSPACE_PATH` を `process.env` と `.env` の両方から読み、`TOKEN_FILE_PATH` をそこから組みます。自分の推論だけに頼らず**既存 test の assert**も外部の根拠として確認しました — `e2e-live/tests/fresh-boot.spec.ts:71` が「`.session-token` は temp workspace 側に書かれる」を実際に検証しています。`docs/CHANGELOG.md:987` にも記録あり。

**2. `(added in this PR)`** — 指している PR は L-FRESH-BOOT でマージ済み（`plans/feat-e2e-live.md:428`）。CLAUDE.md の「コメントに現在のタスク・修正・呼び出し元を書かない」にも反します。

**3. `/workspace` は誤り** — `server/agent/config.ts:20` が `CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude"`、`config.ts:815` がその値に bind mount、`server/agent/index.ts:132` が `useDocker ? CONTAINER_WORKSPACE_PATH : workspacePath` を渡します。`grep -rn '"/workspace"'` の結果はこのコメント 1 件のみで、リポジトリ内に他の出現はありません（同じ誤りが `docs/wiki-html-render-surfaces.md` にもありましたが #2652 で修正済み）。

周辺に同種の記述が残っていないか、`hardcode` / `session-token` で全体を掃いた上で、この 3 件だけが該当であることを確認しています。

## 検証

コメントのみの変更なので、`git diff` から `//` 行を除外すると**空になる**ことを確認した上で、ゲートは全て実行しています。

| ゲート | 結果 |
|---|---|
| `yarn format` | 自分の 2 ファイル以外を触らないことを `git status` で確認 |
| `yarn lint` | **0 errors / 51 warnings**。`git stash` で clean main を測り **51 warnings と一致** — warning を増やしていないことを実測 |
| `yarn typecheck` | 通過 |
| `yarn build` | 通過 |
| `yarn test` | 通過 |

切り分けた 2 件の failure（いずれも本変更とは無関係）:

- **初回 typecheck が `server/remoteHost/index.ts` で 3 件失敗** — `@mulmoclaude/core/remote-host/server` に `createPresenceProbe` / `startResilientHostRunner` が無いというエラー。**ローカルの core dist が古かった**ためで（main が 106 コミット進み core 1.10.0 の外側リング移管が入っていた）、`yarn build` 後は解消。
- **初回 `yarn test` で `test/agent/test_mcp_smoke.ts` が 15s timeout** — **単体で再実行すると 1.15s で通る**ため、全体 282s の並走による負荷依存の flake。再実行した全体は緑。

## この PR に含まれないもの

- **e2e-live を Vite 経路に戻すこと。** #2653 が入った今は技術的に可能ですが（#2653 自身も「戻せる可能性はある」としています）、live test の配線変更は独立したリスクです。
- **#2653 待ち。** 既にマージ済みで、本 PR は #2653 の前後どちらでも正しくなるよう書いてあるため、順序の依存はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Update stale inline comments to match current behavior and configuration without changing runtime behavior.

Documentation:
- Clarify why the Vite dev server is bypassed in e2e live tests in a way that remains accurate before and after proxy changes.
- Update documentation comments about MULMOCLAUDE_CLIENT_DIR and container workspace paths to reflect current environment variables and constants.

Chores:
- Add a planning note documenting the rationale and scope for fixing three outdated comments tied to issue #2651.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated technical comments describing how the isolated production-like dev server is booted for end-to-end testing, including static asset serving and token substitution behavior.
  * Added a documentation plan to remove and correct stale or misleading notes related to prior testing and workspace-path guidance.
  * Corrected an example workspace path to match the configured container workspace location and clarified the host-vs-snapshot mismatch explanation.
  * Removed outdated “added in this PR” wording where it was no longer accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
