### PR TITLE
refactor(plugins): presentMulmoScript の as 型アサーション 7 件を全廃 (#2692)

### DIFF
--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -45,7 +45,7 @@ async function fetchMediaBlob(query: { moviePath?: string; pdfPath?: string }): 
 /** Provide the package's host-adapter injection around the View —
  *  mounted INSIDE wrapWithScope's PluginScopedRoot, forwarding every
  *  prop / attr / slot through verbatim (same shape as wrapWithScope). */
-function withHostAdapter<TInner extends Component>(inner: TInner): TInner {
+function withHostAdapter(inner: Component): Component {
   return markRaw(
     defineComponent({
       name: "MulmoScriptHostAdapter",
@@ -60,13 +60,11 @@ function withHostAdapter<TInner extends Component>(inner: TInner): TInner {
         return () => h(inner, attrs, slots);
       },
     }),
-  ) as unknown as TInner;
+  );
 }
 
 const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
-  // gui-chat-protocol type is externalized but yarn-4's dual-@vue can
-  // make the package's nominal types distinct; coerce once here.
-  toolDefinition: toolDefinition as ToolPlugin<MulmoScriptData>["toolDefinition"],
+  toolDefinition,
 
   // Pass-through: the agent (MCP) and GUI dispatcher both end up at the
   // same backend route, which dispatches between create-new (`script`)
@@ -77,8 +75,8 @@ const presentMulmoScriptPlugin: ToolPlugin<MulmoScriptData> = {
 
   isEnabled: () => true,
   generatingMessage: "Generating MulmoScript storyboard…",
-  viewComponent: wrapWithScope("mulmoScript", withHostAdapter(View as unknown as Component)),
-  previewComponent: wrapWithScope("mulmoScript", Preview as unknown as Component),
+  viewComponent: wrapWithScope("mulmoScript", withHostAdapter(View)),
+  previewComponent: wrapWithScope("mulmoScript", Preview),
 };
 
 export const REGISTRATION: PluginRegistration = {


### PR DESCRIPTION
## Summary

`src/plugins/presentMulmoScript/index.ts` にあった `as` 型アサーション **7 件すべてを削除**しました（issue #2692）。
実体は 2 種類で、1 件は「関数シグネチャの嘘」を隠していた本物の型ミスマッチ、残り 5 件は根拠が失われた古いアサーションでした。
`eslint-disable` / `@ts-ignore` / `any` は一切追加していません。残したアサーションもゼロです。

## Items to Confirm / Review

**1. なぜアサーションが存在したのか（Root cause）**

| 箇所 | 元のコード | 実際の理由 |
|---|---|---|
| L63 | `) as unknown as TInner;` (2 件) | **本物の型ミスマッチ。** `withHostAdapter<TInner extends Component>(inner: TInner): TInner` は「渡されたのと同じ型を返す」と宣言していたが、実際に返すのは `markRaw(defineComponent(...))` で作った**別の新しいラッパーコンポーネント**。`TInner` を満たせるはずがないので `unknown` 経由で洗浄されていた |
| L69 | `toolDefinition as ToolPlugin<MulmoScriptData>["toolDefinition"]` | **陳腐化。** コメントは「yarn-4 の dual-@vue で公称型が別物になる」と説明していたが、現在のツリーは `vue` を1コピーしか解決しない |
| L80 / L81 | `View as unknown as Component` / `Preview as unknown as Component` (計 4 件) | 同上（陳腐化） |

**2. 修正内容**

`withHostAdapter` のシグネチャを実態どおり `(inner: Component): Component` に直しました。これで `as` は不要になります。
残り 5 件は**単に削除するだけで `vue-tsc --noEmit` がクリーン**に通ることを実測で確認しました（下記「検証」の再現手順つき）。
陳腐化した dual-@vue のコメントも、正当化していた `as` と一緒に削除しています。

**3. 他プラグインへの一般化について（レビュー観点）**

`viewComponent` / `previewComponent` を登録している 18 プラグインのうち、キャストしているのは
外部 `@mulmoclaude/*-plugin` パッケージから `View` / `Preview` を import している **4 つだけ**です。

- `src/plugins/chart/index.ts` L27-28
- `src/plugins/markdown/index.ts` L33-34
- `src/plugins/presentHtml/index.ts` L52-53
- `src/plugins/presentMulmoScript/index.ts` ← 本 PR

**同じ「dual-@vue」コメントを持つ残り 3 つも、単純削除で通る可能性が非常に高い**と考えています
（原因が「vue が複数コピー」という共通の前提で、その前提が既に成立していないため）。
ただし本 PR のスコープ外なので触れていません。#2692 の別 PR で拾ってください。
なお `presentForm` は `pkg.viewComponent`（パッケージ側 `ToolPlugin` 経由）を使っており最初からキャスト不要です。

**4. 残した既知のキャスト（本 PR では触っていない）**

`src/plugins/scope.ts` L56 の `) as TInner;` が同じ「ジェネリック戻り値の嘘」パターンです
（`wrapWithScope<TInner extends Component | undefined>(scope, inner): TInner` も新しいラッパーを返す）。
本 PR の修正には不要だったため、レジストリ側の diff を増やさない判断で残しています。
直すなら `withHostAdapter` と同じくオーバーロードか `Component | undefined` 返しに直すのが素直です。

**5. 実行時検証（type-only 変更でも白画面になり得るため実測）**

`yarn build` の成功では「描画された」証拠にならないので、実際にブラウザで View / Preview をマウントさせて確認しました。
詳細は「検証」セクション。**page error 0 件**、View / Preview とも実描画をスクリーンショットで確認済みです。

## 実装方針

- `as` を消すために型を緩めたり `unknown` を経由したりせず、**アサーションが隠していた事実を先に特定**してから直す。
- `withHostAdapter` は「入力と同じ型を返す」ふりをやめ、`Component` を受けて `Component` を返す正直なシグネチャにする。
  実行時の挙動は変わらない（元から新しいラッパーを返していた）。
- 残り 5 件は「本当に型エラーになるのか」を先に実測し、**エラーが出ないことを確認してから削除**する。
  推測で消していない。
- `as` を正当化していたコメント（dual-@vue）も一緒に削除する。根拠が消えたコメントは腐るため。

## 検証

すべて worktree `mc3-wt-present-mulmoscript`（`origin/main` = `f1a9d837c` から分岐）で実行。

**a. 「本当に as が要るのか」の実測（root cause の証拠）**

7 件すべてを機械的に外した状態で型検査したところ、**エラーは 1 件だけ**でした:

```
$ npx vue-tsc --noEmit
src/plugins/presentMulmoScript/index.ts:49:3 - error TS2322: Type 'Raw<DefineComponent<...>>'
is not assignable to type 'TInner'.
  'Raw<DefineComponent<...>>' is assignable to the constraint of type 'TInner',
  but 'TInner' could be instantiated with a different subtype of constraint 'Component'.

49   return markRaw(
     ~~~~~~

Found 1 error in src/plugins/presentMulmoScript/index.ts:49
```

`toolDefinition` / `View` / `Preview` については**一切エラーが出ていません**。
= 5 件は不要なアサーションだった、という外部的な裏付けです。
`node_modules` 側も `vue` は 1 コピーのみ（`ls -d node_modules/vue` + ネスト検索で重複なし）で、コメントの前提が崩れていることを確認しました。

**b. 静的チェック（すべて緑）**

```
$ npx prettier --write src/plugins/presentMulmoScript/index.ts   # (unchanged)
$ npx eslint src/plugins/presentMulmoScript/                     # exit 0 / 出力なし
    → error 0 件、consistent-type-assertions warning 0 件
$ npx vue-tsc --noEmit                                           # 出力なし（= 0 error）
$ yarn build                                                     # ✓ built in 3.43s
```

**c. ユニットテスト（このプラグインに触れるもの全部）**

```
$ npx tsx --test test/plugins/test_runtime_registry.ts \
                 test/plugins/mulmoscript/test_helpers.ts \
                 test/server/api/test_mulmoScriptBeatOp.ts \
                 test/agent/test_activeTools.ts
ℹ tests 103 / pass 103 / fail 0
```

**d. E2E（実ブラウザでのマウント確認）**

```
$ npx playwright test --config e2e/playwright.config.ts present-mulmo-script
7 passed (22.8s)
```

内訳（View / Preview が実際にマウントして描画していることを直接叩いているもの）:

- `Preview shows the script title in the sidebar` ✓
- `View renders script title, description and beat count when selected` ✓
- `View does not crash when the mulmo-script API endpoints return empty` ✓（`pageerror` 0 件をアサート）
- `render-beat success: mocked image surfaces in the View` ✓
- `render-beat error: mocked { error } surfaces to the UI` ✓
- `generateMovie error: inline chip + retry` ✓
- `ThinkingIndicator lights up when the active session is running` ✓
  ← これが `withHostAdapter` が inject する `chatSessionId` 経路を通る

なお Playwright の `reuseExistingServer: true` に他エージェントの dev server を掴まされないよう、
**先に自分の worktree から `vite --port 45173 --strictPort` を起動し、その PID の実行パスが
`mc3-wt-present-mulmoscript/node_modules/.bin/vite` であることを確認**してからテストを回しています
（別ブランチのコードを ground truth にしてしまう事故の回避）。

**e. 実行時証跡（スクリーンショット + console）**

一時的な evidence テストを spec に足して実ブラウザのコンソールとスクリーンショットを取得し、
取得後に `git checkout -- e2e/tests/present-mulmo-script.spec.ts` で戻しています（この PR の diff には含まれません）。

```
PAGE_ERRORS= []
```

- **uncaught page error は 0 件**。
- 残るコンソール error はすべてモック環境由来（未モック API の 403 / 501、backend 無しによる
  `ws://localhost:45173/ws/pubsub/` の失敗、`[runtime-plugin] boot loader threw` — いずれも本変更と無関係で main でも出るもの）。
- スクリーンショット上で以下が実描画されていることを目視確認:
  - サイドバー Preview: `Test Mulmo Script`（タイトル + description）
  - View 本体: タイトル / description / `2 beats` / `scripts/test-mulmo-script.json` / beat カード 2 枚 / `Movie`・`PDF` ボタン
  - 白画面・未マウントではないこと

**f. コミット衛生**

`yarn build` が生成した `server/build/dispatcher.mjs` の差分は `git checkout` で戻し、
`git add` は `src/plugins/presentMulmoScript/index.ts` のみを個別指定しています（`git add .` 不使用）。
最終的な変更は **1 ファイル / +5 -7 行**です。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Remove obsolete type assertions from the MulmoScript plugin and align its host adapter typing with the actual wrapped component behavior.

Enhancements:
- Update withHostAdapter to accept and return generic Vue components directly instead of pretending to preserve the original generic type.
- Simplify presentMulmoScript plugin registration by using toolDefinition, View, and Preview without TypeScript type coercion.