### PR TITLE
refactor(notifier): notifier の state ファイルを assert せず parse する (#2692)

### DIFF
--- a/packages/core/src/notifier/store.ts
+++ b/packages/core/src/notifier/store.ts
@@ -4,44 +4,83 @@
 // writers). Kept separate from `engine.ts` so the path can be
 // overridden in tests without monkey-patching.
 
+import { hasStringProp, isErrorWithCode, isRecord, isUnknownArray } from "@mulmoclaude/common";
 import { promises as fsPromises } from "node:fs";
-import type { NotifierFile, NotifierHistoryFile } from "./types.js";
+import {
+  NOTIFIER_LIFECYCLES,
+  NOTIFIER_SEVERITIES,
+  type NotifierEntry,
+  type NotifierFile,
+  type NotifierHistoryEntry,
+  type NotifierHistoryFile,
+} from "./types.js";
 
 /** Injected atomic JSON writer — the host's `writeJsonAtomic`. */
 export type WriteJson = (filePath: string, data: unknown) => Promise<void>;
 
-function isNotFoundError(err: unknown): boolean {
-  return typeof err === "object" && err !== null && (err as { code?: unknown }).code === "ENOENT";
+const TERMINAL_TYPES = ["cleared", "cancelled"] as const;
+
+function isOneOf<T extends string>(allowed: readonly T[], value: unknown): value is T {
+  return allowed.some((candidate) => candidate === value);
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+// Checks every field `NotifierEntry` declares — `pluginData` is `unknown`,
+// so nothing is left unverified. A partial check would be an assertion
+// wearing a predicate's clothes.
+function isNotifierEntry(value: unknown): value is NotifierEntry {
+  return (
+    hasStringProp(value, "id") &&
+    hasStringProp(value, "pluginPkg") &&
+    hasStringProp(value, "title") &&
+    hasStringProp(value, "createdAt") &&
+    isOneOf(NOTIFIER_SEVERITIES, value.severity) &&
+    (value.lifecycle === undefined || isOneOf(NOTIFIER_LIFECYCLES, value.lifecycle)) &&
+    isOptionalString(value.body) &&
+    isOptionalString(value.navigateTarget)
+  );
+}
+
+function isNotifierHistoryEntry(value: unknown): value is NotifierHistoryEntry {
+  return isNotifierEntry(value) && hasStringProp(value, "terminalAt") && isOneOf(TERMINAL_TYPES, value.terminalType);
+}
+
+// `isRecord` rejects `null` and arrays, so `{ entries: [] }` and
+// `{ entries: null }` stay malformed instead of reading as "no entries" —
+// downstream `engine.get` / `list*` mutations assume a plain object.
+function isNotifierFile(value: unknown): value is NotifierFile {
+  return isRecord(value) && isRecord(value.entries) && Object.values(value.entries).every(isNotifierEntry);
+}
+
+function isNotifierHistoryFile(value: unknown): value is NotifierHistoryFile {
+  return isRecord(value) && isUnknownArray(value.entries) && value.entries.every(isNotifierHistoryEntry);
+}
+
+/** Parsed JSON, or `undefined` when the file doesn't exist yet (first
+ *  ever call on a fresh workspace) — unambiguous as a sentinel because
+ *  no JSON document parses to `undefined`. */
+async function readJsonIfPresent(filePath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await fsPromises.readFile(filePath, "utf-8"));
+  } catch (err) {
+    if (isErrorWithCode(err) && err.code === "ENOENT") return undefined;
+    throw err;
+  }
 }
 
 /** Read the active-entries file. Returns an empty store when the file
- *  doesn't exist yet (first ever call on a fresh workspace). Any other
- *  read or parse failure throws — the caller has to decide whether to
- *  surface or recover, since silently treating "malformed file" as
- *  "no entries" would lose data. */
+ *  doesn't exist yet. Any other read or parse failure throws — the
+ *  caller has to decide whether to surface or recover, since silently
+ *  treating "malformed file" as "no entries" would lose data. A rejected
+ *  file is never rewritten, so it stays on disk intact for repair. */
 export async function loadActive(filePath: string): Promise<NotifierFile> {
-  let text: string;
-  try {
-    text = await fsPromises.readFile(filePath, "utf-8");
-  } catch (err) {
-    if (isNotFoundError(err)) return { entries: {} };
-    throw err;
-  }
-  const parsed: unknown = JSON.parse(text);
-  // `typeof null === "object"` and `Array.isArray([])` is also true,
-  // so a naive `typeof entries !== "object"` check would let
-  // `{ entries: null }` and `{ entries: [] }` through, which then
-  // crash downstream `engine.get` / `list*` mutations. Reject both
-  // shapes here at load time so the failure surfaces as a clear
-  // "malformed file" error.
-  if (typeof parsed !== "object" || parsed === null || !("entries" in parsed)) {
-    throw new Error(`notifier: malformed active.json at ${filePath}`);
-  }
-  const { entries } = parsed as { entries: unknown };
-  if (typeof entries !== "object" || entries === null || Array.isArray(entries)) {
-    throw new Error(`notifier: malformed active.json at ${filePath}`);
-  }
-  return parsed as NotifierFile;
+  const parsed = await readJsonIfPresent(filePath);
+  if (parsed === undefined) return { entries: {} };
+  if (!isNotifierFile(parsed)) throw new Error(`notifier: malformed active.json at ${filePath}`);
+  return parsed;
 }
 
 /** Write the active-entries file via the injected atomic writer so a
@@ -55,18 +94,10 @@ export async function saveActive(writeJson: WriteJson, filePath: string, state: 
 /** Read the history file. Empty array on first run. Same parse-error
  *  policy as `loadActive`. */
 export async function loadHistory(filePath: string): Promise<NotifierHistoryFile> {
-  let text: string;
-  try {
-    text = await fsPromises.readFile(filePath, "utf-8");
-  } catch (err) {
-    if (isNotFoundError(err)) return { entries: [] };
-    throw err;
-  }
-  const parsed: unknown = JSON.parse(text);
-  if (typeof parsed !== "object" || parsed === null || !("entries" in parsed) || !Array.isArray((parsed as { entries: unknown }).entries)) {
-    throw new Error(`notifier: malformed history.json at ${filePath}`);
-  }
-  return parsed as NotifierHistoryFile;
+  const parsed = await readJsonIfPresent(filePath);
+  if (parsed === undefined) return { entries: [] };
+  if (!isNotifierHistoryFile(parsed)) throw new Error(`notifier: malformed history.json at ${filePath}`);
+  return parsed;
 }
 
 export async function saveHistory(writeJson: WriteJson, filePath: string, state: NotifierHistoryFile): Promise<void> {

--- a/packages/core/test/notifier/test_engine.ts
+++ b/packages/core/test/notifier/test_engine.ts
@@ -1,7 +1,7 @@
 import { test, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -164,6 +164,51 @@ test("malformed active.json surfaces as an error", async () => {
     await mkdir(path.dirname(active), { recursive: true });
     await writeFile(active, JSON.stringify({ entries: [] })); // array, not object → malformed
     await assert.rejects(() => listAll(), /malformed active\.json/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function handWrittenEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { id: "hand-1", pluginPkg: "todo", severity: "nudge", title: "hand-written", createdAt: "2026-01-01T00:00:00.000Z", ...overrides };
+}
+
+test("hand-written entries load with only the required fields, and unknown extras are tolerated", async () => {
+  const dir = setup();
+  try {
+    const entries = { a: handWrittenEntry(), b: handWrittenEntry({ id: "hand-2", futureField: 42 }) };
+    await writeFile(path.join(dir, "active.json"), JSON.stringify({ entries }));
+    assert.deepEqual((await listAll()).map((entry) => entry.id).sort(), ["hand-1", "hand-2"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a malformed entry rejects the whole active.json and leaves the file on disk untouched", async () => {
+  const dir = setup();
+  try {
+    const active = path.join(dir, "active.json");
+    const raw = JSON.stringify({ entries: { a: handWrittenEntry(), b: { junk: true } } });
+    await writeFile(active, raw);
+    await assert.rejects(() => listAll(), /malformed active\.json/);
+    await assert.rejects(() => publish({ pluginPkg: "todo", severity: "nudge", title: "blocked" }), /malformed active\.json/);
+    assert.equal(await readFile(active, "utf-8"), raw);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a malformed history entry neither blocks notifications nor rewrites the history file", async () => {
+  const dir = setup();
+  try {
+    const history = path.join(dir, "history.json");
+    const raw = JSON.stringify({ entries: [{ junk: true }] });
+    await writeFile(history, raw);
+    const { id } = await publish({ pluginPkg: "todo", severity: "nudge", title: "still works" });
+    await clear(id);
+    assert.equal((await listAll()).length, 0);
+    await assert.rejects(() => listHistory(), /malformed history\.json/);
+    assert.equal(await readFile(history, "utf-8"), raw);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -201,7 +201,7 @@ function mirrorSkillDelete(workspaceRoot2, slug) {
   return { dest };
 }
 
-// packages/core/dist/dist-Cwk0e12G.js
+// packages/core/dist/dist-DfFWwikm.js
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

`packages/core/src/notifier/store.ts` の `as` 型アサーション 5 件を全て型ガードに置き換えた（残 0 件）。
特に `parsed as NotifierFile` / `parsed as NotifierHistoryFile` は、ユーザー／エージェントが編集しうる
ディスク上の JSON を無検査で型付き値に仕立ててエンジンへ流していたため、宣言されたフィールドを実際に
検査するガードに置き換えている。ENOENT 判定の自前実装は `@mulmoclaude/common` の `isErrorWithCode` に統一。

## Items to Confirm / Review

- **検証の深さ = per-entry（要確認ポイント）**。トップレベルの shape だけでなく、`entries` の各要素も
  `NotifierEntry` / `NotifierHistoryEntry` が宣言する全フィールド（必須の型・任意の型・enum 値）を検査する。
  shape-only では `Record<string, NotifierEntry>` を証明できず、結局「予測子の皮をかぶったアサーション」に
  なるため per-entry を選んだ。
- **壊れたファイルの扱いが today より悪化しないこと**。方針は「捨てない・書き換えない・大声で落とす」:
  - 不正エントリを **黙って drop しない**（drop すると次の mutation の `saveActive` でディスクから消える＝データ喪失）。
  - reject 時は書き込みを一切行わないので、**ファイルはバイト単位でそのまま残る**（テストで実測）。
  - 変化するのは「不正エントリを含むファイル」だけで、エラーは既存と同じ `malformed <file>.json at <path>`。
  - 従来はこのケースで `listAll()` が `[null]` などを返し、`clear()` は `if (!entry) return null` で
    no-op になるため **消せない壊れた行が残り続けた**。今回は原因ファイルのパス付きで即座に失敗する。
  - history 側は `persistHistory` の失敗が `processBatch` で握られるため、**通知の publish / clear は動き続ける**
    （落ちるのは `listHistory()` のみ）。テストで固定した。
- **既存ファイルとの互換性**: 必須フィールド（`id` / `pluginPkg` / `severity` / `title` / `createdAt`）と
  enum の値は notifier 導入時（5a5aa86d4）から一度も変わっておらず、後から必須化されたフィールドは無い。
  `navigateTarget` は追加時から任意。未知フィールドは許容する（テスト済み）。
- **公開 API は不変**。`store.ts` の export は `WriteJson` と 4 関数のままで、`notifier/index.ts` は
  `WriteJson` 型しか再輸出していない。新しいガードは全てモジュール内 private。`packages/core` の
  `version` は据え置き。
- 残した `as` は **0 件**。`TERMINAL_TYPES = [...] as const` のみ（const assertion で、lint ルール対象外）。

## 実装方針

- `isNotifierEntry` / `isNotifierHistoryEntry` / `isNotifierFile` / `isNotifierHistoryFile` を追加。
  それぞれ「型が宣言している内容を全部検査する」ことを守る（`pluginData` は `unknown` なので検査対象なし）。
- `docs/shared-utils.md` に従い、`@mulmoclaude/common` の `isRecord` / `isErrorWithCode` / `isUnknownArray` /
  `hasStringProp` を利用。`isRecord` の 13 個目のコピーは作っていない。自前の `isNotFoundError` は削除。
- `loadActive` / `loadHistory` に重複していた「read → ENOENT なら既定値 → JSON.parse」を
  `readJsonIfPresent` に集約（`undefined` はどの JSON 文書にもならないので番兵として安全）。
  併せて `let text: string` が消え、全て `const` になった。
- `entries` が `null` / 配列のときに「エントリ無し」と読めてしまう罠の WHY コメントは、
  該当ガードの直上に 1 行で残した。

## 検証

すべて worktree 相当のクローン（`packages/core` をビルドし、`@mulmoclaude/core` の解決先を
そのビルドへ差し替えた状態）で実行。

```
prettier --write packages/core/src/notifier/store.ts packages/core/test/notifier/test_engine.ts
eslint      packages/core/src/notifier/store.ts packages/core/test/notifier/test_engine.ts   → exit 0（0 errors / 0 warnings）
tsc --noEmit (packages/core, src + test)                                                     → exit 0
tsx --test  packages/core/test/**/test_*.ts                                                  → 708 pass / 0 fail
tsx --test  ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts                   → 8830 tests / 8815 pass / 1 fail(*)
```

- 変更前の同ファイルは `@typescript-eslint/consistent-type-assertions` が **5 warnings**（14:54 / 40:23 /
  44:10 / 66:98 / 69:10）、変更後は **0**。
- (*) 唯一の fail は `test/workspace/collections/test_derive.ts` の `deriveAll` 参照等価比較で、
  **変更を stash した状態でも同じく fail する**（クローン側 node_modules の二重解決による環境要因）。
  本 PR とは無関係。

### load / save の before / after 実測（外部 ground truth）

一時ディレクトリに実ファイルを書いて `loadActive` / `loadHistory` / `saveActive` / `saveHistory` を
直接叩くスクリプトを、変更前リビジョンと変更後で実行して diff を取得。

| 入力 | before | after |
|---|---|---|
| ファイル無し（ENOENT） | `{entries:{}}` / `{entries:[]}` | 同一 |
| 正常ファイル | ロード成功 | 同一 |
| 不正 JSON | `SyntaxError` 送出 | 同一 |
| JSON が `null` / 数値 / 文字列 / 配列 | `malformed …` 送出 | 同一 |
| `entries` 欠落 / `null` / 文字列 | `malformed …` 送出 | 同一 |
| active で `entries` が配列 / history で `entries` がオブジェクト | `malformed …` 送出 | 同一 |
| entry が必須のみ / 未知フィールド付き | 通過 | 同一（通過） |
| **entry が `null` / 文字列 / `title` 欠落 / `title` が数値 / `severity` 不正 / `lifecycle` 不正** | **そのまま通過** | **`malformed active.json at <path>` 送出** |
| **正常 entry と壊れた entry の混在** | **両方通過** | **送出** |
| **history 要素が `null` / 文字列 / `terminalType` 不正・欠落 / `terminalAt` 欠落** | **そのまま通過** | **`malformed history.json at <path>` 送出** |
| `saveActive` / `saveHistory` の writer 受け渡しペイロード | 入力と同一 | 同一 |
| load → save のラウンドトリップ | 同一 | 同一 |
| 全ケースのディスク上のファイル | 書き換え無し | 書き換え無し |

差分は太字の 3 行だけで、それ以外は完全一致。

### 追加テスト（`packages/core/test/notifier/test_engine.ts`）

- 必須フィールドのみ／未知フィールド付きの手書き entry がロードできる（過剰厳格化の回帰ガード）
- 壊れた entry 1 件で `active.json` 全体が reject され、**ファイルはバイト単位で不変**
- 壊れた history 要素があっても publish / clear は成功し、`history.json` は書き換えられない
  （落ちるのは `listHistory()` のみ）

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Tighten validation of notifier state JSON files by replacing type assertions with comprehensive runtime type guards, while preserving behavior for valid and legacy files and surfacing malformed data as explicit errors without rewriting user-edited files.

Enhancements:
- Introduce runtime guards for notifier active and history entries/files, fully validating declared fields and enums instead of relying on TypeScript type assertions.
- Refactor file reading logic into a shared JSON loader that returns a sentinel for missing files and uses common error helpers for ENOENT detection.
- Ensure malformed active or history entries cause the entire file to be rejected with clear errors while keeping on-disk contents unchanged, improving data integrity and debuggability.

Tests:
- Extend notifier engine tests to cover hand-written entries, tolerance of unknown fields, rejection behavior for malformed entries, and the guarantee that invalid files are not rewritten.