### PR TITLE
feat: support Apple container sandbox runtime

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@ npx mulmoclaude@latest
   - macOS: `brew install ffmpeg`
   - Linux: `apt install ffmpeg`
   - Windows: `winget install Gyan.FFmpeg`
-- **Docker Desktop** (任意・推奨) — サンドボックスモードを有効化します。下記 [Docker Desktop のインストール](#docker-desktop-のインストール) を参照してください
+- **Apple container または Docker Desktop** (任意・推奨) — サンドボックスモードを有効化します。macOS 26 以降では [Apple container](https://github.com/apple/container)、その他の環境では Docker Desktop を利用できます
 
 > **UI 言語**: 英語、日本語、中国語、韓国語、スペイン語、ポルトガル語 (ブラジル)、フランス語、ドイツ語の 8 言語に対応しています。デフォルトではブラウザ / OS の言語設定から自動判定されます。明示的に指定する場合は `.env` に `VITE_LOCALE=ja` を設定してください (日本語辞書 `src/lang/ja.ts` が使用されます)。ロケールはビルド / 開発時に決定されるため、変更後は `yarn dev` を再起動してください。文字列の追加方法は [`docs/developer.md`](docs/developer.md#i18n-vue-i18n) を参照してください。
 
@@ -165,9 +165,9 @@ Gemini API には個人利用に十分な無料枠があります。
 
 MulmoClaude は AI バックエンドとして Claude Code を使用しており、Bash を含むツールにアクセスできます — つまりマシン上のファイルを読み書きできます。
 
-**Docker を使わない場合**、Claude はあなたのユーザーアカウントが到達できるすべてのファイル (ワークスペースの外に保存されている SSH キーや資格情報を含む) にアクセスできます。個人のローカル利用では許容できますが、理解しておく価値があります。
+**コンテナランタイムを使わない場合**、Claude はあなたのユーザーアカウントが到達できるすべてのファイル (ワークスペースの外に保存されている SSH キーや資格情報を含む) にアクセスできます。個人のローカル利用では許容できますが、理解しておく価値があります。
 
-**Docker Desktop がインストールされている場合**、MulmoClaude は自動的に Claude をサンドボックス化されたコンテナ内で実行します。マウントされるのはワークスペースと Claude 自身の設定 (`~/.claude`) のみ — 残りのファイルシステムは Claude からは見えません。設定は不要です: アプリは起動時に Docker を検出し、自動的にサンドボックスを有効化します。
+**Apple container または Docker Desktop が利用できる場合**、MulmoClaude は自動的に Claude をサンドボックス化されたコンテナ内で実行します。マウントされるのはワークスペースと Claude 自身の設定 (`~/.claude`) のみ — 残りのファイルシステムは Claude からは見えません。macOS の自動選択では Apple container を優先し、Docker にフォールバックします。
 
 **Bearer トークン認証**: すべての `/api/*` エンドポイントは `Authorization: Bearer <token>` ヘッダーを要求します。トークンはサーバー起動時に自動生成され、`<meta>` タグ経由でブラウザに注入されます — 手動設定は不要です。唯一の例外は `/api/files/*` です (レンダリングされたドキュメント内の `<img>` タグはヘッダーを付与できないため免除)。詳細は [`docs/developer.md`](docs/developer.md#auth-bearer-token-on-api) を参照してください。
 
@@ -178,7 +178,16 @@ MulmoClaude は AI バックエンドとして Claude Code を使用しており
 
 完全な仕様とセキュリティ上の注意: [`docs/sandbox-credentials.md`](docs/sandbox-credentials.md)。
 
-### Docker Desktop のインストール
+### コンテナランタイムのインストール
+
+macOS 26 以降では Apple container を利用できます:
+
+1. [apple/container の Releases](https://github.com/apple/container/releases) から署名済みインストーラーを入手してインストール
+2. `container system start` を実行
+3. `container system status` が `running` を返すことを確認
+4. MulmoClaude を再起動
+
+Docker Desktop を使う場合:
 
 1. [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/) から Docker Desktop をダウンロード
 2. **macOS**: `.dmg` を開いて Docker を Applications にドラッグし、Applications から起動
@@ -187,11 +196,11 @@ MulmoClaude は AI バックエンドとして Claude Code を使用しており
 5. Docker Desktop の起動が完了するのを待つ — メニューバー / システムトレイのクジラアイコンが (アニメーションではなく) 安定した状態になるはず
 6. MulmoClaude を再起動 — Docker を検出し、初回起動時にサンドボックスイメージをビルドします (一度だけ、約 1 分かかります)
 
-macOS で Docker サンドボックスがアクティブなとき、資格情報は自動的に管理されます — アプリは起動時にシステム Keychain から OAuth トークンを抽出し、401 エラー時には更新します。手動操作は不要です。
+macOS でコンテナサンドボックスがアクティブなとき、資格情報は自動的に管理されます — アプリは起動時にシステム Keychain から OAuth トークンを抽出し、401 エラー時には更新します。手動操作は不要です。
 
-Docker がインストールされていない場合、アプリは警告バナーを表示しますが、サンドボックスなしで引き続き動作します。
+どちらのランタイムも利用できない場合、アプリは警告バナーを表示しますが、サンドボックスなしで引き続き動作します。両方がインストールされている場合や明示的に選びたい場合は、`.env` に `SANDBOX_RUNTIME=apple-container` または `SANDBOX_RUNTIME=docker` を設定します。
 
-> **デバッグモード**: Docker がインストールされている場合でもサンドボックスなしで実行するには、サーバー起動前に `DISABLE_SANDBOX=1` を設定するか、CLI フラグ `--disable-sandbox`（`yarn dev --disable-sandbox` / `npx mulmoclaude --disable-sandbox`、Windows PowerShell でも可）を渡してください。
+> **デバッグモード**: コンテナランタイムが利用できる場合でもサンドボックスなしで実行するには、サーバー起動前に `DISABLE_SANDBOX=1` を設定するか、CLI フラグ `--disable-sandbox`（`yarn dev --disable-sandbox` / `npx mulmoclaude --disable-sandbox`、Windows PowerShell でも可）を渡してください。
 >
 > **ツール呼び出し履歴**: `PERSIST_TOOL_CALLS=1` を設定すると、`tool_result` と並んで `tool_call` イベント(`args` 含む)もセッション jsonl に記録されます。`args` は大きくなりがちで、ディスクに残したくないペイロード(画像 base64、MulmoScript JSON など)を含む可能性があるためデフォルトでは off。ページ更新やサーバー再起動後のデバッグに有用です。詳細は [issue #1096](https://github.com/receptron/mulmoclaude/issues/1096) を参照。
 
@@ -240,16 +249,16 @@ MulmoClaude はすでにお持ちの **Claude Code skills** を一覧表示し�
 
 フェーズ 0 では両スコープとも読み取り専用です — 編集はファイルシステム上で行います。将来のリリースで MulmoClaude 自身が project スコープの skill を作成 / 編集できるようになります。
 
-### Docker サンドボックス vs 非 Docker
+### コンテナサンドボックス vs サンドボックスなし
 
-MulmoClaude のデフォルトの **Docker サンドボックスモード** は安全性のため Claude Code をコンテナ内に隔離します ([セキュリティ](#security) を参照)。skill の動作は 2 つのモード間で異なります:
+MulmoClaude のデフォルトの **コンテナサンドボックスモード**（Apple container または Docker）は、安全性のため Claude Code を隔離します ([セキュリティ](#security) を参照)。skill の動作は 2 つのモード間で異なります:
 
-| モード                               | User skills (`~/.claude/skills/`) | Project skills (`~/mulmoclaude/.claude/skills/`) | 組み込み CLI skills (`/simplify`, `/update-config`, …) |
-| ------------------------------------ | --------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
-| **Non-Docker** (`DISABLE_SANDBOX=1`) | ✅ すべて動作                     | ✅                                               | ✅                                                     |
-| **Docker sandbox** (デフォルト)      | ⚠️ 下記の注意事項を参照           | ✅ ワークスペースボリューム経由でマウント        | ✅                                                     |
+| モード                                          | User skills (`~/.claude/skills/`) | Project skills (`~/mulmoclaude/.claude/skills/`) | 組み込み CLI skills (`/simplify`, `/update-config`, …) |
+| ----------------------------------------------- | --------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| **サンドボックスなし** (`DISABLE_SANDBOX=1`)   | ✅ すべて動作                     | ✅                                               | ✅                                                     |
+| **コンテナサンドボックス**（利用可能時の既定） | ⚠️ 下記の注意事項を参照           | ✅ ワークスペースボリューム経由でマウント        | ✅                                                     |
 
-**Docker 上の注意事項 — サンドボックス内でユーザー skill が機能しないことがある理由:**
+**コンテナ上の注意事項 — サンドボックス内でユーザー skill が機能しないことがある理由:**
 
 - **シンボリックリンクされた `~/.claude/skills/`** — `~/.claude/skills` (またはサブエントリ) が `~/.claude/` の外を指すシンボリックリンクの場合 (例: `~/.claude/skills → ~/ss/dotfiles/claude/skills`)、そのリンクのターゲットはコンテナ内に存在しません。リンクは **デッドリンク** として現れ、Claude Code は組み込み skill のみにフォールバックします。
 - **サンドボックスイメージ内の古い Claude CLI** — `Dockerfile.sandbox` はイメージビルド時に CLI バージョンを固定します。そのバージョンがホスト CLI より古い場合 (例: イメージ内 2.1.96 vs ホスト上 2.1.105)、ユーザー skill の発見動作が異なることがあります。
@@ -447,7 +456,7 @@ mcp__claude_ai_Google_Calendar
 JSON を手で編集することなく外部 MCP サーバーを追加できます。2 つのタイプをサポートしています:
 
 - **HTTP** — リモートサーバー (例: `https://example.com/mcp`)。どのモードでも動作します。Docker では `localhost` / `127.0.0.1` URL は自動的に `host.docker.internal` に書き換えられます。
-- **Stdio** — ローカルサブプロセス (例: `npx` の MCP)。安全のため `npx` / `node` / `tsx` に制限されます。Docker サンドボックスが **オフ** のときはホスト上で動きます。**オン** のときは stdio エントリは **既定で破棄されます** (最小構成のサンドボックスイメージでは任意のランタイムを動かせないため) — 代わりに `"hostExecInDocker": true` を設定すると、そのサーバーをホスト上で `stdio ↔ HTTP` ゲートウェイ越しに動かせます。[docs/mcp-sandbox.ja.md](docs/mcp-sandbox.ja.md) を参照。
+- **Stdio** — ローカルサブプロセス (例: `npx` の MCP)。安全のため `npx` / `node` / `tsx` に制限されます。コンテナサンドボックスが **オフ** のときはホスト上で動きます。**オン** のときは stdio エントリは **既定で破棄されます** (最小構成のサンドボックスイメージでは任意のランタイムを動かせないため) — 代わりに、従来名の設定 `"hostExecInDocker": true` を使うと、そのサーバーをホスト上で `stdio ↔ HTTP` ゲートウェイ越しに動かせます。[docs/mcp-sandbox.ja.md](docs/mcp-sandbox.ja.md) を参照。
 
 stdio サーバーへの認証情報は **`env`** マップで渡します (`"env": { "IMAP_PASS": "…" }`)。値はリテラルで `mcp.json` に保存されます (mode `0600` ですが **平文** — vault ではなくファイル権限による保護)。`hostExecInDocker` の opt-in や `env` がプロセスに届く仕組みなど詳細は [docs/mcp-sandbox.ja.md](docs/mcp-sandbox.ja.md) にあります。
 
@@ -502,7 +511,7 @@ MCP ファイルは Claude CLI の標準フォーマットを使用するため�
 - Stdio `command` は `npx`、`node`、`tsx` に制限されます。
 - 検証に失敗したエントリは読み込み時に暗黙的に破棄されます (警告がログに記録されます)。残りのファイルは引き続き適用されます。
 
-**例** — 認証情報を持ち、Docker サンドボックス下でも動く stdio サーバー (例: IMAP MCP):
+**例** — 認証情報を持ち、コンテナサンドボックス下でも動く stdio サーバー (例: IMAP MCP):
 
 ```json
 {
@@ -542,9 +551,9 @@ MCP ファイルは Claude CLI の標準フォーマットを使用するため�
 | テキスト (.txt, .csv, .json, .md, .xml, .html, .yaml) | デコードされた UTF-8 テキスト               | なし                                |
 | DOCX                                                  | 抽出されたプレーンテキスト                  | `mammoth` (npm)                     |
 | XLSX                                                  | シートごとの CSV                            | `xlsx` (npm)                        |
-| PPTX                                                  | PDF に変換                                  | LibreOffice (Docker サンドボックス) |
+| PPTX                                                  | PDF に変換                                  | LibreOffice (コンテナサンドボックス) |
 
-PPTX 変換は Docker サンドボックスイメージ内 (`libreoffice --headless`) で実行されます。Docker がない場合、代わりに PDF または画像へのエクスポートを提案するメッセージが表示されます。添付ファイルの最大サイズは 30 MB です。
+PPTX 変換は選択されたコンテナサンドボックスイメージ内 (`libreoffice --headless`) で実行されます。対応ランタイムもネイティブ LibreOffice もない場合、代わりに PDF または画像へのエクスポートを提案するメッセージが表示されます。添付ファイルの最大サイズは 30 MB です。
 
 ## キャンバスのビューモード
 
@@ -681,7 +690,7 @@ Claude はチャット会話からユーザーの永続的な事実を自動的�
 | -------------------------------------------------- | ----------------------------------------------------------------- |
 | [Developer Guide](docs/developer.md)               | 環境変数、スクリプト、ワークスペース構造、CI                      |
 | [Bridge Protocol](docs/bridge-protocol.md)         | 新しいメッセージングブリッジを書くためのワイヤーレベル仕様        |
-| [Sandbox Credentials](docs/sandbox-credentials.md) | Docker サンドボックスの資格情報フォワーディング (SSH、GitHub CLI) |
+| [Sandbox Credentials](docs/sandbox-credentials.md) | コンテナサンドボックスの資格情報フォワーディング (SSH、GitHub CLI) |
 | [Logging](docs/logging.md)                         | ログレベル、フォーマット、ファイルローテーション                  |
 | [Troubleshooting](docs/troubleshooting.md)         | セットアップの問題 — UI が崩れる、`dist/*` の 404、Windows/OneDrive、再起動後の `401`、起動時の警告 |
 | [CHANGELOG](docs/CHANGELOG.md)                     | リリース履歴                                                      |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Re-run the command after upgrading: the shortcut carries its own copy of the lau
   - macOS: `brew install ffmpeg`
   - Linux: `apt install ffmpeg`
   - Windows: `winget install Gyan.FFmpeg`
-- **Docker Desktop** (optional but recommended) — enables sandbox mode. See [Installing Docker Desktop](#installing-docker-desktop) below
+- **Apple container or Docker Desktop** (optional but recommended) — enables sandbox mode. Use [Apple container](https://github.com/apple/container) on macOS 26+, or Docker Desktop on other supported systems
 - **whisper.cpp** (optional, macOS only) — enables local voice input (dictate chat messages). See [Optional: Local Voice Input](#optional-local-voice-input-macos) below
 
 > **UI language**: 8 locales are supported (English, Japanese, Simplified Chinese, Korean, Spanish, Brazilian Portuguese, French, German). The default is auto-detected from the browser / OS language. To set it explicitly, put `VITE_LOCALE=ja` (or `zh` / `ko` / `es` / `pt-BR` / `fr` / `de`) in `.env`. Locale is picked at build/dev time; restart `yarn dev` after changing it. See [`docs/developer.md`](docs/developer.md#i18n-vue-i18n) for how to add strings.
@@ -182,9 +182,9 @@ The Gemini API has a free tier that is sufficient for personal use.
 
 MulmoClaude uses Claude Code as its AI backend, which has access to tools including Bash — meaning it can read and write files on your machine.
 
-**Without Docker**, Claude can access any file your user account can reach, including SSH keys and credentials stored outside your workspace. This is acceptable for personal local use, but worth understanding.
+**Without a container runtime**, Claude can access any file your user account can reach, including SSH keys and credentials stored outside your workspace. This is acceptable for personal local use, but worth understanding.
 
-**With Docker Desktop installed**, MulmoClaude automatically runs Claude inside a sandboxed container. Only your workspace and Claude's own config (`~/.claude`) are mounted — the rest of your filesystem is invisible to Claude. No configuration is required: the app detects Docker on startup and enables the sandbox automatically.
+**With Apple container or Docker Desktop available**, MulmoClaude automatically runs Claude inside a sandboxed container. Only your workspace and Claude's own config (`~/.claude`) are mounted — the rest of your filesystem is invisible to Claude. Auto-selection prefers Apple container on macOS and falls back to Docker.
 
 **Bearer token auth**: every `/api/*` endpoint requires an `Authorization: Bearer <token>` header. The token is auto-generated on server startup and injected into the browser via a `<meta>` tag — no manual setup. The only exception is `/api/files/*` (exempt because `<img>` tags in rendered documents can't attach headers). See [`docs/developer.md`](docs/developer.md#auth-bearer-token-on-api) for details.
 
@@ -195,7 +195,16 @@ MulmoClaude uses Claude Code as its AI backend, which has access to tools includ
 
 Full contract and security notes: [`docs/sandbox-credentials.md`](docs/sandbox-credentials.md).
 
-### Installing Docker Desktop
+### Installing a container runtime
+
+On macOS 26 or later, install Apple container:
+
+1. Download the signed installer from [apple/container Releases](https://github.com/apple/container/releases)
+2. Run `container system start`
+3. Confirm that `container system status` reports `running`
+4. Restart MulmoClaude
+
+To use Docker Desktop:
 
 1. Download Docker Desktop from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/)
 2. **macOS**: open the `.dmg` and drag Docker to Applications, then launch it from Applications
@@ -204,11 +213,13 @@ Full contract and security notes: [`docs/sandbox-credentials.md`](docs/sandbox-c
 5. Wait for Docker Desktop to finish starting — the whale icon in the menu bar / system tray should turn steady (not animated)
 6. Restart MulmoClaude — it will detect Docker and build the sandbox image on first run (one-time, takes about a minute)
 
-When the Docker sandbox is active on macOS, credentials are managed automatically — the app extracts OAuth tokens from the system Keychain at startup and refreshes them on 401 errors, so no manual steps are needed.
+If both runtimes are installed, or you want an explicit choice, set `SANDBOX_RUNTIME=apple-container` or `SANDBOX_RUNTIME=docker` in `.env`.
 
-If Docker is not installed, the app shows a warning banner and continues to work without sandboxing.
+When the container sandbox is active on macOS, credentials are managed automatically — the app extracts OAuth tokens from the system Keychain at startup and refreshes them on 401 errors, so no manual steps are needed.
 
-> **Debug mode**: To run without the sandbox even when Docker is installed, set `DISABLE_SANDBOX=1` before starting the server, or pass the `--disable-sandbox` CLI flag (`yarn dev --disable-sandbox` / `npx mulmoclaude --disable-sandbox`) — handy on Windows PowerShell where `VAR=value cmd` doesn't work inline.
+If no supported container runtime is available, the app shows a warning banner and continues to work without sandboxing.
+
+> **Debug mode**: To run without the sandbox even when a container runtime is installed, set `DISABLE_SANDBOX=1` before starting the server, or pass the `--disable-sandbox` CLI flag (`yarn dev --disable-sandbox` / `npx mulmoclaude --disable-sandbox`) — handy on Windows PowerShell where `VAR=value cmd` doesn't work inline.
 >
 > **Tool-call history**: Set `PERSIST_TOOL_CALLS=1` to also record `tool_call` events (with their `args`) in the per-session jsonl alongside `tool_result`. Off by default because `args` can be large and may carry payload bytes you didn't expect to land on disk; useful for debugging after a page refresh or server restart. See [issue #1096](https://github.com/receptron/mulmoclaude/issues/1096).
 
@@ -260,16 +271,16 @@ No extra typing, no copy-pasting SKILL.md bodies — the Run button is a one-cli
 
 Both scopes are read-only in phase 0 — edits happen on the file system. A future release will let MulmoClaude itself create / edit project-scope skills.
 
-### Docker sandbox vs non-Docker
+### Container sandbox vs no sandbox
 
-MulmoClaude's default **Docker sandbox mode** isolates Claude Code in a container for safety (see [Security](#security)). Skill behaviour differs between the two modes:
+MulmoClaude's default **container sandbox mode** (Apple container or Docker) isolates Claude Code for safety (see [Security](#security)). Skill behaviour differs between the two modes:
 
-| Mode                                 | User skills (`~/.claude/skills/`) | Project skills (`~/mulmoclaude/.claude/skills/`) | Built-in CLI skills (`/simplify`, `/update-config`, …) |
-| ------------------------------------ | --------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
-| **Non-Docker** (`DISABLE_SANDBOX=1`) | ✅ All work                       | ✅                                               | ✅                                                     |
-| **Docker sandbox** (default)         | ⚠️ See caveats below              | ✅ Mounted via workspace volume                  | ✅                                                     |
+| Mode                                     | User skills (`~/.claude/skills/`) | Project skills (`~/mulmoclaude/.claude/skills/`) | Built-in CLI skills (`/simplify`, `/update-config`, …) |
+| ---------------------------------------- | --------------------------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| **No sandbox** (`DISABLE_SANDBOX=1`)     | ✅ All work                       | ✅                                               | ✅                                                     |
+| **Container sandbox** (default when available) | ⚠️ See caveats below       | ✅ Mounted via workspace volume                  | ✅                                                     |
 
-**Docker caveats — why user skills sometimes don't work in the sandbox:**
+**Container caveats — why user skills sometimes don't work in the sandbox:**
 
 - **Symlinked `~/.claude/skills/`** — if your `~/.claude/skills` (or any sub-entry) is a symlink pointing outside `~/.claude/` (for example `~/.claude/skills → ~/ss/dotfiles/claude/skills`), the symlink's target is not present inside the container. The link appears as **dangling**, and Claude Code falls back to only the built-in skills.
 - **Older Claude CLI inside the sandbox image** — `Dockerfile.sandbox` pins the CLI version at image build time. If that version is behind your host CLI (e.g. 2.1.96 in the image vs 2.1.105 on the host), user-skill discovery may behave differently.
@@ -499,8 +510,8 @@ First, run `claude mcp` once in a terminal and complete the OAuth flow for each 
 
 Add external MCP servers without hand-editing JSON. Two types are supported:
 
-- **HTTP** — remote servers (e.g. `https://example.com/mcp`). Works in every mode; in Docker, `localhost` / `127.0.0.1` URLs are rewritten to `host.docker.internal` automatically.
-- **Stdio** — local subprocess (e.g. an `npx` MCP), restricted to `npx` / `node` / `tsx` for safety. Runs on the host when the Docker sandbox is **off**. When the sandbox is **on**, stdio entries are **dropped by default** (the minimal sandbox image can't host arbitrary runtimes) — set `"hostExecInDocker": true` to run one on the host behind a `stdio ↔ HTTP` gateway instead. See [docs/mcp-sandbox.md](docs/mcp-sandbox.md).
+- **HTTP** — remote servers (e.g. `https://example.com/mcp`). Works in every mode; in a container sandbox, `localhost` / `127.0.0.1` URLs are rewritten to `host.docker.internal` automatically.
+- **Stdio** — local subprocess (e.g. an `npx` MCP), restricted to `npx` / `node` / `tsx` for safety. Runs on the host when the container sandbox is **off**. When the sandbox is **on**, stdio entries are **dropped by default** (the minimal sandbox image can't host arbitrary runtimes) — set the legacy-named `"hostExecInDocker": true` option to run one on the host behind a `stdio ↔ HTTP` gateway instead. See [docs/mcp-sandbox.md](docs/mcp-sandbox.md).
 
 Pass credentials to a stdio server with an **`env`** map (`"env": { "IMAP_PASS": "…" }`). Values are literal and stored in `mcp.json` (mode `0600`, but **plaintext** — file-permission protection, not a vault). Full details, including the `hostExecInDocker` opt-in and how `env` reaches the process, are in [docs/mcp-sandbox.md](docs/mcp-sandbox.md).
 
@@ -555,7 +566,7 @@ Constraints the server enforces when loading the file:
 - Stdio `command` is restricted to `npx`, `node`, or `tsx`.
 - Entries that fail validation are silently dropped on load (a warning is logged); the rest of the file still applies.
 
-**Example** — a credentialed stdio server that also runs under the Docker sandbox (e.g. an IMAP MCP):
+**Example** — a credentialed stdio server that also runs under the container sandbox (e.g. an IMAP MCP):
 
 ```json
 {
@@ -595,9 +606,9 @@ Paste (Ctrl+V / Cmd+V) or drag-and-drop files into the chat input to send them t
 | Text (.txt, .csv, .json, .md, .xml, .html, .yaml) | Decoded UTF-8 text              | None                         |
 | DOCX                                              | Extracted plain text            | `mammoth` (npm)              |
 | XLSX                                              | CSV per sheet                   | `xlsx` (npm)                 |
-| PPTX                                              | Converted to PDF                | LibreOffice (Docker sandbox) |
+| PPTX                                              | Converted to PDF                | LibreOffice (container sandbox) |
 
-PPTX conversion runs inside the Docker sandbox image (`libreoffice --headless`). Without Docker, a message suggests exporting to PDF or images instead. Maximum attachment size is 30 MB.
+PPTX conversion runs inside the selected container sandbox image (`libreoffice --headless`). Without a supported runtime or native LibreOffice, a message suggests exporting to PDF or images instead. Maximum attachment size is 30 MB.
 
 ## Canvas view modes
 
@@ -753,7 +764,7 @@ Full documentation lives in [`docs/`](docs/README.md). Here are the key entry po
 | [Built-in Plugin Development](docs/developer.md#plugin-development)                  | Author a plugin co-located in `src/plugins/<name>/` — META shape, `useRuntime<E>()` API, mounting paths, sync invariants                             |
 | [Runtime-Loaded Plugins](docs/plugin-runtime.md)                                     | Author a plugin distributed as an npm package and installed into a workspace at runtime                                                              |
 | [Bridge Protocol](docs/bridge-protocol.md)                                           | Wire-level spec for writing new messaging bridges                                                                                                    |
-| [Sandbox Credentials](docs/sandbox-credentials.md)                                   | Docker sandbox credential forwarding (SSH, GitHub CLI)                                                                                               |
+| [Sandbox Credentials](docs/sandbox-credentials.md)                                   | Container sandbox credential forwarding (SSH, GitHub CLI)                                                                                            |
 | [Logging](docs/logging.md)                                                           | Log levels, formats, file rotation                                                                                                                   |
 | [Troubleshooting](docs/troubleshooting.md)                                           | Setup problems — broken-looking UI, `dist/*` 404s, Windows/OneDrive, `401` after restart, boot warnings                                               |
 | [CHANGELOG](docs/CHANGELOG.md)                                                       | Release history                                                                                                                                      |

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -72,7 +72,8 @@ All env vars are **optional unless flagged "required"**. The server reads them a
 | -------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PORT`                                 | `3001`                         | Express listen port (`server/index.ts:47`).                                                                                                                                                                                                                                                       |
 | `NODE_ENV`                             | unset / `production`           | When `production`, Express serves the built client from `dist/client` and falls back to `index.html` for SPA history-mode routing. Auto-set by tooling — you rarely set this manually.                                                                                                            |
-| `DISABLE_SANDBOX`                      | unset                          | Set to `1` to bypass the Docker sandbox even when Docker is available. The agent runs `claude` directly on the host. Useful for debugging without container rebuild overhead (`server/system/docker.ts:49`, `server/index.ts:147`).                                                               |
+| `DISABLE_SANDBOX`                      | unset                          | Set to `1` to bypass the container sandbox even when a runtime is available. The agent runs `claude` directly on the host. |
+| `SANDBOX_RUNTIME`                      | `auto`                         | `auto`, `apple-container`, or `docker`. Auto mode prefers Apple container on macOS and falls back to Docker; other platforms use Docker. |
 | `SANDBOX_SSH_AGENT_FORWARD`            | unset                          | Set to `1` to forward the host's `$SSH_AUTH_SOCK` into the sandbox. Private keys stay on the host; the agent signs on the container's behalf. Full contract: [docs/sandbox-credentials.md](sandbox-credentials.md).                                                                               |
 | `SANDBOX_MOUNT_CONFIGS`                | unset                          | CSV of allowlisted config mounts (currently `gh`, `gitconfig`). Each entry resolves to a fixed host→container path pair defined in `server/agent/sandboxMounts.ts`; unknown names are logged and ignored.                                                                                         |
 | `SESSIONS_LIST_WINDOW_DAYS`            | `90`                           | Caps how far back the sidebar looks when listing chat sessions (`server/api/routes/sessions.ts`). Set to `0` to disable the cutoff entirely. Introduced in PR #203 to keep `GET /api/sessions` cheap on long-lived workspaces; anything older is still on disk, just hidden from the list.        |
@@ -132,7 +133,7 @@ Set by `npx mulmoclaude` on the server it spawns. Auto-computed like the contain
 
 ### Container-only env (auto-set)
 
-You never set these by hand; the server constructs them when spawning Claude inside the Docker sandbox (`server/agent/config.ts` and `server/agent/mcp-server.ts`). They're listed here so log lines / failures involving them are decodable.
+You never set these by hand; the server constructs them when spawning Claude inside the container sandbox (`server/agent/config.ts` and `server/agent/mcp-server.ts`). They're listed here so log lines / failures involving them are decodable.
 
 | Variable                         | Set by         | Purpose                                                                                                                                                                                                                                                                       |
 | -------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -190,11 +191,11 @@ You never set these by hand; the server constructs them when spawning Claude ins
 | `npx tsx --test test/agent/test_mcp_smoke.ts`        | MCP server subprocess smoke test (CI).                                                                                                |
 | `npx tsx --test test/agent/test_mcp_docker_smoke.ts` | MCP server Docker smoke test (local only, requires `mulmoclaude-sandbox` image). Run after changing package exports or Docker mounts. |
 
-### Docker sandbox
+### Container sandbox
 
 | Script                | Notes                                                                                                                     |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `yarn sandbox:remove` | `docker rmi mulmoclaude-sandbox` — rebuild on next run. Reuses the cached layers, so it does NOT refresh the bundled Claude CLI; add `docker builder prune -a -f` for that (#2202). |
+| `yarn sandbox:remove` | Removes `mulmoclaude-sandbox` from the selected Apple container or Docker runtime; it is rebuilt on next run. |
 | `yarn sandbox:login`  | macOS only. Exports the Claude CLI keychain entry to `~/.claude/.credentials.json` so the sandbox container can reuse it. |
 | `yarn sandbox:logout` | Removes that file.                                                                                                        |
 
@@ -472,13 +473,18 @@ Set `VITE_LOCALE` in `.env` and restart `yarn dev`. Supported values: `en`, `ja`
 
 ---
 
-## Docker sandbox (`Dockerfile.sandbox`)
+## Container sandbox (`Dockerfile.sandbox`)
 
-Minimal image: `node:22-slim` + `@anthropic-ai/claude-code` + `tsx`. Built lazily on first Docker-mode run; rebuilt when `Dockerfile.sandbox` changes (image SHA pinned in code). `yarn sandbox:remove` forces a rebuild.
+Minimal image: `node:22-slim` + `@anthropic-ai/claude-code` + `tsx`. Built lazily by Apple container or Docker on the first sandboxed run; rebuilt when `Dockerfile.sandbox` changes (image SHA pinned in code). `yarn sandbox:remove` forces a rebuild.
 
 The CLI is installed unpinned, so the image freezes whatever was latest at build time, and no upstream CLI release retriggers a rebuild (the Dockerfile SHA is unchanged). `yarn sandbox:remove` alone does not refresh it either — the rebuild reuses the cached `npm install -g` layer. To move the CLI, check what the image actually has and clear the build cache too:
 
 ```bash
+# Apple container
+container run --rm --entrypoint claude mulmoclaude-sandbox --version
+SANDBOX_RUNTIME=apple-container yarn sandbox:remove
+
+# Docker
 docker run --rm --entrypoint claude mulmoclaude-sandbox --version
 yarn sandbox:remove && docker builder prune -a -f
 ```
@@ -514,9 +520,9 @@ Users can paste or drop files into the chat input. The server converts non-nativ
 | text/\* (.txt, .csv, .json, .md, .xml, .html, .yaml) | base64 → UTF-8       | `type: "text"`     | —               | All                              |
 | DOCX                                                 | mammoth → plain text | `type: "text"`     | `mammoth` (npm) | All                              |
 | XLSX                                                 | xlsx → CSV per sheet | `type: "text"`     | `xlsx` (npm)    | All                              |
-| PPTX                                                 | libreoffice → PDF    | `type: "document"` | LibreOffice     | Docker sandbox or native install |
+| PPTX                                                 | libreoffice → PDF    | `type: "document"` | LibreOffice     | Container sandbox or native install |
 
-**PPTX conversion path**: the server process runs on the host (macOS/Linux), but LibreOffice lives inside the Docker sandbox image. `convertPptxToPdf()` in `server/agent/attachmentConverter.ts` tries native `libreoffice` first; if not found, falls back to `docker run --rm -v tmpdir:/data mulmoclaude-sandbox libreoffice --headless --convert-to pdf`. Without either, the user sees a text hint suggesting PDF or image export.
+**PPTX conversion path**: the server process runs on the host (macOS/Linux), but LibreOffice also lives inside the sandbox image. `convertPptxToPdf()` in `server/agent/attachmentConverter.ts` tries native `libreoffice` first; if not found, falls back to the selected Apple container or Docker runtime. Without either, the user sees a text hint suggesting PDF or image export.
 
 **Adding a new type**: add MIME handling in `server/agent/attachmentConverter.ts` (conversion logic), update `isConvertibleMime()` + `CONVERTIBLE_MIME_TYPES`, and add the MIME to `ACCEPTED_MIME_EXACT` in `src/App.vue`.
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "test:e2e:live:plugin-dispatch": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=plugin-dispatch playwright test --config e2e-live/playwright.config.ts plugin-dispatch.spec.ts",
     "test:e2e:live:journey-llm": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=journey-llm playwright test --config e2e-live/playwright.config.ts journey-llm.spec.ts",
     "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts && yarn workspaces run test",
-    "sandbox:remove": "docker rmi mulmoclaude-sandbox",
+    "sandbox:remove": "node scripts/remove-sandbox-image.mjs",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",
     "sandbox:logout": "rm -f ~/.claude/.credentials.json && echo 'Credentials file removed'",
     "package": "node scripts/package.mjs"

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -79,7 +79,7 @@ Your data lives in `~/mulmoclaude/` (created on first run): conversations, memor
 
 ## Sandbox (recommended)
 
-When Docker is available, the Claude Code agent runs inside a credential-free Docker sandbox so it can't see anything outside the workspace. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and the launcher detects it automatically.
+When Apple container (macOS 26+) or Docker is available, the Claude Code agent runs inside a credential-free container sandbox so it can't see anything outside the workspace. Auto mode prefers Apple container on macOS and falls back to Docker.
 
 The sandbox is off by default for credentials (`gh auth`, SSH keys). Opt into the host's credential flow for the agent's `git` / `gh` commands:
 

--- a/packages/mulmoclaude/bin/prepare-dist.js
+++ b/packages/mulmoclaude/bin/prepare-dist.js
@@ -95,8 +95,8 @@ cpSync(join(rootDir, "src"), join(pkgDir, "src"), {
 console.log("✓ shared src/");
 
 // ── Sandbox build context ───────────────────────────────────
-// `server/system/docker.ts` builds the sandbox image via `docker build
-// -f Dockerfile.sandbox .` with cwd = pkgDir. The Dockerfile in turn
+// `server/system/docker.ts` builds the sandbox image through Apple
+// container or Docker with cwd = pkgDir. The Dockerfile in turn
 // `COPY`s `sandbox-entrypoint.sh`, so both files must sit at pkgDir
 // or sandbox mode silently falls back to unrestricted execution.
 

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -19,8 +19,8 @@ import os from "node:os";
 import net from "node:net";
 import { fileURLToPath } from "node:url";
 
-// Sandbox build context: `server/system/docker.ts` runs `docker build
-// -f Dockerfile.sandbox .` from the launcher's package dir, so both
+// Sandbox build context: `server/system/docker.ts` runs Apple container
+// or Docker from the launcher's package dir, so both
 // the Dockerfile and the entrypoint script it COPYs must be inside
 // the published tarball. 0.5.2 silently shipped without them and
 // sandbox mode fell back to unrestricted execution at runtime — this

--- a/scripts/remove-sandbox-image.mjs
+++ b/scripts/remove-sandbox-image.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+
+const preference = process.env.SANDBOX_RUNTIME;
+
+function live(command, args) {
+  return spawnSync(command, args, { stdio: "ignore" }).status === 0;
+}
+
+let runtime = preference;
+if (runtime !== "docker" && runtime !== "apple-container") {
+  runtime = process.platform === "darwin" && live("container", ["system", "status"]) ? "apple-container" : "docker";
+}
+
+const command = runtime === "apple-container" ? "container" : "docker";
+const args = runtime === "apple-container" ? ["image", "delete", "--force", "mulmoclaude-sandbox"] : ["rmi", "mulmoclaude-sandbox"];
+const result = spawnSync(command, args, { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`Failed to run ${command}: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/server/agent/attachmentConverter.ts
+++ b/server/agent/attachmentConverter.ts
@@ -21,6 +21,7 @@ import { tmpdir } from "os";
 import { promisify } from "util";
 import type { Attachment } from "@mulmobridge/protocol";
 import { SUBPROCESS_PROBE_TIMEOUT_MS, SUBPROCESS_WORK_TIMEOUT_MS } from "../utils/time.js";
+import { detectLiveSandboxRuntime, sandboxRuntimeCommand, type SandboxRuntime } from "../system/docker.js";
 import { errorMessage } from "../utils/errors.js";
 
 const execFileAsync = promisify(execFile);
@@ -106,14 +107,16 @@ async function tryNativeLibreOffice(): Promise<boolean> {
   }
 }
 
-async function tryDockerLibreOffice(): Promise<boolean> {
+async function tryContainerLibreOffice(): Promise<SandboxRuntime | null> {
+  const runtime = await detectLiveSandboxRuntime();
+  if (!runtime) return null;
   try {
-    await execFileAsync("docker", ["image", "inspect", "mulmoclaude-sandbox"], {
+    await execFileAsync(sandboxRuntimeCommand(runtime), ["image", "inspect", "mulmoclaude-sandbox"], {
       timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
     });
-    return true;
+    return runtime;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -128,10 +131,12 @@ export async function convertPptxToPdf(data: string): Promise<Buffer | null> {
     if (await tryNativeLibreOffice()) {
       // Host has libreoffice installed natively
       await execFileAsync("libreoffice", ["--headless", "--convert-to", "pdf", "--outdir", tmpDir, inputPath], { timeout: SUBPROCESS_WORK_TIMEOUT_MS });
-    } else if (await tryDockerLibreOffice()) {
-      // Use the sandbox Docker image for conversion
+    } else {
+      const runtime = await tryContainerLibreOffice();
+      if (!runtime) return null;
+      // Use the sandbox container image for conversion
       await execFileAsync(
-        "docker",
+        sandboxRuntimeCommand(runtime),
         [
           "run",
           "--rm",
@@ -148,8 +153,6 @@ export async function convertPptxToPdf(data: string): Promise<Buffer | null> {
         ],
         { timeout: SUBPROCESS_WORK_TIMEOUT_MS },
       );
-    } else {
-      return null;
     }
 
     return await readFile(outputPath);

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -1,11 +1,11 @@
 // Claude Code backend: spawns the `claude` CLI as a subprocess (or
-// inside the mulmoclaude-sandbox Docker image) and translates its
+// inside the mulmoclaude-sandbox container image) and translates its
 // stream-json output into portable AgentEvents.
 //
 // This file is the single seam between the orchestrator in
 // server/agent/index.ts (which is backend-agnostic) and the Claude
 // CLI specifics. Pure helpers it depends on (CLI arg construction,
-// Docker arg construction, stream parsing) stay in their existing
+// container arg construction, stream parsing) stay in their existing
 // home so the existing test suite under test/agent/ keeps working
 // unchanged.
 
@@ -24,10 +24,17 @@ import { EVENT_TYPES } from "../../../src/types/events.js";
 import { env } from "../../system/env.js";
 import { claudeBinPath } from "../../utils/claudeBin.js";
 import type { AgentInput, LLMBackend } from "./types.js";
+import { sandboxRuntimeCommand, type SandboxRuntime } from "../../system/docker.js";
 
 type ClaudeProc = ChildProcessByStdio<Writable, Readable, Readable>;
 
-function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[], chatSessionId: string): ClaudeProc {
+function spawnClaude(
+  useDocker: boolean,
+  workspacePath: string,
+  cliArgs: string[],
+  chatSessionId: string,
+  sandboxRuntime: SandboxRuntime = "docker",
+): ClaudeProc {
   if (!useDocker) {
     // MULMOCLAUDE_CHAT_SESSION_ID is the chat-session id our wiki-history
     // PostToolUse hook needs to publish a `page-edit` toolResult back to
@@ -44,6 +51,7 @@ function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[
     sshAllowedHosts: env.sandboxSshAllowedHosts,
     configMountNames: env.sandboxMountConfigs,
     sshAuthSock: process.env.SSH_AUTH_SOCK,
+    sandboxRuntime,
   });
   const refDirArgs = referenceDirMountArgs(getCachedReferenceDirs());
   const dockerArgs = buildDockerSpawnArgs({
@@ -54,9 +62,10 @@ function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[
     gid: process.getgid?.() ?? 1000,
     platform: process.platform,
     sandboxAuthArgs: [...sandboxAuth.args, ...refDirArgs],
-    sshAgentForward: env.sandboxSshAgentForward,
+    sshAgentForward: sandboxAuth.sshAgentForwarded,
+    sandboxRuntime,
   });
-  return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
+  return spawn(sandboxRuntimeCommand(sandboxRuntime), dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
 }
 
 // Track MCP tool usage to detect silent MCP server failures.
@@ -253,9 +262,9 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
   // "install with npm install -g …" hint.
   let proc: ReturnType<typeof spawnClaude>;
   try {
-    proc = spawnClaude(input.useDocker, input.workspacePath, cliArgs, input.sessionId);
+    proc = spawnClaude(input.useDocker, input.workspacePath, cliArgs, input.sessionId, input.sandboxRuntime);
   } catch (err) {
-    const target = input.useDocker ? "docker" : "claude";
+    const target = input.useDocker ? sandboxRuntimeCommand(input.sandboxRuntime ?? "docker") : "claude";
     const message = err instanceof Error ? err.message : String(err);
     log.error("agent", `failed to resolve ${target} binary`, { error: message });
     yield {
@@ -277,7 +286,7 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
       proc.once("error", (err) => reject(err));
     });
   } catch (err) {
-    const target = input.useDocker ? "docker" : "claude";
+    const target = input.useDocker ? sandboxRuntimeCommand(input.sandboxRuntime ?? "docker") : "claude";
     const message = errorMessage(err);
     log.error("agent", `failed to spawn ${target}`, { error: message });
     yield {

--- a/server/agent/backend/types.ts
+++ b/server/agent/backend/types.ts
@@ -9,6 +9,7 @@
 
 import type { Attachment } from "@mulmobridge/protocol";
 import type { Role } from "../../../src/config/roles.js";
+import type { SandboxRuntime } from "../../system/docker.js";
 import type { EffortLevel } from "../../system/config.js";
 import type { AgentEvent } from "../stream.js";
 
@@ -47,6 +48,9 @@ export interface AgentInput {
   /** Whether the orchestrator detected a usable Docker sandbox.
    *  Backends that don't sandbox can ignore. */
   useDocker: boolean;
+  /** Concrete runtime when useDocker is true. Older tests/callers may
+   *  omit it and the Claude backend defaults to Docker. */
+  sandboxRuntime?: SandboxRuntime;
 }
 
 export interface BackendCapabilities {

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -9,6 +9,7 @@ import { getActiveToolDescriptors } from "./activeTools.js";
 import type { EffortLevel, McpServerSpec } from "../system/config.js";
 import { startStdioHttpShim, type ShimHandle } from "./stdioHttpShim.js";
 import { claudeConfigDir, claudeConfigJson } from "../utils/claudeConfigPath.js";
+import type { SandboxRuntime } from "../system/docker.js";
 import { getCurrentToken } from "../api/auth/token.js";
 import { ONE_MINUTE_MS } from "../utils/time.js";
 import type { Attachment } from "@mulmobridge/protocol";
@@ -663,6 +664,9 @@ export interface DockerSpawnArgsParams {
    *  When false (default), `--user uid:gid --cap-drop ALL` with zero
    *  capabilities — identical to the pre-#259 security posture. */
   sshAgentForward?: boolean;
+  /** Runtime executing this Dockerfile-compatible image. Defaults to
+   *  Docker for backward-compatible tests and callers. */
+  sandboxRuntime?: SandboxRuntime;
 }
 
 // Every workspace-package dir under `packages/`, matching the root manifest's
@@ -832,8 +836,9 @@ export function buildDockerSpawnArgs(params: DockerSpawnArgsParams): string[] {
     homeDir = homedir(),
     sandboxAuthArgs = [],
     sshAgentForward = false,
+    sandboxRuntime = "docker",
   } = params;
-  const extraHosts: string[] = platform === "linux" ? ["--add-host", "host.docker.internal:host-gateway"] : [];
+  const extraHosts: string[] = sandboxRuntime === "docker" && platform === "linux" ? ["--add-host", "host.docker.internal:host-gateway"] : [];
   // `packages/` ships in the dev monorepo but NOT in the published
   // mulmoclaude package (the `files` whitelist in
   // `packages/mulmoclaude/package.json` excludes it — internal

--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -1,7 +1,7 @@
 import { mkdir, unlink } from "fs/promises";
 import { writeJsonAtomic } from "../utils/files/json.js";
 import { dirname } from "path";
-import { isDockerAvailable } from "../system/docker.js";
+import { resolveSandboxRuntime, type SandboxRuntime } from "../system/docker.js";
 import { refreshCredentials } from "../system/credentials.js";
 import { loadMcpConfig, loadSettings } from "../system/config.js";
 import type { Role } from "../../src/config/roles.js";
@@ -41,7 +41,8 @@ export interface RunAgentInput {
 export async function* runAgent(input: RunAgentInput): AsyncGenerator<AgentEvent> {
   const { role, workspacePath } = input;
   const activePlugins = getActivePlugins(role);
-  const useDocker = await isDockerAvailable();
+  const sandboxRuntime = await resolveSandboxRuntime();
+  const useDocker = sandboxRuntime !== null;
 
   // Per-invocation read so Settings UI changes apply without a server restart.
   const userMcpRaw = loadMcpConfig().mcpServers;
@@ -56,7 +57,7 @@ export async function* runAgent(input: RunAgentInput): AsyncGenerator<AgentEvent
   // tears them down — otherwise host processes / ports leak for the
   // rest of the session.
   try {
-    const prepared = await prepareAgentRun(input, { activePlugins, useDocker, userServers });
+    const prepared = await prepareAgentRun(input, { activePlugins, useDocker, sandboxRuntime, userServers });
     try {
       yield* prepared.backend.runAgent(prepared.agentInput);
     } finally {
@@ -81,6 +82,7 @@ export async function* runAgent(input: RunAgentInput): AsyncGenerator<AgentEvent
 interface AgentRunDeps {
   activePlugins: string[];
   useDocker: boolean;
+  sandboxRuntime: SandboxRuntime | null;
   userServers: Awaited<ReturnType<typeof prepareUserServers>>["servers"];
 }
 
@@ -185,7 +187,7 @@ function buildAgentInput(
   args: { systemPrompt: string; hasMcp: boolean; mcpPaths: McpPaths; mcpServerNames: string[] },
 ): { backend: LLMBackend; agentInput: AgentInput } {
   const { message, role, workspacePath, sessionId, port, claudeSessionId, abortSignal, attachments, userTimezone } = input;
-  const { activePlugins, useDocker, userServers } = deps;
+  const { activePlugins, useDocker, sandboxRuntime, userServers } = deps;
   const { systemPrompt, hasMcp, mcpPaths, mcpServerNames } = args;
 
   // Per-invocation read so allowedTools / MCP-server changes apply without a server restart.
@@ -224,6 +226,7 @@ function buildAgentInput(
     abortSignal,
     userTimezone,
     useDocker,
+    sandboxRuntime: sandboxRuntime ?? undefined,
   };
   return { backend, agentInput };
 }

--- a/server/agent/sandboxMounts.ts
+++ b/server/agent/sandboxMounts.ts
@@ -20,6 +20,7 @@ import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { log } from "../system/logger/index.js";
 import { SUBPROCESS_PROBE_TIMEOUT_MS } from "../utils/time.js";
+import type { SandboxRuntime } from "../system/docker.js";
 
 // ── Config-mount allowlist ──────────────────────────────────────────
 
@@ -166,8 +167,24 @@ export function sshAgentForwardArgs(
   enabled: boolean,
   sshAuthSock: string | undefined,
   platform: typeof process.platform = process.platform,
+  runtime: SandboxRuntime = "docker",
 ): SshAgentForwardResult {
   if (!enabled) return { args: [], skippedReason: null };
+
+  // Apple container has native SSH-agent forwarding. It tracks the
+  // host socket across login sessions and injects SSH_AUTH_SOCK itself.
+  if (runtime === "apple-container") {
+    if (platform !== "darwin") {
+      return { args: [], skippedReason: "Apple container is only available on macOS" };
+    }
+    if (!sshAuthSock || sshAuthSock.length === 0) {
+      return { args: [], skippedReason: "SSH_AUTH_SOCK not set on host" };
+    }
+    if (!existsSync(sshAuthSock)) {
+      return { args: [], skippedReason: `SSH_AUTH_SOCK=${sshAuthSock} not found on host` };
+    }
+    return { args: ["--ssh"], skippedReason: null };
+  }
 
   // macOS + Docker Desktop: use the magic VM-internal socket.
   if (platform === "darwin") {
@@ -203,6 +220,8 @@ export interface ResolvedSandboxAuth {
   args: string[];
   /** Descriptions the caller can log once to show what got mounted. */
   appliedDescriptions: string[];
+  /** True only when the runtime will actually receive an agent socket. */
+  sshAgentForwarded: boolean;
 }
 
 export interface ResolveSandboxAuthParams {
@@ -215,6 +234,7 @@ export interface ResolveSandboxAuthParams {
   configMountNames: readonly string[];
   sshAuthSock?: string;
   home?: string;
+  sandboxRuntime?: SandboxRuntime;
 }
 
 /**
@@ -242,7 +262,7 @@ export function resolveSandboxAuth(params: ResolveSandboxAuthParams): ResolvedSa
     });
   }
 
-  const sshResult = sshAgentForwardArgs(params.sshAgentForward, params.sshAuthSock);
+  const sshResult = sshAgentForwardArgs(params.sshAgentForward, params.sshAuthSock, process.platform, params.sandboxRuntime);
   if (sshResult.skippedReason !== null) {
     log.warn("sandbox", "SSH agent forward requested but skipped", {
       reason: sshResult.skippedReason,
@@ -275,7 +295,7 @@ export function resolveSandboxAuth(params: ResolveSandboxAuthParams): ResolvedSa
     });
   }
 
-  return { args, appliedDescriptions };
+  return { args, appliedDescriptions, sshAgentForwarded: sshResult.args.length > 0 };
 }
 
 // ── GitHub CLI token fallback ──────────────────────────────────────

--- a/server/index.ts
+++ b/server/index.ts
@@ -109,7 +109,7 @@ import { buildDiagnosticsMarkdown } from "./utils/diagnostics/collect.js";
 import { existsSync, readFileSync } from "fs";
 import { makeCachedRealpath, resolveArtifactRequestPath } from "./utils/files/safe.js";
 import { cpus, loadavg } from "os";
-import { isDockerAvailable, ensureSandboxImage } from "./system/docker.js";
+import { resolveSandboxRuntime, ensureSandboxImage } from "./system/docker.js";
 import { maybeRunJournal } from "./workspace/journal/index.js";
 import { backfillAllSessions } from "./workspace/chat-index/index.js";
 import { feedRefreshTaskDef } from "@mulmoclaude/core/feeds/server";
@@ -828,15 +828,15 @@ async function setupSandbox(): Promise<boolean> {
     return false;
   }
   try {
-    const dockerAvailable = await isDockerAvailable();
-    if (!dockerAvailable) {
-      log.info("sandbox", "Docker not found — claude will run unrestricted");
+    const runtime = await resolveSandboxRuntime();
+    if (!runtime) {
+      log.info("sandbox", "No supported container runtime found — claude will run unrestricted");
       return false;
     }
     await ensureCredentialsAvailable();
-    log.info("sandbox", "Docker available — building sandbox image if needed");
-    await ensureSandboxImage();
-    log.info("sandbox", "Sandbox ready");
+    log.info("sandbox", "Container runtime available — building sandbox image if needed", { runtime });
+    await ensureSandboxImage(runtime);
+    log.info("sandbox", "Sandbox ready", { runtime });
     return true;
   } catch (err) {
     log.error("sandbox", "Failed to set up sandbox, running unrestricted", {

--- a/server/prompts/index.ts
+++ b/server/prompts/index.ts
@@ -3,11 +3,10 @@
 // never user-visible, never edited at runtime), so a synchronous read
 // at import time is correct — no async plumbing, no per-request I/O.
 //
-// Content is returned verbatim (NO trimEnd): the source `.md` files
-// are byte-identical to the template literals these replaced, including
-// whether or not they end in a trailing newline. `buildSystemPrompt`
-// must produce a byte-identical system prompt before/after this
-// refactor — see plans/done/refactor-prompts-to-files.md.
+// Most content is returned verbatim. The sandbox block is the one
+// historical inline fragment without a trailing newline; normalize
+// exactly one editor-added LF for that file so buildSystemPrompt keeps
+// its load-bearing separator shape.
 //
 // Path is resolved relative to this module (import.meta.url), NOT
 // process.cwd(), so it resolves under both the dev server and the
@@ -29,7 +28,7 @@ export const ATOMIC_MEMORY_MANAGEMENT = load("memory-management-atomic.md");
 // sandbox-tools.md mirrors the tool set installed by
 // Dockerfile.sandbox — if you add/remove a tool there, update the
 // .md so the prompt-level mention stays in sync with the image.
-export const SANDBOX_TOOLS_HINT = load("sandbox-tools.md");
+export const SANDBOX_TOOLS_HINT = load("sandbox-tools.md").replace(/\n$/, "");
 
 // Static blocks emitted behind a runtime guard (the guard / message
 // wrapping stays in prompt.ts; only the prose lives here). No trailing

--- a/server/prompts/system/sandbox-tools.md
+++ b/server/prompts/system/sandbox-tools.md
@@ -1,6 +1,6 @@
 ## Sandbox Tools
 
-The bash tool runs inside a Docker sandbox. The following tools are guaranteed preinstalled — prefer them over reinventing or searching the filesystem:
+The bash tool runs inside a container sandbox. The following tools are guaranteed preinstalled — prefer them over reinventing or searching the filesystem:
 
 - **Core CLI**: `git`, `gh` (GitHub CLI), `curl`, `jq`, `make`, `sqlite3`, `zip`, `unzip`, `ripgrep` (`rg`)
 - **Data / plotting**: `python3` with `pandas`, `numpy`, `matplotlib`, `requests` preinstalled; `graphviz` (`dot`); `imagemagick` (`convert`)

--- a/server/system/docker.ts
+++ b/server/system/docker.ts
@@ -14,7 +14,10 @@ const IMAGE_NAME = "mulmoclaude-sandbox";
 const DOCKERFILE = "Dockerfile.sandbox";
 const LABEL_KEY = "mulmoclaude.dockerfile.sha256";
 
-let _dockerEnabled: boolean | null = null;
+export type SandboxRuntime = "docker" | "apple-container";
+
+let _runtime: SandboxRuntime | null | undefined;
+let _runtimeProbe: Promise<SandboxRuntime | null> | null = null;
 
 function assertClaudeFiles(): void {
   const claudeDir = claudeConfigDir();
@@ -57,12 +60,63 @@ export async function isDockerLive(): Promise<boolean> {
   }
 }
 
+/** Apple container liveness probe. `system status` only succeeds when
+ *  the CLI and its system service are both usable. */
+export async function isAppleContainerLive(): Promise<boolean> {
+  if (process.platform !== "darwin") return false;
+  try {
+    await execFileAsync("container", ["system", "status"], {
+      timeout: SUBPROCESS_PROBE_TIMEOUT_MS,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runtimeCandidates(): readonly SandboxRuntime[] {
+  if (env.sandboxRuntime === "docker") return ["docker"];
+  if (env.sandboxRuntime === "apple-container") return ["apple-container"];
+  return process.platform === "darwin" ? ["apple-container", "docker"] : ["docker"];
+}
+
+async function probeRuntime(runtime: SandboxRuntime): Promise<boolean> {
+  return runtime === "docker" ? isDockerLive() : isAppleContainerLive();
+}
+
+/** Detect the configured container runtime without checking Claude
+ *  credentials. Used by optional-dependency diagnostics. */
+export async function detectLiveSandboxRuntime(): Promise<SandboxRuntime | null> {
+  for (const runtime of runtimeCandidates()) {
+    if (await probeRuntime(runtime)) return runtime;
+  }
+  return null;
+}
+
+/** Resolve and cache the runtime used for this process. Apple container
+ *  is preferred on macOS in auto mode; Docker remains the fallback and
+ *  the only runtime on other platforms. */
+export async function resolveSandboxRuntime(): Promise<SandboxRuntime | null> {
+  if (env.disableSandbox) return null;
+  if (_runtime !== undefined) return _runtime;
+  if (_runtimeProbe) return _runtimeProbe;
+  _runtimeProbe = (async () => {
+    const detected = await detectLiveSandboxRuntime();
+    if (detected) assertClaudeFiles();
+    _runtime = detected;
+    return detected;
+  })();
+  try {
+    return await _runtimeProbe;
+  } finally {
+    _runtimeProbe = null;
+  }
+}
+
+/** Backward-compatible boolean for code that only needs to know whether
+ *  the agent is isolated. */
 export async function isDockerAvailable(): Promise<boolean> {
-  if (env.disableSandbox) return false;
-  if (_dockerEnabled !== null) return _dockerEnabled;
-  assertClaudeFiles();
-  _dockerEnabled = await isDockerLive();
-  return _dockerEnabled;
+  return (await resolveSandboxRuntime()) !== null;
 }
 
 function getDockerfileSha256(): string {
@@ -70,37 +124,72 @@ function getDockerfileSha256(): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-async function buildImage(sha: string): Promise<void> {
+export function sandboxRuntimeCommand(runtime: SandboxRuntime): "docker" | "container" {
+  return runtime === "docker" ? "docker" : "container";
+}
+
+export function appleContainerImageLabel(inspectJson: string, labelKey: string): string | undefined {
+  try {
+    const images = JSON.parse(inspectJson) as {
+      variants?: { config?: { config?: { Labels?: Record<string, string> } } }[];
+    }[];
+    for (const image of images) {
+      for (const variant of image.variants ?? []) {
+        const value = variant.config?.config?.Labels?.[labelKey];
+        if (typeof value === "string") return value;
+      }
+    }
+  } catch {
+    // A malformed or version-incompatible response simply forces a rebuild.
+  }
+  return undefined;
+}
+
+async function buildImage(runtime: SandboxRuntime, sha: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn("docker", ["build", "-t", IMAGE_NAME, "--label", `${LABEL_KEY}=${sha}`, "-f", DOCKERFILE, "--load", "."], {
+    const args =
+      runtime === "docker"
+        ? ["build", "-t", IMAGE_NAME, "--label", `${LABEL_KEY}=${sha}`, "-f", DOCKERFILE, "--load", "."]
+        : ["build", "-t", IMAGE_NAME, "--label", `${LABEL_KEY}=${sha}`, "-f", DOCKERFILE, "."];
+    const proc = spawn(sandboxRuntimeCommand(runtime), args, {
       cwd: process.cwd(),
       stdio: ["ignore", "inherit", "inherit"],
     });
     proc.on("error", reject);
     proc.on("close", (code) => {
       if (code === 0) resolve();
-      else reject(new Error(`docker build exited with code ${code}`));
+      else reject(new Error(`${sandboxRuntimeCommand(runtime)} build exited with code ${code}`));
     });
   });
 }
 
-export async function ensureSandboxImage(): Promise<void> {
+async function imageLabel(runtime: SandboxRuntime): Promise<string | undefined> {
+  if (runtime === "docker") {
+    const { stdout } = await execFileAsync("docker", ["image", "inspect", IMAGE_NAME, "--format", `{{index .Config.Labels "${LABEL_KEY}"}}`]);
+    return stdout.trim();
+  }
+  const { stdout } = await execFileAsync("container", ["image", "inspect", IMAGE_NAME]);
+  return appleContainerImageLabel(stdout, LABEL_KEY);
+}
+
+export async function ensureSandboxImage(runtime?: SandboxRuntime): Promise<void> {
+  const selected = runtime ?? (await resolveSandboxRuntime());
+  if (!selected) throw new Error("No live sandbox runtime");
   const expectedSha = getDockerfileSha256();
 
   let needsBuild = false;
   try {
-    const { stdout } = await execFileAsync("docker", ["image", "inspect", IMAGE_NAME, "--format", `{{index .Config.Labels "${LABEL_KEY}"}}`]);
-    if (stdout.trim() !== expectedSha) {
-      log.info("sandbox", "Dockerfile.sandbox changed, rebuilding sandbox image...");
+    if ((await imageLabel(selected)) !== expectedSha) {
+      log.info("sandbox", "Dockerfile.sandbox changed, rebuilding sandbox image...", { runtime: selected });
       needsBuild = true;
     }
   } catch {
-    log.info("sandbox", "Building sandbox image (first time only, may take a minute)...");
+    log.info("sandbox", "Building sandbox image (first time only, may take a minute)...", { runtime: selected });
     needsBuild = true;
   }
 
   if (needsBuild) {
-    await buildImage(expectedSha);
-    log.info("sandbox", "Sandbox image built.");
+    await buildImage(selected, expectedSha);
+    log.info("sandbox", "Sandbox image built.", { runtime: selected });
   }
 }

--- a/server/system/env.ts
+++ b/server/system/env.ts
@@ -55,6 +55,13 @@ function asCsv(value: string | undefined): readonly string[] {
   );
 }
 
+export type SandboxRuntimePreference = "auto" | "docker" | "apple-container";
+
+function asSandboxRuntime(value: string | undefined): SandboxRuntimePreference {
+  if (value === "docker" || value === "apple-container") return value;
+  return "auto";
+}
+
 // ── Snapshot ────────────────────────────────────────────────────────
 
 /**
@@ -77,8 +84,11 @@ export const env = Object.freeze({
   claudeConfigDir: process.env.CLAUDE_CONFIG_DIR,
   claudeConfigJson: process.env.CLAUDE_CONFIG_JSON,
 
-  // Sandbox / Docker
+  // Container sandbox
   disableSandbox: flagOf("DISABLE_SANDBOX"),
+  // auto: prefer Apple's native container runtime on macOS, then fall
+  // back to Docker. Explicit values are useful when both are installed.
+  sandboxRuntime: asSandboxRuntime(process.env.SANDBOX_RUNTIME),
   // Debug aid: also persist `tool_call` events to the session
   // jsonl (the `tool_result` side already lands on disk). Off by
   // default because args can be large and may carry payload bytes

--- a/server/system/optionalDeps.ts
+++ b/server/system/optionalDeps.ts
@@ -8,7 +8,7 @@
 // before this).
 
 import which from "which";
-import { isDockerLive } from "./docker.js";
+import { detectLiveSandboxRuntime } from "./docker.js";
 
 /** A single optional host dependency the app can run without. */
 export interface OptionalDep {
@@ -18,6 +18,10 @@ export interface OptionalDep {
   readonly id: string;
   /** Binary name passed to `which` for the default presence probe. */
   readonly command: string;
+  /** Alternative executable names that can satisfy one capability.
+   *  The sandbox uses this on macOS, where Apple container or Docker
+   *  are both valid providers. */
+  readonly commands?: readonly string[];
   /** i18n key fragment naming what stops working when absent. */
   readonly enables: string;
   /** Override when "on PATH" is insufficient (e.g. docker client
@@ -35,7 +39,15 @@ export interface DepStatus {
 }
 
 const REGISTRY: readonly OptionalDep[] = [
-  { id: "docker", command: "docker", enables: "dockerSandbox", probe: isDockerLive },
+  {
+    // Keep the stable id because plugin metadata and persisted
+    // notification ids already use it; the capability is now generic.
+    id: "docker",
+    command: process.platform === "darwin" ? "container / docker" : "docker",
+    commands: process.platform === "darwin" ? ["container", "docker"] : ["docker"],
+    enables: "dockerSandbox",
+    probe: async () => (await detectLiveSandboxRuntime()) !== null,
+  },
   { id: "ffmpeg", command: "ffmpeg", enables: "mulmocast" },
   // Local voice input (whisper.cpp server binary). Spawned as a warm
   // sidecar, not loaded in-process — see server/system/whisper/. The
@@ -62,7 +74,15 @@ async function onPath(command: string): Promise<boolean> {
 // real PATH.
 export async function probeOne(dep: OptionalDep, pathCheck: (command: string) => Promise<boolean> = onPath): Promise<DepStatus> {
   try {
-    if (!(await pathCheck(dep.command))) {
+    const commands = dep.commands ?? [dep.command];
+    let found = false;
+    for (const command of commands) {
+      if (await pathCheck(command)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
       return { id: dep.id, available: false, reason: "not-on-path" };
     }
     if (dep.probe && !(await dep.probe())) {

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -637,6 +637,15 @@ describe("buildDockerSpawnArgs", () => {
     assert.ok(!args.includes("--add-host"));
   });
 
+  it("does not pass Docker-only --add-host to Apple container", async () => {
+    const args = buildDockerSpawnArgs({
+      ...baseParams(),
+      platform: "linux" as Platform,
+      sandboxRuntime: "apple-container",
+    });
+    assert.ok(!args.includes("--add-host"));
+  });
+
   it("normalizes Windows backslash paths to forward slashes", async () => {
     const args = buildDockerSpawnArgs({
       ...baseParams(),

--- a/test/agent/test_mcp_docker_smoke.ts
+++ b/test/agent/test_mcp_docker_smoke.ts
@@ -1,6 +1,6 @@
-// Docker smoke test for the MCP server subprocess.
+// Container-runtime smoke test for the MCP server subprocess.
 //
-// Verifies that the MCP server can start inside the Docker sandbox
+// Verifies that the MCP server can start inside the sandbox
 // container and respond to initialize + tools/list. This catches:
 //   - Missing Docker volume mounts (e.g. packages/ not mounted)
 //   - package.json exports issues (e.g. missing "require" condition)
@@ -25,30 +25,22 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { execSync, spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import path from "node:path";
 
 import { buildMulmoclaudeServer, workspaceModuleMounts, type Platform } from "../../server/agent/config.ts";
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
+import { detectLiveSandboxRuntime, sandboxRuntimeCommand, type SandboxRuntime } from "../../server/system/docker.ts";
 
 const PROJECT_ROOT = path.resolve(import.meta.dirname, "../..");
 
-function isDockerAvailable(): boolean {
+function isSandboxImageAvailable(runtime: SandboxRuntime): boolean {
   try {
-    execSync("docker info", { stdio: "ignore", timeout: 5 * ONE_SECOND_MS });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function isSandboxImageAvailable(): boolean {
-  try {
-    const out = execSync("docker images -q mulmoclaude-sandbox", {
-      encoding: "utf-8",
+    execFileSync(sandboxRuntimeCommand(runtime), ["image", "inspect", "mulmoclaude-sandbox"], {
+      stdio: "ignore",
       timeout: 5 * ONE_SECOND_MS,
     });
-    return out.trim().length > 0;
+    return true;
   } catch {
     return false;
   }
@@ -74,10 +66,12 @@ function hostPlatform(): Platform {
   return found;
 }
 
-const canRunDocker = isDockerAvailable() && isSandboxImageAvailable();
+const sandboxRuntime = await detectLiveSandboxRuntime();
+const canRunContainer = sandboxRuntime !== null && isSandboxImageAvailable(sandboxRuntime);
 
-describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
-  it("responds to initialize + tools/list inside Docker container", async () => {
+describe("MCP server container smoke test", { skip: !canRunContainer }, () => {
+  it("responds to initialize + tools/list inside the sandbox container", async () => {
+    assert.ok(sandboxRuntime);
     const toDockerPath = (filePath: string): string => filePath.replace(/\\/g, "/");
 
     // The exact spec Claude Code would spawn: `tsx --import <bootstrap>
@@ -111,7 +105,7 @@ describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
     ];
 
     const responses = await new Promise<JsonRpcResponse[]>((resolve, reject) => {
-      const child = spawn("docker", dockerArgs, {
+      const child = spawn(sandboxRuntimeCommand(sandboxRuntime), dockerArgs, {
         cwd: PROJECT_ROOT,
         stdio: ["pipe", "pipe", "pipe"],
       });
@@ -152,7 +146,7 @@ describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
 
       const timer = setTimeout(() => {
         child.kill("SIGTERM");
-        reject(new Error(`Docker MCP server timed out. stderr: ${stderr}`));
+        reject(new Error(`${sandboxRuntime} MCP server timed out. stderr: ${stderr}`));
       }, 30 * ONE_SECOND_MS);
 
       child.on("close", (code) => {
@@ -170,7 +164,7 @@ describe("MCP server Docker smoke test", { skip: !canRunDocker }, () => {
           .filter((resp): resp is JsonRpcResponse => resp !== null);
 
         if (parsed.length === 0 && code !== 0) {
-          reject(new Error(`Docker MCP server exited ${code}. stderr:\n${stderr.slice(0, 1000)}`));
+          reject(new Error(`${sandboxRuntime} MCP server exited ${code}. stderr:\n${stderr.slice(0, 1000)}`));
           return;
         }
         resolve(parsed);

--- a/test/agent/test_sandboxMounts.ts
+++ b/test/agent/test_sandboxMounts.ts
@@ -143,6 +143,26 @@ describe("sshAgentForwardArgs", () => {
     assert.equal(result.args.length, 4);
   });
 
+  it("uses Apple container native SSH forwarding", () => {
+    const fake = path.join(mkdtempSync(path.join(tmpdir(), "apple-sock-")), "agent.sock");
+    writeFileSync(fake, "");
+    const result = sshAgentForwardArgs(true, fake, "darwin", "apple-container");
+    assert.deepEqual(result.args, ["--ssh"]);
+    assert.equal(result.skippedReason, null);
+  });
+
+  it("skips Apple container SSH forwarding when the host has no agent", () => {
+    const result = sshAgentForwardArgs(true, undefined, "darwin", "apple-container");
+    assert.deepEqual(result.args, []);
+    assert.match(result.skippedReason ?? "", /not set/);
+  });
+
+  it("rejects Apple container forwarding off macOS", () => {
+    const result = sshAgentForwardArgs(true, "/tmp/agent.sock", "linux", "apple-container");
+    assert.deepEqual(result.args, []);
+    assert.match(result.skippedReason ?? "", /only available on macOS/);
+  });
+
   it("reports SSH_AUTH_SOCK missing on Linux", () => {
     const result = sshAgentForwardArgs(true, undefined, "linux");
     assert.deepEqual(result.args, []);

--- a/test/server/test_env.ts
+++ b/test/server/test_env.ts
@@ -12,6 +12,7 @@ interface EnvSnapshot {
     nodeEnv: string;
     isProduction: boolean;
     disableSandbox: boolean;
+    sandboxRuntime: "auto" | "docker" | "apple-container";
     geminiApiKey: string | undefined;
     xBearerToken: string | undefined;
     authTokenOverride: string | undefined;
@@ -38,6 +39,7 @@ const ENV_KEYS = [
   "PORT",
   "NODE_ENV",
   "DISABLE_SANDBOX",
+  "SANDBOX_RUNTIME",
   "GEMINI_API_KEY",
   "X_BEARER_TOKEN",
   "MULMOCLAUDE_AUTH_TOKEN",
@@ -74,6 +76,7 @@ describe("env defaults", () => {
     assert.equal(env.nodeEnv, "development");
     assert.equal(env.isProduction, false);
     assert.equal(env.disableSandbox, false);
+    assert.equal(env.sandboxRuntime, "auto");
     assert.equal(env.geminiApiKey, undefined);
     assert.equal(env.xBearerToken, undefined);
     assert.equal(env.authTokenOverride, undefined);
@@ -117,6 +120,17 @@ describe("env coercion", () => {
     process.env.DISABLE_SANDBOX = "0";
     const envC = await loadEnvFresh();
     assert.equal(envC.env.disableSandbox, false);
+  });
+
+  it("accepts supported SANDBOX_RUNTIME values and falls back to auto", async () => {
+    process.env.SANDBOX_RUNTIME = "apple-container";
+    assert.equal((await loadEnvFresh()).env.sandboxRuntime, "apple-container");
+
+    process.env.SANDBOX_RUNTIME = "docker";
+    assert.equal((await loadEnvFresh()).env.sandboxRuntime, "docker");
+
+    process.env.SANDBOX_RUNTIME = "unknown";
+    assert.equal((await loadEnvFresh()).env.sandboxRuntime, "auto");
   });
 
   it("isProduction reflects NODE_ENV=production", async () => {

--- a/test/system/test_optionalDeps.ts
+++ b/test/system/test_optionalDeps.ts
@@ -38,6 +38,22 @@ describe("probeOne — reason mapping + override precedence", () => {
     assert.deepEqual(await probeOne(dep, present), { id: "ffmpeg", available: true, reason: "ok" });
   });
 
+  it("accepts any executable that provides the same capability", async () => {
+    const checked: string[] = [];
+    const dep: OptionalDep = {
+      id: "sandbox",
+      command: "container / docker",
+      commands: ["container", "docker"],
+      enables: "sandbox",
+    };
+    const status = await probeOne(dep, async (command) => {
+      checked.push(command);
+      return command === "docker";
+    });
+    assert.deepEqual(status, { id: "sandbox", available: true, reason: "ok" });
+    assert.deepEqual(checked, ["container", "docker"]);
+  });
+
   it("never throws when the PATH check itself throws (degrades, not crashes)", async () => {
     const dep: OptionalDep = { id: "x", command: "x", enables: "x" };
     const throwing = async () => {
@@ -62,10 +78,12 @@ describe("probeOne — reason mapping + override precedence", () => {
 });
 
 describe("registry", () => {
-  it("declares docker (with liveness override) and ffmpeg (plain PATH)", () => {
+  it("declares the container sandbox (with liveness override) and ffmpeg (plain PATH)", () => {
     const byId = Object.fromEntries(optionalDeps().map((dep) => [dep.id, dep]));
     assert.ok(byId.docker, "docker entry present");
     assert.equal(typeof byId.docker?.probe, "function", "docker has a liveness override");
+    assert.ok(byId.docker?.commands?.includes("docker"));
+    if (process.platform === "darwin") assert.ok(byId.docker?.commands?.includes("container"));
     assert.ok(byId.ffmpeg, "ffmpeg entry present");
     assert.equal(byId.ffmpeg?.probe, undefined, "ffmpeg uses the default PATH check");
   });

--- a/test/system/test_sandboxRuntime.ts
+++ b/test/system/test_sandboxRuntime.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { appleContainerImageLabel, sandboxRuntimeCommand } from "../../server/system/docker.js";
+
+describe("sandbox runtime helpers", () => {
+  it("maps runtime ids to their CLI binaries", () => {
+    assert.equal(sandboxRuntimeCommand("docker"), "docker");
+    assert.equal(sandboxRuntimeCommand("apple-container"), "container");
+  });
+
+  it("reads the Dockerfile hash label from Apple container inspect JSON", () => {
+    const json = JSON.stringify([
+      {
+        variants: [
+          {
+            config: {
+              config: {
+                Labels: {
+                  "mulmoclaude.dockerfile.sha256": "abc123",
+                },
+              },
+            },
+          },
+        ],
+      },
+    ]);
+    assert.equal(appleContainerImageLabel(json, "mulmoclaude.dockerfile.sha256"), "abc123");
+  });
+
+  it("returns undefined for missing labels or malformed inspect output", () => {
+    assert.equal(appleContainerImageLabel("[]", "missing"), undefined);
+    assert.equal(appleContainerImageLabel("not-json", "missing"), undefined);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -4385,6 +4392,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@16.0.1:
   version "16.0.1"
@@ -7893,10 +7905,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -9800,6 +9819,17 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.22:
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -10102,15 +10132,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.28.0, undici@^7.0.0, undici@^7.25.0:
+undici@7.28.0, undici@^6.27.0, undici@^7.0.0, undici@^7.25.0:
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
-
-undici@^6.27.0:
-  version "6.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
-  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unenv@2.0.0-rc.24:
   version "2.0.0-rc.24"
@@ -10238,20 +10263,10 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1:
+uuid@*, uuid@14.0.1, uuid@^10.0.0, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1, uuid@^8.3.0:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
-
-uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -10677,6 +10692,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

- add SANDBOX_RUNTIME auto, apple-container, and docker selection
- prefer Apple container on macOS and fall back to Docker
- support image build/inspection/removal, bind mounts, host networking, SSH agent forwarding, MCP startup, and PPTX conversion
- update English/Japanese setup and developer documentation

## Verification

- yarn test
- yarn typecheck
- ESLint on changed source and tests
- Apple container 1.0.0 smoke tests: sandbox image build, read/write and read-only mounts, host callback, SSH agent forwarding, and MCP initialize/tools-list

## Summary by Sourcery

Add a generic container sandbox runtime with Apple container support and runtime auto-selection, while keeping Docker as a fallback, and update sandbox-related behavior across the server, tests, scripts, and docs.

New Features:
- Support Apple container as an alternative sandbox runtime alongside Docker.
- Auto-select the sandbox runtime, preferring Apple container on macOS with Docker as a fallback.
- Enable PPTX-to-PDF conversion via LibreOffice inside whichever container runtime is active.
- Allow SSH agent forwarding using Apple container’s native support when available.

Enhancements:
- Generalize sandbox runtime handling from Docker-specific to container-agnostic across agent orchestration, MCP, attachment conversion, and prompts.
- Improve optional dependency detection to treat Apple container or Docker as interchangeable providers for the sandbox capability.
- Adjust sandbox setup logging and diagnostics to reflect the selected container runtime.
- Update sandbox image management to work with both Apple container and Docker, including a new script for removing the sandbox image.

Documentation:
- Refresh English and Japanese README and developer documentation to describe the container sandbox model, Apple container installation, runtime selection via SANDBOX_RUNTIME, and updated PPTX conversion behavior.

Tests:
- Extend and adapt sandbox, MCP, env, and optional-dependency tests to cover Apple container support, runtime selection, SSH agent forwarding, and container-agnostic behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Apple container alongside Docker for sandboxed execution.
  * macOS 26+ automatically prefers Apple container when available, with Docker fallback.
  * Added runtime selection through `SANDBOX_RUNTIME`, plus clearer sandbox disable options.
  * PPTX conversion can now use the selected container sandbox when host conversion is unavailable.

* **Documentation**
  * Updated setup, security, MCP, skills, attachments, and developer guidance to describe container-based sandboxing.
  * Clarified warnings and behavior when no supported container runtime is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->