### PR TITLE
docs: availability matrix の Residual note を実測で置き換える (#2235)

### DIFF
--- a/plans/mcp-broker-availability-matrix.md
+++ b/plans/mcp-broker-availability-matrix.md
@@ -52,7 +52,7 @@ Covers D–F end-to-end on real NTFS junctions. Schedule + `workflow_dispatch` o
 | # | Trigger | Platform | Fix | Test | Status |
 |---|---------|----------|-----|------|--------|
 | J | same-minute fan-out (5 tasks at 20:00 UTC) floods CPU, broker boots slowly | any incl. macOS | stagger independent firings by `firingStaggerMs` (default 1s) | `packages/core/test/scheduler/test_scheduler.ts` stagger cases | **FIXED (mitigation)** |
-| K | single-task cold-boot race (broker slower than the first tool call even with 1 task) | any incl. macOS | detect `handlePermission not found` → wait 3s → replay the turn once | `test/agent/test_mcpBrokerFailover.ts` + `test/agent/test_abort_caused_exit.ts` | **FIXED (self-recovery)** |
+| K | single-task cold-boot race (broker slower than the first tool call even with 1 task) | any incl. macOS | (1) prebuilt broker bundle — 20 s cold boot → 0.5 s, so the race window closes (#2235); (2) detect `handlePermission not found` → wait 3s → replay the turn once, kept as backstop | `test/agent/test_mcpBrokerFailover.ts` + `test/agent/test_abort_caused_exit.ts` + the #2233 timing in `docker_sandbox_windows.yaml` | **FIXED (cause removed + self-recovery)** |
 | L | scheduler records the run `"success"` on spawn, not on turn outcome → silent failures | any | record the real outcome from the turn's completion hook, not at dispatch | `test/skills/test_skill_scheduler.ts` (#2057 error-run case) | **FIXED (honest logging)** |
 
 ### J — stagger (`packages/core/src/scheduler/task-manager.ts`)
@@ -105,9 +105,11 @@ latest), not a pin.
 
 - **Layer 1 is done and regression-locked** across every platform × layout × mode combination
   (A–I), plus a real-container Windows e2e for the junction cases.
-- **Layer 2 is done and tested:** J (stagger) cuts multi-task contention, K (retry) self-recovers
-  the single-task race that stagger can't touch, L (honest logging) makes any residual failure
-  visible instead of a false success. All three ship with regression tests.
+- **Layer 2 is done and tested:** J (stagger) cuts multi-task contention, K removes the
+  single-task race at its source (the broker now boots in ~0.5 s instead of ~20 s, #2235) and
+  keeps the retry as a backstop, L (honest logging) makes any residual failure visible instead of
+  a false success. All three ship with regression tests, and K's cold boot is now measured on
+  every Windows canary run rather than inferred.
 - **Layer 3 (M) is open by choice** — no code fix, documented recovery only. The family is
   therefore *not* fully closed; a `handlePermission not found` report that survives a manual
   retry and shows no `Cannot find module` should be checked against M before reopening A–L.
@@ -118,6 +120,36 @@ The race ultimately lives inside the Claude CLI (it spawns our broker AND issues
 call; there is no host-side broker-readiness gate — confirmed: `validateStdioPackages` is
 fire-and-forget over third-party npx servers, and the broker's `runtimeReady` gates plugin tools
 while `handlePermission` already answers without it, #1698). So K is a bounded *self-recovery*
-(one replay), not a guarantee; a further hardening would be to shrink the broker's cold-boot
-window by deferring its heavy top-level imports so stdio answers `initialize` sooner — a larger
-`mcp-server.ts` refactor, tracked separately.
+(one replay), not a guarantee.
+
+The hardening this note used to call for — shrink the cold-boot window so stdio answers
+`initialize` sooner — **shipped in #2235**, though not in the shape proposed here. Deferring the
+broker's heavy top-level imports was measured and rejected: the runtime graph is 292 files and
+most of them are a core shared by several top-level imports, so cutting the biggest single
+import (`mcp-tools/index.ts`) removes only 26 of them. Bundling the broker ahead of time
+collapses all 292 into one file instead.
+
+| broker | cold | warm |
+|---|---|---|
+| `tsx server/agent/mcp-server.ts` (before) | 20,232 ms | 20,828 ms |
+| `node server/build/mcp-server.mjs` (now) | **508 ms** | **555 ms** |
+
+Measured on the Windows bind mount by the timing added to `docker_sandbox_windows.yaml` in
+#2233 — the same harness reports it on every run, so a regression here shows up as a number
+rather than as an intermittent field report.
+
+Two things that are easy to get wrong if this is ever revisited:
+
+- **Measure the runtime graph, not a static one.** esbuild's metafile counts `import type` edges,
+  which tsx erases. It makes `spawnBackgroundChat.ts` look like it drags in 1843 files via
+  `api/routes/agent.ts`; at runtime that file is never read. Use an ESM `resolve` hook.
+- **The bundle must inline its dependencies.** `packages: "external"` gives a 505 KB artifact
+  instead of 6 MB, and dies in the container with `Cannot find package
+  '@mulmoclaude/markdown-utils'` — Layer 1's junction problem again, because a bundle resolving
+  bare specifiers from `server/build/` never reaches the `/app/pkg_modules` fallback. Inlining is
+  what keeps Layer 1 fixed, not just what makes it fast. It looked healthy on native macOS; only
+  the Windows harness caught it.
+
+K's window is now ~40x smaller than the CLI's ~5 s connect wait, so the self-recovery replay
+should effectively stop firing — but it stays in place, since the guarantee still lives in the
+CLI, not here.

--- a/plans/mcp-broker-availability-matrix.md
+++ b/plans/mcp-broker-availability-matrix.md
@@ -150,6 +150,6 @@ Two things that are easy to get wrong if this is ever revisited:
   what keeps Layer 1 fixed, not just what makes it fast. It looked healthy on native macOS; only
   the Windows harness caught it.
 
-K's window is now ~40x smaller than the CLI's ~5 s connect wait, so the self-recovery replay
-should effectively stop firing — but it stays in place, since the guarantee still lives in the
-CLI, not here.
+The broker's cold boot is now ~40x lower than before and ~10x under the CLI's ~5 s connect wait,
+so the self-recovery replay should effectively stop firing — but it stays in place, since the
+guarantee still lives in the CLI, not here.


### PR DESCRIPTION
## Summary

`plans/mcp-broker-availability-matrix.md` の Residual note が、#2235 で解決済みの課題を将来課題として挙げたままだったので更新しました。ドキュメントのみの変更です。

`#2235` を参照（同 issue は PR #2674 で完了済み）。

## Items to Confirm / Review

1. **「解決したが提案とは違う形」の書き方** — Residual note は「重い top-level import を遅延させる」を提案していましたが、実際は事前ビルドで解決しました。単に「done」と書くと次に読む人が同じ遅延化案を再提案しかねないので、**却下した根拠（実行時グラフを測ると最大の import を切っても 26/292 ファイルしか減らない）も残しています**。この判断でよいか。
2. **行 K のステータス変更** — `FIXED (self-recovery)` → `FIXED (cause removed + self-recovery)`。retry は残してあります（保証は依然として CLI 側にあるため）。この表現が実態と合っているか。

## User Prompt

- issue 更新
- matrix も更新して

## 変更内容

### Residual note

- 「将来課題」→ **#2235 で解決済み**（ただし提案された遅延化ではなく事前ビルド）
- 実測値の表（`tsx` 20,232 ms → 事前ビルド 508 ms）と、それが #2233 のハーネスで毎回出ること
- **再訪時に間違えやすい 2 点**を明記：
  - 静的グラフ（esbuild metafile）は `import type` を含むので実行時と食い違う。`spawnBackgroundChat.ts` が 1843 ファイル引き込んでいるように見えるが、実行時には `api/routes/agent.ts` は読まれない
  - バンドルは依存を inline しないと **Layer 1 の junction 問題が再発する**。`packages: "external"` は 505 KB に収まるが `Cannot find package '@mulmoclaude/markdown-utils'` で起動失敗する。**native macOS では健全に見えた**ので、Windows ハーネスだけが捕捉できた

### 行 K / Verdict

`retry で自己回復` → `原因を除去（20 s → 0.5 s）+ retry を保険として維持`。あわせて「コールドブートは推定ではなく毎回の Windows canary で計測される」ことを追記しました。

## 検証

- `yarn format` 通過
- ドキュメントのみの変更（コード・設定に変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude2

## Summary by Sourcery

Update the MCP broker availability matrix documentation to reflect that the cold-boot race is now resolved via prebuilt bundles, with retry retained as a backstop, and to replace the residual note with measured timing data and current guidance.

Documentation:
- Revise row K in the availability matrix to document the cold-boot fix via prebuilt broker bundle, updated tests/timing sources, and the adjusted status description.
- Replace the previous future-work residual note with measured cold/warm boot timings, an explanation of why import deferral was rejected, and pointers on correctly measuring runtime graphs and bundling dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the MCP broker availability matrix to document the prebuilt broker bundle and fallback replay behavior.
  - Added broker cold-start measurements and canary coverage guidance.
  - Documented benchmark results, runtime dependency-analysis guidance, and dependency inlining requirements.
  - Replaced the proposed deferred-import approach with details of the shipped bundling solution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->