### PR TITLE
chore(ci): ブローカーのコールドブート時間を実測する (#2233)

### DIFF
--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -322,13 +322,23 @@ jobs:
           Write-Host $summaryText
           $summaryText | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
-          if ($out -notmatch '"serverInfo"') {
-            throw "MCP server never answered initialize — the child died at load. See stderr above."
+          # Assert per run, not over the combined output: `$out` now holds two
+          # handshakes, so a substring match anywhere would let a warm success
+          # cover for a cold failure — and the cold run is the one that models
+          # the startup race this canary exists to catch.
+          foreach ($run in @("cold", "warm")) {
+            $result = [regex]::Match($out, "RESULT $run serverInfo=(\w+) handlePermission=(\w+)")
+            if (-not $result.Success) {
+              throw "[$run] the handshake produced no RESULT line — the child died before answering. See stderr above."
+            }
+            if ($result.Groups[1].Value -ne "yes") {
+              throw "[$run] MCP server never answered initialize — the child died at load. See stderr above."
+            }
+            if ($result.Groups[2].Value -ne "yes") {
+              throw "[$run] tools/list did not include handlePermission — this is the #2052 symptom."
+            }
           }
-          if ($out -notmatch '"name":"handlePermission"') {
-            throw "tools/list did not include handlePermission — this is the #2052 symptom."
-          }
-          Write-Host "OK: mcp-server.ts started and listed handlePermission under real NTFS junctions."
+          Write-Host "OK: mcp-server.ts started and listed handlePermission under real NTFS junctions (cold and warm)."
 
       - name: "#2052 — reproduce the crash verbatim (static import, production layout)"
         shell: pwsh

--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -256,7 +256,12 @@ jobs:
       # Mounts / env / argv come from the SHIPPED builders via
       # print-mcp-container-spec.ts, so this can never drift the way the
       # hardcoded smoke test did.
-      - name: "#2052 — end-to-end: real mcp-server.ts answers initialize + tools/list"
+      #
+      # The handshake is driven through /repro/time-broker-handshake.sh, which
+      # stamps how long the broker takes to answer — the input #2235 needs to
+      # decide between prebuilding the broker and deferring its imports (#2233).
+      # The assertions below are unchanged; the timing rides along and reports.
+      - name: "#2052 — end-to-end: real mcp-server.ts answers initialize + tools/list (+ #2233 cold-boot timing)"
         shell: pwsh
         run: |
           $wsWin = "${{ github.workspace }}"
@@ -274,12 +279,43 @@ jobs:
           $dockerArgs += @("-v", "${wsLinux}/test/sandbox-repro:/repro:ro")
           foreach ($mount in $spec.pkgModuleMounts) { $dockerArgs += @("-v", $mount) }
           foreach ($entry in $spec.env.PSObject.Properties) { $dockerArgs += @("-e", "$($entry.Name)=$($entry.Value)") }
+          # `npm install -g tsx` stays OUTSIDE the timed window: the shipped
+          # sandbox image already carries tsx, so counting it would inflate a
+          # number that production never pays.
           $dockerArgs += @("-w", "/app", "node:22-slim", "bash", "-c",
-            "npm install -g tsx --silent && cat /repro/mcp-handshake.jsonl | $($spec.command) $($spec.args -join ' ')")
+            "npm install -g tsx --silent && bash /repro/time-broker-handshake.sh $($spec.command) $($spec.args -join ' ')")
 
           Write-Host "pkg_modules mounts: $($spec.pkgModuleMounts.Count)"
+          $runClock = [System.Diagnostics.Stopwatch]::StartNew()
           $out = wsl -d Ubuntu-22.04 -u root -- docker @dockerArgs 2>&1 | Out-String
+          $runClock.Stop()
           Write-Host $out
+
+          # #2233 timing is published BEFORE the assertions below: a broker slow
+          # enough to fail them is exactly when the number is worth reading, and
+          # a thrown assertion would skip everything after it.
+          $measured = @{}
+          foreach ($match in [regex]::Matches($out, 'TIMING (\w+) (\w+) (\d+)')) {
+            $measured["$($match.Groups[1].Value)/$($match.Groups[2].Value)"] = [int]$match.Groups[3].Value
+          }
+          function Format-Timing($key) {
+            if ($measured.ContainsKey($key)) { "$($measured[$key]) ms" } else { "not reported" }
+          }
+          $summary = @(
+            '### MCP broker cold-boot timing (#2233)'
+            ''
+            'Measured inside the sandbox container over the Windows bind mount, from broker spawn to the response line. That is the window the CLI waits through before it gives up and reports `handlePermission not found` (#2201) - not the same as how long the process runs in total.'
+            ''
+            '| run | `initialize` answered | `tools/list` answered |'
+            '|---|---|---|'
+            "| cold (first read over the mount) | $(Format-Timing 'cold/initialize') | $(Format-Timing 'cold/tools_list') |"
+            "| warm (page cache hot) | $(Format-Timing 'warm/initialize') | $(Format-Timing 'warm/tools_list') |"
+            ''
+            "Whole ``docker run``: $([int]$runClock.Elapsed.TotalMilliseconds) ms. That figure includes the one-off ``npm install -g tsx`` which production does not pay, so read the table for the boot cost, not this."
+            ''
+            'Before tuning anything to these numbers: a shared runner under WSL2 9p is the same *class* of slow mount as Docker Desktop file sharing but not the same absolute values, and `npm install -g tsx` leaves node warmer here than a fresh production container would be. Treat `cold` as a floor, not a worst case.'
+          )
+          $summary -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
           if ($out -notmatch '"serverInfo"') {
             throw "MCP server never answered initialize — the child died at load. See stderr above."

--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -315,7 +315,12 @@ jobs:
             ''
             'Before tuning anything to these numbers: a shared runner under WSL2 9p is the same *class* of slow mount as Docker Desktop file sharing but not the same absolute values, and `npm install -g tsx` leaves node warmer here than a fresh production container would be. Treat `cold` as a floor, not a worst case.'
           )
-          $summary -join "`n" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          $summaryText = $summary -join "`n"
+          # Echo it too: the job summary tab has no API, so this is the only way
+          # to see what was actually published (a mis-parsed TIMING line renders
+          # as "not reported" and would otherwise look like a real measurement).
+          Write-Host $summaryText
+          $summaryText | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
           if ($out -notmatch '"serverInfo"') {
             throw "MCP server never answered initialize — the child died at load. See stderr above."

--- a/plans/chore-2233-broker-coldboot-timing.md
+++ b/plans/chore-2233-broker-coldboot-timing.md
@@ -76,6 +76,51 @@ Issue: #2233（#2201 のフォローアップ①）· 後続: #2235（起動時�
 3. **実物** — ブランチを push して `workflow_dispatch` で実行し、job summary に実測値が出ることを見る
    （完了条件そのもの）
 
+## 実測結果（#2235 への引き継ぎ）
+
+`workflow_dispatch` を 3 回。単位は ms、`initialize` に応答するまで。
+
+| run | cold | warm |
+|---|---|---|
+| [30597793909](https://github.com/receptron/mulmoclaude/actions/runs/30597793909) | 21,224 | 20,828 |
+| [30598789585](https://github.com/receptron/mulmoclaude/actions/runs/30598789585) | 22,816 | 23,913 |
+| [30600291086](https://github.com/receptron/mulmoclaude/actions/runs/30600291086) | 20,232 | 21,065 |
+
+### 1. 約 20〜24 秒。CLI 既定の接続待ち（約 5 秒）の 4〜5 倍
+
+#2201 の推定「約15秒」より**さらに遅い**。#2234 が `MCP_CONNECT_TIMEOUT_MS` を 1 分に
+上げたのは正しく、それでも間欠再発が続いていることと整合する。
+
+### 2. cold と warm に有意差なし
+
+差は run 1 で warm が 396ms 速く、run 2/3 では warm が 833〜1,097ms **遅い**。
+run 間のばらつき（約 3 秒）の方が cold/warm 差より大きく、**ページキャッシュは効いていない**。
+
+これが #2235 にとって最重要。#2201 は間欠性を「FS キャッシュ等による揺らぎ」で説明していたが、
+20 秒はキャッシュミスではなく**毎回必ず払う仕事**（tsx が import グラフを変換する作業そのもの）。
+「温まれば速くなる」類の対策には意味がなく、**ビルド済み JS（方式1）か import グラフを減らす
+（方式2）のどちらかが必須**という結論になる。
+
+### 3. `initialize` と `tools/list` の差は 10〜20 ms
+
+handshake 自体はタダ。コストは 100% 起動側で、ツール定義の生成を削っても効かない。
+
+### 4. プリセットプラグインのロードが計測窓の内側
+
+ログに `INFO [plugins/preset] loaded requested=5 succeeded=5` が `initialize` 応答前に出る。
+方式2（遅延 import）の具体的な標的。
+
+### 副次的に見つかったもの（本 issue の範囲外）
+
+ブローカーがコンテナ内で handshake ごとに 2 回吐いている:
+
+```
+[logger] file sink error: Error: ENOENT: no such file or directory, mkdir 'server/system/logs'
+    at async ensureDir (/app/server/system/logger/rotation.ts:14:3)
+```
+
+相対パスでログディレクトリを作ろうとして失敗している。害はなさそうだが起動経路のノイズ。
+
 ## やらないこと
 
 - 閾値でのゲート

--- a/plans/chore-2233-broker-coldboot-timing.md
+++ b/plans/chore-2233-broker-coldboot-timing.md
@@ -1,0 +1,83 @@
+# ブローカーのコールドブート時間を Windows Docker ワークフローで実測する
+
+Issue: #2233（#2201 のフォローアップ①）· 後続: #2235（起動時間そのものを削る）
+
+## なぜ計測が先か
+
+#2201 の「約15秒」は**スモークテスト全体の所要時間（15872ms）からの推定**であって、ブローカー単体の
+起動実測ではない（#2233 本文に明記）。#2234（`alwaysLoad` + `MCP_CONNECT_TIMEOUT_MS` 引き上げ）は
+フィールドで「頻度は大きく下がったが根本解消せず」と判定され（#2234 コメント, 2026-07-27）、
+#2233 / #2235 が再オープンされた。
+
+`MCP_CONNECT_TIMEOUT_MS` は現状 `ONE_MINUTE_MS` で、コード側コメントに「#2233 が実測したら
+その値＋マージンに詰められる」と書かれたまま。#2235 の方式選定（事前ビルド vs 遅延 import）も
+実測待ち。
+
+## 測る対象を間違えると判断を誤る
+
+手元（macOS ネイティブ・warm cache。**Windows bind mount ではないので下限値**）で
+`test/sandbox-repro/mcp-handshake.jsonl` を実物のブローカーに流して計った:
+
+| 測り方 | 値 |
+|---|---|
+| プロセス全体の所要時間 | 約 5.7 秒 |
+| **`initialize` に応答するまで** | **約 1.1 秒** |
+| （内訳）tsx 自体の起動 | 約 0.55 秒 |
+| （内訳）`mcp-tools` の import | 約 0.34 秒 |
+
+同じ環境で **5.7秒 vs 1.1秒**、5 倍ずれる。CLI のレースに効くのは
+「ブローカーが spawn されてから `initialize` に応答するまで」であって、プロセス全体の時間ではない
+（#2201 の 15872ms がまさに全体時間からの推定だった）。
+
+## 変更
+
+`.github/workflows/docker_sandbox_windows.yaml` の既存 end-to-end ステップ
+（`#2052 — end-to-end: real mcp-server.ts answers initialize + tools/list`）に計時を足す。
+新しいコンテナハーネスは作らない — コンテナ spec は既存どおり `print-mcp-container-spec.ts`
+から導出する（derive; never duplicate）。
+
+### コンテナ内で測る
+
+`npm install -g tsx` は**計測窓の外**に置く。本番の sandbox イメージは tsx を同梱していて
+毎ターン払わないコストなので、含めると数字が膨らむ。
+
+`date +%s%3N`（GNU date, node:22-slim は Debian）で、ブローカー spawn 直前を起点に、
+応答行が出た時刻を拾う:
+
+- `initialize` 応答まで = **レースを決める数字**。`MCP_CONNECT_TIMEOUT_MS` と直接比較する
+- `tools/list` 応答まで = handshake 完了（issue 本文が挙げている数字）
+
+### cold / warm の 2 回まわす
+
+同じコンテナ内で handshake を 2 回実行する。1 回目は bind mount 越しの初回読み、2 回目は
+ページキャッシュが温まった状態。本番も**毎ターン新コンテナだがホスト側のページキャッシュは
+残る**ので、2 回目は「2 ターン目以降」のモデルになる。
+
+#2201 は間欠性を「マシン負荷・FS キャッシュ等による起動時間の揺らぎ」で説明しているので、
+この 2 つの差自体が #2235 の判断材料になる（差が大きい＝ FS 起因が支配的＝事前ビルドが効く、
+差が小さい＝ import グラフ自体が重い＝遅延 import が効く）。
+
+### 出力
+
+ログと job summary の両方へ。docker run 全体の wall time も併記するが、
+**`npm install -g tsx` を含む**ことを明示する（本番は払わないコスト）。
+
+**ゲートしない**。共有 runner の負荷ノイズで閾値判定は flaky になるし、issue の完了条件は
+「job summary から読める」こと。同ファイル内の #2052 診断ステップと同じ
+「They REPORT; they do not gate the job」方針に揃える。
+
+## 検証
+
+このワークフローは Windows + WSL2 + Docker が要るのでローカルでは走らない。分けて確かめる:
+
+1. **bash の計時ロジック** — スタブのブローカー（`serverInfo` / `handlePermission` を含む行を
+   遅延付きで吐く）に対してローカルで走らせ、`TIMING` 行が出て値が仕込んだ遅延と一致することを見る
+2. **PowerShell の parse** — 同じ `TIMING` 行を食わせて job summary の表が組めることを見る
+3. **実物** — ブランチを push して `workflow_dispatch` で実行し、job summary に実測値が出ることを見る
+   （完了条件そのもの）
+
+## やらないこと
+
+- 閾値でのゲート
+- `MCP_CONNECT_TIMEOUT_MS` の変更 — 実測が出てからの別作業
+- #2235 の実装（事前ビルド / 遅延 import）

--- a/test/sandbox-repro/time-broker-handshake.sh
+++ b/test/sandbox-repro/time-broker-handshake.sh
@@ -46,6 +46,16 @@ fi
 # Feeds the handshake to the broker and stamps each response as it arrives.
 # The elapsed clock starts at spawn, so it measures exactly the window the CLI
 # is waiting through.
+#
+# Responses are recognised by JSON-RPC id, not by their contents: the fixture
+# assigns id 1 to `initialize` and id 2 to `tools/list`, so a reply that arrives
+# but is missing `serverInfo` / `handlePermission` still gets timed. Keying on
+# the contents would drop the measurement in exactly the #2052 case where the
+# reply comes back without the tool — the run worth measuring most.
+#
+# Whether those contents were there is reported separately, as a per-run RESULT
+# line, so the caller can gate each run on its own rather than on the two runs
+# smeared together.
 run_handshake() {
   local run_label="$1"
   shift
@@ -53,16 +63,27 @@ run_handshake() {
   started_ms=$(now_ms)
   # shellcheck disable=SC2002  # `cat |` keeps the broker's stdin a pipe, which
   # is what the CLI hands it; a `<` redirect would give it a seekable file.
-  cat "$HANDSHAKE_FILE" | "$@" | while IFS= read -r line; do
-    local elapsed_ms=$(($(now_ms) - started_ms))
-    case "$line" in
-    *serverInfo*) echo "TIMING $run_label initialize $elapsed_ms" ;;
-    esac
-    case "$line" in
-    *handlePermission*) echo "TIMING $run_label tools_list $elapsed_ms" ;;
-    esac
-    printf '%s\n' "$line"
-  done
+  # The trailing block keeps the flags and the summary line in one subshell —
+  # a bare `while` at the end of a pipeline cannot export what it saw.
+  cat "$HANDSHAKE_FILE" | "$@" | {
+    saw_server_info=no
+    saw_handle_permission=no
+    while IFS= read -r line; do
+      elapsed_ms=$(($(now_ms) - started_ms))
+      case "$line" in
+      *'"id":1'* | *'"id": 1'*)
+        echo "TIMING $run_label initialize $elapsed_ms"
+        case "$line" in *serverInfo*) saw_server_info=yes ;; esac
+        ;;
+      *'"id":2'* | *'"id": 2'*)
+        echo "TIMING $run_label tools_list $elapsed_ms"
+        case "$line" in *'"name":"handlePermission"'*) saw_handle_permission=yes ;; esac
+        ;;
+      esac
+      printf '%s\n' "$line"
+    done
+    echo "RESULT $run_label serverInfo=$saw_server_info handlePermission=$saw_handle_permission"
+  }
 }
 
 run_handshake cold "$@"

