### PR TITLE
test(calendar): verify the Collection → Google push against a live calendar (#2602)

### DIFF
--- a/docs/e2e-live-testing.md
+++ b/docs/e2e-live-testing.md
@@ -46,6 +46,13 @@ Output knobs:
   running per-category skills (see `test:e2e:live:wiki` etc. in
   `package.json`).
 
+**Exception — live third-party API specs.** `calendar-push.spec.ts`
+drives no browser and no LLM: it calls
+`@mulmoclaude/core/google` directly and asserts on what **Google**
+answers. It needs a linked Google account plus a throwaway calendar
+id in the env, and skips itself with a setup sentence when either
+is missing (see "Specs that need a live Google account" below).
+
 ## Two backends behind the agent
 
 The chat flow goes through an `LLMBackend` (see
@@ -171,6 +178,38 @@ Bypassing the handler defeats the canary value of the test.
 For unit tests that want to drive a different response without
 patching the prompt, use the exported `setFakeResponse(gen)` /
 `resetFakeResponse()` API (pair in `beforeEach` / `afterEach`).
+
+## Specs that need a live Google account
+
+`calendar-push.spec.ts` (#2602) verifies the Collection → Google
+Calendar push against a real calendar. It is a third category
+alongside "real LLM" and "fake-echo": no agent is involved, so
+`MULMOCLAUDE_FAKE_AGENT` and `E2E_LIVE_NO_LLM` are irrelevant to
+it — what it needs is an OAuth grant.
+
+```bash
+export E2E_LIVE_GOOGLE_CALENDAR_ID='…@group.calendar.google.com'
+yarn test:e2e:live:calendar
+```
+
+| Variable | Required | What to point it at |
+|---|---|---|
+| `E2E_LIVE_GOOGLE_CALENDAR_ID` | yes | A **throwaway** calendar the linked account owns. The spec creates and deletes events on it. |
+| `E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID` | no | A calendar the account can read but not write — a subscribed holiday calendar is the easiest. Unlocks the 403 / read-only tests. |
+| `E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID` | no | A calendar shared with write access that is **not** in the account's calendar list. Needs a second account to share one. |
+
+Two things to know before extending it:
+
+- **The spec cannot create its own calendar.** The app's grant is
+  `calendar.events`, not the full `calendar` scope, so calendars are
+  a human setup step. Only events are created and torn down.
+- **A missing optional variable skips exactly one test**, with a
+  sentence naming what to set up. Never widen a skip to the whole
+  describe — a silently skipped suite reads the same as a passing
+  one, which is the failure mode #2602 was filed about.
+
+It is deliberately **not** in the `e2e_live_no_llm` matrix: CI holds
+no Google grant, so every run would skip.
 
 ## CI matrix
 

--- a/docs/e2e-live-testing.md
+++ b/docs/e2e-live-testing.md
@@ -194,7 +194,7 @@ yarn test:e2e:live:calendar
 
 | Variable | Required | What to point it at |
 |---|---|---|
-| `E2E_LIVE_GOOGLE_CALENDAR_ID` | yes | A **throwaway** calendar the linked account owns. The spec creates and deletes events on it. |
+| `E2E_LIVE_GOOGLE_CALENDAR_ID` | yes | A **throwaway** calendar the linked account owns. The spec creates and deletes events on it, and refuses to run against `primary`. |
 | `E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID` | no | A calendar the account can read but not write — a subscribed holiday calendar is the easiest. Unlocks the 403 / read-only tests. |
 | `E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID` | no | A calendar shared with write access that is **not** in the account's calendar list. Needs a second account to share one. |
 

--- a/docs/e2e-live-testing.md
+++ b/docs/e2e-live-testing.md
@@ -198,7 +198,14 @@ yarn test:e2e:live:calendar
 | `E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID` | no | A calendar the account can read but not write — a subscribed holiday calendar is the easiest. Unlocks the 403 / read-only tests. |
 | `E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID` | no | A calendar shared with write access that is **not** in the account's calendar list. Needs a second account to share one. |
 
-Two things to know before extending it:
+Three things to know before extending it:
+
+- **Its script skips `ensure:playwright-browsers`**, unlike every other
+  `test:e2e:live:*`. No test here requests `page` / `context` /
+  `browser`, and Playwright launches a browser only when one of those
+  fixtures is used — verified by running the spec with
+  `PLAYWRIGHT_BROWSERS_PATH` pointed at an empty directory. Add the
+  install step back the moment a test in this file needs a browser.
 
 - **The spec cannot create its own calendar.** The app's grant is
   `calendar.events`, not the full `calendar` scope, so calendars are

--- a/e2e-live/fixtures/live-google.ts
+++ b/e2e-live/fixtures/live-google.ts
@@ -9,16 +9,20 @@
 // `calendar.events`, not the full `calendar` scope, so a throwaway calendar has
 // to be made by a human in Google's UI and handed over by id through the env
 // vars below. EVENTS are created and removed per test.
+//
+// Deliberately free of `@playwright/test`: the seeded workspace is a contract
+// with `@mulmoclaude/core/collection/server`, and without a Google grant the
+// live spec never runs — so that contract would rot unwatched. Staying
+// runner-agnostic lets `test/e2e-live/test_calendarCollectionWorkspace.ts` pin
+// it under plain `yarn test`.
 
 import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { test } from "@playwright/test";
-
 import { configureCollectionHost } from "@mulmoclaude/core/collection/server";
-import { deleteCalendarEvent, isGoogleApiError, loadGoogleTokens } from "@mulmoclaude/core/google";
+import { isGoogleApiError, loadGoogleTokens } from "@mulmoclaude/core/google";
 
 /** A calendar the linked account may write to. These specs own its events, so
  *  point it at a throwaway calendar — never a real one. */
@@ -68,23 +72,6 @@ const CLIENT_EVENT_ID_LENGTH = 8;
 
 export const newEventId = (): string => randomUUID().slice(0, CLIENT_EVENT_ID_LENGTH);
 
-const HTTP_NOT_FOUND = 404;
-const HTTP_GONE = 410;
-/** An event that is already gone: teardown's success case, not a failure. */
-const ALREADY_GONE_STATUSES: readonly number[] = [HTTP_NOT_FOUND, HTTP_GONE];
-
-/** Best-effort teardown. A cleanup failure is recorded as an annotation instead
- *  of thrown: raising here would replace the real assertion failure with a
- *  delete error, and the leftover event still needs to be visible somewhere. */
-export async function deleteEventQuietly(accessToken: string, calendarId: string, eventId: string): Promise<void> {
-  try {
-    await deleteCalendarEvent(accessToken, { calendarId, eventId });
-  } catch (error) {
-    if (isGoogleApiError(error) && ALREADY_GONE_STATUSES.includes(error.status)) return;
-    test.info().annotations.push({ type: "cleanup-failed", description: `${calendarId}/${eventId}: ${String(error)}` });
-  }
-}
-
 /** The `GoogleApiError` status a call answers with, or null when it resolved.
  *
  *  #2602 is mostly a question about STATUS CODES (409 vs 400, 412 vs 409), and
@@ -110,10 +97,11 @@ const DATA_ROOT_SEGMENTS = ["data", "collections"];
 const ITEMS_DIR = "items";
 const SLUG_NONCE_LENGTH = 6;
 
-// The schema declares its dataPath workspace-relative with forward slashes (the
-// on-disk form every other schema uses); `path.normalize` handles the Windows
-// separator on the way in.
-const dataPathFor = (slug: string): string => [...DATA_ROOT_SEGMENTS, slug, ITEMS_DIR].join("/");
+// The schema's `dataPath` is a SERIALIZED value, so it stays POSIX-separated on
+// every host (the on-disk form every other schema uses); `path.normalize`
+// handles the Windows separator when the engine reads it back. `dataDirFor`
+// below is a real filesystem path and so uses the native join.
+const dataPathFor = (slug: string): string => path.posix.join(...DATA_ROOT_SEGMENTS, slug, ITEMS_DIR);
 const dataDirFor = (root: string, slug: string): string => path.join(root, ...DATA_ROOT_SEGMENTS, slug, ITEMS_DIR);
 
 const schemaFor = (slug: string, calendarId: string): Record<string, unknown> => ({

--- a/e2e-live/fixtures/live-google.ts
+++ b/e2e-live/fixtures/live-google.ts
@@ -1,0 +1,173 @@
+// Live Google Calendar helpers for e2e-live (#2602).
+//
+// Unlike every other spec under `e2e-live/`, the Google specs drive no browser
+// and no LLM. What is under test is Google's own answer to the shapes
+// `@mulmoclaude/core/google` sends — a fact no amount of reading our code can
+// settle. Playwright is here for the runner, the trace and the report.
+//
+// Nothing here creates or deletes a CALENDAR. The app's OAuth grant covers
+// `calendar.events`, not the full `calendar` scope, so a throwaway calendar has
+// to be made by a human in Google's UI and handed over by id through the env
+// vars below. EVENTS are created and removed per test.
+
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { test } from "@playwright/test";
+
+import { configureCollectionHost } from "@mulmoclaude/core/collection/server";
+import { deleteCalendarEvent, isGoogleApiError, loadGoogleTokens } from "@mulmoclaude/core/google";
+
+/** A calendar the linked account may write to. These specs own its events, so
+ *  point it at a throwaway calendar — never a real one. */
+export const WRITABLE_CALENDAR_ENV = "E2E_LIVE_GOOGLE_CALENDAR_ID";
+/** A calendar the account can read but not write (a subscribed holiday calendar
+ *  is the easiest one to come by). Optional. */
+export const READONLY_CALENDAR_ENV = "E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID";
+/** A calendar the account may write to but has NOT added to its calendar list —
+ *  #2602 item 5. Needs a second account to share one, so it stays optional. */
+export const UNLISTED_CALENDAR_ENV = "E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID";
+
+export const calendarIdFrom = (envName: string): string => process.env[envName]?.trim() ?? "";
+
+/** Why this run cannot exercise a live calendar, or null when it can.
+ *
+ *  Returned as a sentence rather than a boolean so the skip reason in the report
+ *  tells the next person exactly what to set up — a silently skipped suite reads
+ *  the same as a passing one. */
+export async function liveCalendarBlocker(): Promise<string | null> {
+  if (calendarIdFrom(WRITABLE_CALENDAR_ENV) === "") {
+    return `${WRITABLE_CALENDAR_ENV} is unset — create a throwaway calendar in Google Calendar and export its id`;
+  }
+  const tokens = await loadGoogleTokens();
+  if (!tokens?.refresh_token) return "no Google account is linked on this host — link one in settings, then re-run";
+  return null;
+}
+
+/** Skip reason for a test that needs one of the optional calendars. */
+export const missingCalendarReason = (envName: string, what: string): string => `${envName} is unset — set it to ${what}`;
+
+// Google requires a client-supplied event id to be base32hex (`0-9a-v`), 5-1024
+// characters. A UUID's first 8 characters are lowercase hex, which is exactly
+// the shape #2602 asks about.
+const CLIENT_EVENT_ID_LENGTH = 8;
+
+export const newEventId = (): string => randomUUID().slice(0, CLIENT_EVENT_ID_LENGTH);
+
+const HTTP_NOT_FOUND = 404;
+const HTTP_GONE = 410;
+/** An event that is already gone: teardown's success case, not a failure. */
+const ALREADY_GONE_STATUSES: readonly number[] = [HTTP_NOT_FOUND, HTTP_GONE];
+
+/** Best-effort teardown. A cleanup failure is recorded as an annotation instead
+ *  of thrown: raising here would replace the real assertion failure with a
+ *  delete error, and the leftover event still needs to be visible somewhere. */
+export async function deleteEventQuietly(accessToken: string, calendarId: string, eventId: string): Promise<void> {
+  try {
+    await deleteCalendarEvent(accessToken, { calendarId, eventId });
+  } catch (error) {
+    if (isGoogleApiError(error) && ALREADY_GONE_STATUSES.includes(error.status)) return;
+    test.info().annotations.push({ type: "cleanup-failed", description: `${calendarId}/${eventId}: ${String(error)}` });
+  }
+}
+
+/** The `GoogleApiError` status a call answers with, or null when it resolved.
+ *
+ *  #2602 is mostly a question about STATUS CODES (409 vs 400, 412 vs 409), and
+ *  `rejects.toThrow()` cannot tell them apart. A non-Google error is rethrown so
+ *  a bug in the test itself never reads as "Google said something else". */
+export async function statusOfRejection(run: () => Promise<unknown>): Promise<number | null> {
+  try {
+    await run();
+    return null;
+  } catch (error) {
+    if (isGoogleApiError(error)) return error.status;
+    throw error;
+  }
+}
+
+// --- the collection side ---------------------------------------------------
+
+/** Field names of the seeded collection. Fixed so a spec can address a record
+ *  without restating the schema's map. */
+export const CALENDAR_FIELDS = { id: "gid", summary: "title", start: "on", end: "until" } as const;
+
+const DATA_ROOT_SEGMENTS = ["data", "collections"];
+const ITEMS_DIR = "items";
+const SLUG_NONCE_LENGTH = 6;
+
+// The schema declares its dataPath workspace-relative with forward slashes (the
+// on-disk form every other schema uses); `path.normalize` handles the Windows
+// separator on the way in.
+const dataPathFor = (slug: string): string => [...DATA_ROOT_SEGMENTS, slug, ITEMS_DIR].join("/");
+const dataDirFor = (root: string, slug: string): string => path.join(root, ...DATA_ROOT_SEGMENTS, slug, ITEMS_DIR);
+
+const schemaFor = (slug: string, calendarId: string): Record<string, unknown> => ({
+  title: "e2e-live calendar push",
+  icon: "event",
+  dataPath: dataPathFor(slug),
+  primaryKey: CALENDAR_FIELDS.id,
+  fields: {
+    [CALENDAR_FIELDS.id]: { type: "string", label: "Event id", primary: true },
+    [CALENDAR_FIELDS.summary]: { type: "string", label: "Title" },
+    [CALENDAR_FIELDS.start]: { type: "datetime", label: "Start" },
+    [CALENDAR_FIELDS.end]: { type: "datetime", label: "End" },
+  },
+  googleCalendar: {
+    calendarId,
+    map: { [CALENDAR_FIELDS.summary]: "summary", [CALENDAR_FIELDS.start]: "start", [CALENDAR_FIELDS.end]: "end" },
+  },
+});
+
+// The engine reads the workspace layout off its host binding, so a spec that
+// calls `pushCalendarForCollection` must wire one. Bound once at module scope
+// with a placeholder root — every call passes its own root explicitly, and only
+// the path factories below are actually exercised. `userSkillsDir` points at
+// nothing on purpose: user-scope discovery must not pick up the developer's own
+// collections mid-test.
+const NO_USER_SKILLS_DIR = path.join(tmpdir(), "e2e-live-no-user-skills");
+configureCollectionHost({
+  workspaceRoot: path.join(tmpdir(), "e2e-live-google-placeholder"),
+  log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+  paths: {
+    userSkillsDir: NO_USER_SKILLS_DIR,
+    projectSkillsDir: (root: string) => path.join(root, ".claude", "skills"),
+    feedsRoot: (root: string) => path.join(root, "feeds"),
+    skillsStagingDir: (root: string) => path.join(root, "data", "skills"),
+    archiveDir: ".archive",
+    collectionsRegistriesConfig: (root: string) => path.join(root, "config", "collections-registries.json"),
+  },
+  isPresetSlug: () => false,
+});
+
+/** A throwaway workspace holding one `googleCalendar` collection, ready for
+ *  `pushCalendarForCollection(slug, root)` — the same call the HTTP route makes. */
+export interface CalendarCollectionWorkspace {
+  root: string;
+  slug: string;
+  /** Write (or overwrite) one record file. */
+  putRecord: (recordId: string, record: Record<string, unknown>) => Promise<void>;
+  cleanup: () => Promise<void>;
+}
+
+export async function createCalendarCollectionWorkspace(calendarId: string): Promise<CalendarCollectionWorkspace> {
+  const root = await mkdtemp(path.join(tmpdir(), "e2e-live-calendar-"));
+  const slug = `e2e-live-push-${randomUUID().slice(0, SLUG_NONCE_LENGTH)}`;
+  const skillDir = path.join(root, ".claude", "skills", slug);
+  const dataDir = dataDirFor(root, slug);
+  await mkdir(skillDir, { recursive: true });
+  await mkdir(dataDir, { recursive: true });
+  await writeFile(path.join(skillDir, "schema.json"), JSON.stringify(schemaFor(slug, calendarId), null, 2), "utf-8");
+  return {
+    root,
+    slug,
+    putRecord: async (recordId, record) => {
+      await writeFile(path.join(dataDir, `${recordId}.json`), JSON.stringify(record, null, 2), "utf-8");
+    },
+    cleanup: async () => {
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}

--- a/e2e-live/fixtures/live-google.ts
+++ b/e2e-live/fixtures/live-google.ts
@@ -32,14 +32,26 @@ export const UNLISTED_CALENDAR_ENV = "E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID";
 
 export const calendarIdFrom = (envName: string): string => process.env[envName]?.trim() ?? "";
 
+/** The alias every Google call resolves to when no calendar is named — i.e. the
+ *  user's real calendar. Refused as a target below. */
+const PRIMARY_CALENDAR_ID = "primary";
+
 /** Why this run cannot exercise a live calendar, or null when it can.
  *
  *  Returned as a sentence rather than a boolean so the skip reason in the report
  *  tells the next person exactly what to set up — a silently skipped suite reads
  *  the same as a passing one. */
 export async function liveCalendarBlocker(): Promise<string | null> {
-  if (calendarIdFrom(WRITABLE_CALENDAR_ENV) === "") {
+  const writable = calendarIdFrom(WRITABLE_CALENDAR_ENV);
+  if (writable === "") {
     return `${WRITABLE_CALENDAR_ENV} is unset — create a throwaway calendar in Google Calendar and export its id`;
+  }
+  // These specs create AND delete events, so the one input that must never be
+  // wrong is which calendar they land on. `primary` is the value the engine
+  // itself falls back to, which makes it the easy mistake to make — and the
+  // one that writes into the user's real calendar.
+  if (writable === PRIMARY_CALENDAR_ID) {
+    return `${WRITABLE_CALENDAR_ENV} is "${PRIMARY_CALENDAR_ID}" — these specs create and delete events, so point it at a throwaway calendar instead`;
   }
   const tokens = await loadGoogleTokens();
   if (!tokens?.refresh_token) return "no Google account is linked on this host — link one in settings, then re-run";

--- a/e2e-live/tests/calendar-push.spec.ts
+++ b/e2e-live/tests/calendar-push.spec.ts
@@ -189,10 +189,10 @@ test.describe("Google Calendar contract behind the push (#2602)", () => {
 
       await updateCalendarEvent(accessToken, { eventId, calendarId, start: movedStart, end: movedEnd });
       const moved = await readEvent(accessToken, calendarId, eventId);
+      // A bare date is also what says the event is STILL all-day: a midnight
+      // timed event would come back as `2027-03-18T00:00:00+09:00`.
       expect(moved.event.start).toBe(MOVED_START);
       expect(moved.event.end).toBe(MOVED_END);
-      // A timed event would come back as `…T00:00:00+09:00`.
-      expect(moved.event.start).not.toContain("T");
     } finally {
       await deleteEventQuietly(accessToken, calendarId, eventId);
     }
@@ -235,16 +235,26 @@ test.describe("Google Calendar contract behind the push (#2602)", () => {
     );
 
     const accessToken = await getGoogleAccessToken();
-    // An offset-bearing span, so a rejection can only be about permissions.
-    const status = await statusOfRejection(() =>
-      createCalendarEvent(accessToken, {
-        calendarId: readOnly,
-        summary: SUMMARY,
-        startDateTime: `${SENT_START}Z`,
-        endDateTime: `${SENT_END}Z`,
-      }),
-    );
-    expect(status).toBe(HTTP_FORBIDDEN);
+    // The id is set up front purely so the teardown has something to delete: if
+    // the variable is misconfigured and points at a WRITABLE calendar, the
+    // create succeeds, the assertion below fails, and an event with no known id
+    // would be stranded there. The delete is a no-op on the expected 403.
+    const eventId = newEventId();
+    try {
+      // An offset-bearing span, so a rejection can only be about permissions.
+      const status = await statusOfRejection(() =>
+        createCalendarEvent(accessToken, {
+          eventId,
+          calendarId: readOnly,
+          summary: SUMMARY,
+          startDateTime: `${SENT_START}Z`,
+          endDateTime: `${SENT_END}Z`,
+        }),
+      );
+      expect(status).toBe(HTTP_FORBIDDEN);
+    } finally {
+      await deleteEventQuietly(accessToken, readOnly, eventId);
+    }
   });
 });
 
@@ -305,6 +315,7 @@ test.describe("Collection → Google push, end to end (#2602)", () => {
       missingCalendarReason(READONLY_CALENDAR_ENV, "a calendar this account can read but not write (a subscribed holiday calendar will do)"),
     );
 
+    const accessToken = await getGoogleAccessToken();
     const eventId = newEventId();
     const workspace = await createCalendarCollectionWorkspace(readOnly);
     try {
@@ -324,6 +335,9 @@ test.describe("Collection → Google push, end to end (#2602)", () => {
       if (outcome.kind !== "read-only") throw new Error(`expected a read-only outcome, got ${JSON.stringify(outcome)}`);
       expect(["reader", "freeBusyReader"]).toContain(outcome.accessRole);
     } finally {
+      // Only reached when the gate did NOT refuse — an unlisted calendar leaves
+      // `accessRole` unknown, so the push falls through and really does write.
+      await deleteEventQuietly(accessToken, readOnly, eventId);
       await workspace.cleanup();
     }
   });

--- a/e2e-live/tests/calendar-push.spec.ts
+++ b/e2e-live/tests/calendar-push.spec.ts
@@ -1,0 +1,330 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  createCalendarEvent,
+  getCalendar,
+  getCalendarEvent,
+  getGoogleAccessToken,
+  listCalendars,
+  pushCalendarForCollection,
+  toGoogleEventTime,
+  updateCalendarEvent,
+  HTTP_CONFLICT,
+  HTTP_FORBIDDEN,
+  HTTP_PRECONDITION_FAILED,
+  type CalendarEventTime,
+  type FetchedCalendarEvent,
+} from "@mulmoclaude/core/google";
+
+import {
+  calendarIdFrom,
+  createCalendarCollectionWorkspace,
+  deleteEventQuietly,
+  liveCalendarBlocker,
+  missingCalendarReason,
+  newEventId,
+  statusOfRejection,
+  CALENDAR_FIELDS,
+  READONLY_CALENDAR_ENV,
+  UNLISTED_CALENDAR_ENV,
+  WRITABLE_CALENDAR_ENV,
+} from "../fixtures/live-google.ts";
+
+// Live verification of the Collection → Google Calendar push (#2602).
+//
+// #2598 / #2600 shipped the push with every test fake or mocked: the API shapes
+// were read off the Calendar v3 contract, never off an observed 200. Each test
+// here pins ONE of the claims that shipped unverified:
+//
+//   L-GCAL-01  a client-set event id + an offset-less dateTime           (items 1, 2)
+//   L-GCAL-02  a duplicate client-set id answers 409, not 400            (item 1)
+//   L-GCAL-03  a stale etag answers 412, not 409/400                     (item 3)
+//   L-GCAL-04  an all-day event survives a date move as all-day          (item 4)
+//   L-GCAL-05  an unlisted calendar reports a timeZone and accepts writes (item 5)
+//   L-GCAL-06  a calendar the account only reads answers 403             (item 6)
+//   L-GCAL-07  the real push creates, then stays quiet, then updates     (items 1, 2)
+//   L-GCAL-08  a read-only calendar is refused as a permissions problem  (item 6)
+//
+// L-GCAL-01..06 drive `calendar.ts` directly, because #2602 asks about STATUS
+// CODES and the push folds those into an outcome. L-GCAL-07 / 08 drive
+// `pushCalendarForCollection` — the same function the HTTP route calls — so the
+// feature itself is exercised, baseline persistence included.
+//
+// Nothing here runs without a linked Google account and a throwaway calendar id
+// in the env; see `../fixtures/live-google.ts` for the variables.
+
+// A collection stores the clock with no zone (`toCollectionDateTime` drops it),
+// so these are the values a locally-created record actually holds.
+const LOCAL_START = "2027-03-11T09:30";
+const LOCAL_END = "2027-03-11T10:15";
+// What Google must echo back: the same wall clock, read in the calendar's zone.
+const SENT_START = "2027-03-11T09:30:00";
+const SENT_END = "2027-03-11T10:15:00";
+
+const ALL_DAY_START = "2027-03-15";
+// Google's all-day `end` is EXCLUSIVE — one day on the 15th ends on the 16th.
+const ALL_DAY_END = "2027-03-16";
+const MOVED_START = "2027-03-18";
+const MOVED_END = "2027-03-19";
+
+const SUMMARY = "e2e-live push probe";
+const EDITED_SUMMARY = "e2e-live push probe (edited)";
+
+/** Narrow `toGoogleEventTime`'s nullable result at the call site — a null here
+ *  means the push would have refused the record, which is a test-setup bug. */
+function pushTime(local: string, previous: string | undefined, timeZone: string): CalendarEventTime {
+  const time = toGoogleEventTime(local, previous, timeZone);
+  if (time === null) throw new Error(`the push cannot build a Google time from ${JSON.stringify(local)}`);
+  return time;
+}
+
+/** The event Google currently holds, or a failure naming what was missing. */
+async function readEvent(accessToken: string, calendarId: string, eventId: string): Promise<FetchedCalendarEvent> {
+  const fetched = await getCalendarEvent(accessToken, { calendarId, eventId });
+  if (fetched === null) throw new Error(`Google has no event ${eventId} on ${calendarId}`);
+  return fetched;
+}
+
+/** Google answers RFC3339 with the calendar's own offset, so the civil part is
+ *  what says whether a zone-less dateTime was read in the intended zone. */
+const civilPartOf = (rfc3339: string, expected: string): string => rfc3339.slice(0, expected.length);
+
+test.describe("Google Calendar contract behind the push (#2602)", () => {
+  test.beforeEach(async () => {
+    const blocker = await liveCalendarBlocker();
+    test.skip(blocker !== null, blocker ?? "");
+  });
+
+  test("L-GCAL-01: client 指定の event id と offset 無し dateTime を Google が受ける (#2602 項目1,2)", async () => {
+    const accessToken = await getGoogleAccessToken();
+    const calendarId = calendarIdFrom(WRITABLE_CALENDAR_ENV);
+    const { timeZone } = await getCalendar(accessToken, calendarId);
+    expect(timeZone, "the calendar reports no timeZone, so a zone-less dateTime could never be pushed to it").not.toBe("");
+
+    // Pinned, not merely passed through: if the push ever starts sending an
+    // offset instead, this test must fail rather than quietly verify a
+    // different shape than the one #2602 asks about.
+    const start = pushTime(LOCAL_START, undefined, timeZone);
+    const end = pushTime(LOCAL_END, undefined, timeZone);
+    expect(start).toEqual({ dateTime: SENT_START, timeZone });
+
+    const eventId = newEventId();
+    try {
+      const created = await createCalendarEvent(accessToken, { eventId, calendarId, summary: SUMMARY, start, end });
+      expect(created.id).toBe(eventId);
+
+      const { event } = await readEvent(accessToken, calendarId, eventId);
+      expect(civilPartOf(event.start, SENT_START)).toBe(SENT_START);
+      expect(civilPartOf(event.end, SENT_END)).toBe(SENT_END);
+    } finally {
+      await deleteEventQuietly(accessToken, calendarId, eventId);
+    }
+  });
+
+  test("L-GCAL-02: 同じ client 指定 id での再 insert は 409 で返る (#2602 項目1)", async () => {
+    const accessToken = await getGoogleAccessToken();
+    const calendarId = calendarIdFrom(WRITABLE_CALENDAR_ENV);
+    const { timeZone } = await getCalendar(accessToken, calendarId);
+    const span = { start: pushTime(LOCAL_START, undefined, timeZone), end: pushTime(LOCAL_END, undefined, timeZone) };
+
+    const eventId = newEventId();
+    try {
+      await createCalendarEvent(accessToken, { eventId, calendarId, summary: SUMMARY, ...span });
+      // `createOrAdopt` recovers on 409 and on nothing else, so a 400 here would
+      // turn every duplicate into a hard per-record error.
+      const status = await statusOfRejection(() => createCalendarEvent(accessToken, { eventId, calendarId, summary: SUMMARY, ...span }));
+      expect(status).toBe(HTTP_CONFLICT);
+    } finally {
+      await deleteEventQuietly(accessToken, calendarId, eventId);
+    }
+  });
+
+  test("L-GCAL-03: 古い etag での If-Match 書き込みは 412 で返る (#2602 項目3)", async () => {
+    const accessToken = await getGoogleAccessToken();
+    const calendarId = calendarIdFrom(WRITABLE_CALENDAR_ENV);
+    const { timeZone } = await getCalendar(accessToken, calendarId);
+    const span = { start: pushTime(LOCAL_START, undefined, timeZone), end: pushTime(LOCAL_END, undefined, timeZone) };
+
+    const eventId = newEventId();
+    try {
+      await createCalendarEvent(accessToken, { eventId, calendarId, summary: SUMMARY, ...span });
+      const { etag } = await readEvent(accessToken, calendarId, eventId);
+      expect(etag, "Google returned no etag, so the push's conditional write has nothing to send").not.toBe("");
+
+      // Stands in for the change that lands between the push's read and its
+      // write — the window `If-Match` exists to close.
+      await updateCalendarEvent(accessToken, { eventId, calendarId, summary: "changed by someone else" });
+
+      const status = await statusOfRejection(() => updateCalendarEvent(accessToken, { eventId, calendarId, summary: EDITED_SUMMARY, ifMatch: etag }));
+      expect(status).toBe(HTTP_PRECONDITION_FAILED);
+    } finally {
+      await deleteEventQuietly(accessToken, calendarId, eventId);
+    }
+  });
+
+  test("L-GCAL-04: 終日イベントは日付を動かしても終日のまま、exclusive end もずれない (#2602 項目4)", async () => {
+    const accessToken = await getGoogleAccessToken();
+    const calendarId = calendarIdFrom(WRITABLE_CALENDAR_ENV);
+    const { timeZone } = await getCalendar(accessToken, calendarId);
+
+    const eventId = newEventId();
+    try {
+      await createCalendarEvent(accessToken, {
+        eventId,
+        calendarId,
+        summary: SUMMARY,
+        start: { date: ALL_DAY_START },
+        end: { date: ALL_DAY_END },
+      });
+      const created = await readEvent(accessToken, calendarId, eventId);
+      expect(created.event.start).toBe(ALL_DAY_START);
+      expect(created.event.end).toBe(ALL_DAY_END);
+
+      // What the push does when the user moves the day in the collection: the
+      // stored value is the flattened midnight, the baseline is Google's own
+      // `date`, and the conversion has to keep the event all-day.
+      const movedStart = pushTime(`${MOVED_START}T00:00`, ALL_DAY_START, timeZone);
+      const movedEnd = pushTime(`${MOVED_END}T00:00`, ALL_DAY_END, timeZone);
+      expect(movedStart).toEqual({ date: MOVED_START });
+
+      await updateCalendarEvent(accessToken, { eventId, calendarId, start: movedStart, end: movedEnd });
+      const moved = await readEvent(accessToken, calendarId, eventId);
+      expect(moved.event.start).toBe(MOVED_START);
+      expect(moved.event.end).toBe(MOVED_END);
+      // A timed event would come back as `…T00:00:00+09:00`.
+      expect(moved.event.start).not.toContain("T");
+    } finally {
+      await deleteEventQuietly(accessToken, calendarId, eventId);
+    }
+  });
+
+  test("L-GCAL-05: calendarList に無いカレンダーでも timeZone が取れて書き込める (#2602 項目5)", async () => {
+    const unlisted = calendarIdFrom(UNLISTED_CALENDAR_ENV);
+    test.skip(
+      unlisted === "",
+      missingCalendarReason(UNLISTED_CALENDAR_ENV, "a calendar shared with write access that is NOT added to this account's calendar list"),
+    );
+
+    const accessToken = await getGoogleAccessToken();
+    const listed = await listCalendars(accessToken);
+    expect(
+      listed.map((calendar) => calendar.id),
+      `${UNLISTED_CALENDAR_ENV} is in this account's calendar list, so it cannot exercise the unlisted path — remove it from the list or point the variable elsewhere`,
+    ).not.toContain(unlisted);
+
+    // #2600 iter-4 stopped treating "absent from calendarList" as read-only, on
+    // the assumption that the calendar resource still answers with a timezone.
+    const direct = await getCalendar(accessToken, unlisted);
+    expect(direct.timeZone).not.toBe("");
+
+    const eventId = newEventId();
+    try {
+      const span = { start: pushTime(LOCAL_START, undefined, direct.timeZone), end: pushTime(LOCAL_END, undefined, direct.timeZone) };
+      const created = await createCalendarEvent(accessToken, { eventId, calendarId: unlisted, summary: SUMMARY, ...span });
+      expect(created.id).toBe(eventId);
+    } finally {
+      await deleteEventQuietly(accessToken, unlisted, eventId);
+    }
+  });
+
+  test("L-GCAL-06: 読み取りしかできないカレンダーへの書き込みは 403 で返る (#2602 項目6)", async () => {
+    const readOnly = calendarIdFrom(READONLY_CALENDAR_ENV);
+    test.skip(
+      readOnly === "",
+      missingCalendarReason(READONLY_CALENDAR_ENV, "a calendar this account can read but not write (a subscribed holiday calendar will do)"),
+    );
+
+    const accessToken = await getGoogleAccessToken();
+    // An offset-bearing span, so a rejection can only be about permissions.
+    const status = await statusOfRejection(() =>
+      createCalendarEvent(accessToken, {
+        calendarId: readOnly,
+        summary: SUMMARY,
+        startDateTime: `${SENT_START}Z`,
+        endDateTime: `${SENT_END}Z`,
+      }),
+    );
+    expect(status).toBe(HTTP_FORBIDDEN);
+  });
+});
+
+test.describe("Collection → Google push, end to end (#2602)", () => {
+  test.beforeEach(async () => {
+    const blocker = await liveCalendarBlocker();
+    test.skip(blocker !== null, blocker ?? "");
+  });
+
+  test("L-GCAL-07: ローカル生成レコードが作成され、2回目は無音、編集後は更新される (#2602 項目1,2)", async () => {
+    const accessToken = await getGoogleAccessToken();
+    const calendarId = calendarIdFrom(WRITABLE_CALENDAR_ENV);
+    const eventId = newEventId();
+    const workspace = await createCalendarCollectionWorkspace(calendarId);
+    const quiet = { slug: workspace.slug, created: 0, updated: 0, conflicts: 0, localDeletes: 0, skipped: [], errors: [] };
+
+    try {
+      await workspace.putRecord(eventId, {
+        [CALENDAR_FIELDS.id]: eventId,
+        [CALENDAR_FIELDS.summary]: SUMMARY,
+        [CALENDAR_FIELDS.start]: LOCAL_START,
+        [CALENDAR_FIELDS.end]: LOCAL_END,
+      });
+
+      // Compared whole rather than field by field: a `skipped` message is how
+      // this feature reports a record it could not push, and asserting only
+      // `created` would let that pass silently.
+      expect(await pushCalendarForCollection(workspace.slug, workspace.root)).toEqual({ kind: "pushed", result: { ...quiet, created: 1 } });
+
+      const { event } = await readEvent(accessToken, calendarId, eventId);
+      expect(event.summary).toBe(SUMMARY);
+      expect(civilPartOf(event.start, SENT_START)).toBe(SENT_START);
+
+      // The baseline the first push wrote must make the record look unchanged;
+      // without it every click would re-send it and hit the duplicate-id 409.
+      expect(await pushCalendarForCollection(workspace.slug, workspace.root)).toEqual({ kind: "pushed", result: quiet });
+
+      await workspace.putRecord(eventId, {
+        [CALENDAR_FIELDS.id]: eventId,
+        [CALENDAR_FIELDS.summary]: EDITED_SUMMARY,
+        [CALENDAR_FIELDS.start]: LOCAL_START,
+        [CALENDAR_FIELDS.end]: LOCAL_END,
+      });
+      expect(await pushCalendarForCollection(workspace.slug, workspace.root)).toEqual({ kind: "pushed", result: { ...quiet, updated: 1 } });
+
+      const after = await readEvent(accessToken, calendarId, eventId);
+      expect(after.event.summary).toBe(EDITED_SUMMARY);
+    } finally {
+      await deleteEventQuietly(accessToken, calendarId, eventId);
+      await workspace.cleanup();
+    }
+  });
+
+  test("L-GCAL-08: 読み取り専用カレンダーへの push は権限の問題として返る (#2602 項目6)", async () => {
+    const readOnly = calendarIdFrom(READONLY_CALENDAR_ENV);
+    test.skip(
+      readOnly === "",
+      missingCalendarReason(READONLY_CALENDAR_ENV, "a calendar this account can read but not write (a subscribed holiday calendar will do)"),
+    );
+
+    const eventId = newEventId();
+    const workspace = await createCalendarCollectionWorkspace(readOnly);
+    try {
+      await workspace.putRecord(eventId, {
+        [CALENDAR_FIELDS.id]: eventId,
+        [CALENDAR_FIELDS.summary]: SUMMARY,
+        [CALENDAR_FIELDS.start]: LOCAL_START,
+        [CALENDAR_FIELDS.end]: LOCAL_END,
+      });
+
+      // The up-front role gate, not the per-event 403: a subscribed read-only
+      // calendar IS in the calendar list, so the push learns the real reason
+      // before it writes anything. The 403 branch in `writeFailure` is only
+      // reachable for a calendar that is unlisted AND unwritable, which needs a
+      // second account to set up — L-GCAL-06 pins Google's status for it.
+      const outcome = await pushCalendarForCollection(workspace.slug, workspace.root);
+      if (outcome.kind !== "read-only") throw new Error(`expected a read-only outcome, got ${JSON.stringify(outcome)}`);
+      expect(["reader", "freeBusyReader"]).toContain(outcome.accessRole);
+    } finally {
+      await workspace.cleanup();
+    }
+  });
+});

--- a/e2e-live/tests/calendar-push.spec.ts
+++ b/e2e-live/tests/calendar-push.spec.ts
@@ -2,9 +2,11 @@ import { expect, test } from "@playwright/test";
 
 import {
   createCalendarEvent,
+  deleteCalendarEvent,
   getCalendar,
   getCalendarEvent,
   getGoogleAccessToken,
+  isGoogleApiError,
   listCalendars,
   pushCalendarForCollection,
   toGoogleEventTime,
@@ -19,7 +21,6 @@ import {
 import {
   calendarIdFrom,
   createCalendarCollectionWorkspace,
-  deleteEventQuietly,
   liveCalendarBlocker,
   missingCalendarReason,
   newEventId,
@@ -69,6 +70,23 @@ const MOVED_END = "2027-03-19";
 
 const SUMMARY = "e2e-live push probe";
 const EDITED_SUMMARY = "e2e-live push probe (edited)";
+
+const HTTP_NOT_FOUND = 404;
+const HTTP_GONE = 410;
+/** An event that is already gone: teardown's success case, not a failure. */
+const ALREADY_GONE_STATUSES: readonly number[] = [HTTP_NOT_FOUND, HTTP_GONE];
+
+/** Best-effort teardown. A cleanup failure is recorded as an annotation instead
+ *  of thrown: raising here would replace the real assertion failure with a
+ *  delete error, and the leftover event still needs to be visible somewhere. */
+async function deleteEventQuietly(accessToken: string, calendarId: string, eventId: string): Promise<void> {
+  try {
+    await deleteCalendarEvent(accessToken, { calendarId, eventId });
+  } catch (error) {
+    if (isGoogleApiError(error) && ALREADY_GONE_STATUSES.includes(error.status)) return;
+    test.info().annotations.push({ type: "cleanup-failed", description: `${calendarId}/${eventId}: ${String(error)}` });
+  }
+}
 
 /** Narrow `toGoogleEventTime`'s nullable result at the call site — a null here
  *  means the push would have refused the record, which is a test-setup bug. */

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "test:e2e:live:happy-tour": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=happy-tour playwright test --config e2e-live/playwright.config.ts happy-tour.spec.ts",
     "test:e2e:live:plugin-dispatch": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=plugin-dispatch playwright test --config e2e-live/playwright.config.ts plugin-dispatch.spec.ts",
     "test:e2e:live:journey-llm": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=journey-llm playwright test --config e2e-live/playwright.config.ts journey-llm.spec.ts",
-    "test:e2e:live:calendar": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=calendar playwright test --config e2e-live/playwright.config.ts calendar-push.spec.ts",
+    "test:e2e:live:calendar": "cross-env E2E_LIVE_REPORT_SUBDIR=calendar playwright test --config e2e-live/playwright.config.ts calendar-push.spec.ts",
     "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts && yarn workspaces run test",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:e2e:live:happy-tour": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=happy-tour playwright test --config e2e-live/playwright.config.ts happy-tour.spec.ts",
     "test:e2e:live:plugin-dispatch": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=plugin-dispatch playwright test --config e2e-live/playwright.config.ts plugin-dispatch.spec.ts",
     "test:e2e:live:journey-llm": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=journey-llm playwright test --config e2e-live/playwright.config.ts journey-llm.spec.ts",
+    "test:e2e:live:calendar": "yarn ensure:playwright-browsers && cross-env E2E_LIVE_REPORT_SUBDIR=calendar playwright test --config e2e-live/playwright.config.ts calendar-push.spec.ts",
     "test:coverage": "tsx --test --experimental-test-coverage ./test/*/test_*.ts ./test/*/*/test_*.ts && yarn workspaces run test",
     "sandbox:remove": "docker rmi mulmoclaude-sandbox",
     "sandbox:login": "security find-generic-password -s 'Claude Code-credentials' -w > ~/.claude/.credentials.json && echo 'Credentials exported to ~/.claude/.credentials.json'",

--- a/plans/feat-e2e-live.md
+++ b/plans/feat-e2e-live.md
@@ -216,6 +216,14 @@ e2e-live/
 | L-FRESH-SANDBOX-BUILD | fresh-user | 新規ユーザー: sandbox image 不在から auto-build 経由で起動 | 未実装 |
 | L-FRESH-PRESET-SKILL | fresh-user | 新規ユーザー: preset skill が catalog → `.claude/skills/` に bridge mirror | 未実装 |
 | L-HAPPY-TOUR | happy-tour | 主要 View / route を一通り踏んで 「壊れていない」 を確認する正常系 sweep | ✅ 実装済 (happy-tour.spec.ts) |
+| L-GCAL-01〜08 | google | Collection → Google Calendar push を実カレンダーで検証 (#2602) | ✅ 実装済 (calendar-push.spec.ts) |
+
+> `L-GCAL-*` は LLM もブラウザも使わない第三のカテゴリ。 実 Google の OAuth grant と
+> 使い捨てカレンダー id (`E2E_LIVE_GOOGLE_CALENDAR_ID`) が要り、 無ければ skip する。
+> `MULMOCLAUDE_FAKE_AGENT` / `E2E_LIVE_NO_LLM` とは無関係なので no-LLM matrix にも入れない。
+> 設計は [`plans/test-2602-calendar-push-live.md`](test-2602-calendar-push-live.md)、
+> 運用は [`docs/e2e-live-testing.md`](../docs/e2e-live-testing.md) の
+> 「Specs that need a live Google account」。
 
 ## 未実装シナリオ詳細
 

--- a/plans/test-2602-calendar-push-live.md
+++ b/plans/test-2602-calendar-push-live.md
@@ -1,0 +1,112 @@
+# test(calendar): Collection → Google push を実カレンダーで検証する (#2602)
+
+## 背景
+
+#2598 / #2600 で入った Push to Google は、**一度も実 Google に対して動かしていない**。
+ユニットテストも e2e もすべて fake / mock で、API の形は「既存エンジンの実装」と
+「Calendar v3 のドキュメント」から読んだだけ。観測された 200 は 1 件も無い。
+
+#2602 が挙げる 6 項目は、どれも **Google 側の挙動についての主張** であり、
+こちら側のコードをいくら読んでも真偽が決まらない。外部の ground truth
+（= Google 本体の応答）に当てるしかない。
+
+## 方針
+
+`e2e-live/` に spec を 1 本足す（#2602 の「Suggested approach」どおり）。ただし
+既存の e2e-live spec と違い **LLM もブラウザも使わない**。検証対象は
+`@mulmoclaude/core/google` の関数群と Google Calendar API の契約なので、
+Playwright は「実行と trace/report の器」としてだけ使う。
+
+2 段構えにする。
+
+| 段 | 何を叩くか | 何が分かるか |
+|---|---|---|
+| A. API 契約 | `calendar.ts` の関数を直接 | Google が本当にその形を受け、その status を返すか |
+| B. push 経路 | `pushCalendarForCollection` を一時 workspace で | 機能として通しで動くか（baseline 永続化込み） |
+
+A だけでは「push が実際に動く」ことは言えず、B だけでは「409 か 400 か」のような
+status の断定ができない（push は status を握り潰して outcome に畳む）。両方要る。
+
+### スコープ外にしたもの
+
+- **UI**（Push ボタンと Sync ボタンの並び / 長い locale ラベル）。ブラウザで見る話なので
+  `/pr-ui-test` かスクリーンショットの担当。この PR には含めない。
+- **項目 5 の「共有されているがリストに無いカレンダー」の完全再現**。別アカウントから
+  共有してもらう必要があり、CI でも手元でも自動化できない。env で id を渡された時だけ
+  走る optional なテストにする（後述）。
+
+## 前提（実行者が用意するもの）
+
+アプリの OAuth スコープは `calendar.events` / `calendar.calendarlist.readonly` /
+`tasks` / `drive.file` の 4 つ。**カレンダー自体の作成・削除権限は無い**
+（それには full `calendar` スコープが要る）。したがって「テストが使い捨てカレンダーを
+自動で作って消す」はできない。**人が Google Calendar の UI で作って id を env で渡す。**
+
+| env | 必須 | 何を渡すか |
+|---|---|---|
+| `E2E_LIVE_GOOGLE_CALENDAR_ID` | ○ | 書き込んでよい使い捨てカレンダーの id |
+| `E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID` | — | 読めるが書けないカレンダー（例: 購読中の祝日カレンダー） |
+| `E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID` | — | 書けるが calendarList に無いカレンダー（項目 5） |
+
+必須の env が無ければ describe ごと skip。optional な env が無い項目は
+**その項目だけ** skip し、skip 理由に「何を用意すれば走るか」を書く
+（黙って通過して「検証済み」に見えるのが一番まずい）。
+
+イベントは毎回テスト側が作って `finally` で消す。id には nonce を入れて、
+並列 worker や前回の失敗残骸と衝突させない。
+
+## テスト項目と #2602 の対応
+
+### A. API 契約
+
+| # | #2602 | やること | 判定 |
+|---|---|---|---|
+| A-1 | 1, 2 | `toGoogleEventTime` が作る値をそのまま `createCalendarEvent` に渡す（offset 無し `dateTime` + `timeZone`、client 指定 id） | 201 相当で返り、id が指定どおり。読み戻した `start` が送った壁時計で始まる（= その zone で解釈された） |
+| A-2 | 1 | 同じ id でもう一度 insert | `GoogleApiError.status === 409`（400 ではない） |
+| A-3 | 3 | `getCalendarEvent` で etag を取り → 別経路で PATCH → 古い etag で `If-Match` PATCH | `status === 412`（409 でも 400 でもない） |
+| A-4 | 4 | 終日イベントを作り、push と同じ手順（`toGoogleEventTime(local, previous, tz)`）で日付を動かす | 終日のまま（`date` であり `dateTime` ではない）／ exclusive end が 1 日ずれない |
+| A-5 | 5 | `E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID` があるとき: `listCalendars()` に無いことを確認 → `getCalendar` → 書き込み | `timeZone` が返り、書き込みが通る |
+| A-6 | 6 | `E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID` があるとき: 書き込みを試す | `status === 403` |
+
+A-4 について: `CalendarEventSummary` は `date` と `dateTime` を 1 本の文字列に潰すので、
+`"T"` を含むかどうかで終日かを判定する。読み戻した `end` が `start` の翌日のままであることも見る。
+
+### B. push 経路
+
+一時 workspace（`mkdtemp`）に `.claude/skills/<slug>/schema.json` と records を置き、
+`configureCollectionHost` で core をその workspace に向けてから
+`pushCalendarForCollection(slug, tmp)` を **実 deps のまま** 呼ぶ。HTTP ルートが呼ぶのと同じ関数。
+
+| # | #2602 | やること | 判定 |
+|---|---|---|---|
+| B-1 | 1, 2 | ローカル生成レコード（hex id / offset 無し datetime）を push | `created: 1`, `skipped: []`, `errors: []`。Google 側に指定 id で存在し、summary と壁時計が一致 |
+| B-2 | — | 続けてもう一度 push | `created: 0 / updated: 0`（baseline が効いている＝毎回書き直さない） |
+| B-3 | — | summary を書き換えて push | `updated: 1`、Google 側に反映 |
+| B-4 | 6 | 読み取り専用カレンダーを指す schema で push | `kind: "read-only"`（権限の話として返る。「API が有効か」ヒントではない） |
+
+B-4 は 403 を踏む前の **up-front gate** を通る（購読中の read-only カレンダーは
+calendarList に `accessRole: "reader"` で載るため）。`writeFailure` の 403 → 権限メッセージ
+分岐は「リストに無くかつ書けない」カレンダーでしか踏めず、それは別アカウントが要る。
+A-6 で「Google が 403 を返すこと」だけ押さえ、分岐自体は未カバーと明記する。
+
+## 実装メモ
+
+- 新規 fixture `e2e-live/fixtures/live-google.ts` に env 読み取り / skip 判定 /
+  一時 workspace 構築 / イベント後始末を置く。spec 側は筋書きだけにする。
+- `configureGoogleHost` は呼ばない（未設定でも silent logger で動く設計）。
+  `configureCollectionHost` は必須（`discoverCollections` が host の paths を読む）。
+- 実行スクリプトは `test:e2e:live:calendar`。`E2E_LIVE_REPORT_SUBDIR=calendar` で
+  report を分ける（既存カテゴリの慣習どおり）。
+- `E2E_LIVE_NO_LLM=1` の CI matrix には **入れない**。LLM は使わないが実 Google 認証が要り、
+  CI に token は無い。必須 env が無ければどのみち skip される。
+- `docs/e2e-live-testing.md` に「Google 認証が要る spec」の節を足す。この spec は
+  「実 LLM」でも「fake-echo」でもない第三のカテゴリなので、表に載せないと次の人が迷う。
+
+## 実行後にやること
+
+走らせた結果 6 項目のどれかが **仮定と違っていたら、それは実装バグ**。
+その場で直さず #2602 に観測結果を書き、別 issue / 別 PR に切る（このPR は検証手段の追加）。
+
+特に項目 2 は、通ったら `packages/core/assets/helps/google.md` の
+「date-time は offset 必須、無いと 400」という記述が push 経路について誤りであることの
+証拠になるので、doc 修正を別途起票する。

--- a/plans/test-2602-calendar-push-live.md
+++ b/plans/test-2602-calendar-push-live.md
@@ -92,7 +92,22 @@ A-6 で「Google が 403 を返すこと」だけ押さえ、分岐自体は未�
 ## 実装メモ
 
 - 新規 fixture `e2e-live/fixtures/live-google.ts` に env 読み取り / skip 判定 /
-  一時 workspace 構築 / イベント後始末を置く。spec 側は筋書きだけにする。
+  一時 workspace 構築を置く。spec 側は筋書きだけにする。イベントの後始末
+  (`deleteEventQuietly`) は唯一の利用者である spec 側の local function に置く
+  （`test.info()` を使う＝ runner 依存なので、下記の理由で fixture には置けない）。
+- **fixture は `@playwright/test` に依存させない。** seed する workspace は
+  collection engine との contract（`discoverCollections` が受理する schema、
+  push が読む `googleCalendar` block、`storeFor().list()` が返すレコード）だが、
+  Google grant が無いと live spec は 8 件すべて skip されるので、この contract は
+  放っておくと誰にも見張られない。runner 非依存にしておけば
+  `test/e2e-live/test_calendarCollectionWorkspace.ts` から通常の `yarn test` で
+  当てられる（既存の `test/e2e-live/` の作法どおり）。
+- **`E2E_LIVE_GOOGLE_CALENDAR_ID` が `primary` なら拒否する。** イベントを作って
+  消す spec なので、宛先の誤りだけは避けたい。`primary` はエンジン自身の既定値でも
+  あり、最も踏みやすく最も破壊的な誤りにあたる。token を読む前に落とす。
+- **`test:e2e:live:calendar` だけ `ensure:playwright-browsers` を呼ばない。**
+  `page` / `context` / `browser` のどの fixture も使わないため。
+  `PLAYWRIGHT_BROWSERS_PATH` を空ディレクトリに向けて実測で確認する。
 - `configureGoogleHost` は呼ばない（未設定でも silent logger で動く設計）。
   `configureCollectionHost` は必須（`discoverCollections` が host の paths を読む）。
 - 実行スクリプトは `test:e2e:live:calendar`。`E2E_LIVE_REPORT_SUBDIR=calendar` で

--- a/test/e2e-live/test_calendarCollectionWorkspace.ts
+++ b/test/e2e-live/test_calendarCollectionWorkspace.ts
@@ -1,0 +1,121 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { discoverCollections, storeFor } from "@mulmoclaude/core/collection/server";
+
+import {
+  calendarIdFrom,
+  createCalendarCollectionWorkspace,
+  liveCalendarBlocker,
+  CALENDAR_FIELDS,
+  WRITABLE_CALENDAR_ENV,
+} from "../../e2e-live/fixtures/live-google.ts";
+
+// The workspace `live-google.ts` seeds is a CONTRACT with the collection
+// engine: a schema `discoverCollections` accepts, a `googleCalendar` block the
+// push reads, and record files `storeFor(...).list()` returns. Nothing in the
+// live spec (`e2e-live/tests/calendar-push.spec.ts`) can defend it, because
+// without a Google grant every one of those tests skips — so a schema-validator
+// change would break the fixture silently and only surface months later, in
+// front of whoever finally has credentials.
+//
+// These run with no network and no grant.
+
+const CALENDAR_ID = "e2e-live-contract@group.calendar.google.com";
+
+const cleanups: (() => Promise<void>)[] = [];
+
+const seedWorkspace = async () => {
+  const workspace = await createCalendarCollectionWorkspace(CALENDAR_ID);
+  cleanups.push(workspace.cleanup);
+  return workspace;
+};
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map(async (cleanup) => await cleanup()));
+});
+
+describe("live-google fixture: the seeded calendar collection", () => {
+  it("is discovered by the collection engine", async () => {
+    const workspace = await seedWorkspace();
+    const discovered = await discoverCollections({ workspaceRoot: workspace.root });
+    const found = discovered.find((collection) => collection.slug === workspace.slug);
+    // Discovery drops an invalid schema with a `log.warn` and returns nothing,
+    // so "not found" is exactly how a validator change would present itself.
+    assert.ok(found, `the seeded schema was rejected by discovery; slugs found: ${JSON.stringify(discovered.map((collection) => collection.slug))}`);
+  });
+
+  it("carries the googleCalendar block the push reads", async () => {
+    const workspace = await seedWorkspace();
+    const discovered = await discoverCollections({ workspaceRoot: workspace.root });
+    const found = discovered.find((collection) => collection.slug === workspace.slug);
+    assert.ok(found);
+    assert.equal(found.schema.googleCalendar?.calendarId, CALENDAR_ID);
+    // Every mapped source field must be one the push can actually write, or the
+    // live spec would assert `updated: 1` on a field the push silently ignores.
+    assert.deepEqual(found.schema.googleCalendar?.map, {
+      [CALENDAR_FIELDS.summary]: "summary",
+      [CALENDAR_FIELDS.start]: "start",
+      [CALENDAR_FIELDS.end]: "end",
+    });
+    assert.equal(found.schema.primaryKey, CALENDAR_FIELDS.id);
+  });
+
+  it("stores a record where the collection store reads it back", async () => {
+    const workspace = await seedWorkspace();
+    const record = {
+      [CALENDAR_FIELDS.id]: "deadbeef",
+      [CALENDAR_FIELDS.summary]: "probe",
+      [CALENDAR_FIELDS.start]: "2027-03-11T09:30",
+      [CALENDAR_FIELDS.end]: "2027-03-11T10:15",
+    };
+    await workspace.putRecord("deadbeef", record);
+
+    const discovered = await discoverCollections({ workspaceRoot: workspace.root });
+    const found = discovered.find((collection) => collection.slug === workspace.slug);
+    assert.ok(found);
+    // The push lists records through this same seam, so a dataPath the schema
+    // declares but the store cannot read would make every live test report
+    // `created: 0` with no error.
+    assert.deepEqual(await storeFor(found, { workspaceRoot: workspace.root }).list(), [record]);
+  });
+
+  it("gives each workspace its own slug so parallel workers cannot collide", async () => {
+    const [first, second] = await Promise.all([seedWorkspace(), seedWorkspace()]);
+    assert.notEqual(first.slug, second.slug);
+    assert.notEqual(first.root, second.root);
+  });
+});
+
+// `Reflect.deleteProperty` rather than `delete process.env[name]`: the lint
+// rule bans deleting a computed key, and the env var name is a constant these
+// tests share with the fixture rather than a literal to duplicate here.
+const unsetEnv = (name: string): void => {
+  Reflect.deleteProperty(process.env, name);
+};
+
+describe("live-google fixture: liveCalendarBlocker", () => {
+  const original = process.env[WRITABLE_CALENDAR_ENV];
+  afterEach(() => {
+    if (original === undefined) unsetEnv(WRITABLE_CALENDAR_ENV);
+    else process.env[WRITABLE_CALENDAR_ENV] = original;
+  });
+
+  it("blocks when no target calendar was supplied", async () => {
+    unsetEnv(WRITABLE_CALENDAR_ENV);
+    assert.match((await liveCalendarBlocker()) ?? "", /is unset/);
+  });
+
+  // The guard that matters: the live spec CREATES AND DELETES events, and
+  // `primary` is the value the Google engine itself falls back to — so it is
+  // both the easiest id to supply by mistake and the most destructive.
+  it("refuses `primary` before it ever reads a token", async () => {
+    process.env[WRITABLE_CALENDAR_ENV] = "primary";
+    assert.match((await liveCalendarBlocker()) ?? "", /point it at a throwaway calendar/);
+  });
+
+  it("reads the env value with surrounding whitespace trimmed", () => {
+    process.env[WRITABLE_CALENDAR_ENV] = "  padded@group.calendar.google.com  ";
+    assert.equal(calendarIdFrom(WRITABLE_CALENDAR_ENV), "padded@group.calendar.google.com");
+  });
+});


### PR DESCRIPTION
## Summary

#2598 / #2600 で入った **Push to Google は、一度も実 Google に対して動かしていない**。ユニットも e2e もすべて fake / mock で、API の形は Calendar v3 のドキュメントと既存エンジンの実装から読んだだけ。観測された 200 は 1 件も無い（#2602）。

そこで `e2e-live/tests/calendar-push.spec.ts` を新設し、#2602 が挙げる 6 項目を実 Google に当てて確かめられるようにした。他の e2e-live spec と違い **LLM もブラウザも使わない**（Playwright は runner / trace / report としてのみ使用）。

| テスト | #2602 | 何を確かめるか |
|---|---|---|
| L-GCAL-01 | 1, 2 | client 指定の event id と **offset 無し `dateTime` + `timeZone`** を Google が受け、送った壁時計のまま読み戻せる |
| L-GCAL-02 | 1 | 同じ id での再 insert が **409**（400 ではない） |
| L-GCAL-03 | 3 | 古い etag での `If-Match` が **412**（409 / 400 ではない） |
| L-GCAL-04 | 4 | 終日イベントが日付移動後も終日のまま、exclusive end がずれない |
| L-GCAL-05 | 5 | calendarList に無いカレンダーでも `timeZone` が取れて書ける |
| L-GCAL-06 | 6 | 読み取りしかできないカレンダーへの書き込みが **403** |
| L-GCAL-07 | 1, 2 | `pushCalendarForCollection` が作成 → 2回目は無音 → 編集後は更新（baseline 永続化込み） |
| L-GCAL-08 | 6 | 読み取り専用カレンダーへの push が権限の問題として返る |

加えて `test/e2e-live/test_calendarCollectionWorkspace.ts`（7 テスト、node:test）が **通常の `yarn test` で** fixture の contract を守る。Google grant が無いと上の 8 件は全部 skip されるので、これが無いと fixture は誰にも見張られない。

**⚠️ この PR は「検証手段」であり、「検証結果」ではない。** このホストに Google アカウントがリンクされていないため、**live 実行はまだしていない**。実行して仮定と違う挙動が出たら、それは実装バグとして #2602 に観測結果を書き、別 issue / 別 PR にする。

## Items to Confirm / Review

1. **2 段構えにした判断** — L-GCAL-01..06 は `calendar.ts` を直接叩き、L-GCAL-07..08 は `pushCalendarForCollection`（HTTP ルートが呼ぶのと同じ関数）を通す。理由は、#2602 の問いの大半が **status code**（409 か 400 か、412 か 409 か）であり、push はそれを outcome に畳んでしまって区別できないため。逆に API 直叩きだけでは「機能として動く」が言えない。片方だけで足りるという判断があれば指摘してほしい。
2. **カレンダーを人が用意する前提** — アプリの grant は `calendar.events` のみで **full `calendar` スコープが無い**ため、テストがカレンダーを自動生成・破棄することは**できない**。使い捨てカレンダーは人が Google の UI で作り、id を env で渡す。イベントは毎回テストが作って `finally` で消す。`primary` が渡された場合は拒否する（イベントを作って消す spec なので、宛先の誤りだけは避けたい）。
3. **項目 5 の限界** — 「共有されているが calendarList に無いカレンダー」は別アカウントが要るので optional env 扱い。`E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID` が渡された時だけ走り、渡されたカレンダーが実際にリストに無いことも assert する。
4. **項目 6 が 2 つに割れている点** — 購読中の read-only カレンダーは calendarList に `accessRole: "reader"` で載るため、push は書き込む前の **up-front gate** で止まる（L-GCAL-08）。`writeFailure` の「403 → 権限メッセージ」分岐は **リストに無く、かつ書けない**カレンダーでしか踏めず、これも別アカウントが要る。L-GCAL-06 で「Google が 403 を返すこと」だけ押さえ、分岐自体は未カバーとコメントに明記した。
5. **skip の作法** — 必須 env が無ければ describe ごと skip、optional な env が無い項目は**その項目だけ** skip し、skip 理由に「何を用意すれば走るか」を文で書く。黙って通過して「検証済み」に見えるのが #2602 の元凶なので、ここは意図的に冗長にしている。
6. **no-LLM CI matrix に入れていない** — LLM は使わないが実 Google の grant が要り、CI には無いので毎回 skip になる。`.github/workflows/e2e_live_no_llm.yaml` は触っていない。
7. **`test:e2e:live:calendar` だけ `ensure:playwright-browsers` を呼ばない** — この spec は `page` / `context` / `browser` のどの fixture も使わず、Playwright はそれらが要求されたときにだけブラウザを起動する。`PLAYWRIGHT_BROWSERS_PATH` を空ディレクトリに向けて実際に確認済み。ブラウザを使うテストを足すときは install を戻す必要がある。
8. **UI 項目はスコープ外** — #2602 の「Push ボタンと Sync ボタンの並び / 長い locale ラベル」はブラウザで見る話なので、この PR には含めていない（`/pr-ui-test` かスクリーンショットの担当）。

## User Prompt

- 「残課題ある？ https://github.com/receptron/mulmoclaude/issues/2602」
- （#2602 が未着手のまま 6 項目すべて残っていること、live テストを書くか尋ねたのに対して）「はい、live テスト書いて」
- （Google 連携の準備と commit/PR 方針を尋ねたのに対して）live 実行は「いったん pending」、「コミットして PR も作る」
- 「gh-review-loop」（bot レビューのトリアージ）

## 実装

### 追加したもの

| ファイル | 中身 |
|---|---|
| `e2e-live/tests/calendar-push.spec.ts` | live テスト 8 件（上表） |
| `e2e-live/fixtures/live-google.ts` | env 読み取り / skip 判定 / event id 生成 / 一時 workspace 構築 |
| `test/e2e-live/test_calendarCollectionWorkspace.ts` | fixture の contract テスト 7 件（node:test、grant 不要） |
| `plans/test-2602-calendar-push-live.md` | 設計と、スコープから外したものの理由 |
| `docs/e2e-live-testing.md` | 「Specs that need a live Google account」節 + 冒頭の例外説明 |
| `plans/feat-e2e-live.md` | シナリオ一覧に L-GCAL-01〜08 を追加 |
| `package.json` | `test:e2e:live:calendar` |

production コードには一切触れていない（全 7 ファイル、816 行の追加のみ）。

### 実行方法

```bash
export E2E_LIVE_GOOGLE_CALENDAR_ID='…@group.calendar.google.com'   # 必須・使い捨て
export E2E_LIVE_GOOGLE_READONLY_CALENDAR_ID='…'                    # 任意（項目6）
export E2E_LIVE_GOOGLE_UNLISTED_CALENDAR_ID='…'                    # 任意（項目5）
yarn test:e2e:live:calendar
```

### 設計上の細かい判断

- **`statusOfRejection()`** ヘルパを置いた。`rejects.toThrow()` では 409 と 400 を区別できず、#2602 の問いに答えられないため。Google 由来でないエラーは rethrow するので、テスト自身のバグが「Google が別のことを言った」と読めることはない。
- **送る値を pin している。** L-GCAL-01 は `toGoogleEventTime()` の結果を `{ dateTime: "2027-03-11T09:30:00", timeZone }` と等値比較する。将来 push が offset 付きを送るようになったら、#2602 が問うているのとは別の形を黙って検証し続けるのではなく落ちてほしい。
- **L-GCAL-07 は outcome を丸ごと `toEqual`。** `created` だけ見ると、レコードが push されず `skipped` に落ちたケースを見逃す。
- **後始末の失敗は throw せず annotation に積む。** `finally` で raise すると、本来の assertion 失敗が delete エラーに置き換わる。残ったイベントは report に出る。
- **`live-google.ts` は `@playwright/test` に依存しない。** seed する workspace は collection engine との contract であり、grant が無いと live spec は全部 skip されるので、runner 非依存にして通常の `yarn test` から contract テストを当てられるようにした。

### 実行済みの確認

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` すべて通過
- `test/e2e-live/test_calendarCollectionWorkspace.ts` 7 件パス
- `yarn test:e2e:live:calendar` が 8 テストを認識し、env 未設定時に理由付きで skip する
- ブラウザ未インストール状態（`PLAYWRIGHT_BROWSERS_PATH` を空ディレクトリに向けて）でも同じく動作する
- `liveCalendarBlocker` の 3 状態（未設定 / `primary` / 正常）の分岐を実際に呼んで確認
- `pushCalendarForCollection` が最後の認証境界まで到達する（`{"kind":"not-linked"}`）

### 未実施

**live 実行そのもの。** Google 連携と使い捨てカレンダーの用意が要るため保留中。走らせた結果は #2602 に記録する。特に項目 2 が通れば、`packages/core/assets/helps/google.md` の「date-time は offset 必須、無いと 400」という記述が push 経路について誤りである証拠になるので、doc 修正を別途起票する。

#2602（live 実行が済むまで開けておくため、closing keyword は使わない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Google Calendar end-to-end coverage for event creation, updates, time handling, permissions, and cleanup.
  * Added validation for calendar collection workspace setup, record roundtrips, and parallel execution safety.
  * Added safeguards against using the default calendar for destructive live tests.
* **Documentation**
  * Documented setup requirements, skip conditions, execution guidance, test scenarios, and CI behavior.
* **Test Improvements**
  * Added a dedicated command for running live calendar tests without browser installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->