### PR TITLE
fix(calendar): a cancellation in Google must not outrank a local edit (#2688)

### DIFF
--- a/packages/core/src/google/collectionPush.ts
+++ b/packages/core/src/google/collectionPush.ts
@@ -258,8 +258,16 @@ async function updateFromRecord(
   shadow: ShadowEvent,
 ): Promise<PushOutcome> {
   const fetched = await getCalendarEvent(ctx.accessToken, { calendarId: ctx.calendarId, eventId });
+  // "Sync first" used to be the advice here, and it sent people nowhere: Google
+  // never resends a cancellation, so a sync sees nothing to do — and before
+  // #2688 the sync that DID see it deleted the record along with the edit. Say
+  // what is actually true and what actually resolves it. Deliberately silent on
+  // whether Google will hand this id back: that is unverified (#2688).
   if (fetched === null || fetched.event.status === CANCELLED_EVENT_STATUS) {
-    return { kind: "skipped", message: `${eventId}: the event no longer exists in Google — sync first, then re-create it` };
+    return {
+      kind: "skipped",
+      message: `${eventId}: Google no longer has this event, and your local edit was kept. Delete this record, or copy it into a new one.`,
+    };
   }
   if (conflictingFields(shadow, toShadowEvent(fetched.event), changed).length > 0) return { kind: "conflict" };
   const built = buildPatch(ctx, record, changed, shadow);

--- a/packages/core/src/google/collectionPush.ts
+++ b/packages/core/src/google/collectionPush.ts
@@ -250,6 +250,18 @@ function buildPatch(ctx: PushContext, record: CollectionItem, changed: readonly 
   };
 }
 
+/** Google has dropped the event this record mirrors.
+ *
+ *  The advice used to be "sync first, then re-create it", which sent people
+ *  nowhere: Google never resends a cancellation, so a sync sees nothing to do —
+ *  and before #2688 the sync that DID see it deleted the record along with the
+ *  edit. Deliberately silent on whether Google will hand the id back; that is
+ *  unverified. */
+const goneFromGoogle = (eventId: string): PushOutcome => ({
+  kind: "skipped",
+  message: `${eventId}: Google no longer has this event, and your local edit was kept. Delete this record, or copy it into a new one.`,
+});
+
 async function updateFromRecord(
   ctx: PushContext,
   eventId: string,
@@ -258,17 +270,7 @@ async function updateFromRecord(
   shadow: ShadowEvent,
 ): Promise<PushOutcome> {
   const fetched = await getCalendarEvent(ctx.accessToken, { calendarId: ctx.calendarId, eventId });
-  // "Sync first" used to be the advice here, and it sent people nowhere: Google
-  // never resends a cancellation, so a sync sees nothing to do — and before
-  // #2688 the sync that DID see it deleted the record along with the edit. Say
-  // what is actually true and what actually resolves it. Deliberately silent on
-  // whether Google will hand this id back: that is unverified (#2688).
-  if (fetched === null || fetched.event.status === CANCELLED_EVENT_STATUS) {
-    return {
-      kind: "skipped",
-      message: `${eventId}: Google no longer has this event, and your local edit was kept. Delete this record, or copy it into a new one.`,
-    };
-  }
+  if (fetched === null || fetched.event.status === CANCELLED_EVENT_STATUS) return goneFromGoogle(eventId);
   if (conflictingFields(shadow, toShadowEvent(fetched.event), changed).length > 0) return { kind: "conflict" };
   const built = buildPatch(ctx, record, changed, shadow);
   if (!built.ok) return { kind: "skipped", message: `${eventId}: ${built.reason}` };

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -111,6 +111,22 @@ export function unsentEditGuard(
   };
 }
 
+/** What the pull may do to the record behind one event.
+ *
+ *  The guard runs BEFORE the status is consulted, and that order is the whole
+ *  fix: "is there something local to lose here?" outranks "what did Google do
+ *  to it?". Asking about the status first is how a cancellation kept deleting
+ *  records that held an edit Google had never seen (#2688), long after the
+ *  same guard had been put in front of the overwrite (#2684). */
+export function applyPlanFor(
+  existing: CollectionItem | null,
+  event: CalendarEventSummary,
+  hasUnsentEdit: (existing: CollectionItem, eventId: string) => boolean,
+): "withhold" | "delete" | "write" {
+  if (existing !== null && hasUnsentEdit(existing, event.id)) return "withhold";
+  return event.status === CANCELLED_EVENT_STATUS ? "delete" : "write";
+}
+
 async function applyEvent(
   collection: LoadedCollection,
   event: CalendarEventSummary,
@@ -124,15 +140,13 @@ async function applyEvent(
     // threads the slug into the change publish, so an open view updates live.
     const store = storeFor(collection, { workspaceRoot });
     if (!store.write || !store.delete) return { kind: "unwritable", message: `collection '${collection.slug}' is read-only` };
-    if (event.status === CANCELLED_EVENT_STATUS) {
-      const deleted = await store.delete(event.id);
-      return classifyDelete(event.id, deleted.kind);
-    }
-    // Read and check together, immediately before the write. The set computed
-    // back at push time cannot cover an edit made while the window was in
-    // flight — minutes of it, on a full walk (#2684).
+    // Read and decide immediately before acting. The set computed back at push
+    // time cannot cover an edit made while the window was in flight — minutes
+    // of it, on a full walk (#2684).
     const existing = await store.read(event.id);
-    if (existing !== null && hasUnsentEdit(existing, event.id)) return { kind: "withheld" };
+    const plan = applyPlanFor(existing, event, hasUnsentEdit);
+    if (plan === "withhold") return { kind: "withheld" };
+    if (plan === "delete") return classifyDelete(event.id, (await store.delete(event.id)).kind);
     const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey, schema.fields);
     const written = await store.write(event.id, mergeIntoExisting(existing, record));
     return classifyWrite(event.id, written.kind);

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -127,6 +127,19 @@ export function applyPlanFor(
   return event.status === CANCELLED_EVENT_STATUS ? "delete" : "write";
 }
 
+/** Lay Google's mapped values over whatever the record already holds. Split out
+ *  so `applyEvent` reads as read → decide → act rather than carrying the write
+ *  itself (CodeRabbit review #2689). */
+async function writeProjected(
+  write: NonNullable<ReturnType<typeof storeFor>["write"]>,
+  event: CalendarEventSummary,
+  schema: LoadedCollection["schema"],
+  existing: CollectionItem | null,
+): Promise<ApplyOutcome> {
+  const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey, schema.fields);
+  return classifyWrite(event.id, (await write(event.id, mergeIntoExisting(existing, record))).kind);
+}
+
 async function applyEvent(
   collection: LoadedCollection,
   event: CalendarEventSummary,
@@ -147,9 +160,7 @@ async function applyEvent(
     const plan = applyPlanFor(existing, event, hasUnsentEdit);
     if (plan === "withhold") return { kind: "withheld" };
     if (plan === "delete") return classifyDelete(event.id, (await store.delete(event.id)).kind);
-    const record = toCollectionRecord(event, schema.googleCalendar?.map ?? {}, schema.primaryKey, schema.fields);
-    const written = await store.write(event.id, mergeIntoExisting(existing, record));
-    return classifyWrite(event.id, written.kind);
+    return await writeProjected(store.write, event, schema, existing);
   } catch (error) {
     // A thrown IO error (EACCES, ENOSPC, …) must not abort the remaining events
     // or the other collections on this calendar — record it as retryable so the

--- a/packages/core/src/google/index.ts
+++ b/packages/core/src/google/index.ts
@@ -118,6 +118,7 @@ export {
   classifyDelete,
   classifyWrite,
   anySyncedCollectionSurvives,
+  applyPlanFor,
   groupByCalendar,
   allUnpushed,
   unsentEditGuard,

--- a/plans/fix-2688-protect-cancelled-with-local-edits.md
+++ b/plans/fix-2688-protect-cancelled-with-local-edits.md
@@ -1,0 +1,82 @@
+# fix(calendar): Google が消したイベントでも、ローカル編集があれば record を消さない (#2688)
+
+## Request
+
+#2684（PR #2687）で、pull が record を**上書き**する前にローカル編集を確認するようにした。
+しかし**削除**経路には同じガードが掛かっていない。`applyEvent` (`collectionSync.ts:127-130`):
+
+```ts
+if (event.status === CANCELLED_EVENT_STATUS) {
+  const deleted = await store.delete(event.id);   // ← 無条件
+  return classifyDelete(event.id, deleted.kind);
+}
+```
+
+Google 側でイベントがキャンセルされると、その record がローカル編集されていても**黙って消えます**。
+#2683 / #2684 が閉じたのと同種の損失で、こちらだけ残っていた。
+
+## 起票時の見立ての訂正
+
+issue 本文には「保護に倒すと『sync first と言われて sync すると消される』ループになるので、
+出口の UX 設計から必要」と書いたが、**不正確だった**。
+
+- `withheld` はエラーではないので **token は進む**
+- Google はキャンセルを再送しないので、**次回以降の sync はそのイベントを見ない**
+- よって状態は安定し、ループしない
+
+行き止まりだったのは**メッセージだけ**。`collectionPush.ts` が返す
+`"the event no longer exists in Google — sync first, then re-create it"` が、
+sync しても何も起きない状況で「sync しろ」と言い続ける。
+
+さらに #2684 で `shadowUpdates` に carry-forward が入ったので、**baseline の据え置きは既存機構で
+そのまま成立する** ── キャンセルされたイベントに `null`（baseline 削除）を出す経路も、`withheld` に
+入れば run 開始前の値が書き戻される。追加の仕組みは要らない。
+
+## 方針
+
+書き込み側と削除側で**同じガードを1回だけ**通す。読み取りも1回に集約する。
+
+判定を純粋関数として切り出し、`applyEvent` は薄いディスパッチャにする ── この判定は #2666 / #2683 /
+#2684 が繰り返し間違えてきた箇所なので、I/O 抜きで固定できる形にしておく。
+
+```ts
+export function applyPlanFor(existing, event, hasUnsentEdit): "withhold" | "delete" | "write" {
+  if (existing !== null && hasUnsentEdit(existing, event.id)) return "withhold";
+  return event.status === CANCELLED_EVENT_STATUS ? "delete" : "write";
+}
+```
+
+**ガードが status より先**なのが要点。「Google がこれをどうしたか」より「ローカルに失うものがあるか」が
+先に効く。
+
+## 出口 — メッセージを実態に合わせる
+
+`collectionPush.ts` の該当メッセージを書き換える。ユーザーが取れる行動は2つ:
+
+- その record を削除する（Google と揃う）
+- 別レコードにコピーする（新しい id で create として上がる）
+
+**「同じ id で再作成できる／できない」は主張しない。** Google がキャンセル済みイベントの id を
+再利用させるかは未検証で、根拠のないことをメッセージに書かない。
+
+## スコープ外
+
+- **UI での明示的な選択肢**（「ローカルを残す / 消す」を出す）。メッセージで出口は成立するので、
+  UI 追加と i18n は別途判断
+- **ローカル削除された record の baseline 掃除**。`locallyDeletedIds` が報告するだけで baseline
+  エントリは残る。本 issue とは別の話
+
+## テスト
+
+`applyPlanFor` を純粋関数として:
+
+- 編集済み record + キャンセル → `withhold`（削除しない）
+- 同期済み record + キャンセル → `delete`
+- record 無し + キャンセル → `delete`（存在しないものの削除は `classifyDelete` が `skipped` にする）
+- 編集済み record + 通常イベント → `withhold`（#2684 の挙動が変わらないこと）
+- 同期済み record + 通常イベント → `write`
+
+`shadowUpdates`:
+
+- **キャンセルされたイベントが held のとき、`null` ではなく run 開始前の baseline が残ること**
+  ── これが「conflict を報告し続けられる」条件

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import {
   allUnpushed,
   anySyncedCollectionSurvives,
+  applyPlanFor,
   baselineRecord,
   classifyDelete,
   classifyWrite,
@@ -40,7 +41,7 @@ import type {
   PullProtectionDeps,
 } from "@mulmoclaude/core/google";
 import { parseIsoDateTime } from "@mulmoclaude/core/collection";
-import type { CollectionFieldSpec } from "@mulmoclaude/core/collection";
+import type { CollectionFieldSpec, CollectionItem } from "@mulmoclaude/core/collection";
 import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
 
 const event = (overrides: Partial<CalendarEventSummary> = {}): CalendarEventSummary => ({
@@ -913,5 +914,57 @@ describe("shadowUpdates carry-forward (#2684 a held-back baseline must survive a
 
   it("behaves as before when no carry-forward is supplied", () => {
     assert.deepEqual(shadowUpdates([event({ id: "ev-1" })], new Set(["ev-1"])), {});
+  });
+});
+
+// #2684 put the guard in front of the OVERWRITE but not the DELETE, so a
+// cancellation in Google still removed a record holding an edit Google had
+// never seen — the same silent loss, one branch over (#2688). The guard now
+// runs before the status is consulted: "is there something local to lose?"
+// outranks "what did Google do to it?".
+describe("applyPlanFor (#2688 a cancellation must not outrank a local edit)", () => {
+  const edited = (_existing: CollectionItem, eventId: string) => eventId === "ev-edited";
+  const cancelled = event({ id: "ev-edited", status: "cancelled" });
+  const record = { gid: "ev-edited", title: "mine" };
+
+  it("refuses to delete a record that holds an unsent edit", () => {
+    assert.equal(applyPlanFor(record, cancelled, edited), "withhold");
+  });
+
+  it("still deletes a record that is in sync with Google", () => {
+    assert.equal(applyPlanFor({ gid: "ev-clean" }, event({ id: "ev-clean", status: "cancelled" }), edited), "delete");
+  });
+
+  // Cancelling an event this collection never stored is normal, not a loss —
+  // `classifyDelete` turns the resulting not-found into a benign skip.
+  it("deletes when there is no local record at all", () => {
+    assert.equal(applyPlanFor(null, cancelled, edited), "delete");
+  });
+
+  it("keeps the #2684 behaviour for a live event with an unsent edit", () => {
+    assert.equal(applyPlanFor(record, event({ id: "ev-edited" }), edited), "withhold");
+  });
+
+  it("writes a live event over a record that is in sync", () => {
+    assert.equal(applyPlanFor({ gid: "ev-clean" }, event({ id: "ev-clean" }), edited), "write");
+  });
+});
+
+// The baseline half of #2688. `shadowUpdates` emits `null` for a cancelled
+// event — dropping the baseline — which is right when the record went with it,
+// and wrong when the record was kept: without a baseline the next push reads a
+// conflicted record as a brand-new create. The #2684 carry-forward covers this
+// once the event is held back, so this pins the two halves together.
+describe("shadowUpdates + a withheld cancellation (#2688)", () => {
+  const previously = toShadowEvent(event({ id: "ev-1", summary: "As Google had it" }));
+
+  it("keeps the pre-run baseline instead of nulling it when the record was kept", () => {
+    const updates = shadowUpdates([event({ id: "ev-1", status: "cancelled" })], new Set(["ev-1"]), { "ev-1": previously });
+    assert.deepEqual(updates["ev-1"], previously);
+  });
+
+  it("still nulls the baseline when the record really was deleted", () => {
+    const updates = shadowUpdates([event({ id: "ev-1", status: "cancelled" })], new Set(), { "ev-1": previously });
+    assert.equal(updates["ev-1"], null);
   });
 });


### PR DESCRIPTION
## Summary

#2684 は pull が record を**上書き**する前にローカル編集を確認するようにしましたが、**削除**経路には同じガードが掛かっていませんでした。Google 側でイベントがキャンセルされると、その record がローカル編集されていても黙って消えます ── #2683 / #2684 が閉じたのと**同種の損失が、1つ隣の分岐に残っていた**形です。

判定を `applyPlanFor` に切り出し、**status を見る前にガードを通す**ようにしました。この順序が修正の本体です:

```ts
if (existing !== null && hasUnsentEdit(existing, event.id)) return "withhold";
return event.status === CANCELLED_EVENT_STATUS ? "delete" : "write";
```

残りは #2684 で入れた機構がそのまま効きます。`withheld` は `heldBack` 経由で `shadowUpdates` の carry-forward に入るので、**baseline は `null` で消されず run 開始前の値が残ります** ── これが「次の push が conflict を報告できる」条件です。

## Items to Confirm / Review

1. **起票時の私の見立てが間違っていたので、issue にも訂正コメントを入れています。** #2688 本文には「保護に倒すと『sync first と言われて sync すると消される』ループになるので出口の UX 設計から必要」と書きましたが、**不正確でした**。`withheld` はエラーではないので token は進み、Google はキャンセルを再送しないため、**次回以降の sync はそのイベントを見ません**。状態は安定しループしません。行き止まりだったのは**メッセージだけ**です。

2. **push 側のメッセージを変えました。** 旧: `the event no longer exists in Google — sync first, then re-create it`。新: `Google no longer has this event, and your local edit was kept. Delete this record, or copy it into a new one.` ── UI に出る文言です。

3. **「同じ id で再作成できるか」は意図的に書いていません。** Google がキャンセル済みイベントの id を再利用させるかは**検証していない**ので、根拠のないことをメッセージに書かない方針にしました。ご存知でしたら教えてください。

4. **UI での明示的な選択肢**（「ローカルを残す / 消す」を出す）は入れていません。メッセージで出口は成立する（record を消す / 別レコードにコピーする）と判断しました。UI と i18n を足すべきかは別途ご判断ください。

## User Prompt

> マージもおわったのかな。#2679 本体と新規の #2688ってできる？
> 推奨で。

「#2688 → #2679 の順（#2688 は実際にデータが消えるのに小さく、#2679 はデータが消えず実装が重いため）」という推奨を採用いただいたので、本PRは #2688 です。#2679 は続けて着手します。

## 実装

- `applyPlanFor(existing, event, hasUnsentEdit)` — `"withhold" | "delete" | "write"` を返す純粋関数。この判定は #2666 / #2683 / #2684 が繰り返し間違えてきた箇所なので、I/O 抜きで固定できる形にしました
- `applyEvent` は `store.read` を1回だけ行う薄いディスパッチャに
- `collectionPush.ts` のメッセージを実態に合わせて書き換え

## 検証

- `yarn lint` — ✅ 0 errors / 51 warnings（すべて既存）
- `yarn typecheck` — ✅
- `yarn build` — ✅
- `yarn test` — ✅ 10773 pass / 0 fail（新規7本を含む）

新規テストは `applyPlanFor` の全分岐（編集済み+キャンセル / 同期済み+キャンセル / record 無し+キャンセル / 編集済み+通常 / 同期済み+通常）と、**キャンセルされたイベントが held のとき baseline が `null` されず据え置かれること**（保護した場合／しなかった場合の両方）。

**実機での動作確認はしていません**（Google の grant が要るため）。ユニットテストのみです。

Plan: `plans/fix-2688-protect-cancelled-with-local-edits.md`

refs #2688, #2684, #2683, #2620

work in mulmoclaude

## Summary by Sourcery

Ensure cancelled Google calendar events do not delete locally edited records and align push-side messaging with the new behavior.

Bug Fixes:
- Prevent cancellations from Google from deleting records that contain unsent local edits, preserving local changes during sync.

Enhancements:
- Extract a pure decision function to determine whether to withhold, delete, or write a record for a given event, simplifying collection sync behavior.
- Adjust push-sync user-facing message to describe that the event no longer exists in Google while the local edit is kept, and suggest explicit follow-up actions.

Documentation:
- Add a plan document describing the rationale, scope, and testing strategy for protecting locally edited records from deletions caused by Google cancellations.

Tests:
- Add unit tests covering applyPlanFor decisions for edited, synced, missing, and live events, and verify baseline handling for withheld cancellations in shadowUpdates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Calendar cancellations no longer overwrite or delete records with unsent local edits.
  * Preserved local changes can be reviewed, deleted, or copied into a new record.
  * Cancelled events without local edits continue to be removed as expected.
  * Baseline information is preserved when a cancellation is withheld.

* **Tests**
  * Added coverage for cancellation handling, local edits, deletions, and baseline preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->