--- a/test/sandbox-repro/time-broker-handshake.sh
+++ b/test/sandbox-repro/time-broker-handshake.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Times the SHIPPED MCP broker's cold boot inside the sandbox container (#2233).
+#
+# What decides the `handlePermission not found` race (#2201) is how long the
+# broker takes to answer `initialize` after the CLI spawns it — not how long the
+# process runs in total. Those are not the same number: measured natively on
+# macOS the same handshake was ~1.1s to `initialize` and ~5.7s to process exit.
+# #2201's "about 15 seconds" came from a whole smoke test's duration (15872ms),
+# which is why #2233 exists.
+#
+# Two runs, one container: the first reads the bind mount cold, the second finds
+# the page cache hot. Production spawns a fresh container per turn but the HOST
+# cache survives, so `warm` models turn 2 onward — and the gap between them is
+# how much of the boot is filesystem rather than the import graph itself, which
+# is what picks between #2235's two candidate fixes.
+#
+# Usage (inside the container, `/repro` = test/sandbox-repro):
+#   bash /repro/time-broker-handshake.sh <broker-command> [args...]
+#
+# Emits `TIMING <run> <event> <ms>` lines on stdout alongside the broker's own
+# JSON-RPC output, which the caller parses. Reports only — never gates.
+
+set -uo pipefail
+
+HANDSHAKE_FILE=/repro/mcp-handshake.jsonl
+
+now_ms() { date +%s%3N; }
+
+# `%3N` is GNU-only. On a date that lacks it the value keeps a literal "N" and
+# every subtraction below would fail — loudly here beats reporting nonsense.
+if [[ "$(now_ms)" == *N* ]]; then
+  echo "FATAL: this date(1) does not support %3N, cannot measure milliseconds" >&2
+  exit 1
+fi
+
+if [[ ! -r "$HANDSHAKE_FILE" ]]; then
+  echo "FATAL: $HANDSHAKE_FILE is not readable — is test/sandbox-repro mounted at /repro?" >&2
+  exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "FATAL: no broker command given" >&2
+  exit 1
+fi
+
+# Feeds the handshake to the broker and stamps each response as it arrives.
+# The elapsed clock starts at spawn, so it measures exactly the window the CLI
+# is waiting through.
+run_handshake() {
+  local run_label="$1"
+  shift
+  local started_ms
+  started_ms=$(now_ms)
+  # shellcheck disable=SC2002  # `cat |` keeps the broker's stdin a pipe, which
+  # is what the CLI hands it; a `<` redirect would give it a seekable file.
+  cat "$HANDSHAKE_FILE" | "$@" | while IFS= read -r line; do
+    local elapsed_ms=$(($(now_ms) - started_ms))
+    case "$line" in
+    *serverInfo*) echo "TIMING $run_label initialize $elapsed_ms" ;;
+    esac
+    case "$line" in
+    *handlePermission*) echo "TIMING $run_label tools_list $elapsed_ms" ;;
+    esac
+    printf '%s\n' "$line"
+  done
+}
+
+run_handshake cold "$@"
+run_handshake warm "$@"


