### PR TITLE
chore(release): @mulmoclaude/core@1.12.0, google-plugin@1.2.1, spotify-plugin@1.0.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -41,7 +41,7 @@
     "@mulmoclaude/common": "^1.1.1",
     "@mulmoclaude/core": "^1.12.0",
     "@mulmoclaude/form-plugin": "^1.0.2",
-    "@mulmoclaude/google-plugin": "^1.2.0",
+    "@mulmoclaude/google-plugin": "^1.2.1",
     "@mulmoclaude/html-plugin": "^1.2.0",
     "@mulmoclaude/markdown-plugin": "^1.3.0",
     "@mulmoclaude/markdown-utils": "^1.3.2",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -46,7 +46,7 @@
     "@mulmoclaude/markdown-plugin": "^1.3.0",
     "@mulmoclaude/markdown-utils": "^1.3.2",
     "@mulmoclaude/mulmoscript-plugin": "^1.1.2",
-    "@mulmoclaude/spotify-plugin": "^1.0.2",
+    "@mulmoclaude/spotify-plugin": "^1.0.3",
     "@mulmoclaude/x-plugin": "^1.0.1",
     "@receptron/task-scheduler": "^1.0.1",
     "cors": "^2.8.6",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^1.0.3",
     "@mulmoclaude/collection-plugin": "^1.2.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.0",
     "@mulmoclaude/html-plugin": "^1.2.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.11.0"
+    "@mulmoclaude/core": "^1.12.0"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.11.0"
+    "@mulmoclaude/core": "^1.12.0"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/google-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Google integration tool for MulmoClaude and MulmoTerminal — operates the user's locally linked Google account: Calendar (list, sync, create, update, delete), Tasks and Drive, as one kind-discriminated `google` tool. Server-only; no Vue View.",
   "repository": {
     "type": "git",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.11.0"
+    "@mulmoclaude/core": "^1.12.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.11.0"
+    "@mulmoclaude/core": "^1.12.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,20 +37,20 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "@mulmoclaude/markdown-utils": "^1.3.2",
     "js-yaml": "^5.2.2",
     "marked": "^18.0.7",
     "mermaid": "^11.16.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.11.0"
+    "@mulmoclaude/core": "^1.12.0"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",

--- a/packages/plugins/spotify-plugin/package.json
+++ b/packages/plugins/spotify-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/spotify-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Read-only Spotify integration for MulmoClaude — Liked Songs / playlists / recently played, OAuth via PKCE. Built as a runtime plugin (issue #1162).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

3パッケージの publish 用バージョン更新と、consumer の宣言レンジ掃き。**コード変更はありません**（`package.json` のみ）。

| パッケージ | | 中身 |
|---|---|---|
| `@mulmoclaude/core` | 1.11.0 → **1.12.0** | #2678（PR #2680）のカレンダー同期ホスト間 dedup。新規 export があるので minor |
| `@mulmoclaude/google-plugin` | 1.2.0 → **1.2.1** | #2583 の dispatch 切り出し（PR #2665）が未公開のまま残っていた分。挙動不変のリファクタ |
| `@mulmoclaude/spotify-plugin` | 1.0.2 → **1.0.3** | 同上（PR #2670）。挙動不変のリファクタ |

`yarn audit:releases --code-only` で検出した code drift 3件がちょうどこれで、他はすべて manifest drift（レンジ掃きの反映待ち）です。

## レンジ掃き

- `@mulmoclaude/core` → `^1.12.0`: 8ファイル14箇所（collection / accounting / html / chart / mulmoscript / markdown / google の各プラグイン + launcher）
- `@mulmoclaude/google-plugin` → `^1.2.1`、`@mulmoclaude/spotify-plugin` → `^1.0.3`: launcher の各1箇所

`yarn check:launcher-sync` は green。**launcher 自身の `version` は 1.9.0 のまま触っていません** — CLAUDE.md のとおり、あのフィールドは `/publish-mulmoclaude` の領分です。

## Items to Confirm / Review

- **コミット粒度** — 過去の release commit（`542591090` 等）に合わせ、1パッケージ1コミット + その consumer レンジ掃き、の3コミットに分けています
- **本来は main へ直接 push する運用**（`4a0c2d392` などがその形）ですが、今回はハーネス側で直接 push がブロックされたため PR 経由にしています。3つの release commit の SHA は変わらないので、タグはそれぞれのコミットに付きます

## 検証

`yarn install` / `yarn lint`（0 error）/ `yarn typecheck` / `yarn build` / `yarn test`（失敗0）/ `yarn check:launcher-sync` すべて green。ツリーが検証時と同一であることも確認済みです。

マージ後に tag → npm publish → GH release → CHANGELOG 追記の順で進めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core platform and related plugins to their latest compatible versions.
  * Improved compatibility across accounting, chart, collection, HTML, Markdown, scripting, Google, and Spotify integrations.
  * Published patch updates for the Google and Spotify plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->