### PR TITLE
fix(plugins): plugin runtime の as キャスト 8 件を全廃（SharedArrayBuffer body の実バグ修正を含む）

### DIFF
--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -14,11 +14,12 @@
 import path from "node:path";
 import { readFile, readdir, stat as fsStat, unlink as fsUnlink } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import type { FileOps, PluginRuntime } from "gui-chat-protocol";
+import type { FileOps, PluginFetchJsonOptions, PluginFetchOptions, PluginRuntime } from "gui-chat-protocol";
 
 import { WORKSPACE_PATHS, workspacePath } from "../workspace/paths.js";
 import { writeFileAtomic } from "../utils/files/atomic.js";
 import { errorMessage } from "../utils/errors.js";
+import { isErrorWithCode, isRecord } from "../utils/types.js";
 import { log as hostLog, type Logger } from "../system/logger/index.js";
 import { ensureInsideBase } from "./runtime-loader.js";
 import { ONE_SECOND_MS } from "../utils/time.js";
@@ -91,10 +92,6 @@ export function normalizePluginPath(scopeRoot: string, rel: string): string {
 // Scoped FileOps factory
 // ─────────────────────────────────────────────────────────────────────
 
-function isErrnoException(value: unknown): value is { code: string } {
-  return typeof value === "object" && value !== null && "code" in value && typeof (value as { code: unknown }).code === "string";
-}
-
 /** Shared (NOT per-plugin) FileOps rooted at the workspace `artifacts/`
  *  dir. Backs `runtime.files.artifacts`, and is exported so host routes can
  *  inject the same generic capability into directly-consumed plugins (e.g.
@@ -129,7 +126,7 @@ function makeFileOps(scopeRoot: string): FileOps {
       try {
         return await readdir(abs);
       } catch (err) {
-        if (isErrnoException(err) && err.code === "ENOENT") return [];
+        if (isErrorWithCode(err) && err.code === "ENOENT") return [];
         throw err;
       }
     },
@@ -142,7 +139,7 @@ function makeFileOps(scopeRoot: string): FileOps {
         await fsStat(normalizePluginPath(scopeRoot, rel));
         return true;
       } catch (err) {
-        if (isErrnoException(err) && err.code === "ENOENT") return false;
+        if (isErrorWithCode(err) && err.code === "ENOENT") return false;
         throw err;
       }
     },
@@ -150,7 +147,7 @@ function makeFileOps(scopeRoot: string): FileOps {
       try {
         await fsUnlink(normalizePluginPath(scopeRoot, rel));
       } catch (err) {
-        if (isErrnoException(err) && err.code === "ENOENT") return;
+        if (isErrorWithCode(err) && err.code === "ENOENT") return;
         throw err;
       }
     },
@@ -175,19 +172,37 @@ export function sanitisePackageNameForFs(pkgName: string): string {
 // Scoped logger
 // ─────────────────────────────────────────────────────────────────────
 
+/** The protocol lets a plugin log any `object`; the host logger and its
+ *  sinks contract for a keyed record. Wrap rather than drop a non-record
+ *  (an array) so the payload still reaches the log line. */
+function toLogData(data: object | undefined): Record<string, unknown> | undefined {
+  if (data === undefined || isRecord(data)) return data;
+  return { value: data };
+}
+
 function makeScopedLogger(pkgName: string): PluginRuntime["log"] {
   const prefix = `plugin/${pkgName}`;
   return {
-    debug: (msg, data) => hostLog.debug(prefix, msg, data as Record<string, unknown> | undefined),
-    info: (msg, data) => hostLog.info(prefix, msg, data as Record<string, unknown> | undefined),
-    warn: (msg, data) => hostLog.warn(prefix, msg, data as Record<string, unknown> | undefined),
-    error: (msg, data) => hostLog.error(prefix, msg, data as Record<string, unknown> | undefined),
+    debug: (msg, data) => hostLog.debug(prefix, msg, toLogData(data)),
+    info: (msg, data) => hostLog.info(prefix, msg, toLogData(data)),
+    warn: (msg, data) => hostLog.warn(prefix, msg, toLogData(data)),
+    error: (msg, data) => hostLog.error(prefix, msg, toLogData(data)),
   };
 }
 
 // ─────────────────────────────────────────────────────────────────────
 // Scoped fetch (timeout + optional host allowlist)
 // ─────────────────────────────────────────────────────────────────────
+
+const isArrayBufferBacked = (view: Uint8Array): view is Uint8Array<ArrayBuffer> => view.buffer instanceof ArrayBuffer;
+
+/** `fetch` accepts a byte view only when it is `ArrayBuffer`-backed. A
+ *  `SharedArrayBuffer`-backed one is not a `BodyInit`, and undici sends
+ *  its `toString()` ("104,105,33") as the body instead of the bytes — so
+ *  copy those into a transferable buffer. */
+function toTransferableBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  return isArrayBufferBacked(bytes) ? bytes : new Uint8Array(bytes);
+}
 
 function makeScopedFetch(pkgName: string): PluginRuntime["fetch"] {
   return async (url, opts = {}) => {
@@ -205,9 +220,7 @@ function makeScopedFetch(pkgName: string): PluginRuntime["fetch"] {
       // signal. AbortSignal.any returns a signal that fires when
       // either input fires — Node 20+.
       const signal = opts.signal ? AbortSignal.any([opts.signal, controller.signal]) : controller.signal;
-      // The runtime cast keeps PluginFetchInit narrow (string | Uint8Array)
-      // so plugin authors don't need to know the wider DOM BodyInit union.
-      const body = opts.body as Parameters<typeof fetch>[1] extends infer T ? (T extends { body?: infer B } ? B : never) : never;
+      const body = opts.body instanceof Uint8Array ? toTransferableBytes(opts.body) : opts.body;
       return await fetch(url, { method: opts.method, headers: opts.headers, body, signal });
     } catch (err) {
       // Re-throw with plugin context so a fan-out failure in the
@@ -227,17 +240,19 @@ function makeScopedFetch(pkgName: string): PluginRuntime["fetch"] {
 }
 
 function makeScopedFetchJson(pkgName: string, scopedFetch: PluginRuntime["fetch"]): PluginRuntime["fetchJson"] {
-  // When `opts.parse` is provided we trust its narrowing; when absent
-  // the caller asserts the JSON shape themselves (same contract as
-  // `JSON.parse(...) as T`).
-  return async function fetchJson<T>(url: string, opts: { parse?: (raw: unknown) => T } & Parameters<PluginRuntime["fetch"]>[1] = {}): Promise<T> {
+  // Overloads mirror the protocol's: `T` is reachable only through
+  // `opts.parse`, so un-validated JSON is never handed back as `T`.
+  function fetchJson(url: string, opts?: PluginFetchOptions): Promise<unknown>;
+  function fetchJson<T>(url: string, opts: PluginFetchJsonOptions<T>): Promise<T>;
+  async function fetchJson(url: string, opts: PluginFetchOptions & { parse?: (raw: unknown) => unknown } = {}): Promise<unknown> {
     const response = await scopedFetch(url, opts);
     if (!response.ok) {
       throw new Error(`plugin/${pkgName}: fetchJson HTTP ${response.status} for ${url}`);
     }
-    const raw = (await response.json()) as unknown;
-    return opts.parse ? opts.parse(raw) : (raw as T);
-  };
+    const raw: unknown = await response.json();
+    return opts.parse ? opts.parse(raw) : raw;
+  }
+  return fetchJson;
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -11,15 +11,23 @@
 //     two plugins on the same host can't see each other's events;
 //     `files.data` and `files.config` write into separate roots and
 //     reject traversal.
+//   - `log.*`: a non-record payload (the protocol allows any `object`)
+//     reaches the host logger wrapped, never dropped or reshaped.
+//   - `fetch`: a `SharedArrayBuffer`-backed `Uint8Array` body arrives on
+//     the wire as its raw bytes, not as its `toString()`.
 
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, before, after, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { Buffer } from "node:buffer";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { makePluginRuntime, normalizePluginPath, pluginChannelName, pluginTaskId, sanitisePackageNameForFs } from "../../server/plugins/runtime.js";
 import { WORKSPACE_PATHS } from "../../server/workspace/paths.js";
+import { hasNumberProp, hasStringProp } from "../../server/utils/types.js";
+import { log as hostLog, type LogLevel } from "../../server/system/logger/index.js";
 import type { IPubSub } from "../../server/events/pub-sub/index.js";
 import { createTaskManager, type ITaskManager } from "../../server/events/task-manager/index.js";
 
@@ -41,6 +49,11 @@ function makeRecordingPubSub(): { pubsub: IPubSub; published: { channel: string;
 // the registration lands under the contracted id.
 function makeStubTaskManager(): ITaskManager {
   return createTaskManager();
+}
+
+function makeTestRuntime(pkgName: string) {
+  const { pubsub } = makeRecordingPubSub();
+  return makePluginRuntime({ pkgName, pubsub, locale: "en", taskManager: makeStubTaskManager() });
 }
 
 describe("normalizePluginPath", () => {
@@ -314,5 +327,144 @@ describe("makePluginRuntime — files.data and files.config", () => {
     await runtime.files.data.write("books\\2026\\journal.jsonl", "winpath");
     // Reads with the POSIX form because that's the contract.
     assert.equal(await runtime.files.data.read("books/2026/journal.jsonl"), "winpath");
+  });
+});
+
+describe("makePluginRuntime — scoped logger payload", () => {
+  const LOG_LEVELS: readonly LogLevel[] = ["debug", "info", "warn", "error"];
+  const calls: { level: LogLevel; prefix: string; message: string; data: Record<string, unknown> | undefined }[] = [];
+  const originals = { debug: hostLog.debug, info: hostLog.info, warn: hostLog.warn, error: hostLog.error };
+
+  // Assert on what the scoped logger hands the HOST logger: that is the
+  // contract boundary the plugin runtime owns, and `LogRecord.data` is
+  // where a non-record payload used to break the declared shape.
+  beforeEach(() => {
+    calls.length = 0;
+    LOG_LEVELS.forEach((level) => {
+      hostLog[level] = (prefix, message, data) => {
+        calls.push({ level, prefix, message, data });
+      };
+    });
+  });
+
+  afterEach(() => {
+    LOG_LEVELS.forEach((level) => {
+      hostLog[level] = originals[level];
+    });
+  });
+
+  it("forwards a record payload by reference on every level", () => {
+    const runtime = makeTestRuntime("@example/foo");
+    const payload = { a: 1, b: "two" };
+    LOG_LEVELS.forEach((level) => runtime.log[level](`msg-${level}`, payload));
+    assert.equal(calls.length, LOG_LEVELS.length);
+    calls.forEach((call, index) => {
+      assert.equal(call.level, LOG_LEVELS[index]);
+      assert.equal(call.prefix, "plugin/@example/foo");
+      assert.equal(call.message, `msg-${LOG_LEVELS[index]}`);
+      assert.equal(call.data, payload);
+    });
+  });
+
+  it("wraps a non-record payload instead of dropping it", () => {
+    const runtime = makeTestRuntime("@example/foo");
+    const payload = ["x", "y"];
+    LOG_LEVELS.forEach((level) => runtime.log[level]("msg-array", payload));
+    assert.equal(calls.length, LOG_LEVELS.length);
+    calls.forEach((call) => {
+      // Dropping the payload would be the silent-data-loss regression.
+      assert.notEqual(call.data, undefined);
+      // The host contracts for a keyed record; the array survives under it.
+      assert.deepEqual(call.data, { value: ["x", "y"] });
+      assert.equal(call.data?.value, payload);
+    });
+  });
+
+  it("leaves an absent payload absent (no empty wrapper)", () => {
+    const runtime = makeTestRuntime("@example/foo");
+    runtime.log.warn("msg-none");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].data, undefined);
+  });
+
+  it("does not wrap an Error payload — it is already a record", () => {
+    const runtime = makeTestRuntime("@example/foo");
+    const failure = Object.assign(new Error("boom"), { code: "ENOENT" });
+    runtime.log.error("msg-error", failure);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].data, failure);
+  });
+
+  it("scopes the prefix per plugin", () => {
+    makeTestRuntime("@a/p").log.info("from-a");
+    makeTestRuntime("@b/p").log.info("from-b");
+    assert.deepEqual(
+      calls.map((call) => call.prefix),
+      ["plugin/@a/p", "plugin/@b/p"],
+    );
+  });
+});
+
+describe("makePluginRuntime — scoped fetch body", () => {
+  const BODY_TEXT = "hi!";
+  const expectedHex = Buffer.from(BODY_TEXT, "utf-8").toString("hex");
+  // Filled in by `before` once the OS has assigned a port.
+  const echo = { url: "" };
+
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ bodyHex: Buffer.concat(chunks).toString("hex") }));
+    });
+  });
+
+  before(async () => {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!hasNumberProp(address, "port")) throw new Error("echo server did not report a TCP port");
+    echo.url = `http://127.0.0.1:${address.port}/echo`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  // The body assertion is against what actually arrived on the wire,
+  // not against our own construction of it.
+  async function postBodyHex(body?: string | Uint8Array): Promise<string> {
+    const response = await makeTestRuntime("@example/foo").fetch(echo.url, { method: "POST", body });
+    const parsed: unknown = await response.json();
+    assert.ok(hasStringProp(parsed, "bodyHex"), "echo server must answer with bodyHex");
+    return parsed.bodyHex;
+  }
+
+  it("sends a string body verbatim", async () => {
+    assert.equal(await postBodyHex(BODY_TEXT), expectedHex);
+  });
+
+  it("sends an ArrayBuffer-backed Uint8Array as raw bytes", async () => {
+    assert.equal(await postBodyHex(new TextEncoder().encode(BODY_TEXT)), expectedHex);
+  });
+
+  it("sends a SharedArrayBuffer-backed Uint8Array as raw bytes, not its toString()", async () => {
+    const bytes = new TextEncoder().encode(BODY_TEXT);
+    const shared = new Uint8Array(new SharedArrayBuffer(bytes.byteLength));
+    shared.set(bytes);
+    const received = await postBodyHex(shared);
+    // A SharedArrayBuffer-backed view is not a `BodyInit`, so undici
+    // stringifies it ("104,105,33") unless the runtime copies it into a
+    // transferable buffer first.
+    assert.notEqual(received, Buffer.from(shared.toString(), "utf-8").toString("hex"));
+    assert.equal(received, expectedHex);
+  });
+
+  it("sends no body when none was supplied", async () => {
+    assert.equal(await postBodyHex(), "");
+  });
+
+  it("sends an empty string body as an empty payload", async () => {
+    assert.equal(await postBodyHex(""), "");
   });
 });

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -435,6 +435,9 @@ describe("makePluginRuntime — scoped fetch body", () => {
   // not against our own construction of it.
   async function postBodyHex(body?: string | Uint8Array): Promise<string> {
     const response = await makeTestRuntime("@example/foo").fetch(echo.url, { method: "POST", body });
+    // Name the status before parsing, so an echo-server fault reads as a
+    // fault rather than as "the body arrived wrong".
+    assert.ok(response.ok, `echo server returned HTTP ${response.status}`);
     const parsed: unknown = await response.json();
     assert.ok(hasStringProp(parsed, "bodyHex"), "echo server must answer with bodyHex");
     return parsed.bodyHex;


### PR DESCRIPTION
## Summary

`server/plugins/runtime.ts` の `as` 型アサーション 8 件をすべて除去した（#2692 の一部）。プラグインに公開される `PluginRuntime` の型シグネチャは 1 つも変更していない。

うち 1 件（`fetch` の `body`）は**実バグを隠していた**。`SharedArrayBuffer` 由来の `Uint8Array` は `BodyInit` ではないため TypeScript は正しく拒否していたが、`as` がそれを黙らせており、undici は実バイトではなく `toString()` した文字列 `"104,105,33"` をボディとして送信していた（エラーも出ない）。型どおりに直したことで実バイトが送られる。

残り 7 件は、共有ガード `isErrorWithCode` への置き換え（4 件）、ログ payload の reader 化（4 件のうち重複を 1 helper に集約）、protocol 自身と同じ overload 宣言による `fetchJson` の実装（2 件）で解消した。

## Items to Confirm / Review

1. **`fetch` の body は挙動が変わる（バグ修正のため意図的）** — `SharedArrayBuffer` 由来の `Uint8Array` を渡した場合のみ。修正前は文字列 `"104,105,33"` が送信され、修正後は 3 バイト `hi!` が送信される。実測は下記「検証」の差分どおり。通常の `ArrayBuffer` 由来の `Uint8Array` / `string` はコピーも発生せず完全に同一。この挙動変更を受け入れてよいか確認してほしい（現状の送信内容は明らかに壊れているため、直すのが正しいという判断）。
2. **ログ payload が record でないとき「捨てる」ではなく「包む」を選んだ** — protocol は `data?: object` を許すが、ホスト logger と `LogRecord.data` は `Record<string, unknown>` を契約している。`isRecord(data) ? data : undefined` にすると配列 payload が**無言で消える**ため、`{ value: data }` に包む方を選択した。理由は (a) logger が診断情報を黙って落とすのは最悪の変更、(b) 修正前は配列をそのまま流していたので JSON sink が `"data":[...]` を出力し、`LogRecord.data` の宣言型を破っていた（= `as` が隠していたもう 1 つの型の嘘）。包むことでその不変条件が回復する。text sink の見え方も改善する（下記差分。文字列 payload が `0=p 1=l 2=a 3=i 4=n` → `value=plain`）。捨てる方が良いという判断ならその方針に変更する。
3. **`fetchJson` の公開シグネチャは変更していない** — 返り値型は従来どおり protocol の `PluginRuntime["fetchJson"]`（`parse` なし → `Promise<unknown>` / `parse` あり → `Promise<T>`）。つまり「`parse` を要求する」契約は元々 protocol 側にあり、`raw as T` は実装内部だけの嘘だった。内部実装をその overload 2 本で書き直しただけなので、呼び出し側への影響は無い（実際 host 側に `runtime.fetchJson` の呼び出し元は存在せず、プラグイン向け API のみ）。
4. **`isErrnoException` を削除して `isErrorWithCode`（`@mulmoclaude/common`、`server/utils/types.ts` 経由）に置き換えた** — 唯一の意味差は**配列**の扱い。旧実装は `code: string` を持つ配列を通したが、`isErrorWithCode` は `isRecord` ベースなので配列を弾く。Node の fs エラーが配列であることは無いため実挙動に差は無い。
5. 意図的に残した `as` は**ゼロ**。

## 実装方針

| 旧コード | 対応 |
| --- | --- |
| `isErrnoException`（`(value as { code: unknown }).code`）| 削除し、共有ガード `isErrorWithCode` を import。呼び出し 3 箇所（`readDir` / `exists` / `unlink`）を置換 |
| `log.{debug,info,warn,error}` の `data as Record<string, unknown> \| undefined` × 4 | `toLogData(data)` 1 つに集約（DRY）。`undefined` / record はそのまま、それ以外は `{ value: data }` |
| `opts.body as Parameters<typeof fetch>[1] extends …` | 条件型を廃止。`isArrayBufferBacked`（`view.buffer instanceof ArrayBuffer` を実際に検査する述語）+ `toTransferableBytes` で、`SharedArrayBuffer` 由来のときだけ転送可能なバッファへコピー。通常経路はゼロコピー |
| `(await response.json()) as unknown` | `const raw: unknown = await response.json()`（注釈による受け取りでキャスト不要） |
| `opts.parse ? opts.parse(raw) : (raw as T)` | 実装を protocol と同じ overload 2 本で宣言。`T` は `opts.parse` 経由でしか到達できないので、未検証 JSON が `T` として返ることが型で不可能になる |

`PluginFetchOptions` / `PluginFetchJsonOptions` は `gui-chat-protocol` から type import した。

## 検証

すべて `server/plugins/runtime.ts` のみを変更した状態で実行。

```
npx prettier --check server/plugins/runtime.ts            # All matched files use Prettier code style!
npx eslint server/plugins/runtime.ts --max-warnings 0     # 0 errors / 0 warnings
npx eslint server/plugins/runtime.ts \
  --rule '{"@typescript-eslint/consistent-type-assertions":["error",{"assertionStyle":"never"}]}' \
  --max-warnings 0                                        # 0 — 残存アサーション無し
npx tsc -p server/tsconfig.json --noEmit                  # エラー無し
npx tsx --test test/plugins/*.ts test/plugins/*/*.ts \
  test/api/routes/test_runtimePluginRoot.ts \
  test/agent/test_activeTools.ts test/tools/test_runtimeLoader.ts
# tests 946 / pass 939 / fail 0 / skipped 7
```

`npx tsc -p test/tsconfig.json --noEmit` は `test/services/google/test_calendarCollectionSync.ts` で 1 件失敗するが、**本 PR 適用前（stash した状態）でも同一に失敗する**既存の問題（`@mulmoclaude/core/google` の `applyPlanFor` 未 export）で、本変更とは無関係。

### 外部 ground truth による before/after 差分

`makePluginRuntime()` で実際に runtime を組み立て、`log.*` を 8 種の payload（record / 配列 / 文字列 / undefined / Error / Date / 関数 / ネスト）× 4 レベルで叩き、`fetch` / `fetchJson` を実際の `http.createServer` に対して 17 ケース（string body / bytes body / SharedArrayBuffer body / body 無し / 非 2xx / allowedHosts 拒否・許可 / timeout / caller abort / 接続拒否 / parse あり・無し・throw / 不正 JSON / POST bytes 等）実行するスクリプトを書き、**本 PR 適用版と `git stash` した未適用版の両方で実行して出力を diff**（スクリプトは検証後に削除）。

JSON ログ形式・text ログ形式の両方で実行し、差分は以下の 4 種のみ。それ以外（record / ネスト / Date / Error / undefined payload、および `fetch` / `fetchJson` の全 17 ケースの結果とエラーメッセージ）は**完全に一致**。

```diff
  # 1. 配列 payload（意図的: LogRecord.data の宣言型を回復）
- {"level":"info","message":"msg-array","data":["x","y"]}
+ {"level":"info","message":"msg-array","data":{"value":["x","y"]}}
- T INFO  [plugin/@probe/plugin] msg-array 0=x 1=y
+ T INFO  [plugin/@probe/plugin] msg-array value=["x","y"]

  # 2. 文字列 payload（型上は不可能。素の JS プラグインのみ到達）
- T INFO  [plugin/@probe/plugin] msg-string 0=p 1=l 2=a 3=i 4=n
+ T INFO  [plugin/@probe/plugin] msg-string value=plain

  # 3. 関数 payload（どちらもシリアライズ不可。行がわずかに冗長になるだけ）
- T INFO  [plugin/@probe/plugin] msg-fn
+ T INFO  [plugin/@probe/plugin] msg-fn value=undefined

  # 4. SharedArrayBuffer 由来の body（バグ修正）
- ### fetch/shared-bytes-body -> {"bodyUtf8":"104,105,33","bodyHex":"3130342c3130352c3333"}
+ ### fetch/shared-bytes-body -> {"bodyUtf8":"hi!","bodyHex":"686921"}
```

4 のバグは Node 24.12.0 上で単体再現も取っている（`fetch` に `new Uint8Array(new SharedArrayBuffer(3))` を渡すと、サーバに届くのは 3 バイトではなく文字列 `"104,105,33"`）。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Remove unsafe type assertions from the plugin runtime and align fetch/fetchJson and logging behavior with protocol and host contracts.

Bug Fixes:
- Correct fetch body handling so SharedArrayBuffer-backed Uint8Array payloads are sent as raw bytes instead of a stringified representation.
- Tighten filesystem error handling by using a shared error guard that more accurately matches Node errno errors.

Enhancements:
- Wrap non-record log payloads into a keyed record to preserve diagnostic data while matching logger data shape.
- Refine plugin fetch body handling to copy only SharedArrayBuffer-backed views into transferable buffers while keeping ArrayBuffer-backed and other bodies zero-copy.
- Reimplement fetchJson using protocol-mirrored overloads so typed results are only produced via explicit parse functions, without exposing unsafe casts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file and directory errors during runtime operations.
  * Improved logging for error, object, and empty payloads.
  * Fixed requests using shared-buffer-backed data so they are transmitted reliably.
  * Improved JSON fetch handling, including empty responses and unvalidated response data.
* **Tests**
  * Expanded coverage for logging behavior and fetch request payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->