### PR DESCRIPTION
## Summary

Windows Docker ワークフローの既存 end-to-end ステップに、**ブローカーが `initialize` に応答するまでの時間**の計測を足しました。job summary に cold / warm の 2 行で出ます。

`Closes #2233`。後続の #2235（起動時間そのものを削る）は、この実測を見てから方式（事前ビルド vs 遅延 import）を選ぶ関係です。

**ゲートしません** — 共有 runner の負荷ノイズで閾値判定は flaky になるし、#2233 の完了条件は「job summary から読める」ことです。同ファイル内の #2052 診断ステップと同じ「They REPORT; they do not gate the job」方針に揃えています。

## Items to Confirm / Review

1. **測る対象を変えた点（最重要・issue 本文からの逸脱）** — #2233 本文は「コンテナ起動〜handshake 完了（`tools/list` 応答）」と書いていますが、**CLI のレースに効くのは「ブローカーが spawn されてから `initialize` に応答するまで」**です。手元（macOS ネイティブ）で同じ handshake を計ったところ、プロセス全体 **5.7 秒**に対し `initialize` 応答は **1.1 秒**で、同じ環境で 5 倍ずれました。#2201 の「約15秒」がまさにスモークテスト全体（15872ms）からの推定だったので、同じ間違いを繰り返さないよう **両方**（`initialize` / `tools/list`）を出しています。この判断でよいかご確認ください。
2. **`npm install -g tsx` を計測窓の外に置いた**こと — 本番の sandbox イメージは tsx を同梱していて毎ターン払わないコストなので、含めると数字が膨らみます。ただし裏返しとして「CI の cold は node が本番より温まっている」ので、**下限値であって worst case ではない**旨を summary 自体にも書いています。
3. **cold / warm の 2 回まわす設計** — 本番は毎ターン新コンテナですが**ホスト側のページキャッシュは残る**ので、warm は「2ターン目以降」のモデルのつもりです。この読み替えが妥当かどうか。
4. **PowerShell 部分をローカルで実行できていない**こと — macOS に pwsh が無く、勝手に入れるのは避けました。actionlint は通っていますが PowerShell の構文チェックはしていません。**実物のワークフロー実行（`workflow_dispatch`）で確認**しており、結果はこの PR にコメントで貼ります。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2235 これなにかある？
- （状況報告を受けて）**2233 から**

