### PR TITLE
fix(lint): ban `as` type assertions at warn + drain accounting router (#2692)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -255,7 +255,16 @@ export default [
       "no-useless-return": "error",
       "prefer-regex-literals": "error",
       "prefer-exponentiation-operator": "error",
-      "@typescript-eslint/consistent-type-assertions": "error",
+      // CLAUDE.md bans `as` casts outright ("MUST use type guards instead"),
+      // but the rule's default `assertionStyle: "as"` only enforces the
+      // *syntax*, so the ban was never machine-checked and the codebase
+      // accumulated ~190 casts in production code (#2692). `never` is the
+      // setting that matches the written rule.
+      //
+      // Staged at `warn` while the backlog drains file by file; it graduates
+      // to `error` once production code is clean. Tests keep the permissive
+      // setting via the test override below.
+      "@typescript-eslint/consistent-type-assertions": ["warn", { assertionStyle: "never" }],
       "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/prefer-enum-initializers": "error",
       "import/first": "error",
@@ -389,6 +398,17 @@ export default [
       // readability — it doesn't map onto a describe() block that
       // happens to hold ten it() cases.
       "max-lines-per-function": "off",
+      // Tests have a legitimate use for `as` that production code does not:
+      // constructing input the types say is impossible, so the runtime guard
+      // being tested has something to reject, and handing partial mocks to
+      // code that wants a full interface. Writing a type guard to produce
+      // deliberately-invalid data defeats the point of the test. Production
+      // code stays on `assertionStyle: "never"` (#2692); this restores the
+      // rule's default, which still enforces `as` over angle-bracket syntax.
+      // The options must be spelled out: flat config keeps the options from
+      // the previous match when an override supplies only a severity, so a
+      // bare `"error"` here would inherit `never` and ban `as` in tests too.
+      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "as", objectLiteralTypeAssertions: "allow" }],
     },
   },
   {

--- a/packages/plugins/accounting-plugin/src/server/bodyFields.ts
+++ b/packages/plugins/accounting-plugin/src/server/bodyFields.ts
@@ -1,0 +1,37 @@
+// Readers for the loosely-typed dispatch body, and for the service
+// payloads the message builders narrate back.
+//
+// Everything below the `action` discriminator arrives as `unknown` off
+// the wire, so a field is only a string once something has checked. A
+// non-string reads as absent, which lets the service layer reject it on
+// its own terms — `bookId: 42` gets "bookId is required" instead of
+// being smuggled through as a string the rest of the stack believes in.
+
+import { isRecord } from "@mulmoclaude/common";
+
+import type { ReportPeriod } from "../shared/types.js";
+
+export const optionalString = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined);
+
+export const optionalRecord = (value: unknown): Record<string, unknown> | undefined => (isRecord(value) ? value : undefined);
+
+/** Rebuilt field by field rather than narrowed with a predicate, so the
+ *  returned object is one this function actually proved. A half-formed
+ *  `{ kind: "month" }` reads as absent and the caller raises its own
+ *  "period is required" — previously it reached the report builders and
+ *  produced an `undefined-01` date. */
+export const optionalReportPeriod = (value: unknown): ReportPeriod | undefined => {
+  const period = optionalRecord(value);
+  if (period?.kind === "month" && typeof period.period === "string") return { kind: "month", period: period.period };
+  if (period?.kind === "range" && typeof period.from === "string" && typeof period.to === "string") {
+    return { kind: "range", from: period.from, to: period.to };
+  }
+  return undefined;
+};
+
+/** The two fields the addEntries narration quotes back, read out of a
+ *  service payload that is only `unknown` to the router. */
+export const describeEntry = (entry: unknown): { id?: string; date?: string } => {
+  const record = optionalRecord(entry);
+  return { id: optionalString(record?.id), date: optionalString(record?.date) };
+};

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -11,6 +11,9 @@
 // identical state changes.
 
 import { Router, Request, Response } from "express";
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
+
+import { describeEntry, optionalRecord, optionalReportPeriod, optionalString } from "./bodyFields.js";
 
 import {
   AccountingError,
@@ -89,14 +92,20 @@ async function handleOpenBook(rest: ActionRest): Promise<OpenBookToolResult> {
 
 async function handleGetReport(rest: ActionRest): Promise<unknown> {
   const kind = typeof rest.kind === "string" ? rest.kind : "";
-  const periodInput = rest.period as { kind: "month"; period: string } | { kind: "range"; from: string; to: string } | undefined;
-  const bookId = rest.bookId as string | undefined;
+  const periodInput = optionalReportPeriod(rest.period);
+  const bookId = optionalString(rest.bookId);
+  // A period that is present but malformed reads as absent, so it
+  // lands on this same message rather than reaching the report
+  // builders as `${undefined}-01`. Spell the accepted shapes out —
+  // the LLM repairs its own payload from this text.
+  const periodRequired = (label: string) =>
+    new AccountingError(400, `${label}: period is required — { kind: "month", period: "YYYY-MM" } or { kind: "range", from: "YYYY-MM-DD", to: "YYYY-MM-DD" }`);
   if (kind === "balance") {
-    if (!periodInput) throw new AccountingError(400, "getReport balance: period is required");
+    if (!periodInput) throw periodRequired("getReport balance");
     return getBalanceSheetReport({ bookId, period: periodInput });
   }
   if (kind === "pl") {
-    if (!periodInput) throw new AccountingError(400, "getReport pl: period is required");
+    if (!periodInput) throw periodRequired("getReport pl");
     return getProfitLossReport({ bookId, period: periodInput });
   }
   if (kind === "ledger") {
@@ -140,52 +149,60 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
     return { bookId: result.book.id, ...result };
   },
   [ACCOUNTING_ACTIONS.deleteBook]: (rest) => deleteBook({ bookId: typeof rest.bookId === "string" ? rest.bookId : "", confirm: rest.confirm === true }),
-  [ACCOUNTING_ACTIONS.getAccounts]: (rest) => listAccounts({ bookId: rest.bookId as string | undefined }),
+  [ACCOUNTING_ACTIONS.getAccounts]: (rest) => listAccounts({ bookId: optionalString(rest.bookId) }),
+  // The three `as never` below are the last casts in this file. Removing
+  // them means making the service signatures honest — `entries` / `lines`
+  // / `account` are declared as validated shapes but arrive raw, and the
+  // validators that were written to turn bad input into a structured 400
+  // read `item.date` / `line.accountCode` off elements that may not be
+  // objects. `entries: [null]` therefore throws a TypeError and 500s
+  // instead. That is a validation-layer fix (journal.ts, openingBalances.ts,
+  // service.ts) with its own tests, tracked on #2692.
   [ACCOUNTING_ACTIONS.upsertAccount]: (rest) =>
     upsertAccount({
-      bookId: rest.bookId as string | undefined,
+      bookId: optionalString(rest.bookId),
       // Service validates the shape — route doesn't reach into it.
       account: rest.account as never,
     }),
   [ACCOUNTING_ACTIONS.addEntries]: (rest) =>
     addEntries({
-      bookId: rest.bookId as string | undefined,
+      bookId: optionalString(rest.bookId),
       // Service validates each entry's shape — route doesn't reach into it.
       entries: (rest.entries ?? []) as never,
     }),
   [ACCOUNTING_ACTIONS.voidEntry]: (rest) =>
     voidEntry({
-      bookId: rest.bookId as string | undefined,
+      bookId: optionalString(rest.bookId),
       entryId: typeof rest.entryId === "string" ? rest.entryId : "",
-      reason: rest.reason as string | undefined,
-      voidDate: rest.voidDate as string | undefined,
+      reason: optionalString(rest.reason),
+      voidDate: optionalString(rest.voidDate),
     }),
   [ACCOUNTING_ACTIONS.getJournalEntries]: (rest) =>
     listEntries({
-      bookId: rest.bookId as string | undefined,
-      from: rest.from as string | undefined,
-      to: rest.to as string | undefined,
-      accountCode: rest.accountCode as string | undefined,
+      bookId: optionalString(rest.bookId),
+      from: optionalString(rest.from),
+      to: optionalString(rest.to),
+      accountCode: optionalString(rest.accountCode),
     }),
-  [ACCOUNTING_ACTIONS.getOpeningBalances]: (rest) => getOpeningBalances({ bookId: rest.bookId as string | undefined }),
+  [ACCOUNTING_ACTIONS.getOpeningBalances]: (rest) => getOpeningBalances({ bookId: optionalString(rest.bookId) }),
   [ACCOUNTING_ACTIONS.setOpeningBalances]: (rest) =>
     setOpeningBalances({
-      bookId: rest.bookId as string | undefined,
+      bookId: optionalString(rest.bookId),
       asOfDate: typeof rest.asOfDate === "string" ? rest.asOfDate : "",
       lines: (rest.lines ?? []) as never,
-      memo: rest.memo as string | undefined,
+      memo: optionalString(rest.memo),
     }),
   [ACCOUNTING_ACTIONS.getReport]: handleGetReport,
   [ACCOUNTING_ACTIONS.getTimeSeries]: (rest) =>
     getTimeSeriesReport({
-      bookId: rest.bookId as string | undefined,
+      bookId: optionalString(rest.bookId),
       metric: rest.metric,
       granularity: rest.granularity,
       from: rest.from,
       to: rest.to,
       accountCode: rest.accountCode,
     }),
-  [ACCOUNTING_ACTIONS.rebuildSnapshots]: (rest) => rebuildSnapshots({ bookId: rest.bookId as string | undefined }),
+  [ACCOUNTING_ACTIONS.rebuildSnapshots]: (rest) => rebuildSnapshots({ bookId: optionalString(rest.bookId) }),
 };
 
 // Actions whose tool-result envelope should carry a `data` field so
@@ -224,12 +241,14 @@ const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
     return `Mounted the accounting app in the canvas${idFragment}.${booksFragment}`;
   },
   [ACCOUNTING_ACTIONS.createBook]: (fields) => {
-    const book = fields.book as { id?: string; name?: string } | undefined;
-    const subject = book?.name ? `A new book named ${JSON.stringify(book.name)}` : "A new book";
+    const book = optionalRecord(fields.book);
+    const name = optionalString(book?.name);
+    const bookId = optionalString(book?.id);
+    const subject = name ? `A new book named ${JSON.stringify(name)}` : "A new book";
     // The LLM needs book.id to call any follow-up action on this
     // book (getAccounts, addEntries, etc.), so include it in the
     // status message instead of forcing a round-trip via getBooks.
-    const idFragment = book?.id ? ` (id: ${book.id})` : "";
+    const idFragment = bookId ? ` (id: ${bookId})` : "";
     // The View's opening-gate hides every tab except `opening` and
     // `settings` until an opening entry is on file (even a zero-line
     // one). If the agent doesn't tell the user to set opening
@@ -240,52 +259,57 @@ const MESSAGE_BUILDERS: Record<string, MessageBuilder> = {
     return `${subject} has been created${idFragment}. Next required step: set opening balances via setOpeningBalances — the journal-entry, ledger, and report tabs are locked until an opening (even an empty one) is saved.`;
   },
   [ACCOUNTING_ACTIONS.upsertAccount]: (fields) => {
-    const account = fields.account as { code?: string; name?: string } | undefined;
-    if (account?.code && account?.name) {
-      return `Upserted account ${account.code} ${JSON.stringify(account.name)}.`;
+    const account = optionalRecord(fields.account);
+    const code = optionalString(account?.code);
+    const name = optionalString(account?.name);
+    if (code && name) {
+      return `Upserted account ${code} ${JSON.stringify(name)}.`;
     }
     return "Updated the chart of accounts.";
   },
   [ACCOUNTING_ACTIONS.addEntries]: (fields) => {
-    const entries = Array.isArray(fields.entries) ? (fields.entries as { id?: string; date?: string }[]) : [];
+    const entries = (isUnknownArray(fields.entries) ? fields.entries : []).map(describeEntry);
     if (entries.length === 0) return "Posted 0 journal entries.";
     if (entries.length === 1) {
       const [entry] = entries;
-      const idFragment = entry?.id ? ` (id: ${entry.id})` : "";
-      return `Posted a journal entry on ${entry?.date ?? "the requested date"}${idFragment}.`;
+      const idFragment = entry.id ? ` (id: ${entry.id})` : "";
+      return `Posted a journal entry on ${entry.date ?? "the requested date"}${idFragment}.`;
     }
     // Surface every id so the LLM can later voidEntry any one of
     // them without a follow-up getJournalEntries round-trip.
-    const summary = entries.map((entry) => `${entry?.date ?? "?"} (id: ${entry?.id ?? "?"})`).join(", ");
+    const summary = entries.map((entry) => `${entry.date ?? "?"} (id: ${entry.id ?? "?"})`).join(", ");
     return `Posted ${entries.length} journal entries: ${summary}.`;
   },
   [ACCOUNTING_ACTIONS.voidEntry]: (fields) => {
-    const reverse = fields.reverseEntry as { date?: string } | undefined;
-    return `Voided the entry; a reversing pair was posted on ${reverse?.date ?? "today"}.`;
+    const reverseDate = optionalString(optionalRecord(fields.reverseEntry)?.date);
+    return `Voided the entry; a reversing pair was posted on ${reverseDate ?? "today"}.`;
   },
   [ACCOUNTING_ACTIONS.setOpeningBalances]: (fields) => {
-    const opening = fields.openingEntry as { date?: string; lines?: unknown } | undefined;
+    const opening = optionalRecord(fields.openingEntry);
     const verb = fields.replacedExisting === true ? "replaced" : "set";
-    const date = opening?.date ?? "the requested date";
+    const date = optionalString(opening?.date) ?? "the requested date";
     // Surface the actual lines so the LLM can answer follow-up
     // questions like "what's my opening cash?" without a separate
     // getOpeningBalances round-trip. An empty-marker opening
     // (zero lines, used to unlock the gate) gets no fragment.
-    const lines = Array.isArray(opening?.lines) ? (opening.lines as unknown[]) : [];
+    const openingLines = opening?.lines;
+    const lines = isUnknownArray(openingLines) ? openingLines : [];
     const linesFragment = lines.length > 0 ? ` Lines: ${JSON.stringify(lines)}.` : "";
     return `Opening balances were ${verb} as of ${date}.${linesFragment}`;
   },
   [ACCOUNTING_ACTIONS.deleteBook]: (fields) => {
-    const bookId = fields.deletedBookId as string | undefined;
-    const name = fields.deletedBookName as string | undefined;
+    const bookId = optionalString(fields.deletedBookId);
+    const name = optionalString(fields.deletedBookName);
     const subject = name ? `the book ${JSON.stringify(name)}` : "the book";
     const idFragment = bookId ? ` (id: ${bookId})` : "";
     return `Deleted ${subject}${idFragment}.`;
   },
   [ACCOUNTING_ACTIONS.updateBook]: (fields) => {
-    const book = fields.book as { id?: string; name?: string; country?: string; currency?: string } | undefined;
-    const name = book?.name ? JSON.stringify(book.name) : "the book";
-    const countryFragment = book?.country ? ` (country: ${book.country})` : "";
+    const book = optionalRecord(fields.book);
+    const bookName = optionalString(book?.name);
+    const country = optionalString(book?.country);
+    const name = bookName ? JSON.stringify(bookName) : "the book";
+    const countryFragment = country ? ` (country: ${country})` : "";
     return `Updated ${name}${countryFragment}.`;
   },
 };
@@ -314,7 +338,11 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   // Direct browser callers (the AccountingApp view) ignore the field.
   // Service responses that already set `action` win via the spread.
   const result = await handler(rest);
-  const handlerFields = result && typeof result === "object" ? (result as Record<string, unknown>) : { value: result };
+  // `isRecord` rejects arrays where the previous `typeof === "object"`
+  // check accepted them — an array result would have spread into
+  // `{0: …, 1: …}`. Every service function returns a plain object, so
+  // nothing changes today; an array would now arrive as `{ value: [...] }`.
+  const handlerFields = isRecord(result) ? result : { value: result };
   // `data` is the host's preview-eligibility signal (see
   // SessionSidebar.vue's v-if gate). Mirror the handler payload
   // into it for the actions that should render a card; leave it

--- a/packages/plugins/accounting-plugin/test/accounting/test_bodyFields.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_bodyFields.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { describeEntry, optionalRecord, optionalReportPeriod, optionalString } from "../../src/server/bodyFields.js";
+
+describe("optionalString", () => {
+  it("passes a string through", () => {
+    assert.equal(optionalString("book-1"), "book-1");
+  });
+
+  it("keeps the empty string — the service decides whether blank is valid", () => {
+    assert.equal(optionalString(""), "");
+  });
+
+  it("reads a non-string as absent so the service raises its own error", () => {
+    // The router previously wrote `rest.bookId as string | undefined`, so a
+    // number reached `resolveBookId` typed as a string. Now it reads as
+    // absent and the service answers "bookId is required".
+    assert.equal(optionalString(42), undefined);
+    assert.equal(optionalString(null), undefined);
+    assert.equal(optionalString(undefined), undefined);
+    assert.equal(optionalString({ toString: () => "book-1" }), undefined);
+    assert.equal(optionalString(["book-1"]), undefined);
+  });
+});
+
+describe("optionalRecord", () => {
+  it("passes a plain object through by reference", () => {
+    const value = { id: "b1" };
+    assert.equal(optionalRecord(value), value);
+  });
+
+  it("rejects arrays, null, and primitives", () => {
+    assert.equal(optionalRecord([1, 2]), undefined);
+    assert.equal(optionalRecord(null), undefined);
+    assert.equal(optionalRecord("book"), undefined);
+  });
+});
+
+describe("optionalReportPeriod", () => {
+  it("rebuilds a month period", () => {
+    assert.deepEqual(optionalReportPeriod({ kind: "month", period: "2026-01" }), { kind: "month", period: "2026-01" });
+  });
+
+  it("rebuilds a range period", () => {
+    assert.deepEqual(optionalReportPeriod({ kind: "range", from: "2026-01-01", to: "2026-03-31" }), {
+      kind: "range",
+      from: "2026-01-01",
+      to: "2026-03-31",
+    });
+  });
+
+  it("drops fields outside the declared shape", () => {
+    // The result is rebuilt, not narrowed, so extra keys can't ride along
+    // into the report builders.
+    assert.deepEqual(optionalReportPeriod({ kind: "month", period: "2026-01", extra: "x" }), { kind: "month", period: "2026-01" });
+  });
+
+  it("reads a half-formed period as absent", () => {
+    // `{ kind: "month" }` used to reach buildProfitLoss and produce an
+    // `undefined-01` from-date; now the caller raises "period is required".
+    assert.equal(optionalReportPeriod({ kind: "month" }), undefined);
+    assert.equal(optionalReportPeriod({ kind: "month", period: 202601 }), undefined);
+    assert.equal(optionalReportPeriod({ kind: "range", from: "2026-01-01" }), undefined);
+  });
+
+  it("reads an unknown kind or a non-object as absent", () => {
+    assert.equal(optionalReportPeriod({ kind: "quarter", period: "2026-Q1" }), undefined);
+    assert.equal(optionalReportPeriod("2026-01"), undefined);
+    assert.equal(optionalReportPeriod(undefined), undefined);
+    assert.equal(optionalReportPeriod(null), undefined);
+  });
+});
+
+describe("describeEntry", () => {
+  it("reads id and date off an entry payload", () => {
+    assert.deepEqual(describeEntry({ id: "e1", date: "2026-01-05", lines: [] }), { id: "e1", date: "2026-01-05" });
+  });
+
+  it("yields both fields undefined for a non-object element", () => {
+    // The narration maps over whatever the service returned; a null element
+    // must not throw on property access.
+    assert.deepEqual(describeEntry(null), { id: undefined, date: undefined });
+    assert.deepEqual(describeEntry("e1"), { id: undefined, date: undefined });
+  });
+
+  it("drops non-string id and date", () => {
+    assert.deepEqual(describeEntry({ id: 7, date: 20260105 }), { id: undefined, date: undefined });
+  });
+});

--- a/packages/plugins/accounting-plugin/test/accounting/test_router.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_router.ts
@@ -1,0 +1,159 @@
+// Endpoint-level regression tests for the dispatch route.
+//
+// `test_bodyFields.ts` pins the readers in isolation; these drive the real
+// Express router so the reader → handler → service wiring is covered too.
+// The malformed-`period` cases are the ones that matter: before #2692 a
+// string period returned HTTP 200 with an all-zero balance sheet for a book
+// holding real balances, and a half-formed month object 500'd.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import express from "express";
+import type { Server } from "node:http";
+
+import { configureAccountingServer } from "../../src/server/context.js";
+import { createAccountingRouter } from "../../src/server/router.js";
+import { ACCOUNTING_ACTIONS, ACCOUNTING_API } from "../../src/shared/index.js";
+
+const OPENING_CASH = 500;
+
+interface DispatchResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+const silentLogger = { error() {}, warn() {}, info() {}, debug() {} };
+
+let server: Server;
+let baseUrl: string;
+let workspaceRoot: string;
+let bookId: string;
+
+const dispatch = async (payload: Record<string, unknown>): Promise<DispatchResult> => {
+  const response = await fetch(`${baseUrl}${ACCOUNTING_API.dispatch.path}`, {
+    method: ACCOUNTING_API.dispatch.method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return { status: response.status, body: await response.json() };
+};
+
+const listen = async (app: express.Express): Promise<Server> =>
+  new Promise((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+before(async () => {
+  workspaceRoot = mkdtempSync(path.join(tmpdir(), "mulmo-acct-router-"));
+  configureAccountingServer({ workspaceRoot, logger: silentLogger });
+
+  const app = express();
+  app.use(express.json());
+  app.use(createAccountingRouter());
+  server = await listen(app);
+  const address = server.address();
+  assert.ok(address !== null && typeof address === "object", "server must be listening on a TCP port");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+
+  const created = await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Router Test Co" });
+  assert.equal(created.status, 200);
+  const { book } = created.body;
+  assert.ok(book !== null && typeof book === "object" && "id" in book && typeof book.id === "string");
+  bookId = book.id;
+
+  // Real balances, so an "empty report" answer is distinguishable from a
+  // correct one — the silent-200 bug returned all zeros here.
+  const opened = await dispatch({
+    action: ACCOUNTING_ACTIONS.setOpeningBalances,
+    bookId,
+    asOfDate: "2026-01-01",
+    lines: [
+      { accountCode: "1000", debit: OPENING_CASH },
+      { accountCode: "3000", credit: OPENING_CASH },
+    ],
+  });
+  assert.equal(opened.status, 200);
+});
+
+after(() => {
+  server?.close();
+  if (workspaceRoot) rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+describe("getReport period validation", () => {
+  it("returns a populated balance sheet for a well-formed month period", async () => {
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "balance",
+      bookId,
+      period: { kind: "month", period: "2026-01" },
+    });
+    assert.equal(status, 200);
+    // Guards the fix from the other side: the report must carry the real
+    // opening cash, not the all-zero sheet the cast used to produce.
+    assert.match(JSON.stringify(body), new RegExp(`"balance":${OPENING_CASH}`));
+  });
+
+  it("rejects a period that is a string instead of the union object", async () => {
+    // Regression: this returned 200 with an all-zero balance sheet.
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "balance",
+      bookId,
+      period: "2026-01",
+    });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /period is required/);
+  });
+
+  it("rejects a half-formed month period", async () => {
+    // Regression: `period.period` was undefined, so the report layer threw
+    // `Cannot read properties of undefined (reading 'split')` and 500'd.
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "pl",
+      bookId,
+      period: { kind: "month" },
+    });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /period is required/);
+  });
+
+  it("rejects a range period missing an endpoint", async () => {
+    const { status } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "pl",
+      bookId,
+      period: { kind: "range", from: "2026-01-01" },
+    });
+    assert.equal(status, 400);
+  });
+
+  it("still allows ledger without a period", async () => {
+    const { status } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "ledger",
+      bookId,
+      accountCode: "1000",
+    });
+    assert.equal(status, 200);
+  });
+});
+
+describe("bookId reading", () => {
+  it("treats a non-string bookId as absent", async () => {
+    // Previously cast to `string | undefined`, so a number reached
+    // `resolveBookId` and came back as "book 42 not found".
+    const { status, body } = await dispatch({ action: ACCOUNTING_ACTIONS.getAccounts, bookId: 42 });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /bookId is required/);
+  });
+
+  it("still resolves a well-formed bookId", async () => {
+    const { status } = await dispatch({ action: ACCOUNTING_ACTIONS.getAccounts, bookId });
+    assert.equal(status, 200);
+  });
+});

