### PR TITLE
fix(plugins): 6 つの `null as never` を実体のある空 ToolContext に置換（mindmap の 500 クラッシュも解消）

### DIFF
--- a/server/api/routes/plugins.ts
+++ b/server/api/routes/plugins.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import type { ToolContext } from "gui-chat-protocol";
 import { executeMindMap } from "@gui-chat-plugin/mindmap";
 import { executeSpreadsheet, type SpreadsheetArgs } from "../../../src/plugins/spreadsheet/definition.js";
 import { executeQuiz } from "@mulmochat-plugin/quiz";
@@ -222,12 +223,11 @@ bindRoute(
   },
 );
 
-// `null as never` in the calls below: each plugin's `execute*`
-// function expects a client-side context object as its first
-// argument. The server-side bridge has no such context — these
-// functions only touch their second arg (the request body) on this
-// path — so we satisfy the type signature with a never cast rather
-// than fabricating a fake context.
+// Every `ToolContext` field is optional, so `{}` is a valid context carrying no
+// client-side state — what the server has, and what `runtime-plugin.ts` already
+// passes. `null` is not: `executeMindMap` reads `context.currentResult` unguarded
+// and throws on it. Frozen because one instance serves every request.
+const SERVER_TOOL_CONTEXT: ToolContext = Object.freeze({});
 
 // presentSpreadsheet — validate, then save sheets to disk
 bindRoute(
@@ -294,20 +294,20 @@ bindRoute(
 // createMindMap — uses package execute for node layout computation
 router.post(
   API_ROUTES.plugins.mindmap,
-  wrapPluginExecute<Parameters<typeof executeMindMap>[1]>((req) => executeMindMap(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeMindMap>[1]>((req) => executeMindMap(SERVER_TOOL_CONTEXT, req.body)),
 );
 
 // putQuestions — quiz
 router.post(
   API_ROUTES.plugins.quiz,
-  wrapPluginExecute<Parameters<typeof executeQuiz>[1]>((req) => executeQuiz(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeQuiz>[1]>((req) => executeQuiz(SERVER_TOOL_CONTEXT, req.body)),
 );
 
 // presentForm — form
 bindRoute(
   router,
   API_ROUTES.form.dispatch,
-  wrapPluginExecute<Parameters<typeof executeForm>[1]>((req) => executeForm(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeForm>[1]>((req) => executeForm(SERVER_TOOL_CONTEXT, req.body)),
 );
 
 // presentCollection — render a collection (or one item) as an inline,
@@ -325,7 +325,7 @@ bindRoute(
 // filename, id, or enum value) can't be read as instructions once appended to
 // the LLM-facing result.
 async function dispatchPresentCollection(req: Request<object, unknown, PresentCollectionArgs>) {
-  const result = await executePresentCollection(null as never, req.body);
+  const result = await executePresentCollection(SERVER_TOOL_CONTEXT, req.body);
   const slug = result.data?.collectionSlug;
   if (!slug) return result; // error result (no slug) — nothing to validate
   if (isAblated("validation")) return result; // evaluation-only: issue reporting ablated
@@ -368,7 +368,7 @@ bindRoute(
 // present3d — 3D visualization
 router.post(
   API_ROUTES.plugins.present3d,
-  wrapPluginExecute<Parameters<typeof executePresent3D>[1]>((req) => executePresent3D(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executePresent3D>[1]>((req) => executePresent3D(SERVER_TOOL_CONTEXT, req.body)),
 );
 
 // mapControl — Google Map (showLocation / Places / Directions etc.)
@@ -378,7 +378,7 @@ router.post(
 // receives the API key as a prop sourced from `AppSettings`.
 router.post(
   API_ROUTES.plugins.googleMap,
-  wrapPluginExecute<Parameters<typeof executeMapControl>[1]>((req) => executeMapControl(null as never, req.body)),
+  wrapPluginExecute<Parameters<typeof executeMapControl>[1]>((req) => executeMapControl(SERVER_TOOL_CONTEXT, req.body)),
 );
 
 // META aggregator diagnostics — boot-time host/plugin or plugin/plugin


### PR DESCRIPTION
## Summary

`server/api/routes/plugins.ts` の 6 箇所の `null as never` を撤去した。gui-chat-protocol の `ToolContext` はフィールドが全て optional なので、空オブジェクトは「クライアント側の状態を持たない正当な context」であり、サーバー側ブリッジの実態そのもの。同じ値をランタイムプラグインの dispatch ルート (`server/api/routes/runtime-plugin.ts:107`) が既に渡しており、本ファイルだけがその慣習から外れていた。

調査の過程で **既存バグを発見・修正** した。`null` は単なる型の嘘ではなく実クラッシュで、`POST /api/mindmap` は `create` 以外の全アクションが 500 を返していた。

## Items to Confirm / Review

各 executor がどのケースに該当したか（第 1 引数 `context` の実使用状況を実装本体で確認）:

| executor | 実体 | context 使用 | ケース |
|---|---|---|---|
| `executeMindMap` | `@gui-chat-plugin/mindmap`（外部 npm） | **使用する** — `getExistingMapData` が `context.currentResult?.data` を **context 自体を optional chaining せずに** 読む | **ケース 2（バグ）** |
| `executeQuiz` | `@mulmochat-plugin/quiz`（外部 npm） | 未使用（第 1 引数は即座にシャドウされる） | ケース 1 |
| `executeForm` | `packages/plugins/form-plugin/src/core/plugin.ts:61` | 未使用（`_context`） | ケース 1 |
| `executePresentCollection` | `packages/core/src/collection/core/presentCollection.ts:46` | 未使用（`_context`） | ケース 1 |
| `executePresent3D` | `@gui-chat-plugin/present3d`（外部 npm） | 未使用 | ケース 1 |
| `executeMapControl` | `@gui-chat-plugin/google-map`（外部 npm） | 未使用 | ケース 1 |

- **シグネチャ変更なし / blast radius ゼロ**。executor 側は 1 行も触っていない。変更は `server/api/routes/plugins.ts` の 1 ファイルのみ。プラグイン境界も動かしていない（host 側で完結）。
- **残した cast: 0 件**（6/6 撤去）。`eslint-disable` / `@ts-ignore` / `any` / `let` の追加もなし。
- **確認してほしい点**: mindmap のバグ修正により、`/api/mindmap` の `add_node` / `delete_node` / `connect` / `update` / `rebalance` が 500 → 200 に変わる（意図した挙動修正）。他 5 ルートはバイト単位で不変。
- **上流について**: `@gui-chat-plugin/mindmap` 側の `getExistingMapData` は `ToolContext`（non-nullable 宣言）を受ける前提なので実装として不正ではない。非があるのは `null` を渡していた host 側で、本 PR で解消した。上流パッケージは変更していない。

## 実装方針

```ts
// Every `ToolContext` field is optional, so `{}` is a valid context carrying no
// client-side state — what the server has, and what `runtime-plugin.ts` already
// passes. `null` is not: `executeMindMap` reads `context.currentResult` unguarded
// and throws on it. Frozen because one instance serves every request.
const SERVER_TOOL_CONTEXT: ToolContext = Object.freeze({});
```

- 型ガードを書く余地は無い（証明すべき事実が無く、`{}` が宣言型を素で満たす）。偽のガードを足すより、型が既に表現している「空の context」をそのまま渡すのが正直な形。
- `Object.freeze` は全リクエストで 1 インスタンスを共有するため。executor が context に書き戻したらリクエスト間で状態が漏れるので、静かに漏れるより例外で落とす。
- ファイル内 1 箇所の定数なので export せず、`docs/shared-utils.md` への追記も不要（共有ヘルパではない）。
- `runtime-plugin.ts` の `const context = {}` との共通定数化も検討したが、本 issue の scope 外のファイルを触ることになるため見送り（コメントで相互参照のみ）。

## 検証

### 静的チェック

```bash
npx prettier --write server/api/routes/plugins.ts   # unchanged
npx eslint server/api/routes/plugins.ts             # 出力なし（error 0 / warning 0）
npx tsc -p server/tsconfig.json --noEmit            # 出力なし
```

`consistent-type-assertions` (`assertionStyle: "never"`) は main で warn として有効。変更後の本ファイルは警告 0 件。

### テスト

対象 executor / ルートを含むテストを抽出して実行:

```bash
grep -rl "executeMindMap\|executeQuiz\|executeForm\|executePresentCollection\|executePresent3D\|executeMapControl" test src server packages
npx tsx --test test/routes/test_pluginPaths.ts test/routes/test_presentDocumentRoute.ts \
  test/routes/test_canvasImageRoutes.ts test/workspace/collections/test_validate.ts \
  test/utils/collections/test_presentSeed.ts test/api/routes/test_runtimePluginRoot.ts \
  test/components/test_stackview_googlemap_wiring.ts
# → tests 83 / pass 83 / fail 0

npx tsx --test packages/core/test/collection/*.ts
# → tests 52 / pass 52 / fail 0
```

フルスイート (`tsx --test ./test/*/test_*.ts ...`) も実行。`test/composables/*` に負荷依存の flaky な file-level 失敗が出るが、**変更前（stash 済み）でも同一現象が再現し、失敗するファイル集合は実行ごとに変わり、単独実行では全て pass する**（`test_useFileTree` / `test_useMcpTools` / `test_usePluginErrorBoundary` を単独実行 → 10/10 pass）。本変更とは無関係。

### 6 ルートの before/after 実挙動 diff（ground truth）

本物の `plugins.ts` の router を express にマウントし、各ルートへ実際の payload を POST するスクリプトを scratch に作成。**同一スクリプトを変更前（`git stash`）と変更後の両方で実行して diff**（スクリプトは検証後に削除）。

8 プローブ（mindmap は 3 アクション）中 **6 つがバイト単位で完全一致**:

- `mindmap/create` → 200、同一
- `quiz` → 200、同一
- `form` → 200、同一
- `presentCollection` → 200、同一
- `present3d` → 200、同一
- `googleMap` → 200、同一

差分は mindmap の 2 アクションのみ:

```diff
-### mindmap/add_node [/api/mindmap] -> 500
-{"message":"Cannot read properties of null (reading 'currentResult')"}
-### mindmap/rebalance [/api/mindmap] -> 500
-{"message":"Cannot read properties of null (reading 'currentResult')"}
+### mindmap/add_node [/api/mindmap] -> 200
+{"toolName":"createMindMap","message":"Added \"testing\" to the mind map","data":{...},"updating":true}
+### mindmap/rebalance [/api/mindmap] -> 200
+{"toolName":"createMindMap","message":"Existing map is required for rebalance","instructions":"The mind map data is missing."}
```

### バグの root cause

`@gui-chat-plugin/mindmap` の `getExistingMapData(context, args.existingMap)` 冒頭:

```js
function b(e, t) {
  let n = e.currentResult?.data;   // ← e (= context) 自体は optional chaining されていない
```

`context` が `null` だと `TypeError: Cannot read properties of null (reading 'currentResult')`。この関数を呼ぶのは `add_node` / `delete_node` / `connect` / `update` / `rebalance` の 5 アクションで、`create` だけが呼ばないため唯一生き残っていた。`{}` を渡せば `undefined` になり、args 側の `existingMap` へフォールバックする本来の設計どおりに動く。

再現コマンド（変更前のリビジョンで）:

```bash
curl -s -XPOST localhost:<port>/api/mindmap -H 'content-type: application/json' \
  -d '{"action":"rebalance"}'
# {"message":"Cannot read properties of null (reading 'currentResult')"}   ← HTTP 500
```

サーバーログにも同内容が出る:

```
ERROR [plugins] execute: threw route=/api/mindmap error="Cannot read properties of null (reading 'currentResult')"
```

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Replace unsafe null ToolContext usage in plugin routes with a shared empty ToolContext to align with runtime-plugin behavior and prevent mindmap crashes.

Bug Fixes:
- Fix mindmap plugin actions that returned HTTP 500 by providing a valid ToolContext instead of null.
- Ensure mindmap add_node, delete_node, connect, update, and rebalance actions now execute successfully with proper fallback behavior.

Enhancements:
- Introduce a frozen, shared server-side ToolContext for plugin executors to avoid per-request fabrication and potential state leakage.
- Remove all `null as never` casts from plugin route handlers in favor of a typed, empty ToolContext to better reflect actual server context.