### PR TITLE
fix(calendar): decide the pull's protection immediately before each write (#2684)

### DIFF
--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -11,6 +11,7 @@
 import { stat } from "node:fs/promises";
 import { MISSED_RUN_POLICIES, SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import type { SystemTaskDef } from "../scheduler/adapter.js";
+import type { CollectionItem } from "../collection/core/schema.js";
 import { discoverCollections } from "../collection/server/discovery.js";
 import { getWorkspaceRoot } from "../collection/server/host.js";
 import type { LoadedCollection } from "../collection/server/discoveredCollection.js";
@@ -29,7 +30,8 @@ import {
   saveCalendarSyncToken,
 } from "./calendarSyncStore.js";
 import { calendarSyncDueWindowMs, isCalendarSyncDue } from "./calendarSyncDue.js";
-import { clearCalendarShadow, saveCalendarShadow, toShadowEvent, type ShadowEvent } from "./calendarPushState.js";
+import { clearCalendarShadow, loadCalendarShadow, saveCalendarShadow, toShadowEvent, type ShadowEvent } from "./calendarPushState.js";
+import { baselineRecord, locallyChangedFields, pushableMap } from "./pushPlan.js";
 import { loadGoogleTokens } from "./tokenStore.js";
 import { log } from "./host.js";
 
@@ -43,14 +45,24 @@ export interface CalendarCollectionSyncResult {
   /** Events that can NEVER be stored — e.g. an id the record-file sanitiser
    *  rejects. Reported and skipped rather than retried; see `classifyWrite`. */
   unwritable: string[];
+  /** Events left alone because the record they would overwrite holds an edit
+   *  Google has not seen. NOT an error — the token still advances past them; only
+   *  the baseline is held back, so the next push reports the conflict (#2684). */
+  withheld: string[];
   /** Retryable failures. Any of these hold the sync token back. */
   errors: string[];
 }
 
 /** `skipped` is a benign no-op; `unwritable` can never succeed so it must NOT
- *  hold the token; `error` is retryable and does hold it. */
+ *  hold the token; `error` is retryable and does hold it; `withheld` is a
+ *  deliberate refusal to overwrite a local edit. */
 type ApplyOutcome =
-  { kind: "written" } | { kind: "removed" } | { kind: "skipped" } | { kind: "unwritable"; message: string } | { kind: "error"; message: string };
+  | { kind: "written" }
+  | { kind: "removed" }
+  | { kind: "skipped" }
+  | { kind: "withheld" }
+  | { kind: "unwritable"; message: string }
+  | { kind: "error"; message: string };
 
 // `writeItem` / `deleteItem` report most failures by RETURNING a non-`ok` kind
 // rather than throwing. Ignoring that would let the token advance past events
@@ -76,7 +88,33 @@ export function classifyDelete(eventId: string, kind: DeleteItemResult["kind"]):
   return { kind: "error", message: `delete ${eventId}: ${kind}` };
 }
 
