### PR TITLE
docs: README に X (Singularity Society / snakajima) の案内を追加

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -20,6 +20,13 @@ Unter der Haube ist MulmoClaude eine KI-native Anwendungsplattform: Fähigkeiten
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — die Architektur-, UX- und Protokollthese hinter MulmoClaude.
 
+### 📣 Neuigkeiten / アップデート情報
+
+Neue Releases und Funktionen werden **auf Japanisch** auf X angekündigt — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — Ankündigungen zu Releases und neuen Funktionen
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — Eigentümer von MulmoClaude
+
 ## Schnellstart
 
 ```bash

--- a/README.es.md
+++ b/README.es.md
@@ -20,6 +20,13 @@ Por debajo, MulmoClaude es una plataforma de aplicaciones AI-nativa: las capacid
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — la tesis sobre arquitectura, UX y protocolo que hay detrás de MulmoClaude.
 
+### 📣 Novedades / アップデート情報
+
+Las nuevas versiones y funciones se anuncian **en japonés** en X — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — anuncios de versiones y nuevas funciones
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — propietario de MulmoClaude
+
 ## Inicio rápido
 
 ```bash

--- a/README.fr.md
+++ b/README.fr.md
@@ -20,6 +20,13 @@ Sous le capot, MulmoClaude est une plateforme d'applications AI-natives : les ca
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — la thèse architecturale, UX et protocolaire derrière MulmoClaude.
 
+### 📣 Actualités / アップデート情報
+
+Les nouvelles versions et fonctionnalités sont annoncées **en japonais** sur X — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — annonces de versions et de nouvelles fonctionnalités
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — propriétaire de MulmoClaude
+
 ## Démarrage rapide
 
 ```bash

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,13 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — MulmoClaude の背後にあるアーキテクチャ、UX、プロトコルに関する論考。
 
+### 📣 アップデート情報
+
+新バージョンや新機能のお知らせは X で発信しています。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — リリース・新機能のお知らせ
+- [中島聡 (@snakajima)](https://x.com/snakajima) — MulmoClaude のオーナー
+
 ## クイックスタート
 
 ```bash

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,6 +20,13 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — MulmoClaude의 아키텍처, UX, 그리고 프로토콜에 대한 주장.
 
+### 📣 업데이트 소식 / アップデート情報
+
+새 릴리스와 새 기능은 X에서 **일본어**로 안내합니다 — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — 릴리스 및 새 기능 안내
+- [나카지마 사토시 (@snakajima)](https://x.com/snakajima) — MulmoClaude 오너
+
 ## 빠른 시작
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Under the hood, MulmoClaude is an AI-native application platform: capabilities a
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — the architecture, UX, and protocol thesis behind MulmoClaude.
 
+### 📣 Updates / アップデート情報
+
+New releases and features are announced **in Japanese** on X — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements / リリース・新機能のお知らせ
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner / MulmoClaude のオーナー
+
 ## Quick Start
 
 ```bash

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -20,6 +20,13 @@ Por baixo dos panos, o MulmoClaude é uma plataforma de aplicações AI-nativa: 
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — a tese de arquitetura, UX e protocolo por trás do MulmoClaude.
 
+### 📣 Novidades / アップデート情報
+
+Novas versões e funcionalidades são anunciadas **em japonês** no X — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — anúncios de lançamentos e novas funcionalidades
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — proprietário do MulmoClaude
+
 ## Início Rápido
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,13 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** —— MulmoClaude 背后的架构、UX 与协议论述。
 
+### 📣 更新资讯 / アップデート情報
+
+新版本与新功能会在 X 上以**日语**发布 —— 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) —— 发布与新功能通知
+- [中岛聪 (@snakajima)](https://x.com/snakajima) —— MulmoClaude 的所有者
+
 ## 快速开始
 
 ```bash

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -163,6 +163,13 @@ Server-side `definePlugin` factory edits still require a launcher restart (Node 
 - Architecture, scripts, and the publish flow live in `docs/developer.md` of the repo.
 - Publish flow for this package: see `bin/prepare-dist.js` header comment plus `.claude/skills/publish-mulmoclaude/SKILL.md`.
 
+## Updates / アップデート情報
+
+New releases and features are announced **in Japanese** on X — 新バージョンや新機能のお知らせは X で。
+
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements / リリース・新機能のお知らせ
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner / MulmoClaude のオーナー
+
 ## Related projects
 
 This launcher is published by [Receptron](https://github.com/receptron), who also build MulmoTerminal below.


### PR DESCRIPTION
## Summary

mulmoterminal の README と同じ形で、**新バージョン・新機能のお知らせを発信している X アカウント**へのリンクを README に追加しました。あわせてオーナー (@snakajima) のアカウントも記載しています。

- ルート README **8 言語すべて** — MANIFEST 行の直下 (Quick Start の直前) に `### 📣 Updates / アップデート情報` セクションを追加
- **npm 公開用の launcher README** (`packages/mulmoclaude/README.md`) — `## Related projects` の直前に同じ内容を追加

追加した内容 (英語版):

```markdown
### 📣 Updates / アップデート情報

New releases and features are announced **in Japanese** on X — 新バージョンや新機能のお知らせは X で。

- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements / リリース・新機能のお知らせ
- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner / MulmoClaude のオーナー
```

## Items to Confirm / Review

- **アカウントの表記** — `@SingularitySoci` は mulmoterminal の README で使われているものをそのまま採用しました。`@snakajima` を「オーナー」と表現していますが、`Receptron` / `Singularity Society` との関係の書き分けとして適切か確認をお願いします (組織の性格については断定的な説明を避け、リンクとロールのみに留めています)。
- **配置** — 最初の `##` (Quick Start) より前に `###` 見出しが来る形です。mulmoterminal の `### 📖 Documentation` と同じ構成に合わせましたが、`##` にすべきか好みがあれば直します。
- **翻訳** — 各言語版は見出しと説明文をローカライズしつつ、「お知らせは日本語」である旨は各言語で明記し、日本語の一文も併記しています。日本語版のみ日本語ネイティブ向けに「日本語で」の断りを省いています。
- **npm README の位置** — launcher README では末尾寄り (Related projects の直前) に置きました。もっと上 (Quick Start 直後) が良ければ移動します。

## User Prompt

> mulmoterminal と同様に README で、日本語情報として ss の twitter の紹介、リンクを追加しよう。あと、snakajima のアカウントも（オーナー）

## 実装メモ

- 対象は Markdown のみで、`yarn format` / `yarn lint` の対象パス (`{src,server,test,e2e,e2e-live,packages}/**/*.{ts,json,yaml,vue}` / eslint 対象ディレクトリ) にルート直下の `*.md` は含まれないため、フォーマッタ・リンタへの影響はありません。
- `scripts/packages/check-readme-translations.mjs` は `packages/**` のパッケージ tarball に翻訳 README が同梱されるかを見るもので、ルート README とは無関係です。
- ローカル `main` が 34 コミット遅れていたため、`origin/main` から直接ブランチを切っています。

work in mulmoclaude5

## Summary by Sourcery

Add X (Twitter) update information links to all root README translations and the mulmoclaude launcher README.

Documentation:
- Add an Updates section in all localized root READMEs linking to the Singularity Society and Satoshi Nakajima X accounts, noting that announcements are in Japanese.
- Document the same X accounts and update information in the npm-facing mulmoclaude launcher README.