### PR TITLE
fix(plugins): runtime-loader の as キャスト 18 個を除去（stub runtime のメンバー欠落バグ修正を含む）

### DIFF
--- a/server/plugins/runtime-loader.ts
+++ b/server/plugins/runtime-loader.ts
@@ -24,6 +24,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { PluginRuntime, ToolDefinition } from "gui-chat-protocol";
 import { isPluginFactory } from "gui-chat-protocol";
+import type { MulmoclaudeRuntime } from "../notifier/runtime-api.js";
 import { WORKSPACE_PATHS } from "../workspace/paths.js";
 import { readLedger, type LedgerEntry } from "../utils/files/plugins-io.js";
 import { isRecord } from "../utils/types.js";
@@ -69,7 +70,10 @@ export interface RuntimePlugin {
 interface PackageJson {
   name?: string;
   version?: string;
-  exports?: string | Record<string, unknown>;
+  /** Left unnarrowed because every legal Node.js `exports` value is
+   *  accepted here — string sugar, array fallback chain, condition or
+   *  subpath map. `pickExportsTarget` is what discriminates them. */
+  exports?: unknown;
   main?: string;
   module?: string;
 }
@@ -78,6 +82,23 @@ const isToolDefinition = (value: unknown): value is ToolDefinition => {
   if (!isRecord(value)) return false;
   return typeof value.name === "string" && typeof value.description === "string";
 };
+
+const optionalString = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined);
+
+/** Rebuild the fields the loader reads from arbitrary parsed JSON.
+ *  Field-by-field rather than a predicate, so a plugin shipping a
+ *  non-string `main` can't reach `path.join` as if it were one.
+ *  Returns null when the parsed value isn't an object at all. */
+export function toPackageJson(value: unknown): PackageJson | null {
+  if (!isRecord(value)) return null;
+  return {
+    name: optionalString(value.name),
+    version: optionalString(value.version),
+    exports: value.exports,
+    main: optionalString(value.main),
+    module: optionalString(value.module),
+  };
+}
 
 /** Resolve the entry-point path from a plugin's `package.json`. Covers
  *  the four legal `exports` shapes per the Node.js spec, then falls
@@ -100,7 +121,7 @@ function resolveEntrySpecifier(pkg: PackageJson): string | null {
   return null;
 }
 
-function resolveExportsField(exportsField: PackageJson["exports"]): string | null {
+function resolveExportsField(exportsField: unknown): string | null {
   // Form 1: top-level string sugar.
   // Form A: array fallback chain (e.g. ["./dist/index.js", "./fallback.js"]).
   // Form 2: conditional root (e.g. `{ import, require, default }`).
@@ -187,7 +208,10 @@ function extractTgz(tgzAbs: string, destDir: string): void {
 function readPackageJson(cachePath: string): PackageJson | null {
   const pkgPath = path.join(cachePath, "package.json");
   try {
-    return JSON.parse(readFileSync(pkgPath, "utf-8")) as PackageJson;
+    const parsed: unknown = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    const pkg = toPackageJson(parsed);
+    if (!pkg) log.warn(LOG_PREFIX, "package.json is not an object — skipping", { path: pkgPath });
+    return pkg;
   } catch (err) {
     log.warn(LOG_PREFIX, "package.json read/parse failed", { path: pkgPath, error: String(err) });
     return null;
@@ -206,6 +230,34 @@ export interface LoaderDeps {
   runtimeFactory?: (pkgName: string) => PluginRuntime;
 }
 
+/** Naming the operation in the message is what lets a plugin author
+ *  tell "the host is a definition-only loader" apart from a bug in
+ *  their own setup code. */
+const unavailable = (name: string, operation: string) => (): never => {
+  throw new Error(`plugin/${name}: runtime.${operation} unavailable in this process (definition-only load)`);
+};
+
+function makeStubFileOps(name: string): MulmoclaudeRuntime["files"]["data"] {
+  return {
+    read: unavailable(name, "files.read"),
+    readBytes: unavailable(name, "files.readBytes"),
+    write: unavailable(name, "files.write"),
+    readDir: unavailable(name, "files.readDir"),
+    stat: unavailable(name, "files.stat"),
+    exists: unavailable(name, "files.exists"),
+    unlink: unavailable(name, "files.unlink"),
+  };
+}
+
+function makeStubNotifier(name: string): MulmoclaudeRuntime["notifier"] {
+  return {
+    publish: unavailable(name, "notifier.publish"),
+    update: unavailable(name, "notifier.update"),
+    clear: unavailable(name, "notifier.clear"),
+    get: unavailable(name, "notifier.get"),
+  };
+}
+
 /** Stub runtime — the factory pattern requires SOME runtime to call,
  *  even if we only care about extracting `TOOL_DEFINITION`. Methods
  *  throw rather than silently no-op so a plugin that mistakenly does
@@ -221,46 +273,28 @@ export interface LoaderDeps {
  *  process has no task manager to register against. `chat.start`
  *  matches the throw pattern of `fetch` / `files`, since starting a
  *  chat is a parent-only side effect a plugin should never trigger
- *  at setup time. The stub deliberately doesn't carry the
- *  `MulmoclaudeRuntime` type — the cast lives at the plugin call
- *  site (Phase 3 of Encore upstreams these into PluginRuntime). */
-function makeStubRuntime(name: string): PluginRuntime {
-  const error = (operation: string) => () => {
-    throw new Error(`plugin/${name}: runtime.${operation} unavailable in this process (definition-only load)`);
-  };
-  const fileOps = {
-    read: error("files.read"),
-    readBytes: error("files.readBytes"),
-    write: error("files.write"),
-    readDir: error("files.readDir"),
-    stat: error("files.stat"),
-    exists: error("files.exists"),
-    unlink: error("files.unlink"),
-  };
-  const stub = {
-    pubsub: { publish: () => undefined },
+ *  at setup time.
+ *
+ *  Typed as the full `MulmoclaudeRuntime` so the compiler — not a
+ *  reviewer — notices when the real runtime grows a member the stub
+ *  lacks (`files.artifacts` and `notifier.update` / `.get` had each
+ *  drifted out of it, surfacing to plugins as `undefined`). */
+function makeStubRuntime(name: string): MulmoclaudeRuntime {
+  const fileOps = makeStubFileOps(name);
+  const noop = () => undefined;
+  return {
+    pubsub: { publish: noop },
     locale: "en",
-    files: { data: fileOps, config: fileOps },
-    log: { debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined },
-    fetch: error("fetch") as unknown as PluginRuntime["fetch"],
-    fetchJson: error("fetchJson") as unknown as PluginRuntime["fetchJson"],
-    notifier: {
-      publish: error("notifier.publish") as unknown as (...args: unknown[]) => Promise<{ id: string }>,
-      clear: error("notifier.clear") as unknown as (id: string) => Promise<void>,
-    },
-    tasks: {
-      // Silent no-op: definition-only loads (MCP child) shouldn't fail
-      // just because the plugin declared a tick at setup time.
-      register: () => undefined,
-    },
-    chat: {
-      start: error("chat.start") as unknown as (...args: unknown[]) => Promise<{ chatId: string }>,
-    },
+    files: { data: fileOps, config: fileOps, artifacts: fileOps },
+    log: { debug: noop, info: noop, warn: noop, error: noop },
+    fetch: unavailable(name, "fetch"),
+    fetchJson: unavailable(name, "fetchJson"),
+    notifier: makeStubNotifier(name),
+    // Silent no-op: definition-only loads (MCP child) shouldn't fail
+    // just because the plugin declared a tick at setup time.
+    tasks: { register: noop },
+    chat: { start: unavailable(name, "chat.start") },
   };
-  // Returned typed as `PluginRuntime` — host extensions (notifier /
-  // tasks / chat) are accessed by plugins via the `MulmoclaudeRuntime`
-  // cast and thus aren't part of the stub's nominal type yet.
-  return stub as unknown as PluginRuntime;
 }
 
 /** Two carrier shapes (#1110 backward compatibility):
@@ -280,10 +314,15 @@ function resolveCarrier(name: string, mod: Record<string, unknown>, deps: Loader
   const defaultExport = mod.default;
   if (isPluginFactory(defaultExport)) {
     const runtime = deps.runtimeFactory ? deps.runtimeFactory(name) : makeStubRuntime(name);
-    return { carrier: defaultExport(runtime) as unknown as Record<string, unknown>, usingFactory: true };
+    return { carrier: defaultExport(runtime), usingFactory: true };
   }
   return { carrier: mod, usingFactory: false };
 }
+
+/** Callability is the whole of what a dynamically imported export can be
+ *  proved to have, so parameters and result stay `unknown` — the loader
+ *  never inspects either. */
+const isPluginHandler = (value: unknown): value is (...args: unknown[]) => unknown => typeof value === "function";
 
 /** Pull the executable from a carrier. Factory-shape handlers take
  *  `(args)` only (runtime is closed over) so we wrap to discard the
@@ -300,12 +339,9 @@ export function resolveExecute(
   // tool `constructor` / `toString` resolves to an Object.prototype function,
   // defeating the `typeof … !== "function"` gate below (#2319).
   const handler = Object.hasOwn(carrier, definitionName) ? carrier[definitionName] : undefined;
-  if (typeof handler !== "function") return null;
-  if (usingFactory) {
-    const factoryHandler = handler as (args: unknown) => unknown;
-    return (_context, args) => factoryHandler(args);
-  }
-  return handler as (context: unknown, args: unknown) => unknown;
+  if (!isPluginHandler(handler)) return null;
+  if (usingFactory) return (_context, args) => handler(args);
+  return handler;
 }
 
 /** Read the optional `OAUTH_CALLBACK_ALIAS` named export. Validated
@@ -340,7 +376,11 @@ export async function loadPluginFromCacheDir(name: string, version: string, cach
   }
   const entryAbs = path.join(cachePath, entrySpec);
   try {
-    const mod = (await import(pathToFileURL(entryAbs).href)) as Record<string, unknown>;
+    const mod: unknown = await import(pathToFileURL(entryAbs).href);
+    if (!isRecord(mod)) {
+      log.warn(LOG_PREFIX, "plugin module namespace is not an object — skipping", { name, entrySpec });
+      return null;
+    }
     const { carrier, usingFactory } = resolveCarrier(name, mod, deps);
     const definition = carrier.TOOL_DEFINITION;
     if (!isToolDefinition(definition)) {

--- a/test/plugins/test_runtime_loader.ts
+++ b/test/plugins/test_runtime_loader.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { loadPluginFromCacheDir, isCacheValid, EXTRACT_MARKER, ensureInsideBase, resolveExecute } from "../../server/plugins/runtime-loader.js";
+import { loadPluginFromCacheDir, isCacheValid, EXTRACT_MARKER, ensureInsideBase, resolveExecute, toPackageJson } from "../../server/plugins/runtime-loader.js";
 
 interface FixtureOpts {
   exportsImport?: string;
@@ -206,6 +206,47 @@ describe("loadPluginFromCacheDir", () => {
       const handler = () => "real";
       assert.equal(resolveExecute({ toString: handler }, "toString", false), handler);
     });
+
+    it("wraps a factory handler so the dispatch route's `context` arg is dropped", () => {
+      const seen: unknown[][] = [];
+      const execute = resolveExecute({ myTool: (...args: unknown[]) => seen.push(args) }, "myTool", true);
+      assert.ok(execute);
+      execute({ ctx: true }, { a: 1 });
+      assert.deepEqual(seen, [[{ a: 1 }]]);
+    });
+
+    for (const notAFunction of [undefined, null, 42, "handler", { call: true }, []]) {
+      it(`returns null when the exported value is ${JSON.stringify(notAFunction) ?? "undefined"} rather than a function`, () => {
+        assert.equal(resolveExecute({ myTool: notAFunction }, "myTool", false), null);
+      });
+    }
+  });
+
+  // `package.json` is plugin-authored, so every field the loader reads has to
+  // survive being the wrong type. Before #2692 the parsed JSON was asserted
+  // straight to `PackageJson`, which let a non-string `main` reach `path.join`.
+  describe("toPackageJson", () => {
+    it("keeps the string fields the entry resolver reads", () => {
+      const pkg = toPackageJson({ name: "@x/p", version: "1.2.3", main: "./m.js", module: "./esm.js" });
+      assert.deepEqual(pkg, { name: "@x/p", version: "1.2.3", exports: undefined, main: "./m.js", module: "./esm.js" });
+    });
+
+    it("drops non-string values instead of letting them pose as strings", () => {
+      const pkg = toPackageJson({ name: 42, version: null, main: { nested: true }, module: ["./a.js"] });
+      assert.deepEqual(pkg, { name: undefined, version: undefined, exports: undefined, main: undefined, module: undefined });
+    });
+
+    it("passes `exports` through unnarrowed so every legal Node.js shape survives", () => {
+      assert.deepEqual(toPackageJson({ exports: "./e.js" })?.exports, "./e.js");
+      assert.deepEqual(toPackageJson({ exports: ["./a.js", "./b.js"] })?.exports, ["./a.js", "./b.js"]);
+      assert.deepEqual(toPackageJson({ exports: { ".": { import: "./e.js" } } })?.exports, { ".": { import: "./e.js" } });
+    });
+
+    for (const notAnObject of [null, 42, "pkg", [], true]) {
+      it(`returns null for a package.json parsing to ${JSON.stringify(notAnObject) ?? "null"}`, () => {
+        assert.equal(toPackageJson(notAnObject), null);
+      });
+    }
   });
 
   it("returns null when entry file is missing on disk", async () => {

--- a/test/plugins/test_runtime_loader_factory.ts
+++ b/test/plugins/test_runtime_loader_factory.ts
@@ -121,6 +121,44 @@ export default definePlugin(({ pubsub }) => ({
     // that path live above.
   });
 
+  // The stub runtime used to be asserted into `PluginRuntime` with a double
+  // cast, so members the real runtime had since grown (`files.artifacts`,
+  // `notifier.update` / `.get`) silently stayed `undefined` — a plugin
+  // touching one got `TypeError: … is not a function` instead of the
+  // loader's "unavailable in this process" message.
+  it("stub runtime exposes every member the real runtime provides", async () => {
+    const dir = makeFixture({
+      entryContent: `
+function definePlugin(setup) { return setup; }
+export default definePlugin((runtime) => ({
+  TOOL_DEFINITION: {
+    name: "fixtureTool",
+    description: "runtime-shape probe",
+    parameters: { type: "object", properties: {} },
+  },
+  async fixtureTool() {
+    // The stub throws synchronously rather than rejecting, so this cannot
+    // be a \`.catch\`.
+    let artifactsReadError = null;
+    try { await runtime.files.artifacts.read("x"); } catch (err) { artifactsReadError = err.message; }
+    return {
+      files: Object.keys(runtime.files),
+      notifier: Object.keys(runtime.notifier),
+      artifactsReadError,
+    };
+  },
+}));
+`,
+    });
+    const plugin = await loadPluginFromCacheDir("@fixture/plugin", "1.0.0", dir);
+    assert.ok(plugin?.execute);
+    assert.deepEqual(await plugin.execute({}, {}), {
+      files: ["data", "config", "artifacts"],
+      notifier: ["publish", "update", "clear", "get"],
+      artifactsReadError: "plugin/@fixture/plugin: runtime.files.read unavailable in this process (definition-only load)",
+    });
+  });
+
   it("legacy shape continues to load (backward compatibility)", async () => {
     const dir = makeFixture({
       entryContent: `


### PR DESCRIPTION
## Summary

`server/plugins/runtime-loader.ts` から `as` 型アサーション 18 個（`as unknown as` の二重キャストを 2 個として数えた総数）をすべて除去した。
除去の過程で **実バグを 1 件発見・修正**: stub runtime を `as unknown as PluginRuntime` で偽装していたため、実 runtime 側に増えた `files.artifacts` と `notifier.update` / `notifier.get` が stub に反映されておらず、definition-only ロード（MCP 子プロセス）ではプラグインから `undefined` に見えていた。
stub の型を `MulmoclaudeRuntime` にしてコンパイラに形を検査させ、欠落メンバーを補った。テストを追加。

## Items to Confirm / Review

- **[挙動が変わる箇所 / 要確認]** stub runtime に `files.artifacts` / `notifier.update` / `notifier.get` を追加した。
  これまでは `undefined` で、プラグインが触ると `TypeError: Cannot read properties of undefined` になっていた。
  今後は他のメンバーと同じ `plugin/<pkg>: runtime.<op> unavailable in this process (definition-only load)` を throw する。
  「TypeError で落ちる」→「意図したエラーで落ちる」への変更で、この stub の設計意図（"fails loudly"）どおりのはずだが、
  `undefined` チェックに依存していたプラグインが無いかは一応確認してほしい。
  なお `files.artifacts` は `data` / `config` と同じ stub FileOps インスタンスを共有するので、
  エラーメッセージは `runtime.files.read` のまま（`files.artifacts.read` にはならない）。既存挙動を維持した。
- **[型を緩めた箇所]** `PackageJson["exports"]` を `string | Record<string, unknown>` から `unknown` にした。
  旧宣言は「配列 fallback chain」を型上排除していたが、`pickExportsTarget` は意図的に配列を扱っており
  `test_runtime_loader.ts` にもテストがある。つまり旧型は `as PackageJson` によって初めて成立していた嘘。
  `unknown` にして `pickExportsTarget` の実行時判定に一本化した（挙動不変）。
- **[ログが 1 箇所増える]** `package.json` が object 以外（配列 / `null` / スカラー）に parse された場合、
  `package.json is not an object — skipping` を warn するようにした。ローダーの返り値（`null` = skip）は変わらない。
- `resolveExecute` の legacy 分岐は **ハンドラ参照をそのまま返す**（ラップしない）ままにしてある。
  既存テストが `assert.equal(resolveExecute({ myTool: handler }, "myTool", false), handler)` で参照同一性を見ているため。
- 意図的に残したキャストは **ゼロ**。

## 実装方針

| 元の行 | キャスト | 置き換え |
| --- | --- | --- |
| 190 | `JSON.parse(...) as PackageJson` | `toPackageJson(value: unknown)` を新設。`isRecord` で object を確認したうえで**フィールドごとに組み直す**（`optionalString` で非 string を落とす）。型述語ではなく「証明した値を返す reader」。`export` してユニットテスト対象にした。 |
| 245, 246 | `error("fetch") as unknown as PluginRuntime["fetch"]` ほか | 不要だった。`error()` が返すのは `() => never` で、引数の少ない関数 + `never` 戻り値はどの関数型にも代入可能。ヘルパを `unavailable(name, operation)` にリネームし、戻り値型を `(): never` と明示しただけでキャスト不要になった。 |
| 248, 249 | `notifier.publish` / `clear` の二重キャスト | `makeStubNotifier(name): MulmoclaudeRuntime["notifier"]` に切り出し。型が要求する `update` / `get` の欠落がここで初めて顕在化した。 |
| 257 | `chat.start` の二重キャスト | 同上、`unavailable(name, "chat.start")` をそのまま代入。 |
| 263 | `return stub as unknown as PluginRuntime` | 戻り値型を `MulmoclaudeRuntime`（= `PluginRuntime` + host 拡張 notifier/tasks/chat）にして、object literal を直接 return。`files.artifacts` 欠落はここで検出された。20 行制限を守るため `makeStubFileOps` / `makeStubNotifier` に分割。 |
| 283 | `defaultExport(runtime) as unknown as Record<string, unknown>` | 不要だった。`isPluginFactory` が返す `PluginFactoryResult` は `[exportName: string]: unknown` のインデックスシグネチャを持つので `Record<string, unknown>` に代入可能。 |
| 305, 308 | `handler as (args) => unknown` / `as (context, args) => unknown` | `isPluginHandler(value): value is (...args: unknown[]) => unknown = typeof value === "function"` を導入。`typeof === "function"` は「呼べる」ことを実際に証明しており、引数・戻り値は `unknown` のままなので偽りが無い。narrow 後は factory 分岐がラッパ、legacy 分岐が参照そのままを返す。 |
| 343 | `(await import(...)) as Record<string, unknown>` | `const mod: unknown = await import(...)` にして `isRecord(mod)` で判定。false のときは他の構造エラーと同じく warn + skip。module namespace object は常に `isRecord` を通るため実挙動は不変。 |

追加テスト:

- `test/plugins/test_runtime_loader.ts` — `toPackageJson` の 13 ケース（正常 / 非 string フィールドの落下 / `exports` の 3 形状の素通し / 非 object 5 種）と `resolveExecute` の非関数 6 種 + factory ラップ。
- `test/plugins/test_runtime_loader_factory.ts` — stub runtime が実 runtime と同じメンバーを持つことを、fixture プラグインから `Object.keys(runtime.files)` / `Object.keys(runtime.notifier)` を返させて検証（このテストは修正前のコードでは落ちる）。

## 検証

**1. バグの再現（origin/main の素の状態）** — worktree を `origin/main` から切った直後、`tmp-repro/stub-runtime-probe.mts`（factory プラグインを `runtimeFactory` 無しでロードし、渡された runtime の形を返させるスクリプト）を実行:

```
$ npx tsx tmp-repro/stub-runtime-probe.mts
{"filesKeys":["data","config"],"artifactsType":"undefined","notifierKeys":["publish","clear"]}
```

`files.artifacts` が存在せず、`notifier` も 2 メンバーしか無い。実 runtime（`server/plugins/runtime.ts:372-389`）は `artifacts` を含む 3 つと notifier 4 メンバーを提供している。

**2. 修正後、同じスクリプト:**

```
$ npx tsx tmp-repro/stub-runtime-probe.mts
{"filesKeys":["data","config","artifacts"],"artifactsType":"object","notifierKeys":["publish","update","clear","get"]}
```

（probe スクリプトは検証後に削除済み。同じ内容は `test_runtime_loader_factory.ts` の "stub runtime exposes every member the real runtime provides" として恒久化した。）

**3. キャストが残っていないこと** — 本 PR 時点の main にまだ入っていないルールなので CLI で指定:

```
$ npx eslint server/plugins/runtime-loader.ts test/plugins/test_runtime_loader.ts test/plugins/test_runtime_loader_factory.ts \
    --rule '{"@typescript-eslint/consistent-type-assertions":["warn",{"assertionStyle":"never"}]}'
（出力なし / exit 0）
```

**4. 通常の lint / typecheck / format:**

```
$ npx prettier --write server/plugins/runtime-loader.ts test/plugins/test_runtime_loader.ts test/plugins/test_runtime_loader_factory.ts
$ npx eslint server/plugins/runtime-loader.ts test/plugins/test_runtime_loader.ts test/plugins/test_runtime_loader_factory.ts
（出力なし / exit 0）
$ npx tsc -p server/tsconfig.json --noEmit   # error TS: 0 件
$ npx tsc -p test/tsconfig.json --noEmit     # 出力なし
```

**5. テスト** — このモジュールを import しているファイルを grep で洗い出し（`test/plugins/*`, `test/agent/test_activeTools.ts`, `test/api/routes/test_runtimePluginRoot.ts`）、まず該当分、次に host のユニットテスト全体:

```
$ npx tsx --test test/plugins/*.ts test/agent/test_activeTools.ts test/api/routes/test_runtimePluginRoot.ts
ℹ tests 224 / pass 217 / fail 0 / skipped 7

$ npx tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts
ℹ tests 8839 / pass 8825 / fail 0 / skipped 14
```

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Remove unsafe type assertions from the plugin runtime loader while aligning stub runtime behavior and validation with the real runtime.

Bug Fixes:
- Ensure stub plugin runtime exposes `files.artifacts` and full notifier API so plugins see explicit "unavailable" errors instead of TypeErrors during definition-only loads.

Enhancements:
- Harden `package.json` parsing by rebuilding a typed view via `toPackageJson` and logging when the parsed value is not an object.
- Relax the `exports` field typing to support all Node.js legal shapes and rely on runtime discrimination in the entry resolver.
- Update stub runtime typing to the full `MulmoclaudeRuntime` so missing members are caught at compile time and centralize "unavailable" error helpers.
- Improve handler resolution by validating callability without type assertions and preserving legacy handler identity.
- Validate imported plugin modules and warn when the module namespace is not an object before attempting to load definitions.

Tests:
- Extend runtime loader tests to cover factory handler wrapping, non-function handler cases, and `toPackageJson` behavior across valid and invalid inputs.
- Add a factory plugin fixture test ensuring the stub runtime exposes all members the real runtime provides, including `files.artifacts` and full notifier operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading reliability when package metadata is malformed or module exports use different supported shapes.
  * Invalid plugin modules are now safely skipped with clear logging.
  * Improved handling of factory-based plugins and unavailable runtime operations.

* **Tests**
  * Added coverage for malformed metadata, invalid exports, factory handlers, and runtime stub behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->