-async function applyEvent(collection: LoadedCollection, event: CalendarEventSummary, workspaceRoot: string): Promise<ApplyOutcome> {
+/** Whether this record still says what the workspace last saw Google say.
+ *
+ *  Compared against the baseline as it stood when this run STARTED READING, not
+ *  as it stands now: a full re-walk clears the baseline before writing a new one
+ *  (`restartFullSync`), so reading it live would answer "no baseline" for every
+ *  event and protect nothing exactly when the window is widest (#2684).
+ *
+ *  A record with no baseline at all is NOT withheld — that is an event this
+ *  workspace has never held, so there is no local edit to lose. */
+export function hasUnsentEdit(
+  existing: CollectionItem,
+  event: CalendarEventSummary,
+  schema: LoadedCollection["schema"],
+  baseline: Record<string, ShadowEvent>,
+): boolean {
+  const shadow = baseline[event.id];
+  if (shadow === undefined) return false;
+  const map = pushableMap(schema.googleCalendar?.map ?? {});
+  return locallyChangedFields(existing, baselineRecord(event.id, shadow, map, schema.primaryKey, schema.fields), map).length > 0;
+}
+
+async function applyEvent(
+  collection: LoadedCollection,
+  event: CalendarEventSummary,
+  workspaceRoot: string,
+  baseline: Record<string, ShadowEvent>,
+): Promise<ApplyOutcome> {
   const { schema } = collection;
   try {
     // Discovery rejects googleCalendar on a read-only (dataSource) schema,
@@ -88,8 +126,13 @@ async function applyEvent(collection: LoadedCollection, event: CalendarEventSumm
       const deleted = await store.delete(event.id);
       return classifyDelete(event.id, deleted.kind);
     }
+    // Read and check together, immediately before the write. The set computed
+    // back at push time cannot cover an edit made while the window was in
+    // flight — minutes of it, on a full walk (#2684).
+    const existing = await store.read(event.id);
+    if (existing !== null && hasUnsentEdit(existing, event, schema, baseline)) return { kind: "withheld" };
     const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey, schema.fields);
-    const written = await store.write(event.id, mergeIntoExisting(await store.read(event.id), record));
+    const written = await store.write(event.id, mergeIntoExisting(existing, record));
     return classifyWrite(event.id, written.kind);
   } catch (error) {
     // A thrown IO error (EACCES, ENOSPC, …) must not abort the remaining events
@@ -344,6 +387,16 @@ async function releaseCalendarSyncClaim(calendarId: string | undefined, workspac
   }
 }
 
+/** Every event whose baseline must NOT advance: what the push could not send,
+ *  plus what the apply refused to overwrite.
+ *
+ *  The two must agree exactly. The apply's refusals only became visible after it
+ *  ran, so they join the union here rather than at push time — leaving them out
+ *  would advance the baseline past a record the pull deliberately left holding a
+ *  local edit, which is the silent overwrite this whole path exists to stop. */
+export const heldBack = (unpushed: UnpushedBySlug, results: readonly CalendarCollectionSyncResult[]): ReadonlySet<string> =>
+  new Set([...allUnpushed(unpushed), ...results.flatMap((result) => result.withheld)]);
+
 async function syncCalendarGroupNow(
   calendarId: string | undefined,
   collections: readonly LoadedCollection[],
@@ -355,17 +408,24 @@ async function syncCalendarGroupNow(
   // very edit that was waiting to go up (#2620).
   const unpushed = await pushAndProtect(collections, workspaceRoot);
 
+  // Snapshot AFTER the push and BEFORE the window is read. After, because the
+  // push writes a baseline per record it sends, and an earlier snapshot would
+  // read those records as locally edited. Before, because `restartFullSync`
+  // clears the baseline — the snapshot is what survives that clear and lets the
+  // apply still tell an edit from an untouched record (#2684).
+  const baseline = await loadCalendarShadow(calendarId, workspaceRoot);
+
   const accessToken = await getGoogleAccessToken();
   const storedToken = await loadCalendarSyncToken(calendarId, workspaceRoot);
   const first = await syncCalendarEvents(accessToken, { calendarId, syncToken: storedToken ?? undefined });
   const result = first.fullResyncRequired ? await restartFullSync(accessToken, calendarId, workspaceRoot) : first;
 
-  const results = await applyWindowToGroup(collections, result.events, workspaceRoot, unpushed);
+  const results = await applyWindowToGroup(collections, result.events, workspaceRoot, unpushed, baseline);
   if (windowFullyLanded(calendarId, results)) {
     // Gated with the token, for the same reason: a baseline recorded for a window
     // the records never received would make the next push read a local edit where
     // there was only a failed write.
-    await saveCalendarShadow(calendarId, shadowUpdates(result.events, allUnpushed(unpushed)), workspaceRoot);
+    await saveCalendarShadow(calendarId, shadowUpdates(result.events, heldBack(unpushed, results)), workspaceRoot);
     if (result.nextSyncToken) await advanceToken(calendarId, result.nextSyncToken, collections, workspaceRoot);
   }
   return results;
@@ -380,14 +440,15 @@ async function applyWindowToGroup(
   events: readonly CalendarEventSummary[],
   workspaceRoot: string,
   unpushed: UnpushedBySlug,
+  baseline: Record<string, ShadowEvent>,
 ): Promise<CalendarCollectionSyncResult[]> {
   const results: CalendarCollectionSyncResult[] = [];
   for (const collection of collections) {
     const protection = unpushedFor(unpushed, collection.slug);
     results.push(
       protection === null
-        ? { slug: collection.slug, written: 0, removed: 0, unwritable: [], errors: [PROTECTION_UNKNOWN] }
-        : await applyEventsToCollection(collection, events, workspaceRoot, protection),
+        ? { slug: collection.slug, written: 0, removed: 0, unwritable: [], withheld: [], errors: [PROTECTION_UNKNOWN] }
+        : await applyEventsToCollection(collection, events, workspaceRoot, protection, baseline),
     );
   }
   return results;
@@ -408,6 +469,15 @@ function windowFullyLanded(calendarId: string | undefined, results: readonly Cal
     .filter((entry) => entry.unwritable.length > 0)
     .forEach((entry) =>
       log.warn("google", "skipping calendar events that can never be stored", { calendarId, slug: entry.slug, unwritable: entry.unwritable }),
+    );
+  // A withheld event is a decision, not a failure: the record kept a local edit
+  // Google has not seen, so re-fetching the window would only refuse it again.
+  // The token advances past it and the BASELINE is what holds back, which is
+  // what keeps the next push able to report the conflict (#2684).
+  results
+    .filter((entry) => entry.withheld.length > 0)
+    .forEach((entry) =>
+      log.warn("google", "leaving calendar records alone — they hold edits Google has not seen", { calendarId, slug: entry.slug, withheld: entry.withheld }),
     );
   const failed = results.filter((entry) => entry.errors.length > 0);
   failed.forEach((entry) => log.warn("google", "holding back calendar sync token after failed writes", { calendarId, slug: entry.slug, errors: entry.errors }));
@@ -476,15 +546,18 @@ async function applyEventsToCollection(
   events: readonly CalendarEventSummary[],
   workspaceRoot: string,
   unpushed: ReadonlySet<string>,
+  baseline: Record<string, ShadowEvent>,
 ): Promise<CalendarCollectionSyncResult> {
-  const outcomes: ApplyOutcome[] = [];
+  const attempts: { eventId: string; outcome: ApplyOutcome }[] = [];
   for (const event of pullableEvents(events, unpushed)) {
-    outcomes.push(await applyEvent(collection, event, workspaceRoot));
+    attempts.push({ eventId: event.id, outcome: await applyEvent(collection, event, workspaceRoot, baseline) });
   }
+  const outcomes = attempts.map((attempt) => attempt.outcome);
   return {
     slug: collection.slug,
     written: outcomes.filter((outcome) => outcome.kind === "written").length,
     removed: outcomes.filter((outcome) => outcome.kind === "removed").length,
+    withheld: attempts.flatMap((attempt) => (attempt.outcome.kind === "withheld" ? [attempt.eventId] : [])),
     unwritable: outcomes.flatMap((outcome) => (outcome.kind === "unwritable" ? [outcome.message] : [])),
     errors: outcomes.flatMap((outcome) => (outcome.kind === "error" ? [outcome.message] : [])),
   };
@@ -603,7 +676,9 @@ async function runCalendarGroups(
       results.push(...(await syncCalendarGroup(calendarId, collections, workspaceRoot, mayClaim)));
     } catch (error) {
       log.warn("google", "calendar sync failed", { calendarId, error: String(error) });
-      results.push(...collections.map((collection) => ({ slug: collection.slug, written: 0, removed: 0, unwritable: [], errors: [String(error)] })));
+      results.push(
+        ...collections.map((collection) => ({ slug: collection.slug, written: 0, removed: 0, unwritable: [], withheld: [], errors: [String(error)] })),
+      );
     }
   }
   return results;

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -97,23 +97,25 @@ export function classifyDelete(eventId: string, kind: DeleteItemResult["kind"]):
  *
  *  A record with no baseline at all is NOT withheld — that is an event this
  *  workspace has never held, so there is no local edit to lose. */
-export function hasUnsentEdit(
-  existing: CollectionItem,
-  event: CalendarEventSummary,
+export function unsentEditGuard(
   schema: LoadedCollection["schema"],
   baseline: Record<string, ShadowEvent>,
-): boolean {
-  const shadow = baseline[event.id];
-  if (shadow === undefined) return false;
+): (existing: CollectionItem, eventId: string) => boolean {
+  // Built once per collection rather than per event: a full walk runs this over
+  // every event the calendar has (Sourcery review #2687).
   const map = pushableMap(schema.googleCalendar?.map ?? {});
-  return locallyChangedFields(existing, baselineRecord(event.id, shadow, map, schema.primaryKey, schema.fields), map).length > 0;
+  return (existing, eventId) => {
+    const shadow = baseline[eventId];
+    if (shadow === undefined) return false;
+    return locallyChangedFields(existing, baselineRecord(eventId, shadow, map, schema.primaryKey, schema.fields), map).length > 0;
+  };
 }
 
 async function applyEvent(
   collection: LoadedCollection,
   event: CalendarEventSummary,
   workspaceRoot: string,
-  baseline: Record<string, ShadowEvent>,
+  hasUnsentEdit: (existing: CollectionItem, eventId: string) => boolean,
 ): Promise<ApplyOutcome> {
   const { schema } = collection;
   try {
@@ -130,7 +132,7 @@ async function applyEvent(
     // back at push time cannot cover an edit made while the window was in
     // flight — minutes of it, on a full walk (#2684).
     const existing = await store.read(event.id);
-    if (existing !== null && hasUnsentEdit(existing, event, schema, baseline)) return { kind: "withheld" };
+    if (existing !== null && hasUnsentEdit(existing, event.id)) return { kind: "withheld" };
     const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey, schema.fields);
     const written = await store.write(event.id, mergeIntoExisting(existing, record));
     return classifyWrite(event.id, written.kind);
@@ -425,7 +427,7 @@ async function syncCalendarGroupNow(
     // Gated with the token, for the same reason: a baseline recorded for a window
     // the records never received would make the next push read a local edit where
     // there was only a failed write.
-    await saveCalendarShadow(calendarId, shadowUpdates(result.events, heldBack(unpushed, results)), workspaceRoot);
+    await saveCalendarShadow(calendarId, shadowUpdates(result.events, heldBack(unpushed, results), baseline), workspaceRoot);
     if (result.nextSyncToken) await advanceToken(calendarId, result.nextSyncToken, collections, workspaceRoot);
   }
   return results;
@@ -492,10 +494,27 @@ function windowFullyLanded(calendarId: string | undefined, results: readonly Cal
  *  keeps the local one would make the next push read a plain one-sided edit —
  *  no conflict to detect any more — and quietly overwrite Google. Held back, the
  *  baseline stays older than both sides, so the conflict keeps being reported
- *  until someone resolves it (#2620). */
-export function shadowUpdates(events: readonly CalendarEventSummary[], unpushed: ReadonlySet<string> = new Set()): Record<string, ShadowEvent | null> {
-  const carried = pullableEvents(events, unpushed);
-  return Object.fromEntries(carried.map((event) => [event.id, event.status === CANCELLED_EVENT_STATUS ? null : toShadowEvent(event)]));
+ *  until someone resolves it (#2620).
+ *
+ *  `held` carries what those events must KEEP. Omitting them is enough on an
+ *  incremental run, where the file is merged rather than replaced — but a full
+ *  re-walk CLEARS the baseline first (`restartFullSync`), and there omission
+ *  drops the entry for good. The next push would then read a conflicted record
+ *  as a brand-new create, hit Google's duplicate-id 409 and refuse it, instead
+ *  of reporting the conflict it actually is. Re-stating the pre-run value makes
+ *  a held-back event behave the same either way (observed during Claude review;
+ *  no bot flagged it). */
+export function shadowUpdates(
+  events: readonly CalendarEventSummary[],
+  unpushed: ReadonlySet<string> = new Set(),
+  held: Record<string, ShadowEvent> = {},
+): Record<string, ShadowEvent | null> {
+  const advanced = pullableEvents(events, unpushed).map((event): [string, ShadowEvent | null] => [
+    event.id,
+    event.status === CANCELLED_EVENT_STATUS ? null : toShadowEvent(event),
+  ]);
+  const kept = [...unpushed].flatMap((eventId): [string, ShadowEvent][] => (held[eventId] === undefined ? [] : [[eventId, held[eventId]]]));
+  return Object.fromEntries([...kept, ...advanced]);
 }
 
 /** Save the window's token unless every collection that consumed it was deleted
@@ -548,9 +567,10 @@ async function applyEventsToCollection(
   unpushed: ReadonlySet<string>,
   baseline: Record<string, ShadowEvent>,
 ): Promise<CalendarCollectionSyncResult> {
+  const hasUnsentEdit = unsentEditGuard(collection.schema, baseline);
   const attempts: { eventId: string; outcome: ApplyOutcome }[] = [];
   for (const event of pullableEvents(events, unpushed)) {
-    attempts.push({ eventId: event.id, outcome: await applyEvent(collection, event, workspaceRoot, baseline) });
+    attempts.push({ eventId: event.id, outcome: await applyEvent(collection, event, workspaceRoot, hasUnsentEdit) });
   }
   const outcomes = attempts.map((attempt) => attempt.outcome);
   return {

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -120,7 +120,7 @@ export {
   anySyncedCollectionSurvives,
   groupByCalendar,
   allUnpushed,
-  hasUnsentEdit,
+  unsentEditGuard,
   heldBack,
   orphanedCalendarId,
   pullableEvents,

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -120,6 +120,8 @@ export {
   anySyncedCollectionSurvives,
   groupByCalendar,
   allUnpushed,
+  hasUnsentEdit,
+  heldBack,
   orphanedCalendarId,
   pullableEvents,
   pullProtectionFor,

--- a/plans/fix-2683-protect-non-autopush-collections.md
+++ b/plans/fix-2683-protect-non-autopush-collections.md
@@ -11,7 +11,7 @@
 
 `syncCalendarGroupNow` (`collectionSync.ts:315-339`) は必ずこの順で動く:
 
-```
+```text
 ① push     … autoPush の collection を Google へ送り、送れなかった id 集合 unpushed を得る
 ② fetch    … Google から変更ウィンドウを取る
 ③ apply    … events を record ファイルに書く（unpushed のものは除外）

--- a/plans/fix-2684-protect-at-write-time.md
+++ b/plans/fix-2684-protect-at-write-time.md
@@ -11,7 +11,7 @@
 
 `syncCalendarGroupNow` はこの順で動く:
 
-```
+```text
 ① push     … autoPush の collection を Google へ送り、保護集合 unpushed を得る
 ② fetch    … Google から変更ウィンドウを取る            ← 数秒〜数分
 ③ apply    … events を record ファイルに書く（unpushed のものは除外）
@@ -60,12 +60,28 @@ Google が勝つ）、④が baseline も進める。
 
 1. `ApplyOutcome` に `{ kind: "withheld" }` を足す
 2. `CalendarCollectionSyncResult` に `withheld: string[]` を足す（構築箇所4つを更新）
-3. `applyEvent` に baseline スナップショットを渡し、書き込み直前に
-   `locallyChangedFields(existing, baselineRecord(...), pushableMap(map))` が空でなければ `withheld`
+3. `unsentEditGuard(schema, baseline)` — 判定を返す述語。`applyEventsToCollection` が
+   **collection ごとに1回だけ**作り、`applyEvent` へ渡す。`applyEvent` は `store.read` の直後、
+   書き込み直前にこれを呼び、真なら `withheld`
+   （map の構築を毎イベント繰り返さないための形。Sourcery review #2687）
 4. `applyEventsToCollection` が `withheld` を集める
-5. `syncCalendarGroupNow` が①直後にスナップショットを取り、③の `withheld` を `allUnpushed(unpushed)` と
-   union して④の `shadowUpdates` に渡す
+5. `syncCalendarGroupNow` が①直後にスナップショットを取り、`heldBack(unpushed, results)` で
+   ③の `withheld` を `allUnpushed(unpushed)` と union して④の `shadowUpdates` に渡す
    ── ③の保護と④の保護は**必ず一致していなければならない**（`pullableEvents` の docstring が明記）
+
+### held-back の baseline はフルウォークで消えてしまう（レビュー中に発見）
+
+④で「省く」だけでは足りない。増分同期なら `.push-state.json` はマージ書き込みなので既存エントリが
+残るが、**`restartFullSync` は先に `clearCalendarShadow` を呼ぶ**ので、そこでは省略がそのまま
+エントリ消滅になる。すると次の push は conflict しているレコードを**新規 create として扱い**、
+Google の duplicate-id 409 を踏んで `createOrAdopt` に拒否される ── conflict として報告されるべき
+ものが別のエラーに化ける。
+
+`shadowUpdates` に第3引数（carry-forward）を足し、held-back のイベントについては **run 開始前の
+スナップショット値を書き戻す**。増分・フルウォークのどちらでも同じ挙動になる。
+
+baseline を持たない held-back（ローカル作成でまだ push していないレコード）は carry しない ──
+無いものを捏造すると、次の push が「同期済み」と誤読するため。
 
 ### token は進めてよい、baseline は進めてはいけない
 
@@ -84,8 +100,27 @@ Google が勝つ）、④が baseline も進める。
 
 ## テスト
 
-- ②の最中に編集された record が上書きされないこと（スナップショットと食い違う record を withheld に）
-- baseline と一致する record は普通に上書きされること（全件凍結しない回帰）
-- withheld のイベントが `shadowUpdates` から外れること（③と④の一致）
-- withheld が token を止めないこと（`windowFullyLanded` が true のまま）
-- baseline が無い record（純粋な新規イベント）は withheld にならないこと
+`test/services/google/test_calendarCollectionSync.ts` に3ブロック。
+
+`unsentEditGuard`:
+
+- baseline と一致する record は保護しない（全件凍結しない回帰）
+- スナップショット以降に編集された record は保護する
+- baseline を持たないイベントは保護しない（初めて受け取るイベントを止めない）
+- map が覆わないローカル列の差分は保護理由にしない
+- Google 側だけが動き record が無変更なら保護しない
+
+`heldBack`:
+
+- ①の未送信と③の拒否を union すること／collection をまたいで union すること
+- union に入ったイベントが `shadowUpdates` から外れること（③と④の一致）
+
+`shadowUpdates` carry-forward:
+
+- held-back は run 開始前の値を書き戻し、Google の現在値へは進めないこと
+- held-back でないものは通常どおり進むこと
+- baseline を持たない held-back は carry しないこと
+- 第3引数を渡さない従来の呼び出しは挙動が変わらないこと
+
+**「withheld が token を止めない」は構造で担保**している（`windowFullyLanded` は `errors` しか見ず、
+`withheld` は別フィールド）。`windowFullyLanded` は private なので直接のテストは書いていない。

--- a/plans/fix-2684-protect-at-write-time.md
+++ b/plans/fix-2684-protect-at-write-time.md
@@ -1,0 +1,91 @@
+# fix(calendar): pull の保護を書き込み直前に判定する (#2684)
+
+#2683 の上に積む（同じ関数群に触るため）。
+
+## Request
+
+#2679 の調査から分離した2本目。#2683 が「保護集合が最初から空」を閉じたのに対し、こちらは
+**「保護集合が古い」**を閉じる。どちらも「保護を①の時点で決め打ちする」という同じ構造から出ている。
+
+## 何が壊れているか
+
+`syncCalendarGroupNow` はこの順で動く:
+
+```
+① push     … autoPush の collection を Google へ送り、保護集合 unpushed を得る
+② fetch    … Google から変更ウィンドウを取る            ← 数秒〜数分
+③ apply    … events を record ファイルに書く（unpushed のものは除外）
+④ baseline … events を .push-state.json に書く（unpushed のものは除外）
+```
+
+`unpushed` は①時点のスナップショット。**②の最中にユーザーが record を編集すると、その編集は
+`unpushed` に載らない。** ③が Google の値で上書きし（`mergeIntoExisting` は map が覆うフィールドで
+Google が勝つ）、④が baseline も進める。
+
+→ 次の push から見ると record と baseline が一致している = ローカル編集など無かったことになり、
+**conflict は永遠に検出されない。編集は痕跡なく消える。**
+
+窓の広さは2段階:
+
+- **増分同期** — ②が返すのは Google 側で変わったイベントだけなので、被害には *同じ窓で Google 側でも
+  変わっていた* ことが要る（＝本物の conflict が黙って Google 勝ちで解決される）。窓は API 1往復
+- **フルウォーク** — 410 復旧 (`restartFullSync`) や初回同期では②が全イベントを返す。Google 側の変更すら
+  不要で、**walk が走っている数分間に編集された record は片っ端から該当する**
+
+プロセスを跨ぐ必要はなく、#2679 のカレンダーロックでも塞げない（ユーザーの record 編集はロックを取らない）。
+
+## 方針 — 保護を「集合」から「書き込み直前の判定」へ
+
+③が1イベントを書く直前に、**その record が baseline と食い違っていないか**を見る。食い違っていれば
+書かない（＝ローカル編集を残す）。判定と書き込みの間に窓が無いので、TOCTOU が消える。
+
+### 壁：フルウォークは判定材料を消してしまう
+
+`restartFullSync` は `clearCalendarShadow` を呼ぶ (`collectionSync.ts`)。baseline が空になった状態で
+③が走るので、「baseline が無い」を保護と解釈すると **full re-walk が丸ごと凍る**。かといって
+非保護と解釈すると、いちばん窓が広いフルウォークで何も守れない。
+
+**解: ①の直後に baseline のスナップショットを取り、その run の判定にはスナップショットを使う。**
+
+スナップショットを取る位置が重要:
+
+- **①より前ではだめ。** push は record ごとに baseline を書く (`collectionPush.ts`)。push 前の
+  スナップショットは push が送った分だけ古く、送ったばかりの record が「ローカル編集あり」と誤判定され、
+  baseline が据え置かれて偽陽性 conflict になる
+- **①の直後、②より前が正しい。** これは「この run が読み始めた時点で、ワークスペースが
+  『Google はこうだ』と信じていた状態」そのもの。それ以降に編集された record だけが食い違う
+- `restartFullSync` は②の1回目の fetch の後に走るので、①直後のスナップショットは clear より前に取れる
+
+## 実装
+
+1. `ApplyOutcome` に `{ kind: "withheld" }` を足す
+2. `CalendarCollectionSyncResult` に `withheld: string[]` を足す（構築箇所4つを更新）
+3. `applyEvent` に baseline スナップショットを渡し、書き込み直前に
+   `locallyChangedFields(existing, baselineRecord(...), pushableMap(map))` が空でなければ `withheld`
+4. `applyEventsToCollection` が `withheld` を集める
+5. `syncCalendarGroupNow` が①直後にスナップショットを取り、③の `withheld` を `allUnpushed(unpushed)` と
+   union して④の `shadowUpdates` に渡す
+   ── ③の保護と④の保護は**必ず一致していなければならない**（`pullableEvents` の docstring が明記）
+
+### token は進めてよい、baseline は進めてはいけない
+
+`withheld` はエラーではないので `windowFullyLanded` を false にしない ── token は進む。Google が
+そのイベントを再送しなくても、record はローカル編集を保ったままで、次の push が conflict として
+報告するので失われない。**進めてはいけないのは baseline だけ**。
+
+## スコープ外（意図的に手を付けない）
+
+- **キャンセル（削除）経路。** Google 側で消えたイベントの record がローカル編集されていた場合、
+  今は削除される。これも同種の損失だが、保留すると「Google に無い record が残り、次の push が
+  『sync first』と言い続ける」という別の行き止まりを作る。#2684 は書き込み側の TOCTOU に絞る
+- **①の早期計算の撤去。** 書き込み直前の判定は①の `unpushedIds` を包含するが（送れなかった record は
+  record ≠ baseline なので必ず引っかかる）、`PROTECTION_UNKNOWN`（record が読めない → その collection は
+  pull しない）は書き込み判定では表現できないため①は残す。冗長だが安全側
+
+## テスト
+
+- ②の最中に編集された record が上書きされないこと（スナップショットと食い違う record を withheld に）
+- baseline と一致する record は普通に上書きされること（全件凍結しない回帰）
+- withheld のイベントが `shadowUpdates` から外れること（③と④の一致）
+- withheld が token を止めないこと（`windowFullyLanded` が true のまま）
+- baseline が無い record（純粋な新規イベント）は withheld にならないこと

--- a/test/routes/test_collectionCalendarRefresh.ts
+++ b/test/routes/test_collectionCalendarRefresh.ts
@@ -12,6 +12,7 @@ const result = (overrides: Partial<CalendarCollectionSyncResult> & { slug: strin
   written: 0,
   removed: 0,
   unwritable: [],
+  withheld: [],
   errors: [],
   ...overrides,
 });

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -16,6 +16,8 @@ import {
   pushableMap,
   toShadowEvent,
   groupByCalendar,
+  hasUnsentEdit,
+  heldBack,
   isUnpushed,
   mergeIntoExisting,
   orphanedCalendarId,
@@ -620,7 +622,7 @@ describe("withKeyedLock (#2566 per-calendar queuing)", () => {
 // missing grant explains. Exercised through injected fakes, so no workspace on
 // disk and no Google grant (CodeRabbit review #2566).
 describe("syncCalendarForCollection (#2427 manual refresh)", () => {
-  const syncedResult = (slug: string): CalendarCollectionSyncResult => ({ slug, written: 2, removed: 0, unwritable: [], errors: [] });
+  const syncedResult = (slug: string): CalendarCollectionSyncResult => ({ slug, written: 2, removed: 0, unwritable: [], withheld: [], errors: [] });
 
   const deps = (overrides: Partial<ManualCalendarSyncDeps> = {}): ManualCalendarSyncDeps & { ranWith: Map<string, LoadedCollection[]>[] } => {
     const ranWith: Map<string, LoadedCollection[]>[] = [];
@@ -792,5 +794,84 @@ describe("pullProtectionFor / pushAndProtect (#2683 a collection that never push
     const unpushed = await pushAndProtect([calendarCollection("mirror", false)], "/ws", deps);
     assert.deepEqual([...allUnpushed(unpushed)], ["ev-5"]);
     assert.deepEqual(shadowUpdates([event({ id: "ev-5" })], allUnpushed(unpushed)), {});
+  });
+});
+
+// The protected set used to be a snapshot taken when the push finished, so an
+// edit made while the window was in flight — minutes of it on a full walk — was
+// invisible to it. The pull then wrote Google's value over that edit AND advanced
+// the shared baseline past it, after which the next push saw a one-sided edit
+// and no conflict to report (#2684). The apply now decides per event, immediately
+// before its own write, and reports what it refused so the baseline agrees.
+describe("heldBack (#2684 the apply's refusals must reach the baseline)", () => {
+  const applied = (slug: string, withheld: string[]): CalendarCollectionSyncResult => ({
+    slug,
+    written: 0,
+    removed: 0,
+    unwritable: [],
+    withheld,
+    errors: [],
+  });
+
+  it("holds back what the push could not send AND what the apply refused", () => {
+    const unpushed = new Map<string, ReadonlySet<string>>([["mine", new Set(["pushed-conflict"])]]);
+    assert.deepEqual([...heldBack(unpushed, [applied("mine", ["edited-mid-window"])])].sort(), ["edited-mid-window", "pushed-conflict"]);
+  });
+
+  it("keeps the baseline off every event the apply left alone", () => {
+    const held = heldBack(new Map(), [applied("mine", ["ev-1"])]);
+    assert.deepEqual(shadowUpdates([event({ id: "ev-1" }), event({ id: "ev-2" })], held), {
+      "ev-2": toShadowEvent(event({ id: "ev-2" })),
+    });
+  });
+
+  it("advances the baseline normally when nothing was withheld", () => {
+    const held = heldBack(new Map(), [applied("mine", [])]);
+    assert.deepEqual(Object.keys(shadowUpdates([event({ id: "ev-1" })], held)), ["ev-1"]);
+  });
+
+  it("unions the refusals of every collection on the calendar", () => {
+    const held = heldBack(new Map(), [applied("mine", ["a"]), applied("theirs", ["b"])]);
+    assert.deepEqual([...held].sort(), ["a", "b"]);
+  });
+});
+
+// The rule the apply now runs immediately before each write. It has to answer
+// "would writing Google's value here destroy something Google has not seen?" —
+// and it must answer NO for a record the pull itself just wrote, or the whole
+// pull freezes (#2684).
+describe("hasUnsentEdit (#2684 the per-event guard)", () => {
+  const map = { title: "summary", on: "start", until: "end", colour: "colorId" } as const;
+  const schema = { googleCalendar: { map }, primaryKey: "gid", fields: recipeFields } as unknown as LoadedCollection["schema"];
+  const synced = event();
+  const baseline = { "ev-1": toShadowEvent(synced) };
+  const syncedRecord = toCollectionRecord(synced, map, "gid", recipeFields);
+
+  it("says no for a record that still matches the baseline", () => {
+    assert.equal(hasUnsentEdit(syncedRecord, synced, schema, baseline), false);
+  });
+
+  it("says yes for a record edited since the baseline was taken", () => {
+    assert.equal(hasUnsentEdit({ ...syncedRecord, title: "Standup (moved)" }, synced, schema, baseline), true);
+  });
+
+  // A brand-new event this workspace has never held. There is no local edit to
+  // lose, so withholding it would just stop the collection ever receiving it.
+  it("says no when the workspace holds no baseline for the event", () => {
+    assert.equal(hasUnsentEdit(syncedRecord, synced, schema, {}), false);
+  });
+
+  // Local-only columns are the point of `mergeIntoExisting` — the pull keeps
+  // them, so they are not a reason to refuse Google's own fields.
+  it("ignores a column the map does not name", () => {
+    assert.equal(hasUnsentEdit({ ...syncedRecord, notes: "call Alice first" }, synced, schema, baseline), false);
+  });
+
+  // Google changing the event is not what this guard is about: it compares the
+  // RECORD against the baseline, so a moved event with an untouched record still
+  // pulls normally and the conflict check on the next push does its own job.
+  it("says no when only Google moved, and the record never diverged", () => {
+    const moved = event({ start: "2026-07-19T10:00:00+09:00" });
+    assert.equal(hasUnsentEdit(syncedRecord, moved, schema, baseline), false);
   });
 });

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -16,7 +16,7 @@ import {
   pushableMap,
   toShadowEvent,
   groupByCalendar,
-  hasUnsentEdit,
+  unsentEditGuard,
   heldBack,
   isUnpushed,
   mergeIntoExisting,
@@ -840,31 +840,33 @@ describe("heldBack (#2684 the apply's refusals must reach the baseline)", () => 
 // "would writing Google's value here destroy something Google has not seen?" —
 // and it must answer NO for a record the pull itself just wrote, or the whole
 // pull freezes (#2684).
-describe("hasUnsentEdit (#2684 the per-event guard)", () => {
+describe("unsentEditGuard (#2684 the per-event guard)", () => {
   const map = { title: "summary", on: "start", until: "end", colour: "colorId" } as const;
   const schema = { googleCalendar: { map }, primaryKey: "gid", fields: recipeFields } as unknown as LoadedCollection["schema"];
   const synced = event();
   const baseline = { "ev-1": toShadowEvent(synced) };
   const syncedRecord = toCollectionRecord(synced, map, "gid", recipeFields);
 
+  const guard = unsentEditGuard(schema, baseline);
+
   it("says no for a record that still matches the baseline", () => {
-    assert.equal(hasUnsentEdit(syncedRecord, synced, schema, baseline), false);
+    assert.equal(guard(syncedRecord, synced.id), false);
   });
 
   it("says yes for a record edited since the baseline was taken", () => {
-    assert.equal(hasUnsentEdit({ ...syncedRecord, title: "Standup (moved)" }, synced, schema, baseline), true);
+    assert.equal(guard({ ...syncedRecord, title: "Standup (moved)" }, synced.id), true);
   });
 
   // A brand-new event this workspace has never held. There is no local edit to
   // lose, so withholding it would just stop the collection ever receiving it.
   it("says no when the workspace holds no baseline for the event", () => {
-    assert.equal(hasUnsentEdit(syncedRecord, synced, schema, {}), false);
+    assert.equal(unsentEditGuard(schema, {})(syncedRecord, synced.id), false);
   });
 
   // Local-only columns are the point of `mergeIntoExisting` — the pull keeps
   // them, so they are not a reason to refuse Google's own fields.
   it("ignores a column the map does not name", () => {
-    assert.equal(hasUnsentEdit({ ...syncedRecord, notes: "call Alice first" }, synced, schema, baseline), false);
+    assert.equal(guard({ ...syncedRecord, notes: "call Alice first" }, synced.id), false);
   });
 
   // Google changing the event is not what this guard is about: it compares the
@@ -872,6 +874,44 @@ describe("hasUnsentEdit (#2684 the per-event guard)", () => {
   // pulls normally and the conflict check on the next push does its own job.
   it("says no when only Google moved, and the record never diverged", () => {
     const moved = event({ start: "2026-07-19T10:00:00+09:00" });
-    assert.equal(hasUnsentEdit(syncedRecord, moved, schema, baseline), false);
+    assert.equal(guard(syncedRecord, moved.id), false);
+  });
+});
+
+// Omitting a held-back event is enough on an incremental run — `.push-state.json`
+// is merged, not replaced, so the old entry survives. A full re-walk CLEARS the
+// baseline first, and there the omission dropped the entry for good: the next
+// push then read a conflicted record as a brand-new create, hit Google's
+// duplicate-id 409 and refused it instead of reporting the conflict.
+// (Observed during Claude review of #2684; no bot flagged it.)
+describe("shadowUpdates carry-forward (#2684 a held-back baseline must survive a full re-walk)", () => {
+  const held = { "ev-1": toShadowEvent(event({ id: "ev-1", summary: "As Google had it" })) };
+
+  it("re-states the pre-run baseline for a held-back event", () => {
+    const updates = shadowUpdates([event({ id: "ev-1", summary: "Google moved on" })], new Set(["ev-1"]), held);
+    assert.deepEqual(updates["ev-1"], held["ev-1"]);
+  });
+
+  it("never advances a held-back event to what Google now says", () => {
+    const updates = shadowUpdates([event({ id: "ev-1", summary: "Google moved on" })], new Set(["ev-1"]), held);
+    assert.notDeepEqual(updates["ev-1"], toShadowEvent(event({ id: "ev-1", summary: "Google moved on" })));
+  });
+
+  it("still advances everything that was not held back", () => {
+    const moved = event({ id: "ev-2" });
+    const updates = shadowUpdates([event({ id: "ev-1" }), moved], new Set(["ev-1"]), held);
+    assert.deepEqual(updates["ev-2"], toShadowEvent(moved));
+  });
+
+  // A held-back id the workspace holds no baseline for — a record created
+  // locally and never pushed. There is nothing to carry, and inventing one would
+  // make the next push read it as already-synced.
+  it("carries nothing for a held-back event with no previous baseline", () => {
+    const updates = shadowUpdates([event({ id: "ev-3" })], new Set(["ev-3"]), held);
+    assert.equal("ev-3" in updates, false);
+  });
+
+  it("behaves as before when no carry-forward is supplied", () => {
+    assert.deepEqual(shadowUpdates([event({ id: "ev-1" })], new Set(["ev-1"])), {});
   });
 });


### PR DESCRIPTION
## Summary

> **Stacked on #2686 (#2683)。** 同じ関数群に触るため #2686 の上に積んでいます。**#2686 を先にマージしてください。** 差分は最新コミット1本 (`4f424e2`) だけです。

pull の保護集合は **push が終わった時点のスナップショット**だったので、②の window 取得中にユーザーが編集した record を守れませんでした。pull が Google の値で上書きし、共有 baseline もその先へ進むため、**次の push は片側編集しか見えず conflict を報告できない** — 編集は痕跡なく消えます。

**並行性も失敗も不要**で、しかも **#2679 のクロスプロセスロックでは塞げません**（ユーザーの record 編集はロックを取らないため）。

保護を「①で決め打ちする集合」から「**③の各書き込み直前の判定**」に変えました。判定と書き込みの間に窓が無いので TOCTOU が消えます。

## Items to Confirm / Review

1. **baseline スナップショットを取る位置が設計の肝です。** ①の直後・②の前です。
   - **①より前はだめ** — push は送った record ごとに baseline を書くので、push 前のスナップショットでは送ったばかりの record が「編集あり」と誤判定され、偽陽性 conflict になります
   - **②より前でなければならない** — `restartFullSync` が `clearCalendarShadow` を呼ぶので、apply 時に live で読むと**全イベントが「baseline なし」**になり、いちばん窓が広いフルウォークで何も守れません

   ここが逆だと静かに壊れるので、**特にレビューしていただきたい点です。**

2. **キャンセル（削除）経路は意図的に手つかず**です。Google 側で消えたイベントの record がローカル編集されていた場合、今も削除されます。同種の損失ですが、保留すると「Google に無い record が残り、次の push が『sync first』と言い続ける」別の行き止まりを作るため、本PRは書き込み側の TOCTOU に絞りました。**別 issue にすべきか判断をください。**

3. **①の早期計算は残しています**（冗長）。書き込み直前の判定は `unpushedIds` を包含しますが（送れなかった record は record ≠ baseline なので必ず引っかかる）、`PROTECTION_UNKNOWN`（record が読めない → その collection は pull しない）は書き込み判定では表現できないためです。

4. **`withheld` は token を止めません。** エラーではなく決定なので、window を取り直しても同じ判断になるだけです。**止めるのは baseline だけ** — それが次の push が conflict を報告できる条件です。この非対称は意図的です。

5. **UI には出していません。** `withheld` は warn ログに出しますが、Refresh のレスポンスには載せていません（ローカル編集が守られたのは望ましい結果で、conflict は Push 時に出るため）。件数を出すべきなら i18n を含めて別途対応します。

## User Prompt

> これなんだっけ？ https://github.com/receptron/mulmoclaude/issues/2679
> （中略：#2679 のスコープ確認を経て）
> 2ホストが同時に同じカレンダーへ push するって、ここのscopeにはいっているんだっけ？
> はい、では特定して
> ok 分けて実装。経路A / 経路Bの話はよく分かるように再度詳しく説明して

#2679 の調査から分離した2本目（経路A）です。1本目は #2683 / PR #2686。調査結果の詳細は #2679 のコメントに記載しています。

## 実装

- `ApplyOutcome` に `{ kind: "withheld" }`、`CalendarCollectionSyncResult` に `withheld: string[]`
- `hasUnsentEdit(existing, event, schema, baseline)` — 書き込み直前の判定（純粋関数、export してテスト）
- `applyEvent` が `store.read` の直後に判定し、食い違えば書かない
- `heldBack(unpushed, results)` — ①の保護と③の拒否を union して④へ
  ── **③と④は必ず同じイベントを飛ばさなければならない**（`pullableEvents` の docstring が明記）
- `syncCalendarGroupNow` が①直後に `loadCalendarShadow` でスナップショット

## 検証

- `yarn lint` — ✅ 0 errors / 51 warnings（すべて既存）
- `yarn typecheck` — ✅
- `yarn build` — ✅
- `yarn test` — ✅ 10761 pass / 0 fail（新規9本を含む）

新規テストは `hasUnsentEdit` の各分岐（baseline 一致 / 編集後 / baseline 無し / map 外の列 / Google だけが動いた場合）と、`heldBack` が③の拒否を④へ確実に伝えること。

**実機での動作確認はしていません**（Google の grant が要るため）。ユニットテストのみです。

Plan: `plans/fix-2684-protect-at-write-time.md`

refs #2684, #2683, #2679, #2666, #2620

work in mulmoclaude

## Summary by Sourcery

Protect locally edited calendar records during pull by basing overwrite decisions on a baseline snapshot taken after push and checking immediately before each write.

New Features:
- Track withheld calendar events that were intentionally not overwritten due to unsynced local edits and surface them in sync results and logs.

Bug Fixes:
- Prevent silent loss of local calendar edits made while a Google sync window is in flight by withholding conflicting pull writes and keeping the baseline behind them.

Enhancements:
- Introduce per-event guard logic to detect unsent edits against the baseline snapshot and union push-time and apply-time protections when advancing the calendar baseline.
- Extend calendar sync result plumbing to carry withheld event IDs through manual refresh and error paths so push and pull protection remain consistent.

Documentation:
- Add a plan document outlining the new write-time protection strategy for calendar pull and its interaction with baseline snapshots and sync tokens.

Tests:
- Add unit tests for the per-event unsent edit detection, held-back baseline computation, and updated calendar sync behavior across collections and refresh routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Calendar synchronization to prevent local edits from being overwritten by incoming Google changes.
  * Records with unsent local edits are now safely withheld during synchronization and reported in the results.
  * Protected records retain their previous synchronization baseline while other calendar updates continue normally.
  * Synchronization tokens can advance without losing locally modified records, including during full calendar refreshes.
  * Protection results are consistently reported across calendar collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->