### PR TITLE
refactor(google): dispatch を core/dispatch.ts に切り出す (#2583)

### DIFF
--- a/packages/plugins/google-plugin/src/core/dispatch.ts
+++ b/packages/plugins/google-plugin/src/core/dispatch.ts
@@ -1,0 +1,259 @@
+// Server-side router for the `google` tool. Engine calls arrive through
+// `context.api` rather than module-scope imports, so "which kind calls which
+// engine function with which arguments" can be checked with a stub — while the
+// calls were fixed imports, only module mocking could reach that mapping and
+// nothing did (#2583). Same shape as `html-plugin/src/core/dispatch.ts`.
+import { DEFAULT_LIST_MAX_RESULTS } from "@mulmoclaude/core/google";
+import type * as GoogleEngine from "@mulmoclaude/core/google";
+import type { PluginRuntime } from "gui-chat-protocol";
+import type { GoogleArgs } from "../args";
+
+/** The engine surface the router calls. Signatures are taken from
+ *  `@mulmoclaude/core/google` itself, so a change there fails this file
+ *  instead of drifting past a hand-written duplicate. */
+export type GoogleApi = Pick<
+  typeof GoogleEngine,
+  | "clearCalendarSyncToken"
+  | "clientSecretPresence"
+  | "completeTask"
+  | "createCalendarEvent"
+  | "createDriveFile"
+  | "createTask"
+  | "deleteCalendarEvent"
+  | "deleteTask"
+  | "getCalendarColors"
+  | "getGoogleAccessToken"
+  | "listCalendarEvents"
+  | "listCalendars"
+  | "listDriveFiles"
+  | "listTaskLists"
+  | "listTasks"
+  | "loadCalendarSyncToken"
+  | "loadGoogleTokens"
+  | "readDriveFile"
+  | "saveCalendarSyncToken"
+  | "syncCalendarEvents"
+  | "uncompleteTask"
+  | "updateCalendarEvent"
+  | "updateTask"
+>;
+
+export interface GoogleDispatchContext {
+  api: GoogleApi;
+  /** Narrowed to what the router actually writes, so a test stub stays small. */
+  log: Pick<PluginRuntime["log"], "info">;
+}
+
+type ArgsOf<K extends GoogleArgs["kind"]> = Extract<GoogleArgs, { kind: K }>;
+
+const LINK_GUIDANCE = "Ask the user to link their Google account in this app's settings, then retry.";
+
+// A sync can legitimately return an entire calendar's history on its first
+// run, so the tool answers with counts plus a capped sample — the whole point
+// of incremental sync is to stop burning context on calendar data (#2095).
+export const SYNC_SAMPLE_LIMIT = 20;
+
+const summarizeSync = (result: GoogleEngine.CalendarSyncResult, incremental: boolean) => {
+  const active = result.events.filter((event) => event.status !== "cancelled");
+  const cancelled = result.events.length - active.length;
+  return {
+    ok: true,
+    incremental,
+    changed: active.length,
+    cancelled,
+    events: active.slice(0, SYNC_SAMPLE_LIMIT),
+    truncated: active.length > SYNC_SAMPLE_LIMIT,
+  };
+};
+
+// 410 means the stored token aged out; drop it and start clean rather than
+// surfacing an error the user can do nothing about.
+async function restartFullSync(api: GoogleApi, accessToken: string, calendarId: string | undefined): Promise<GoogleEngine.CalendarSyncResult> {
+  await api.clearCalendarSyncToken(calendarId);
+  return await api.syncCalendarEvents(accessToken, { calendarId });
+}
+
+async function runCalendarSync(api: GoogleApi, calendarId: string | undefined, fullResync: boolean): Promise<unknown> {
+  const accessToken = await api.getGoogleAccessToken();
+  // Drop the token BEFORE rebuilding, not after: if the full sync then fails
+  // mid-way, the next run must still start clean rather than silently resuming
+  // from the stale state the user asked to discard.
+  if (fullResync) await api.clearCalendarSyncToken(calendarId);
+  const storedToken = fullResync ? null : await api.loadCalendarSyncToken(calendarId);
+  const first = await api.syncCalendarEvents(accessToken, { calendarId, syncToken: storedToken ?? undefined });
+  const result = first.fullResyncRequired ? await restartFullSync(api, accessToken, calendarId) : first;
+  if (result.nextSyncToken) await api.saveCalendarSyncToken(calendarId, result.nextSyncToken);
+  const incremental = Boolean(storedToken) && !first.fullResyncRequired;
+  return { ...summarizeSync(result, incremental), expiredToken: first.fullResyncRequired };
+}
+
+// One handler per kind, named after the kind, so the router below reads as the
+// kind → call table it is.
+
+const status = async ({ api }: GoogleDispatchContext) => {
+  const [tokens, clientSecret] = await Promise.all([api.loadGoogleTokens(), api.clientSecretPresence()]);
+  const linked = Boolean(tokens?.refresh_token);
+  return { ok: true, linked, clientSecret, ...(linked ? {} : { guidance: LINK_GUIDANCE }) };
+};
+
+const calendarListCalendars = async ({ api }: GoogleDispatchContext) => ({ ok: true, calendars: await api.listCalendars(await api.getGoogleAccessToken()) });
+
+const calendarColors = async ({ api }: GoogleDispatchContext) => ({ ok: true, colors: await api.getCalendarColors(await api.getGoogleAccessToken()) });
+
+const calendarListEvents = async ({ api }: GoogleDispatchContext, args: ArgsOf<"calendarListEvents">) => {
+  const events = await api.listCalendarEvents(await api.getGoogleAccessToken(), {
+    calendarId: args.calendarId,
+    timeMin: args.timeMin,
+    maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS,
+  });
+  return { ok: true, events };
+};
+
+const calendarSync = async ({ api }: GoogleDispatchContext, args: ArgsOf<"calendarSync">) =>
+  await runCalendarSync(api, args.calendarId, args.fullResync ?? false);
+
+const calendarCreateEvent = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"calendarCreateEvent">) => {
+  const event = await api.createCalendarEvent(await api.getGoogleAccessToken(), {
+    summary: args.summary,
+    startDateTime: args.start,
+    endDateTime: args.end,
+    description: args.description,
+    calendarId: args.calendarId,
+    colorId: args.colorId,
+  });
+  // Log ids only — titles / bodies are personal content.
+  log.info("calendar event created", { id: event.id });
+  return { ok: true, event };
+};
+
+const calendarUpdateEvent = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"calendarUpdateEvent">) => {
+  const event = await api.updateCalendarEvent(await api.getGoogleAccessToken(), {
+    eventId: args.eventId,
+    summary: args.summary,
+    startDateTime: args.start,
+    endDateTime: args.end,
+    description: args.description,
+    calendarId: args.calendarId,
+    colorId: args.colorId,
+  });
+  log.info("calendar event updated", { id: event.id });
+  return { ok: true, event };
+};
+
+const calendarDeleteEvent = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"calendarDeleteEvent">) => {
+  await api.deleteCalendarEvent(await api.getGoogleAccessToken(), { eventId: args.eventId, calendarId: args.calendarId });
+  log.info("calendar event deleted", { id: args.eventId });
+  return { ok: true, deleted: args.eventId };
+};
+
+const taskListsList = async ({ api }: GoogleDispatchContext) => ({ ok: true, taskLists: await api.listTaskLists(await api.getGoogleAccessToken()) });
+
+const tasksList = async ({ api }: GoogleDispatchContext, args: ArgsOf<"tasksList">) => {
+  const tasks = await api.listTasks(await api.getGoogleAccessToken(), {
+    taskListId: args.taskListId,
+    maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS,
+    showCompleted: args.showCompleted,
+  });
+  return { ok: true, tasks };
+};
+
+const tasksCreate = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"tasksCreate">) => {
+  const task = await api.createTask(await api.getGoogleAccessToken(), {
+    title: args.title,
+    notes: args.notes,
+    due: args.due,
+    taskListId: args.taskListId,
+  });
+  log.info("task created", { id: task.id });
+  return { ok: true, task };
+};
+
+const tasksUpdate = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"tasksUpdate">) => {
+  const task = await api.updateTask(await api.getGoogleAccessToken(), {
+    taskId: args.taskId,
+    title: args.title,
+    notes: args.notes,
+    due: args.due,
+    taskListId: args.taskListId,
+  });
+  log.info("task updated", { id: task.id });
+  return { ok: true, task };
+};
+
+const tasksComplete = async ({ api }: GoogleDispatchContext, args: ArgsOf<"tasksComplete">) => {
+  const task = await api.completeTask(await api.getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
+  return { ok: true, task };
+};
+
+const tasksUncomplete = async ({ api }: GoogleDispatchContext, args: ArgsOf<"tasksUncomplete">) => {
+  const task = await api.uncompleteTask(await api.getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
+  return { ok: true, task };
+};
+
+const tasksDelete = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"tasksDelete">) => {
+  await api.deleteTask(await api.getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
+  log.info("task deleted", { id: args.taskId });
+  return { ok: true, deleted: args.taskId };
+};
+
+const driveList = async ({ api }: GoogleDispatchContext, args: ArgsOf<"driveList">) => {
+  const files = await api.listDriveFiles(await api.getGoogleAccessToken(), { maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS });
+  return { ok: true, files };
+};
+
+const driveCreate = async ({ api, log }: GoogleDispatchContext, args: ArgsOf<"driveCreate">) => {
+  const file = await api.createDriveFile(await api.getGoogleAccessToken(), { name: args.name, content: args.content, mimeType: args.mimeType });
+  log.info("drive file created", { id: file.id });
+  return { ok: true, file };
+};
+
+const driveRead = async ({ api }: GoogleDispatchContext, args: ArgsOf<"driveRead">) => {
+  const { file, content } = await api.readDriveFile(await api.getGoogleAccessToken(), { fileId: args.fileId });
+  return { ok: true, file, content };
+};
+
+export async function executeGoogleDispatch(context: GoogleDispatchContext, args: GoogleArgs): Promise<unknown> {
+  switch (args.kind) {
+    case "status":
+      return await status(context);
+    case "calendarListCalendars":
+      return await calendarListCalendars(context);
+    case "calendarColors":
+      return await calendarColors(context);
+    case "calendarListEvents":
+      return await calendarListEvents(context, args);
+    case "calendarSync":
+      return await calendarSync(context, args);
+    case "calendarCreateEvent":
+      return await calendarCreateEvent(context, args);
+    case "calendarUpdateEvent":
+      return await calendarUpdateEvent(context, args);
+    case "calendarDeleteEvent":
+      return await calendarDeleteEvent(context, args);
+    case "taskListsList":
+      return await taskListsList(context);
+    case "tasksList":
+      return await tasksList(context, args);
+    case "tasksCreate":
+      return await tasksCreate(context, args);
+    case "tasksUpdate":
+      return await tasksUpdate(context, args);
+    case "tasksComplete":
+      return await tasksComplete(context, args);
+    case "tasksUncomplete":
+      return await tasksUncomplete(context, args);
+    case "tasksDelete":
+      return await tasksDelete(context, args);
+    case "driveList":
+      return await driveList(context, args);
+    case "driveCreate":
+      return await driveCreate(context, args);
+    case "driveRead":
+      return await driveRead(context, args);
+    default: {
+      // Exhaustiveness guard: a new kind without a branch trips this at compile time.
+      const exhaustive: never = args;
+      throw new Error(`unknown kind: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}

--- a/packages/plugins/google-plugin/src/index.ts
+++ b/packages/plugins/google-plugin/src/index.ts
@@ -6,206 +6,21 @@
 // chat. User-facing guidance stays host-neutral (#2128): the plugin runs on
 // multiple hosts (MulmoClaude, MulmoTerminal) whose link flows differ, and
 // each host's own help carries the specific steps.
+//
+// This file only wires the real engine into the router; the kind → call
+// mapping lives in `core/dispatch.ts`, where it is testable with a stub.
+import * as googleApi from "@mulmoclaude/core/google";
 import { definePlugin } from "gui-chat-protocol";
-import {
-  clearCalendarSyncToken,
-  clientSecretPresence,
-  completeTask,
-  createCalendarEvent,
-  createDriveFile,
-  createTask,
-  deleteCalendarEvent,
-  deleteTask,
-  getCalendarColors,
-  getGoogleAccessToken,
-  listCalendarEvents,
-  listCalendars,
-  listDriveFiles,
-  listTaskLists,
-  listTasks,
-  loadCalendarSyncToken,
-  loadGoogleTokens,
-  readDriveFile,
-  saveCalendarSyncToken,
-  syncCalendarEvents,
-  uncompleteTask,
-  updateCalendarEvent,
-  updateTask,
-  DEFAULT_LIST_MAX_RESULTS,
-  type CalendarSyncResult,
-} from "@mulmoclaude/core/google";
 import { GoogleArgs } from "./args";
+import { executeGoogleDispatch } from "./core/dispatch";
 import { TOOL_DEFINITION } from "./definition";
 
 export { TOOL_DEFINITION };
 
-const LINK_GUIDANCE = "Ask the user to link their Google account in this app's settings, then retry.";
+export default definePlugin(({ log }) => ({
+  TOOL_DEFINITION,
 
-// A sync can legitimately return an entire calendar's history on its first
-// run, so the tool answers with counts plus a capped sample — the whole point
-// of incremental sync is to stop burning context on calendar data (#2095).
-const SYNC_SAMPLE_LIMIT = 20;
-
-const summarizeSync = (result: CalendarSyncResult, incremental: boolean) => {
-  const active = result.events.filter((event) => event.status !== "cancelled");
-  const cancelled = result.events.length - active.length;
-  return {
-    ok: true,
-    incremental,
-    changed: active.length,
-    cancelled,
-    events: active.slice(0, SYNC_SAMPLE_LIMIT),
-    truncated: active.length > SYNC_SAMPLE_LIMIT,
-  };
-};
-
-// 410 means the stored token aged out; drop it and start clean rather than
-// surfacing an error the user can do nothing about.
-async function restartFullSync(accessToken: string, calendarId: string | undefined): Promise<CalendarSyncResult> {
-  await clearCalendarSyncToken(calendarId);
-  return await syncCalendarEvents(accessToken, { calendarId });
-}
-
-async function runCalendarSync(calendarId: string | undefined, fullResync: boolean): Promise<unknown> {
-  const accessToken = await getGoogleAccessToken();
-  // Drop the token BEFORE rebuilding, not after: if the full sync then fails
-  // mid-way, the next run must still start clean rather than silently resuming
-  // from the stale state the user asked to discard.
-  if (fullResync) await clearCalendarSyncToken(calendarId);
-  const storedToken = fullResync ? null : await loadCalendarSyncToken(calendarId);
-  const first = await syncCalendarEvents(accessToken, { calendarId, syncToken: storedToken ?? undefined });
-  const result = first.fullResyncRequired ? await restartFullSync(accessToken, calendarId) : first;
-  if (result.nextSyncToken) await saveCalendarSyncToken(calendarId, result.nextSyncToken);
-  const incremental = Boolean(storedToken) && !first.fullResyncRequired;
-  return { ...summarizeSync(result, incremental), expiredToken: first.fullResyncRequired };
-}
-
-export default definePlugin(({ log }) => {
-  const dispatch = async (args: GoogleArgs): Promise<unknown> => {
-    switch (args.kind) {
-      case "status": {
-        const [tokens, clientSecret] = await Promise.all([loadGoogleTokens(), clientSecretPresence()]);
-        const linked = Boolean(tokens?.refresh_token);
-        return { ok: true, linked, clientSecret, ...(linked ? {} : { guidance: LINK_GUIDANCE }) };
-      }
-      case "calendarListCalendars": {
-        return { ok: true, calendars: await listCalendars(await getGoogleAccessToken()) };
-      }
-      case "calendarColors": {
-        return { ok: true, colors: await getCalendarColors(await getGoogleAccessToken()) };
-      }
-      case "calendarListEvents": {
-        const events = await listCalendarEvents(await getGoogleAccessToken(), {
-          calendarId: args.calendarId,
-          timeMin: args.timeMin,
-          maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS,
-        });
-        return { ok: true, events };
-      }
-      case "calendarSync": {
-        return await runCalendarSync(args.calendarId, args.fullResync ?? false);
-      }
-      case "calendarCreateEvent": {
-        const event = await createCalendarEvent(await getGoogleAccessToken(), {
-          summary: args.summary,
-          startDateTime: args.start,
-          endDateTime: args.end,
-          description: args.description,
-          calendarId: args.calendarId,
-          colorId: args.colorId,
-        });
-        // Log ids only — titles / bodies are personal content.
-        log.info("calendar event created", { id: event.id });
-        return { ok: true, event };
-      }
-      case "calendarUpdateEvent": {
-        const event = await updateCalendarEvent(await getGoogleAccessToken(), {
-          eventId: args.eventId,
-          summary: args.summary,
-          startDateTime: args.start,
-          endDateTime: args.end,
-          description: args.description,
-          calendarId: args.calendarId,
-          colorId: args.colorId,
-        });
-        log.info("calendar event updated", { id: event.id });
-        return { ok: true, event };
-      }
-      case "calendarDeleteEvent": {
-        await deleteCalendarEvent(await getGoogleAccessToken(), { eventId: args.eventId, calendarId: args.calendarId });
-        log.info("calendar event deleted", { id: args.eventId });
-        return { ok: true, deleted: args.eventId };
-      }
-      case "taskListsList": {
-        return { ok: true, taskLists: await listTaskLists(await getGoogleAccessToken()) };
-      }
-      case "tasksList": {
-        const tasks = await listTasks(await getGoogleAccessToken(), {
-          taskListId: args.taskListId,
-          maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS,
-          showCompleted: args.showCompleted,
-        });
-        return { ok: true, tasks };
-      }
-      case "tasksCreate": {
-        const task = await createTask(await getGoogleAccessToken(), {
-          title: args.title,
-          notes: args.notes,
-          due: args.due,
-          taskListId: args.taskListId,
-        });
-        log.info("task created", { id: task.id });
-        return { ok: true, task };
-      }
-      case "tasksUpdate": {
-        const task = await updateTask(await getGoogleAccessToken(), {
-          taskId: args.taskId,
-          title: args.title,
-          notes: args.notes,
-          due: args.due,
-          taskListId: args.taskListId,
-        });
-        log.info("task updated", { id: task.id });
-        return { ok: true, task };
-      }
-      case "tasksComplete": {
-        const task = await completeTask(await getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
-        return { ok: true, task };
-      }
-      case "tasksUncomplete": {
-        const task = await uncompleteTask(await getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
-        return { ok: true, task };
-      }
-      case "tasksDelete": {
-        await deleteTask(await getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
-        log.info("task deleted", { id: args.taskId });
-        return { ok: true, deleted: args.taskId };
-      }
-      case "driveList": {
-        const files = await listDriveFiles(await getGoogleAccessToken(), { maxResults: args.maxResults ?? DEFAULT_LIST_MAX_RESULTS });
-        return { ok: true, files };
-      }
-      case "driveCreate": {
-        const file = await createDriveFile(await getGoogleAccessToken(), { name: args.name, content: args.content, mimeType: args.mimeType });
-        log.info("drive file created", { id: file.id });
-        return { ok: true, file };
-      }
-      case "driveRead": {
-        const { file, content } = await readDriveFile(await getGoogleAccessToken(), { fileId: args.fileId });
-        return { ok: true, file, content };
-      }
-      default: {
-        const exhaustive: never = args;
-        throw new Error(`unknown kind: ${JSON.stringify(exhaustive)}`);
-      }
-    }
-  };
-
-  return {
-    TOOL_DEFINITION,
-
-    async google(rawArgs: unknown) {
-      return await dispatch(GoogleArgs.parse(rawArgs));
-    },
-  };
-});
+  async google(rawArgs: unknown) {
+    return await executeGoogleDispatch({ api: googleApi, log }, GoogleArgs.parse(rawArgs));
+  },
+}));

--- a/packages/plugins/google-plugin/test/test_dispatch.ts
+++ b/packages/plugins/google-plugin/test/test_dispatch.ts
@@ -1,0 +1,342 @@
+// What each `kind` actually calls, and with which arguments. The engine is a
+// stub here — no network, no token file — which is the point: before the
+// router took its dependencies through a context (#2583) this mapping was only
+// reachable by mocking modules, so nothing checked it and a kind wired to the
+// wrong call or the wrong field name would have shipped silently.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_LIST_MAX_RESULTS, type CalendarEventSummary, type CalendarSyncResult, type ClientSecretPresence } from "@mulmoclaude/core/google";
+
+import { GoogleArgs } from "../src/args";
+import { executeGoogleDispatch, SYNC_SAMPLE_LIMIT, type GoogleApi, type GoogleDispatchContext } from "../src/core/dispatch";
+import { TOOL_DEFINITION } from "../src/definition";
+
+const ACCESS_TOKEN = "test-access-token";
+const NEXT_SYNC_TOKEN = "next-sync-token";
+
+const EVENT: CalendarEventSummary = {
+  id: "evt-1",
+  summary: "Lunch",
+  start: "2026-07-31T12:00:00+09:00",
+  end: "2026-07-31T13:00:00+09:00",
+  htmlLink: "https://calendar.google.com/event?eid=evt-1",
+  status: "confirmed",
+  colorId: "",
+};
+const CANCELLED_EVENT: CalendarEventSummary = { ...EVENT, id: "evt-cancelled", status: "cancelled" };
+const TASK = { id: "task-1", title: "Buy milk", status: "needsAction", due: "", notes: "" };
+const TASK_LIST = { id: "list-1", title: "My list" };
+const DRIVE_FILE = { id: "file-1", name: "notes.txt", mimeType: "text/plain", webViewLink: "https://drive.google.com/file/d/file-1", modifiedTime: "" };
+const SYNC_RESULT: CalendarSyncResult = { events: [EVENT], nextSyncToken: NEXT_SYNC_TOKEN, fullResyncRequired: false };
+
+/** A recorded call: the engine function's name followed by its arguments. */
+type Call = unknown[];
+
+interface SpyKit {
+  /** Records every call and always answers `result`. */
+  spy: <R>(name: string, result: R) => (...args: unknown[]) => Promise<R>;
+  /** Records every call and answers `results` in order, repeating the last. */
+  spyQueue: <R>(name: string, results: [R, ...R[]]) => (...args: unknown[]) => Promise<R>;
+}
+
+const createStub = (buildOverrides: (kit: SpyKit) => Partial<GoogleApi> = () => ({})) => {
+  const calls: Call[] = [];
+  const logged: Call[] = [];
+  const spy =
+    <R>(name: string, result: R) =>
+    async (...args: unknown[]): Promise<R> => {
+      calls.push([name, ...args]);
+      return result;
+    };
+  const spyQueue = <R>(name: string, results: [R, ...R[]]) => {
+    const remaining = [...results];
+    return async (...args: unknown[]): Promise<R> => {
+      calls.push([name, ...args]);
+      return remaining.length > 1 ? (remaining.shift() ?? results[0]) : remaining[0];
+    };
+  };
+  const api: GoogleApi = {
+    getGoogleAccessToken: spy("getGoogleAccessToken", ACCESS_TOKEN),
+    loadGoogleTokens: spy("loadGoogleTokens", { refresh_token: "stored-refresh" }),
+    clientSecretPresence: spy<ClientSecretPresence>("clientSecretPresence", "found"),
+    listCalendars: spy("listCalendars", []),
+    getCalendarColors: spy("getCalendarColors", { event: {}, calendar: {} }),
+    listCalendarEvents: spy("listCalendarEvents", [EVENT]),
+    syncCalendarEvents: spy("syncCalendarEvents", SYNC_RESULT),
+    loadCalendarSyncToken: spy("loadCalendarSyncToken", null),
+    saveCalendarSyncToken: spy("saveCalendarSyncToken", undefined),
+    clearCalendarSyncToken: spy("clearCalendarSyncToken", undefined),
+    createCalendarEvent: spy("createCalendarEvent", EVENT),
+    updateCalendarEvent: spy("updateCalendarEvent", EVENT),
+    deleteCalendarEvent: spy("deleteCalendarEvent", undefined),
+    listTaskLists: spy("listTaskLists", [TASK_LIST]),
+    listTasks: spy("listTasks", [TASK]),
+    createTask: spy("createTask", TASK),
+    updateTask: spy("updateTask", TASK),
+    completeTask: spy("completeTask", TASK),
+    uncompleteTask: spy("uncompleteTask", TASK),
+    deleteTask: spy("deleteTask", undefined),
+    listDriveFiles: spy("listDriveFiles", [DRIVE_FILE]),
+    createDriveFile: spy("createDriveFile", DRIVE_FILE),
+    readDriveFile: spy("readDriveFile", { file: DRIVE_FILE, content: "hello" }),
+    ...buildOverrides({ spy, spyQueue }),
+  };
+  const context: GoogleDispatchContext = {
+    api,
+    log: {
+      info: (msg: string, data?: object) => {
+        logged.push([msg, data]);
+      },
+    },
+  };
+  return { context, calls, logged };
+};
+
+/** Parses like the tool does, so a route's arguments must also be arguments the
+ *  LLM could actually send. */
+const dispatch = async (rawArgs: unknown, buildOverrides?: (kit: SpyKit) => Partial<GoogleApi>) => {
+  const stub = createStub(buildOverrides);
+  const result = await executeGoogleDispatch(stub.context, GoogleArgs.parse(rawArgs));
+  return { result, calls: stub.calls, logged: stub.logged };
+};
+
+interface Route {
+  args: GoogleArgs;
+  calls: Call[];
+  /** Expected `log.info` calls — ids only, never titles or bodies. */
+  logged?: Call[];
+}
+
+const ROUTES: Route[] = [
+  { args: { kind: "status" }, calls: [["loadGoogleTokens"], ["clientSecretPresence"]] },
+  { args: { kind: "calendarListCalendars" }, calls: [["getGoogleAccessToken"], ["listCalendars", ACCESS_TOKEN]] },
+  { args: { kind: "calendarColors" }, calls: [["getGoogleAccessToken"], ["getCalendarColors", ACCESS_TOKEN]] },
+  {
+    args: { kind: "calendarListEvents", calendarId: "cal-1", timeMin: "2026-07-31T00:00:00+09:00" },
+    calls: [
+      ["getGoogleAccessToken"],
+      ["listCalendarEvents", ACCESS_TOKEN, { calendarId: "cal-1", timeMin: "2026-07-31T00:00:00+09:00", maxResults: DEFAULT_LIST_MAX_RESULTS }],
+    ],
+  },
+  {
+    args: { kind: "calendarSync", calendarId: "cal-1" },
+    calls: [
+      ["getGoogleAccessToken"],
+      ["loadCalendarSyncToken", "cal-1"],
+      ["syncCalendarEvents", ACCESS_TOKEN, { calendarId: "cal-1", syncToken: undefined }],
+      ["saveCalendarSyncToken", "cal-1", NEXT_SYNC_TOKEN],
+    ],
+  },
+  {
+    args: { kind: "calendarCreateEvent", summary: "Lunch", start: "2026-07-31T12:00:00+09:00", end: "2026-07-31T13:00:00+09:00" },
+    calls: [
+      ["getGoogleAccessToken"],
+      [
+        "createCalendarEvent",
+        ACCESS_TOKEN,
+        {
+          summary: "Lunch",
+          startDateTime: "2026-07-31T12:00:00+09:00",
+          endDateTime: "2026-07-31T13:00:00+09:00",
+          description: undefined,
+          calendarId: undefined,
+          colorId: undefined,
+        },
+      ],
+    ],
+    logged: [["calendar event created", { id: EVENT.id }]],
+  },
+  {
+    args: { kind: "calendarUpdateEvent", eventId: "evt-1", summary: "Brunch" },
+    calls: [
+      ["getGoogleAccessToken"],
+      [
+        "updateCalendarEvent",
+        ACCESS_TOKEN,
+        {
+          eventId: "evt-1",
+          summary: "Brunch",
+          startDateTime: undefined,
+          endDateTime: undefined,
+          description: undefined,
+          calendarId: undefined,
+          colorId: undefined,
+        },
+      ],
+    ],
+    logged: [["calendar event updated", { id: EVENT.id }]],
+  },
+  {
+    args: { kind: "calendarDeleteEvent", eventId: "evt-1" },
+    calls: [["getGoogleAccessToken"], ["deleteCalendarEvent", ACCESS_TOKEN, { eventId: "evt-1", calendarId: undefined }]],
+    logged: [["calendar event deleted", { id: "evt-1" }]],
+  },
+  { args: { kind: "taskListsList" }, calls: [["getGoogleAccessToken"], ["listTaskLists", ACCESS_TOKEN]] },
+  {
+    args: { kind: "tasksList", showCompleted: true },
+    calls: [["getGoogleAccessToken"], ["listTasks", ACCESS_TOKEN, { taskListId: undefined, maxResults: DEFAULT_LIST_MAX_RESULTS, showCompleted: true }]],
+  },
+  {
+    args: { kind: "tasksCreate", title: "Buy milk" },
+    calls: [["getGoogleAccessToken"], ["createTask", ACCESS_TOKEN, { title: "Buy milk", notes: undefined, due: undefined, taskListId: undefined }]],
+    logged: [["task created", { id: TASK.id }]],
+  },
+  {
+    args: { kind: "tasksUpdate", taskId: "task-1", notes: "2 litres" },
+    calls: [
+      ["getGoogleAccessToken"],
+      ["updateTask", ACCESS_TOKEN, { taskId: "task-1", title: undefined, notes: "2 litres", due: undefined, taskListId: undefined }],
+    ],
+    logged: [["task updated", { id: TASK.id }]],
+  },
+  {
+    args: { kind: "tasksComplete", taskId: "task-1" },
+    calls: [["getGoogleAccessToken"], ["completeTask", ACCESS_TOKEN, { taskId: "task-1", taskListId: undefined }]],
+  },
+  {
+    args: { kind: "tasksUncomplete", taskId: "task-1" },
+    calls: [["getGoogleAccessToken"], ["uncompleteTask", ACCESS_TOKEN, { taskId: "task-1", taskListId: undefined }]],
+  },
+  {
+    args: { kind: "tasksDelete", taskId: "task-1", taskListId: "list-1" },
+    calls: [["getGoogleAccessToken"], ["deleteTask", ACCESS_TOKEN, { taskId: "task-1", taskListId: "list-1" }]],
+    logged: [["task deleted", { id: "task-1" }]],
+  },
+  { args: { kind: "driveList" }, calls: [["getGoogleAccessToken"], ["listDriveFiles", ACCESS_TOKEN, { maxResults: DEFAULT_LIST_MAX_RESULTS }]] },
+  {
+    args: { kind: "driveCreate", name: "notes.txt", content: "hello" },
+    calls: [["getGoogleAccessToken"], ["createDriveFile", ACCESS_TOKEN, { name: "notes.txt", content: "hello", mimeType: undefined }]],
+    logged: [["drive file created", { id: DRIVE_FILE.id }]],
+  },
+  { args: { kind: "driveRead", fileId: "file-1" }, calls: [["getGoogleAccessToken"], ["readDriveFile", ACCESS_TOKEN, { fileId: "file-1" }]] },
+];
+
+describe("executeGoogleDispatch routing", () => {
+  for (const route of ROUTES) {
+    it(`${route.args.kind} calls the engine it says it does`, async () => {
+      const { calls, logged } = await dispatch(route.args);
+      assert.deepEqual(calls, route.calls);
+      assert.deepEqual(logged, route.logged ?? []);
+    });
+  }
+
+  it("routes every kind the tool advertises", () => {
+    // `test_kind_coverage.ts` already pins this enum to the Zod union, so
+    // covering the enum covers the schema — and a new kind added without a
+    // route here fails rather than going untested.
+    const routed: string[] = ROUTES.map((route) => route.args.kind);
+    const missing = [...TOOL_DEFINITION.parameters.properties.kind.enum].filter((kind) => !routed.includes(kind));
+    assert.deepEqual(missing, [], `advertised kinds with no routing test: ${missing.join(", ")}`);
+  });
+
+  it("rejects a kind the schema does not accept", async () => {
+    await assert.rejects(() => dispatch({ kind: "calendarDropEverything" }));
+  });
+});
+
+describe("google dispatch results", () => {
+  it("reports a linked account without guidance", async () => {
+    const { result } = await dispatch({ kind: "status" });
+    assert.deepEqual(result, { ok: true, linked: true, clientSecret: "found" });
+  });
+
+  it("adds guidance when no refresh token is stored", async () => {
+    const { result } = await dispatch({ kind: "status" }, ({ spy }) => ({
+      loadGoogleTokens: spy("loadGoogleTokens", null),
+      clientSecretPresence: spy<ClientSecretPresence>("clientSecretPresence", "missing"),
+    }));
+    assert.deepEqual(result, {
+      ok: true,
+      linked: false,
+      clientSecret: "missing",
+      guidance: "Ask the user to link their Google account in this app's settings, then retry.",
+    });
+  });
+
+  it("returns the file and its content for driveRead", async () => {
+    const { result } = await dispatch({ kind: "driveRead", fileId: "file-1" });
+    assert.deepEqual(result, { ok: true, file: DRIVE_FILE, content: "hello" });
+  });
+});
+
+describe("calendarSync", () => {
+  it("counts changed and cancelled events separately", async () => {
+    const { result } = await dispatch({ kind: "calendarSync" }, ({ spy }) => ({
+      syncCalendarEvents: spy("syncCalendarEvents", { events: [EVENT, CANCELLED_EVENT], nextSyncToken: NEXT_SYNC_TOKEN, fullResyncRequired: false }),
+    }));
+    assert.deepEqual(result, { ok: true, incremental: false, changed: 1, cancelled: 1, events: [EVENT], truncated: false, expiredToken: false });
+  });
+
+  it("caps the returned sample and says it did", async () => {
+    const events = Array.from({ length: SYNC_SAMPLE_LIMIT + 5 }, (__unused, index) => ({ ...EVENT, id: `evt-${index}` }));
+    const { result } = await dispatch({ kind: "calendarSync" }, ({ spy }) => ({
+      syncCalendarEvents: spy("syncCalendarEvents", { events, nextSyncToken: NEXT_SYNC_TOKEN, fullResyncRequired: false }),
+    }));
+    assert.deepEqual(result, {
+      ok: true,
+      incremental: false,
+      changed: events.length,
+      cancelled: 0,
+      events: events.slice(0, SYNC_SAMPLE_LIMIT),
+      truncated: true,
+      expiredToken: false,
+    });
+  });
+
+  it("passes the stored token and reports the sync as incremental", async () => {
+    const { result, calls } = await dispatch({ kind: "calendarSync" }, ({ spy }) => ({
+      loadCalendarSyncToken: spy("loadCalendarSyncToken", "stored-token"),
+    }));
+    assert.deepEqual(
+      calls.find((call) => call[0] === "syncCalendarEvents"),
+      ["syncCalendarEvents", ACCESS_TOKEN, { calendarId: undefined, syncToken: "stored-token" }],
+    );
+    assert.deepEqual(result, { ok: true, incremental: true, changed: 1, cancelled: 0, events: [EVENT], truncated: false, expiredToken: false });
+  });
+
+  it("drops the stored token before rebuilding on fullResync", async () => {
+    // Order matters: a full sync that dies mid-way must still leave the next
+    // run starting clean, which only holds if the token is gone first.
+    const { calls } = await dispatch({ kind: "calendarSync", fullResync: true });
+    assert.deepEqual(
+      calls.map((call) => call[0]),
+      ["getGoogleAccessToken", "clearCalendarSyncToken", "syncCalendarEvents", "saveCalendarSyncToken"],
+    );
+  });
+
+  it("never reads a stored token on fullResync", async () => {
+    const { result, calls } = await dispatch({ kind: "calendarSync", fullResync: true }, ({ spy }) => ({
+      loadCalendarSyncToken: spy("loadCalendarSyncToken", "stored-token"),
+    }));
+    assert.equal(
+      calls.some((call) => call[0] === "loadCalendarSyncToken"),
+      false,
+    );
+    assert.deepEqual(result, { ok: true, incremental: false, changed: 1, cancelled: 0, events: [EVENT], truncated: false, expiredToken: false });
+  });
+
+  it("restarts from scratch when the stored token expired", async () => {
+    const { result, calls } = await dispatch({ kind: "calendarSync" }, ({ spy, spyQueue }) => ({
+      loadCalendarSyncToken: spy("loadCalendarSyncToken", "expired-token"),
+      syncCalendarEvents: spyQueue("syncCalendarEvents", [{ events: [], fullResyncRequired: true }, SYNC_RESULT]),
+    }));
+    assert.deepEqual(
+      calls.map((call) => call[0]),
+      ["getGoogleAccessToken", "loadCalendarSyncToken", "syncCalendarEvents", "clearCalendarSyncToken", "syncCalendarEvents", "saveCalendarSyncToken"],
+    );
+    // The retry is a full sync, so it is not incremental even though a token
+    // was stored — and the caller is told the token expired.
+    assert.deepEqual(result, { ok: true, incremental: false, changed: 1, cancelled: 0, events: [EVENT], truncated: false, expiredToken: true });
+  });
+
+  it("keeps the old token when the sync returns none", async () => {
+    const { calls } = await dispatch({ kind: "calendarSync" }, ({ spy }) => ({
+      syncCalendarEvents: spy("syncCalendarEvents", { events: [EVENT], fullResyncRequired: false }),
+    }));
+    assert.equal(
+      calls.some((call) => call[0] === "saveCalendarSyncToken"),
+      false,
+    );
+  });
+});

--- a/packages/plugins/google-plugin/test/test_dispatch.ts
+++ b/packages/plugins/google-plugin/test/test_dispatch.ts
@@ -40,9 +40,10 @@ interface SpyKit {
   spyQueue: <R>(name: string, results: [R, ...R[]]) => (...args: unknown[]) => Promise<R>;
 }
 
-const createStub = (buildOverrides: (kit: SpyKit) => Partial<GoogleApi> = () => ({})) => {
+/** Spies that append to one shared call log, so a test can read the whole
+ *  conversation with the engine in order. */
+const createRecorder = () => {
   const calls: Call[] = [];
-  const logged: Call[] = [];
   const spy =
     <R>(name: string, result: R) =>
     async (...args: unknown[]): Promise<R> => {
@@ -53,43 +54,52 @@ const createStub = (buildOverrides: (kit: SpyKit) => Partial<GoogleApi> = () => 
     const remaining = [...results];
     return async (...args: unknown[]): Promise<R> => {
       calls.push([name, ...args]);
-      return remaining.length > 1 ? (remaining.shift() ?? results[0]) : remaining[0];
+      const [next] = remaining;
+      if (remaining.length > 1) remaining.shift();
+      return next;
     };
   };
-  const api: GoogleApi = {
-    getGoogleAccessToken: spy("getGoogleAccessToken", ACCESS_TOKEN),
-    loadGoogleTokens: spy("loadGoogleTokens", { refresh_token: "stored-refresh" }),
-    clientSecretPresence: spy<ClientSecretPresence>("clientSecretPresence", "found"),
-    listCalendars: spy("listCalendars", []),
-    getCalendarColors: spy("getCalendarColors", { event: {}, calendar: {} }),
-    listCalendarEvents: spy("listCalendarEvents", [EVENT]),
-    syncCalendarEvents: spy("syncCalendarEvents", SYNC_RESULT),
-    loadCalendarSyncToken: spy("loadCalendarSyncToken", null),
-    saveCalendarSyncToken: spy("saveCalendarSyncToken", undefined),
-    clearCalendarSyncToken: spy("clearCalendarSyncToken", undefined),
-    createCalendarEvent: spy("createCalendarEvent", EVENT),
-    updateCalendarEvent: spy("updateCalendarEvent", EVENT),
-    deleteCalendarEvent: spy("deleteCalendarEvent", undefined),
-    listTaskLists: spy("listTaskLists", [TASK_LIST]),
-    listTasks: spy("listTasks", [TASK]),
-    createTask: spy("createTask", TASK),
-    updateTask: spy("updateTask", TASK),
-    completeTask: spy("completeTask", TASK),
-    uncompleteTask: spy("uncompleteTask", TASK),
-    deleteTask: spy("deleteTask", undefined),
-    listDriveFiles: spy("listDriveFiles", [DRIVE_FILE]),
-    createDriveFile: spy("createDriveFile", DRIVE_FILE),
-    readDriveFile: spy("readDriveFile", { file: DRIVE_FILE, content: "hello" }),
-    ...buildOverrides({ spy, spyQueue }),
-  };
-  const context: GoogleDispatchContext = {
-    api,
-    log: {
-      info: (msg: string, data?: object) => {
-        logged.push([msg, data]);
-      },
+  return { calls, spy, spyQueue };
+};
+
+/** A linked account whose every call succeeds. Tests override only the one
+ *  answer they are about. */
+const linkedAccountApi = ({ spy }: SpyKit): GoogleApi => ({
+  getGoogleAccessToken: spy("getGoogleAccessToken", ACCESS_TOKEN),
+  loadGoogleTokens: spy("loadGoogleTokens", { refresh_token: "stored-refresh" }),
+  clientSecretPresence: spy<ClientSecretPresence>("clientSecretPresence", "found"),
+  listCalendars: spy("listCalendars", []),
+  getCalendarColors: spy("getCalendarColors", { event: {}, calendar: {} }),
+  listCalendarEvents: spy("listCalendarEvents", [EVENT]),
+  syncCalendarEvents: spy("syncCalendarEvents", SYNC_RESULT),
+  loadCalendarSyncToken: spy("loadCalendarSyncToken", null),
+  saveCalendarSyncToken: spy("saveCalendarSyncToken", undefined),
+  clearCalendarSyncToken: spy("clearCalendarSyncToken", undefined),
+  createCalendarEvent: spy("createCalendarEvent", EVENT),
+  updateCalendarEvent: spy("updateCalendarEvent", EVENT),
+  deleteCalendarEvent: spy("deleteCalendarEvent", undefined),
+  listTaskLists: spy("listTaskLists", [TASK_LIST]),
+  listTasks: spy("listTasks", [TASK]),
+  createTask: spy("createTask", TASK),
+  updateTask: spy("updateTask", TASK),
+  completeTask: spy("completeTask", TASK),
+  uncompleteTask: spy("uncompleteTask", TASK),
+  deleteTask: spy("deleteTask", undefined),
+  listDriveFiles: spy("listDriveFiles", [DRIVE_FILE]),
+  createDriveFile: spy("createDriveFile", DRIVE_FILE),
+  readDriveFile: spy("readDriveFile", { file: DRIVE_FILE, content: "hello" }),
+});
+
+const createStub = (buildOverrides: (kit: SpyKit) => Partial<GoogleApi> = () => ({})) => {
+  const { calls, spy, spyQueue } = createRecorder();
+  const logged: Call[] = [];
+  const api: GoogleApi = { ...linkedAccountApi({ spy, spyQueue }), ...buildOverrides({ spy, spyQueue }) };
+  const log = {
+    info: (msg: string, data?: object) => {
+      logged.push([msg, data]);
     },
   };
+  const context: GoogleDispatchContext = { api, log };
   return { context, calls, logged };
 };
 
@@ -254,6 +264,16 @@ describe("google dispatch results", () => {
     });
   });
 
+  it("passes an explicit maxResults through instead of the default", async () => {
+    // The table above only covers the omitted case, which a handler that
+    // ignored the argument entirely would also satisfy.
+    const { calls } = await dispatch({ kind: "calendarListEvents", maxResults: 3 });
+    assert.deepEqual(
+      calls.find((call) => call[0] === "listCalendarEvents"),
+      ["listCalendarEvents", ACCESS_TOKEN, { calendarId: undefined, timeMin: undefined, maxResults: 3 }],
+    );
+  });
+
   it("returns the file and its content for driveRead", async () => {
     const { result } = await dispatch({ kind: "driveRead", fileId: "file-1" });
     assert.deepEqual(result, { ok: true, file: DRIVE_FILE, content: "hello" });
@@ -325,6 +345,12 @@ describe("calendarSync", () => {
       calls.map((call) => call[0]),
       ["getGoogleAccessToken", "loadCalendarSyncToken", "syncCalendarEvents", "clearCalendarSyncToken", "syncCalendarEvents", "saveCalendarSyncToken"],
     );
+    // The retry must carry no token at all. Asserting only the call order
+    // would still pass if it re-sent the expired one — which is the whole
+    // failure this branch exists to avoid.
+    const [firstSync, retrySync] = calls.filter((call) => call[0] === "syncCalendarEvents");
+    assert.deepEqual(firstSync, ["syncCalendarEvents", ACCESS_TOKEN, { calendarId: undefined, syncToken: "expired-token" }]);
+    assert.deepEqual(retrySync, ["syncCalendarEvents", ACCESS_TOKEN, { calendarId: undefined }]);
     // The retry is a full sync, so it is not incremental even though a token
     // was stored — and the caller is told the token expired.
     assert.deepEqual(result, { ok: true, incremental: false, changed: 1, cancelled: 0, events: [EVENT], truncated: false, expiredToken: true });

--- a/plans/refactor-2583-google-dispatch.md
+++ b/plans/refactor-2583-google-dispatch.md
@@ -1,0 +1,74 @@
+# google-plugin の dispatch を core/dispatch.ts に切り出す
+
+Issue: #2583（spotify 37 / google 18 のうち **google 側**）· 発端: #2577 の CodeRabbit 指摘
+
+## 何が問題か（行数ではない）
+
+`packages/plugins/google-plugin/src/index.ts` の `dispatch` は 18 ケース・118 行だが、
+本当のコストは**ルーティングをテストできないこと**。各ケースが依存をモジュールスコープの
+import から直接呼ぶ:
+
+```ts
+case "tasksUncomplete": {
+  const task = await uncompleteTask(await getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
+  return { ok: true, task };
+}
+```
+
+`getGoogleAccessToken` / `uncompleteTask` が固定の import なので、「kind → 正しい関数 →
+正しい引数」を検証するにはモジュールモックが要る。結果、現状のテストは args スキーマ
+(`test_args_validation.ts`) と kind の網羅 (`test_kind_coverage.ts`) だけで、**対応表そのものは
+誰も検証していない**。`sonarjs/cognitive-complexity` はフラットな switch を積み上げないので
+自動ゲートも素通りする（plugin 配下には `complexity` / `max-lines-per-function` すら効いていない
+— root の該当ブロックは `{src,test}/**` スコープ）。
+
+## 形は html-plugin に合わせる
+
+`packages/plugins/html-plugin/src/core/dispatch.ts` が先例。依存を context で注入し、
+`never` の網羅性ガードを持つ。google も同じ形にする。
+
+## 変更
+
+### 新規 `src/core/dispatch.ts`
+
+- `GoogleApi` — 注入される engine 関数の型。**シグネチャを手書きしない**:
+  `Pick<typeof GoogleEngine, "getGoogleAccessToken" | …>`（`import type * as GoogleEngine from
+  "@mulmoclaude/core/google"`）。core 側が引数を変えたらここが即座に型エラーになる = drift しない。
+- `GoogleDispatchContext = { api: GoogleApi; log: Pick<PluginRuntime["log"], "info"> }`。
+  `log` は `info` だけ使うので `Pick` で絞る（テストのスタブが小さくなる）。
+- `executeGoogleDispatch(context, args)` — **1 ケース 1 行**の router。各ケースは名前付きハンドラ
+  (`listEvents` / `createEvent` / `syncCalendar` …) を呼ぶだけにして、「kind → 呼ばれる関数」を
+  目次として読めるようにする。`default` の `const exhaustive: never = args` は現状のまま維持。
+- `runCalendarSync` / `restartFullSync` / `summarizeSync` も一緒に移し、engine 呼び出しを
+  `context.api` 経由に付け替える。
+
+router 本体は 18 ケース + default で 20 行を超えるが、これは issue の「やらないこと」に該当
+（動機は行数ではない）。ハンドラ側は 1〜8 行に収まる。
+
+### `src/index.ts`
+
+薄くなる: `import * as googleApi from "@mulmoclaude/core/google"` を **namespace のまま**
+context に渡す（`GoogleApi` は `Pick` なので構造的に満たす。23 関数を手で並べ直さない）。
+`definePlugin` の中身は「args を parse して executeGoogleDispatch を呼ぶ」だけになる。
+
+### 新規 `test/test_dispatch.ts`
+
+呼び出しを記録するスタブ context（ネットワークもトークンも無し）で:
+
+- **ルーティング**: 全 18 kind について「呼ばれた engine 関数」と「渡された引数」を検証。
+  特に `maxResults` 未指定時の `DEFAULT_LIST_MAX_RESULTS` 適用、`args.start/end` →
+  `startDateTime/endDateTime` の名前の付け替えなど、**今まで誰も見ていなかった対応**を固定する。
+- **calendarSync のロジック**（回帰価値が最も高い）:
+  - `fullResync: true` は **同期前に** token を捨てる（#2095 の意図。捨てる前に落ちても次回はクリーン）
+  - 410 → `fullResyncRequired` で token を捨てて全同期をやり直す
+  - `nextSyncToken` があれば保存する
+  - `incremental` は「保存 token あり かつ 再同期不要」のときだけ true
+  - `cancelled` の集計と `SYNC_SAMPLE_LIMIT` での truncate
+- 網羅性: `GoogleArgs` の全 kind がテストに現れることを、スキーマ側の kind 一覧と突き合わせて確認
+  （kind を足してテストを足し忘れたら落ちる）。
+
+## やらないこと
+
+- spotify（37 ケース）— issue の指示どおり **別 PR**
+- 7 ケース以下のプラグイン（debug / edgar / markdown / recipe-book / bookmarks / email）
+- 挙動の変更。返り値の形・ログ・エラー文言は現状のまま（純粋な構造変更）


### PR DESCRIPTION
## Summary

`google-plugin` の 18 ケースの dispatch switch を `src/core/dispatch.ts` に切り出し、依存を **context 注入**で受け取る形（`html-plugin/src/core/dispatch.ts` と同形）にしました。あわせて「kind → 呼ばれる engine 関数 → 渡される引数」を検証するテストを新設しています。

**挙動は不変**（返り値の形・ログ・エラー文言はそのまま）。`src/index.ts` は 211 行 → 26 行。

Closes #2583 の google 側（spotify 37 ケースは issue の指示どおり**別 PR**）。

## Items to Confirm / Review

人間に見てほしい点：

1. **`GoogleApi` の型の作り方** — `Pick<typeof GoogleEngine, "getGoogleAccessToken" | …>`（`import type * as GoogleEngine from "@mulmoclaude/core/google"`）でシグネチャを core から借りています。手書きの重複を作らない代わりに、やや珍しい書き方です。この方針で良いか。
2. **router が 20 行を超えること** — 18 ケース + default で 25 行。issue の「やらないこと」に「20 行制限を機械的に全 switch へ適用しない（動機は行数ではなくテスト可能性）」と明記されているため、1 ケース 1 行の対応表として残しました。ハンドラ側は 1〜8 行です。
3. **テストが引数を完全一致で pin していること** — `description: undefined` のような「値は undefined だがキーは存在する」ところまで `deepEqual` で固定しています。将来 undefined キーを落とす変更をすると赤くなります（意図的：payload の形を pin するのが目的）。
4. **`import * as googleApi`（namespace import）** — 23 関数を手で並べ直さないための選択。core は vite の external なので `dist/index.js` では `import * as googleApi from "@mulmoclaude/core/google"` のまま出ます（確認済み）。
5. **バージョン据え置き** — 公開 API・挙動とも不変なので `@mulmoclaude/google-plugin` は 1.2.0 のまま。次の publish にまとめる想定。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2583 に残課題があるか確認してほしい
- 残課題のうち **google から着手して**ほしい

## なぜ行数ではなくテスト可能性が問題だったか

変更前は各ケースが engine をモジュールスコープの import から直接呼んでいました：

```ts
case "tasksUncomplete": {
  const task = await uncompleteTask(await getGoogleAccessToken(), { taskId: args.taskId, taskListId: args.taskListId });
  return { ok: true, task };
}
```

`getGoogleAccessToken` / `uncompleteTask` が固定の import なので、ルーティングの正しさを見るにはモジュールモックが必要。結果として既存テストは args スキーマ（`test_args_validation.ts`）と kind の網羅（`test_kind_coverage.ts`）だけで、**対応表そのものは誰も検証していませんでした**。`sonarjs/cognitive-complexity` はフラットな switch を積み上げないので自動ゲートも素通りします（そもそも `packages/plugins/**` には `complexity` / `max-lines-per-function` が効いていません — root の該当ブロックは `{src,test}/**` スコープ）。

## 実装

### 新規 `packages/plugins/google-plugin/src/core/dispatch.ts`

- `GoogleApi` — 注入される engine 関数の型。`Pick<typeof GoogleEngine, …>` で core 側のシグネチャをそのまま借りるので、core が引数を変えたらこのファイルが型エラーになります（drift しない）。
- `GoogleDispatchContext = { api: GoogleApi; log: Pick<PluginRuntime["log"], "info"> }`。`log` は実際に使う `info` だけに絞ってテストのスタブを小さくしています。
- `executeGoogleDispatch(context, args)` — **1 ケース 1 行**の router。各 kind と同名のハンドラ（`tasksUncomplete` → `tasksUncomplete()`）を呼ぶだけなので、「kind → 呼ばれる関数」が目次として読めます。`default` の `const exhaustive: never = args` は維持。
- `runCalendarSync` / `restartFullSync` / `summarizeSync` も移設し、engine 呼び出しを `context.api` 経由に付け替え。`SYNC_SAMPLE_LIMIT` はテストが定数を再宣言しないよう export しました。

### `src/index.ts`

`import * as googleApi from "@mulmoclaude/core/google"` を namespace のまま context に渡し、`GoogleArgs.parse` → `executeGoogleDispatch` するだけの薄い層に。

### 新規 `test/test_dispatch.ts`（30 tests）

ネットワークもトークンも使わないスタブ（呼び出しを `[name, ...args]` で記録）で：

- **ルーティング**: 全 18 kind について呼ばれた engine 関数と引数を完全一致で検証。`args.start` → `startDateTime` の付け替え、`maxResults` 未指定時の `DEFAULT_LIST_MAX_RESULTS` 適用、`log.info` が **id だけ**を出すこと（タイトル・本文を出さない、というプライバシー上の意図）まで固定。
- **`calendarSync` のロジック**（回帰価値が最も高い）: `fullResync` は同期**前**に token を破棄する（呼び出し順を assert）／`fullResync` 時は保存 token を読まない／410 で token を捨てて全同期をやり直す／`nextSyncToken` が無ければ保存しない／`incremental` は「保存 token あり かつ 再同期不要」のときだけ true／cancelled の集計と `SYNC_SAMPLE_LIMIT` での truncate。
- **網羅性**: `TOOL_DEFINITION` の enum に routing テストの無い kind があれば落ちる（`test_kind_coverage.ts` が enum ↔ Zod union を既に pin しているので、そこを経由してスキーマも覆えます）。

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck`（exit 0）/ `yarn build`（exit 0）/ `yarn test`（exit 0、plugin の 111 tests を含む）
- **テストが実際に効くことを確認**: `tasksUncomplete` を `completeTask` に誤配線し、`calendarCreateEvent` の start/end を入れ替えたところ、該当 2 テストが赤。戻して green。
- **網羅性ガードが生きていることを確認**: `case "tasksUncomplete"` を削ると `TS2322: … is not assignable to type 'never'` で `tsc` が落ちる。
- **挙動不変の機械的確認**: 変更前 `index.ts` と新 `dispatch.ts` の engine 呼び出しの**多重集合が完全一致**。

## やらないこと

- spotify（37 ケース）— issue の指示どおり別 PR
- 7 ケース以下のプラグイン（debug / edgar / markdown / recipe-book / bookmarks / email）
- 挙動の変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude2

## Summary by Sourcery

Extract the Google plugin dispatch logic into a dedicated, context-injected core router while keeping external behavior unchanged.

Enhancements:
- Introduce a core-level google dispatch module that routes kinds through a context-injected Google API and logging interface.
- Simplify the google plugin entrypoint to parse arguments and delegate to the shared dispatch function.
- Export the calendar sync sampling limit constant from the new dispatch module for reuse.

Tests:
- Add comprehensive dispatch tests that stub the Google engine to verify routing for all kinds, argument shapes, logging, and calendar sync behavior, including token handling and sampling.
- Add a coverage check that every advertised tool kind has a corresponding routing test and that invalid kinds are rejected.

Chores:
- Document the google dispatch refactor plan and rationale in a new markdown plan file under the plans directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Google tool request routing while preserving existing behavior and response formats.
  * Calendar synchronization continues to support incremental updates, full resynchronization, expired-token recovery, event summaries, and capped samples.
  * Google Calendar, Tasks, and Drive operations remain available through the same entry point.

* **Tests**
  * Added comprehensive coverage for routing, argument handling, synchronization scenarios, status responses, and Drive file reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->