## 背景 — なぜ計測が先か

#2201 の「約15秒」はスモークテスト全体の所要時間（15872ms）からの推定であって、ブローカー単体の起動実測ではありません（#2233 本文に明記）。

#2234（`alwaysLoad` + `MCP_CONNECT_TIMEOUT_MS` 引き上げ、PR #2240）はフィールド検証で「発生頻度は大きく下がったが根本的な解消には至っていない」と判定され（#2234 コメント, 2026-07-27）、#2233 / #2235 が再オープンされました。報告者は現在 `DISABLE_SANDBOX=1` で回避中です。

`server/agent/config.ts` の `MCP_CONNECT_TIMEOUT_MS` は現状 `ONE_MINUTE_MS` で、コメントに「#2233 が実測したらその値＋マージンに詰められる」と書かれたままです。

## 実装

### 新規 `test/sandbox-repro/time-broker-handshake.sh`

コンテナ内で handshake を流し、**spawn を起点に**応答行が出た時刻を刻みます（`date +%s%3N`）。`/repro` は既にマウント済みで、`probe.ts` / `diagnose-2052.ts` と同じ「コンテナ内で走る committed ファイル」の既存パターンに乗せました（インライン YAML より読めて、ローカルで単体検証できます）。

FATAL ガードを 3 つ入れています。特に `%3N` 非対応の `date` は、値に文字 `N` が残って以降の算術が壊れるため、**黙って変な数字を出すより落とす**方を選びました。

