### PR TITLE
docs: 日本語版以外の README の Updates 節から日本語併記を外す

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -20,7 +20,7 @@ Unter der Haube ist MulmoClaude eine KI-native Anwendungsplattform: Fähigkeiten
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — die Architektur-, UX- und Protokollthese hinter MulmoClaude.
 
-### 📣 Neuigkeiten
+## 📣 Neuigkeiten
 
 Neue Releases und Funktionen werden **auf Japanisch** auf X angekündigt.
 

--- a/README.de.md
+++ b/README.de.md
@@ -20,9 +20,9 @@ Unter der Haube ist MulmoClaude eine KI-native Anwendungsplattform: Fähigkeiten
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — die Architektur-, UX- und Protokollthese hinter MulmoClaude.
 
-### 📣 Neuigkeiten / アップデート情報
+### 📣 Neuigkeiten
 
-Neue Releases und Funktionen werden **auf Japanisch** auf X angekündigt — 新バージョンや新機能のお知らせは X で。
+Neue Releases und Funktionen werden **auf Japanisch** auf X angekündigt.
 
 - [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — Ankündigungen zu Releases und neuen Funktionen
 - [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — Eigentümer von MulmoClaude

--- a/README.es.md
+++ b/README.es.md
@@ -20,7 +20,7 @@ Por debajo, MulmoClaude es una plataforma de aplicaciones AI-nativa: las capacid
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — la tesis sobre arquitectura, UX y protocolo que hay detrás de MulmoClaude.
 
-### 📣 Novedades
+## 📣 Novedades
 
 Las nuevas versiones y funciones se anuncian **en japonés** en X.
 

--- a/README.es.md
+++ b/README.es.md
@@ -20,9 +20,9 @@ Por debajo, MulmoClaude es una plataforma de aplicaciones AI-nativa: las capacid
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — la tesis sobre arquitectura, UX y protocolo que hay detrás de MulmoClaude.
 
-### 📣 Novedades / アップデート情報
+### 📣 Novedades
 
-Las nuevas versiones y funciones se anuncian **en japonés** en X — 新バージョンや新機能のお知らせは X で。
+Las nuevas versiones y funciones se anuncian **en japonés** en X.
 
 - [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — anuncios de versiones y nuevas funciones
 - [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — propietario de MulmoClaude

--- a/README.fr.md
+++ b/README.fr.md
@@ -20,7 +20,7 @@ Sous le capot, MulmoClaude est une plateforme d'applications AI-natives : les ca
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — la thèse architecturale, UX et protocolaire derrière MulmoClaude.
 
-### 📣 Actualités
+## 📣 Actualités
 
 Les nouvelles versions et fonctionnalités sont annoncées **en japonais** sur X.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -20,9 +20,9 @@ Sous le capot, MulmoClaude est une plateforme d'applications AI-natives : les ca
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — la thèse architecturale, UX et protocolaire derrière MulmoClaude.
 
-### 📣 Actualités / アップデート情報
+### 📣 Actualités
 
-Les nouvelles versions et fonctionnalités sont annoncées **en japonais** sur X — 新バージョンや新機能のお知らせは X で。
+Les nouvelles versions et fonctionnalités sont annoncées **en japonais** sur X.
 
 - [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — annonces de versions et de nouvelles fonctionnalités
 - [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — propriétaire de MulmoClaude

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — MulmoClaude の背後にあるアーキテクチャ、UX、プロトコルに関する論考。
 
-### 📣 アップデート情報
+## 📣 アップデート情報
 
 新バージョンや新機能のお知らせは X で発信しています。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,9 +20,9 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — MulmoClaude의 아키텍처, UX, 그리고 프로토콜에 대한 주장.
 
-### 📣 업데이트 소식 / アップデート情報
+### 📣 업데이트 소식
 
-새 릴리스와 새 기능은 X에서 **일본어**로 안내합니다 — 新バージョンや新機能のお知らせは X で。
+새 릴리스와 새 기능은 X에서 **일본어**로 안내합니다.
 
 - [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — 릴리스 및 새 기능 안내
 - [나카지마 사토시 (@snakajima)](https://x.com/snakajima) — MulmoClaude 오너

--- a/README.ko.md
+++ b/README.ko.md
@@ -20,7 +20,7 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — MulmoClaude의 아키텍처, UX, 그리고 프로토콜에 대한 주장.
 
-### 📣 업데이트 소식
+## 📣 업데이트 소식
 
 새 릴리스와 새 기능은 X에서 **일본어**로 안내합니다.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Under the hood, MulmoClaude is an AI-native application platform: capabilities a
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — the architecture, UX, and protocol thesis behind MulmoClaude.
 
-### 📣 Updates
+## 📣 Updates
 
 New releases and features are announced on X, **in Japanese**.
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Under the hood, MulmoClaude is an AI-native application platform: capabilities a
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — the architecture, UX, and protocol thesis behind MulmoClaude.
 
-### 📣 Updates / アップデート情報
+### 📣 Updates
 
-New releases and features are announced **in Japanese** on X — 新バージョンや新機能のお知らせは X で。
+New releases and features are announced on X, **in Japanese**.
 
-- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements / リリース・新機能のお知らせ
-- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner / MulmoClaude のオーナー
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner
 
 ## Quick Start
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -20,9 +20,9 @@ Por baixo dos panos, o MulmoClaude é uma plataforma de aplicações AI-nativa: 
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — a tese de arquitetura, UX e protocolo por trás do MulmoClaude.
 
-### 📣 Novidades / アップデート情報
+### 📣 Novidades
 
-Novas versões e funcionalidades são anunciadas **em japonês** no X — 新バージョンや新機能のお知らせは X で。
+Novas versões e funcionalidades são anunciadas **em japonês** no X.
 
 - [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — anúncios de lançamentos e novas funcionalidades
 - [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — proprietário do MulmoClaude

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -20,7 +20,7 @@ Por baixo dos panos, o MulmoClaude é uma plataforma de aplicações AI-nativa: 
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** — a tese de arquitetura, UX e protocolo por trás do MulmoClaude.
 
-### 📣 Novidades
+## 📣 Novidades
 
 Novas versões e funcionalidades são anunciadas **em japonês** no X.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** —— MulmoClaude 背后的架构、UX 与协议论述。
 
-### 📣 更新资讯
+## 📣 更新资讯
 
 新版本与新功能会在 X 上以**日语**发布。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,9 +20,9 @@
 
 > **[How AI-Native Applications Should Be Built](MANIFEST.md)** —— MulmoClaude 背后的架构、UX 与协议论述。
 
-### 📣 更新资讯 / アップデート情報
+### 📣 更新资讯
 
-新版本与新功能会在 X 上以**日语**发布 —— 新バージョンや新機能のお知らせは X で。
+新版本与新功能会在 X 上以**日语**发布。
 
 - [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) —— 发布与新功能通知
 - [中岛聪 (@snakajima)](https://x.com/snakajima) —— MulmoClaude 的所有者

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -163,12 +163,12 @@ Server-side `definePlugin` factory edits still require a launcher restart (Node 
 - Architecture, scripts, and the publish flow live in `docs/developer.md` of the repo.
 - Publish flow for this package: see `bin/prepare-dist.js` header comment plus `.claude/skills/publish-mulmoclaude/SKILL.md`.
 
-## Updates / アップデート情報
+## Updates
 
-New releases and features are announced **in Japanese** on X — 新バージョンや新機能のお知らせは X で。
+New releases and features are announced on X, **in Japanese**.
 
-- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements / リリース・新機能のお知らせ
-- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner / MulmoClaude のオーナー
+- [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci) — release and feature announcements
+- [Satoshi Nakajima (@snakajima)](https://x.com/snakajima) — MulmoClaude's owner
 
 ## Related projects
 


### PR DESCRIPTION
## Summary

#2671 で追加した `Updates` 節に日本語を併記していたのを、**日本語版 (`README.ja.md`) 以外からすべて外しました**。各 README はその言語だけで完結します。

| ファイル | Before | After |
| --- | --- | --- |
| `README.md` (英語) | `### 📣 Updates / アップデート情報` + 文末に日本語 + 箇条書きに日本語訳 | `### 📣 Updates` — 英語のみ |
| `README.zh/ko/es/pt-BR/fr/de` | `<各言語> / アップデート情報` + 文末に日本語 | 各言語のみ |
| `packages/mulmoclaude/README.md` | 同上 (英語) | 英語のみ |
| `README.ja.md` | — | **変更なし** (元から日本語のみ) |

「お知らせは日本語で発信している」という事実は、各言語での記述として残しています (例: `announced on X, **in Japanese**` / `以**日语**发布` / `**en japonés**`)。

## Items to Confirm / Review

- **「英語にして」の解釈** — 各翻訳版は「日本語を消して**その言語**に統一」しました (中国語版の見出しは `更新资讯`、韓国語版は `업데이트 소식` のまま)。もし「翻訳版もすべて英語見出し (`Updates`) に統一」という意図であれば、その形に直します。
- **英語版の文** — `New releases and features are announced **in Japanese** on X — …` から `New releases and features are announced on X, **in Japanese**.` へ変更しました (日本語部分を削ったあと em dash が宙に浮くため)。

## User Prompt

> 多言語で、アップデート情報って日本語を入れるくらいなら英語にして

(前提: #2671 「mulmoterminal と同様に README で、日本語情報として ss の twitter の紹介、リンクを追加しよう。あと、snakajima のアカウントも（オーナー）」)

## 実装メモ

- Markdown のみの変更で、`yarn format` / `yarn lint` の対象パスには含まれません。
- `README.ja.md` は差分ゼロです。

work in mulmoclaude5

## Summary by Sourcery

Unify the Updates sections across non-Japanese READMEs by removing inline Japanese text and keeping each README self-contained in its own language while still noting that announcements are made in Japanese on X.

Documentation:
- Update the Updates headings and descriptions in all non-Japanese READMEs to omit Japanese copy and use only the respective language, retaining a note that announcements themselves are in Japanese.
- Align the package README’s Updates section with the main README by removing Japanese translations from the heading and link descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified Updates and News sections across English, German, Spanish, French, Korean, Portuguese, Chinese, and package documentation.
  * Removed bilingual headings and duplicate Japanese notices in favor of clear, localized descriptions.
  * Clarified that release and feature announcements are published in Japanese on X while retaining announcement links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->