--- a/plans/fix-2692-ban-type-assertions.md
+++ b/plans/fix-2692-ban-type-assertions.md
@@ -1,0 +1,74 @@
+# fix(lint): ban `as` type assertions in production code (#2692)
+
+`CLAUDE.md` says "NEVER use `as` type casts; MUST use type guards instead", but
+ESLint never enforced it: `@typescript-eslint/consistent-type-assertions` was on
+at its default `assertionStyle: "as"`, which only polices the *syntax* (`as T`
+over `<T>x`). The written ban was therefore unmachined, and casts accumulated.
+
+Follows the approach established in
+[mulmoterminal#1231](https://github.com/receptron/mulmoterminal/issues/1231).
+
+## Measured baseline (2026-08-02, this branch)
+
+Switching the rule to `assertionStyle: "never"` reports **474 casts across 200
+files**. The issue's headline number (187) counted `src/` + `server/` only;
+`packages/` contributes the rest.
+
+By shape:
+
+| count | shape | intended treatment |
+|---|---|---|
+| 218 | other | case by case |
+| 68 | `as unknown as T` (double cast) | **fix** — the most dangerous kind |
+| 64 | `as Record<…>` | usually a typed reader / guard |
+| 35 | `as string \| undefined` | typed field reader |
+| 25 | error narrowing (`err as NodeJS.ErrnoException`) | shared guard helper |
+| 25 | `JSON.parse(…) as T` | **fix** — parse + validate |
+| 18 | DOM element (`$event.target as HTMLInputElement`) | allowlist candidate |
+| 11 | `as never` | fix — hides a real type mismatch |
+| 10 | `Object.fromEntries(…) as …` | TS inference limit — allowlist candidate |
+
+## Approach
+
+1. **Rule in at `warn`** (this PR) so the whole backlog is visible without
+   failing CI. `yarn lint` has no `--max-warnings`, so nothing breaks.
+2. **Tests are exempt.** They have a legitimate use production code doesn't:
+   constructing input the types call impossible so a runtime guard has
+   something to reject, and handing partial mocks to code wanting a full
+   interface. The exemption lives in the existing test override and spells out
+   its options — flat config *keeps* the previous match's options when an
+   override supplies only a severity, so a bare `"error"` there would have
+   inherited `never` and banned `as` in tests too.
+3. **Drain file by file.** One file per commit, each one a real fix (type
+   guard, typed reader, or corrected signature) — never an inline
+   `eslint-disable`.
+4. **Genuine exceptions go in `eslint.config.mjs`**, one entry per reason, in
+   the style of the existing allowlists. Inline disables stay at zero.
+5. **Graduate to `error`** once production code is clean.
+
+## Progress
+
+Drain order is largest-file-first, so the dominant shapes get a reusable fix
+early.
+
+- [x] `eslint.config.mjs` — rule at `warn`, tests exempt
+- [x] `accounting-plugin/src/server/router.ts` — 30 → 3
+- [ ] 447 casts / 199 files remaining
+
+### Deferred: the accounting validation layer
+
+The three casts left in `router.ts` (`account` / `entries` / `lines`
+`as never`) can't be removed at the router. The service declares them as
+already-validated shapes (`Account`, `AddEntriesItem[]`, `JournalLine[]`) while
+receiving them raw, and the validators written to turn bad input into a
+structured 400 read `item.date` / `line.accountCode` off elements that may not
+be objects. Fixing it honestly means changing `journal.ts`,
+`openingBalances.ts` and `service.ts` together, with their tests. Reported on
+#2692 with the repro.
+
+## Notes
+
+Bugs found while removing a cast are reported on #2692 with their root cause —
+a cast that was hiding a real type mismatch is a finding, not just churn. Two
+came out of `router.ts` alone, one of them returning HTTP 200 with wrong
+numbers.


### PR DESCRIPTION
## Summary

`@typescript-eslint/consistent-type-assertions` を `assertionStyle: "never"` で導入し（`warn`）、1ファイル目として `accounting-plugin/src/server/router.ts` の `as` を 30 → 3 に減らしました。

- **ルール導入**: CLAUDE.md の「NEVER use `as` type casts」は今まで機械的に止めていませんでした（デフォルトの `assertionStyle: "as"` は `<T>x` 記法を禁じるだけ）。
- **実測ベースライン: 474 箇所 / 200 ファイル**（issue 本文の 187 は `src` + `server` のみ。`packages/` 配下が差分）
- **テストは対象外**（意図的に不正な入力を作る／部分モックを渡す用途があるため）
- **`warn` 開始**: `yarn lint` に `--max-warnings` は無いので CI は落ちません

## Items to Confirm / Review

1. **バグ①を修正しています（重い / 要確認）** — `period` の形が違うと **HTTP 200 で全科目ゼロの B/S** が返っていました。資産 500 の帳簿が「空」に見えます。500 で落ちるより悪いです。詳細は下の「見つかったバグ」。挙動変更なので確認をお願いします。
2. **`bookId: 42` の応答が 404 → 400 に変わります**。どちらも 4xx ですが、メッセージが `book 42 not found` から `bookId is required` になります。
3. **`as never` 3件を残しています**。router では消せません（理由は下記）。別 issue を立てます。
4. **flat config の落とし穴** — override が severity だけを渡すと**直前のマッチの options を引き継ぎます**。テスト override に `"error"` とだけ書くと `never` を継承してテストでも `as` が禁止され、1887 件出ました。options を明示しています。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2692 １ファイルずつ進めていこう！最初はwarnでよいよ
>
> cast修正中にバグみつかったら元のissueに詳細と原因を残して。

## 見つかったバグ

キャストを外す過程で 2 件出ました。どちらも「キャストが型の不一致を隠していた」ケースです。`@mulmoclaude/accounting-plugin@1.1.0` として npm に出ています。詳細と再現は #2692 のコメントに残しました。

### ① `period` の形が違うと 200 で中身が間違った財務諸表（この PR で修正）

```ts
const periodInput = rest.period as { kind: "month"; period: string } | { kind: "range"; from: string; to: string } | undefined;
```

`rest.period` は HTTP ボディ由来の `unknown` です。キャストが union だと言い切るので何を送っても素通りし、レポート層は `period.kind` で分岐できず「期間なし」として集計してそのまま 200 を返します。

資産 500 が計上済みの book に対する実測:

```
period: "2026-02"（オブジェクトでなく文字列）
  修正前 -> 200 {"balanceSheet":{"sections":[{"type":"asset","rows":[],"total":0}, ...],"imbalance":0}}
  修正後 -> 400 getReport balance: period is required — { kind: "month", period: "YYYY-MM" } or { kind: "range", ... }

period: { kind: "month" }（period フィールド欠落）
  修正前 -> 500 TypeError: Cannot read properties of undefined (reading 'split')
  修正後 -> 400（同上）
```

### ② `entries: [null]` / `lines: [null]` で 500（この PR では未修正）

```ts
entries: (rest.entries ?? []) as never,
lines:   (rest.lines   ?? []) as never,
account: rest.account as never,
```

service 側の宣言は検証済みの型（`AddEntriesItem[]` / `JournalLine[]` / `Account`）ですが、実際に届くのは生のボディです。`as never` は何にでも代入できるのでこの嘘が通ります。そして「不正入力を構造化 400 に変換するために書かれた」バリデータ自身が、要素がオブジェクトである前提で `item.date` / `line.accountCode` を読みます。

```
addEntries entries:[null]  -> TypeError: Cannot read properties of null (reading 'date')        -> HTTP 500
setOpening lines:[null]    -> TypeError: Cannot read properties of null (reading 'accountCode') -> HTTP 500
```

`validateEntry` の doc コメントは *"so the REST handler can return a structured 400 instead of an opaque 500"* と書いてありますが、まさにその opaque 500 を出しています。

**この PR に含めていない理由**: 直すには `journal.ts` / `openingBalances.ts` / `service.ts` のバリデータを `unknown` 受け取りに変える必要があり（`validateEntry` は現状 parse ではなく validate なので通過後に型が付かない）、テストも含めて別 PR の規模です。router.ts に理由をコメントで残しました。

## 実装方針

キャストではなく **reader** に置き換えました（`src/server/bodyFields.ts`）。

| 関数 | 役割 |
|---|---|
| `optionalString(value)` | 文字列以外は「無い」として読む。service が自分のルールで 400 を返す |
| `optionalRecord(value)` | 配列・null・プリミティブを弾く（`@mulmoclaude/common` の `isRecord`） |
| `optionalReportPeriod(value)` | **述語で narrow せず組み立て直す**。証明できたフィールドだけで新オブジェクトを作るので、半端な形は `undefined` |
| `describeEntry(entry)` | narration が引用する `id` / `date` だけを読む |

`optionalReportPeriod` を「述語」ではなく「組み立て」にしたのが要点です。型述語 (`value is T`) 自体が検査されないアサーションなので、嘘をつけばキャストと同じ問題が残ります。

`dispatch` の `result as Record<string, unknown>` は `isRecord(result)` に置き換えました。`isRecord` は配列を弾くので、以前なら `{0: …, 1: …}` に展開されていた配列が `{ value: [...] }` になります（service は全て object を返すので今日は差分なし。コメント済み）。

## 検証

- **外部 ground truth で確認**: 変更前後の router を実際に express で起動し、同じペイロードを HTTP で投げて出力を diff しました。**happy path の全メッセージがバイト一致**、差分は上記の malformed 3ケースのみ。
- `packages/plugins/accounting-plugin`: typecheck clean、テスト **243 pass / 0 fail**（+13 = `test_bodyFields.ts`）
- リポジトリ全体: `yarn format` / `yarn lint`（0 errors, 493 warnings — 全て新ルール）/ `yarn build` / `yarn test` **全 workspace 0 fail**
- `yarn typecheck` は google calendar のテスト 4 ファイルで 21 errors ですが、**main 時点で既存**（stash して確認済み）。本 PR とは無関係です。

## 今後

`plans/fix-2692-ban-type-assertions.md` に手順を残しました。以降は **1ファイル 1PR** で進めます。

進捗: **474 → 447**

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Introduce stricter linting to discourage TypeScript `as` assertions in production code and refactor the accounting router to use typed body readers, fixing malformed period handling and improving message construction safety.

Bug Fixes:
- Fix report generation to reject malformed or half-formed `period` inputs with a structured 400 error instead of returning incorrect or crashing responses.
- Change handling of non-string `bookId` inputs so they are treated as missing and yield a "bookId is required" error rather than being coerced and misinterpreted.

Enhancements:
- Refactor the accounting router to read request and response fields via helper functions instead of raw `as` casts, reducing reliance on type assertions.
- Add shared body reader utilities for accounting plugin server code to safely interpret loosely typed payload fields.
- Improve dispatch result handling to avoid treating array responses as plain objects in the accounting router.
- Clarify the lint configuration for `@typescript-eslint/consistent-type-assertions`, staging a `never` style ban in production code while explicitly exempting tests.
- Document the stepwise plan for eliminating `as` type assertions across the codebase.

Tests:
- Add unit tests for the new body reader helpers to verify safe handling of strings, records, report periods, and entry descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accounting report validation, including month and date-range periods.
  * Added clearer error responses for missing or malformed report periods and invalid book identifiers.
  * Prevented malformed dispatch data from causing incorrect responses or service requests.
  * Preserved accounting details such as opening balances, entry identifiers, dates, and reversing dates in report messages.

* **Tests**
  * Expanded coverage for valid, invalid, and incomplete accounting inputs across reports and dispatch operations.

* **Documentation**
  * Added guidance for addressing TypeScript assertion usage in production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->