### `.github/workflows/docker_sandbox_windows.yaml`

既存ステップから上記スクリプトを呼ぶだけで、**新しいコンテナハーネスは作っていません**。コンテナ spec は従来どおり `print-mcp-container-spec.ts` から導出（derive; never duplicate）。

計時の出力は **assertion の前**に置きました。assertion を落とすほど遅いブローカーこそ数字が要るのに、`throw` すると後続が飛ぶためです。

## 検証

- **bash の計時ロジック**: 既知の遅延（400ms → `serverInfo`、+300ms → `handlePermission`）を持つスタブブローカーに対して実行し、`TIMING warm initialize 444` / `TIMING warm tools_list 757` と**仕込んだ遅延に一致**することを確認
- **3 つの FATAL ガード**: `%3N` 非対応の date / handshake ファイル欠落 / コマンド未指定 で、それぞれ意図したメッセージが出ることを確認
- `shellcheck` exit 0 / `actionlint` exit 0 / `yarn format` `yarn lint` `yarn typecheck` すべて exit 0
- **実物**: ブランチに対して `workflow_dispatch` 実行中。job summary に実測値が出ることの確認結果は、このあとコメントで貼ります

## やらないこと

- 閾値でのゲート
- `MCP_CONNECT_TIMEOUT_MS` の変更 — 実測が出てからの別作業
- #2235 の実装（事前ビルド / 遅延 import）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude2

## Summary by Sourcery

Measure MCP broker cold-boot handshake timing in the Windows Docker sandbox workflow and publish the results in the job summary to inform follow-up tuning work.

New Features:
- Add in-container timing of MCP broker handshake (initialize and tools/list) for cold and warm runs in the Windows Docker sandbox workflow and surface the measurements in the GitHub Actions job summary.

Enhancements:
- Extend the existing Windows Docker end-to-end handshake step to route through a reusable timing harness script without changing its assertions or gating behavior.

Documentation:
- Add a planning document outlining the motivation, measurement strategy, and non-goals for broker cold-boot timing on the Windows Docker workflow.

Tests:
- Introduce a sandbox repro script that drives the MCP broker handshake twice (cold and warm) and emits structured timing markers for CI to parse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cold- and warm-start timing measurements for broker initialization and tool listing in the Windows Docker workflow.
  * Added diagnostic output for handshake response timings, broker startup duration, and key response details.
  * Published formatted timing results and caveats in GitHub Actions job summaries.
  * Added independent validation for each cold and warm run.

* **Documentation**
  * Added an implementation plan covering timing measurement, validation, and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->