### PR TITLE
refactor(events): drop type assertions in session-store

### DIFF
--- a/server/events/session-store/index.ts
+++ b/server/events/session-store/index.ts
@@ -13,6 +13,7 @@ import { updateHasUnread } from "../../utils/files/session-io.js";
 import { EVENT_TYPES, GENERATION_KINDS, type GenerationKind, type PendingGeneration, generationKey } from "../../../src/types/events.js";
 import { ONE_HOUR_MS, ONE_MINUTE_MS } from "../../utils/time.js";
 import { errorMessage } from "../../utils/errors.js";
+import { hasStringProp } from "../../utils/types.js";
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -223,7 +224,7 @@ export async function markRead(chatSessionId: string): Promise<void> {
 
 /** Publish an agent event to the session's channel + update store. */
 export function pushSessionEvent(chatSessionId: string, event: Record<string, unknown>): void {
-  const type = event.type as string;
+  const type = hasStringProp(event, "type") ? event.type : undefined;
   const isGenerationEvent = type === EVENT_TYPES.generationStarted || type === EVENT_TYPES.generationFinished;
 
   // Non-generation events keep the pre-existing "store or drop"
@@ -281,7 +282,7 @@ export function pushSessionEvent(chatSessionId: string, event: Record<string, un
  * Returns the empty↔non-empty transition so the caller can decide
  * whether to flip hasUnread and notify.
  */
-function resolveGenerationDelta(chatSessionId: string, type: string, event: Record<string, unknown>): GenerationDelta {
+function resolveGenerationDelta(chatSessionId: string, type: string | undefined, event: Record<string, unknown>): GenerationDelta {
   const session = store.get(chatSessionId);
   if (session) return applyEventToSession(session, type, event);
   if (type === EVENT_TYPES.generationStarted || type === EVENT_TYPES.generationFinished) {
@@ -381,44 +382,64 @@ export async function persistToolCallEvent(resultsFilePath: string, event: Recor
   await appendFile(resultsFilePath, buildToolCallLine(event));
 }
 
-function applyEventToSession(session: ServerSession, type: string, event: Record<string, unknown>): GenerationDelta {
+function applyEventToSession(session: ServerSession, type: string | undefined, event: Record<string, unknown>): GenerationDelta {
   if (type === EVENT_TYPES.toolCall) {
-    session.toolCallHistory.push({
-      toolUseId: event.toolUseId as string,
-      toolName: event.toolName as string,
-      args: event.args,
-      timestamp: Date.now(),
-    });
-    if (env.persistToolCalls) {
-      // Fire-and-forget: a write failure shouldn't block the live
-      // SSE flow. The in-memory `toolCallHistory` is the
-      // authoritative copy during the run; the jsonl line is a
-      // debug aid that survives refresh.
-      //
-      // Goes through `enqueueJsonlAppend` so this append precedes
-      // any `tool_result` for the same toolUseId — `pushToolResult`
-      // also enqueues, and the queue is FIFO. Without the queue, the
-      // awaited `tool_result` could hit disk before the unawaited
-      // `tool_call`, and a downstream reader assuming call-before-
-      // result ordering would mis-associate events.
-      enqueueJsonlAppend(session, buildToolCallLine(event)).catch((err: unknown) => {
-        log.warn("session-store", "persist tool_call failed (non-fatal)", {
-          chatSessionId: session.chatSessionId,
-          error: errorMessage(err),
-        });
-      });
-    }
+    recordToolCall(session, event);
   } else if (type === EVENT_TYPES.toolCallResult) {
-    const entry = session.toolCallHistory.find((historyEntry) => historyEntry.toolUseId === event.toolUseId);
-    if (entry) entry.result = event.content as string;
+    applyToolCallResult(session, event);
   } else if (type === EVENT_TYPES.status) {
-    session.statusMessage = event.message as string;
+    // Empty string is the same "no status" value `beginRun` / `endRun` write,
+    // so a message-less event can't leave a non-string in a `string` field.
+    session.statusMessage = hasStringProp(event, "message") ? event.message : "";
     // No notifySessionsChanged() here — status updates are high-frequency
     // and flow to subscribed clients via the session.<id> channel directly.
   } else if (type === EVENT_TYPES.generationStarted || type === EVENT_TYPES.generationFinished) {
     return updatePendingGenerations(session, type, event);
   }
   return "same";
+}
+
+/**
+ * Append one validated `tool_call` to the session history. `toolUseId`
+ * and `toolName` identify the call for every later `tool_call_result`
+ * lookup, so an event missing either is logged and dropped rather than
+ * stored as a history row that nothing can ever match.
+ */
+function recordToolCall(session: ServerSession, event: Record<string, unknown>): void {
+  if (!hasStringProp(event, "toolUseId") || !hasStringProp(event, "toolName")) {
+    log.warn("session-store", "malformed tool_call event", { chatSessionId: session.chatSessionId });
+    return;
+  }
+  session.toolCallHistory.push({
+    toolUseId: event.toolUseId,
+    toolName: event.toolName,
+    args: event.args,
+    timestamp: Date.now(),
+  });
+  if (!env.persistToolCalls) return;
+  // Fire-and-forget: a write failure shouldn't block the live
+  // SSE flow. The in-memory `toolCallHistory` is the
+  // authoritative copy during the run; the jsonl line is a
+  // debug aid that survives refresh.
+  //
+  // Goes through `enqueueJsonlAppend` so this append precedes
+  // any `tool_result` for the same toolUseId — `pushToolResult`
+  // also enqueues, and the queue is FIFO. Without the queue, the
+  // awaited `tool_result` could hit disk before the unawaited
+  // `tool_call`, and a downstream reader assuming call-before-
+  // result ordering would mis-associate events.
+  enqueueJsonlAppend(session, buildToolCallLine(event)).catch((err: unknown) => {
+    log.warn("session-store", "persist tool_call failed (non-fatal)", {
+      chatSessionId: session.chatSessionId,
+      error: errorMessage(err),
+    });
+  });
+}
+
+function applyToolCallResult(session: ServerSession, event: Record<string, unknown>): void {
+  const entry = session.toolCallHistory.find((historyEntry) => historyEntry.toolUseId === event.toolUseId);
+  if (!entry) return;
+  entry.result = hasStringProp(event, "content") ? event.content : undefined;
 }
 
 function updatePendingGenerations(session: ServerSession, type: string, event: Record<string, unknown>): GenerationDelta {
@@ -543,12 +564,12 @@ async function persistHasUnread(chatSessionId: string, hasUnread: boolean): Prom
   }
 }
 
-function publishToSessionChannel(chatSessionId: string, data: unknown): void {
+function publishToSessionChannel(chatSessionId: string, data: Record<string, unknown>): void {
   pubsub?.publish(sessionChannel(chatSessionId), data);
   const listeners = sessionListeners.get(chatSessionId);
   if (listeners) {
     for (const listener of listeners) {
-      listener(data as Record<string, unknown>);
+      listener(data);
     }
   }
 }

--- a/test/events/test_session_store.ts
+++ b/test/events/test_session_store.ts
@@ -218,3 +218,55 @@ describe("pushSessionEvent — pendingGenerations lifecycle", () => {
     assert.equal(Object.keys(pending).length, 0, "no leftover keys");
   });
 });
+
+// The store reads these fields off a `Record<string, unknown>` whose shape
+// nothing validates upstream. Pin that a field the declared type promises is
+// a string can never be stored as `undefined`, a number, or an object.
+describe("pushSessionEvent — malformed payload fields", () => {
+  beforeEach(() => {
+    initSessionStore(stubPubSub());
+    getOrCreateSession("s1", sessionOpts());
+  });
+
+  const history = () => getSession("s1")?.toolCallHistory ?? [];
+
+  it("drops a tool_call missing toolUseId or toolName", () => {
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolName: "Bash", args: {} });
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolUseId: "t1", args: {} });
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolUseId: 42, toolName: 7, args: {} });
+    assert.deepEqual(history(), []);
+  });
+
+  it("keeps a well-formed tool_call and its result", () => {
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolUseId: "t1", toolName: "Bash", args: { cmd: "ls" } });
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCallResult, toolUseId: "t1", content: "out" });
+    assert.equal(history().length, 1);
+    assert.equal(history()[0].toolUseId, "t1");
+    assert.equal(history()[0].toolName, "Bash");
+    assert.equal(history()[0].result, "out");
+  });
+
+  it("leaves result undefined when tool_call_result content is absent or not a string", () => {
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolUseId: "t1", toolName: "Bash", args: {} });
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCallResult, toolUseId: "t1" });
+    assert.equal(history()[0].result, undefined);
+    pushSessionEvent("s1", { type: EVENT_TYPES.toolCallResult, toolUseId: "t1", content: { nested: true } });
+    assert.equal(history()[0].result, undefined);
+  });
+
+  it("falls back to an empty statusMessage when status.message is absent or not a string", () => {
+    pushSessionEvent("s1", { type: EVENT_TYPES.status, message: "Thinking..." });
+    assert.equal(getSession("s1")?.statusMessage, "Thinking...");
+    pushSessionEvent("s1", { type: EVENT_TYPES.status });
+    assert.equal(getSession("s1")?.statusMessage, "");
+    pushSessionEvent("s1", { type: EVENT_TYPES.status, message: 123 });
+    assert.equal(getSession("s1")?.statusMessage, "");
+  });
+
+  it("ignores an event whose type is absent or not a string", () => {
+    pushSessionEvent("s1", { message: "no type" });
+    pushSessionEvent("s1", { type: 99, toolUseId: "t1", toolName: "Bash", args: {} });
+    assert.deepEqual(history(), []);
+    assert.equal(getSession("s1")?.statusMessage, "");
+  });
+});


### PR DESCRIPTION
## Summary

`server/events/session-store/index.ts` にあった 6 個の `as` キャストをすべて除去した（#2692）。
これらはすべて、上流で一切検証されていない `Record<string, unknown>` のイベントペイロードから
「string のはずのフィールド」を読み出す箇所で、実際には `undefined` / number / object が
`string` と宣言された欄にそのまま格納され、永続化・UI 描画まで流れていた。
共有ガード `hasStringProp`（`@mulmoclaude/common` → `server/utils/types.ts`）で置き換え、
新しいヘルパーは一切追加していない。`eslint-disable` / `@ts-ignore` / `any` / `let` も不使用。

## Items to Confirm / Review

まず前提として、`tool_call` / `tool_call_result` / `status` の唯一の実プロデューサは
`server/agent/stream.ts` の `AgentEvent` 判別ユニオン（`blockToEvent()`）であり、
そこでは `toolUseId: string` / `toolName: string` / `content: string`（`undefined` は `""` に正規化）/
`message: string` が **型として保証されている**。つまり以下の「malformed」ケースは
現行のプロデューサからは発生しない。キャストは型情報が `Record<string, unknown>` で
消えたことの穴埋めにすぎなかった。

フィールドごとの判断:

| 行 | フィールド | 変更前の実挙動 | 採用した方針 | 理由 |
|---|---|---|---|---|
| 226 | `event.type` | 欠落時 `undefined` を `string` として保持。全比較が不一致になり何も起きない | `string \| undefined` として読む | **挙動完全不変**。非 string 値でも全比較が外れる点は変更前と同じ |
| 387/388 | `toolUseId` / `toolName` | `undefined` / number のまま履歴に push され、jsonl にも欠損キーのまま書かれる | **log.warn + そのイベントを破棄** | この 2 つは後続の `tool_call_result` 突合キー。欠けた行は永久に一致しないゴミ行になる。同ファイル既存の `parseGenerationPayload` の「malformed は warn して no-op」と同じ流儀 |
| 413 | `content` | 欠落時 `undefined`（変更後と同じ）。非 string 時は object をそのまま `result?: string` に格納 | `string \| undefined` として読む | 代入先が `result?: string` で `undefined` が正当な値。**欠落ケースは変更前と完全に同一** |
| 415 | `message` | 欠落時 `undefined`、`123` なら number をそのまま `statusMessage: string` に格納 | `""` へフォールバック | `statusMessage` は required `string`。`""` は `beginRun` / `endRun` が書く「状態なし」値そのもので、描画上も `undefined` と同じく falsy |
| 551 | `data as Record<string, unknown>` | — | `publishToSessionChannel(data)` の引数型を `unknown` → `Record<string, unknown>` に**狭める** | 呼び出し 3 箇所はすべて record を渡している。リスナ側（`SessionEventListener`、および `@mulmobridge/chat-service` の `OnSessionEventFn`）は `Record<string, unknown>` を要求するため「リスナを `unknown` に広げる」は不可。**ランタイム挙動ゼロ変更** |

**レビューしてほしい点**

- 387/388 の「破棄」判断。malformed な `tool_call` は現行プロデューサからは出ないが、挙動としては
  変更前は履歴に 1 行増え、`PERSIST_TOOL_CALLS=1` なら jsonl にも 1 行増えていた。これを止めている。
  「壊れた行でも残したい」という運用意図があればここは再検討が必要。
- 415 の `undefined` → `""`。JSON 化されるとキーが消える／`""` になる差が出るが、
  どちらも falsy で `v-if` / 表示ともに同じ扱いになるはず、という前提で判断している。
- 残したキャスト: **なし**（6/6 除去）。

**ついでに見つかった型不整合（バグ）**

`tool_call_result` の `content` が string でない場合、変更前は `entry.result`（宣言は
`result?: string`）に **object がそのまま入っていた**。`server/events/session-store` の
`ToolCallHistoryItem.result` は右サイドバーのツール履歴でそのまま描画されるため、
キャストが型の嘘を隠していた実例。再現は「検証」節のリプレイ差分（`resultType: "object"` →
`"undefined"`）を参照。現行プロデューサ（`blockToEvent`）は必ず string に正規化するので
実運用では踏まないが、キャストがある限りコンパイラは検出できない。

## 実装方針

- 新規ヘルパーは書かず、`docs/shared-utils.md` 記載の共有ガード `hasStringProp(value, key)`
  （`@mulmoclaude/common`、`server/utils/types.ts` 経由）を使用。
- `applyEventToSession` が 20 行超になっていたので、`tool_call` 分岐を `recordToolCall()`、
  `tool_call_result` 分岐を `applyToolCallResult()` に抽出。既存コメント（jsonl FIFO キューの
  根拠、`notifySessionsChanged` を呼ばない理由）はそのまま移設している。
- `resolveGenerationDelta` / `applyEventToSession` の `type` 引数を `string` → `string | undefined` に。
  generation 系ヘルパーは `type === EVENT_TYPES.generation*` で絞り込んだ後に呼ばれるため
  `string` のままで型が通る。
- `test/events/test_session_store.ts` に malformed ペイロード用の describe を追加（5 ケース）。

## 検証

すべて worktree `mc3-wt-session-store`（`origin/main` = `f1a9d837c` から分岐）で実行。

```
npx prettier --write server/events/session-store/index.ts test/events/test_session_store.ts
  → both "(unchanged)"
npx eslint server/events/session-store/index.ts test/events/test_session_store.ts
  → exit 0（error 0 / consistent-type-assertions warning 0）
yarn typecheck:server   → exit 0
yarn typecheck:test     → exit 0
yarn typecheck (full)   → exit 0
yarn lint (repo 全体)    → exit 0
```

関連テスト（`grep -rl "session-store" test server` で抽出した全 test）:

```
npx tsx --test test/events/test_session_store.ts test/events/test_persistToolCalls.ts \
                test/agent/test_agent_lifecycle_resilience.ts test/routes/test_wikiInternalSnapshotRoute.ts
  → tests 38 / pass 38 / fail 0   （追加テスト込みでは 24 + ... / fail 0）
```

さらに commit 時に pre-commit フック
（`yarn build:packages && yarn format --check && yarn lint && yarn typecheck && yarn build && yarn test`）
がフルで走り、通過している。

### イベントリプレイ差分（外部 ground truth）

`initSessionStore` にスタブ pubsub を刺し、`PERSIST_TOOL_CALLS=1` で
「正常な tool_call → tool_call_result → status → text → generation_started/finished → endRun」
に加えて malformed イベント（`toolUseId` 欠落 / `toolName` 欠落 / 両方 number /
`content` 欠落 / `content` が object / `message` 欠落 / `message` が number /
`type` 欠落 / `type` が number / 未知の generation kind / store に無いセッション）を流し、
**変更前リビジョン（`origin/main` チェックアウト）と変更後 worktree の両方**で
セッション状態・pubsub publish 列・in-process リスナ受信列・jsonl を JSON ダンプして diff した。
`undefined` は `JSON.stringify` で消えるため、全フィールドに `typeof` を併記している。

差分は **malformed イベントのみ**。以下がすべて:

1. `toolCallHistory` — 変更前は malformed な `tool_call` 3 件も push されていた:
   - `{toolUseId: undefined (typeof "undefined"), toolName: "MissingId"}`
   - `{toolUseId: "toolu_3", toolName: undefined (typeof "undefined")}`
   - `{toolUseId: 42 (typeof "number"), toolName: 7 (typeof "number")}`
   変更後はこの 3 件が消え、履歴長 `6 → 3`。**正常な 3 件は完全に同一**。
2. `result` — `content: {nested:true}` のケースが `"[object Object]" / resultType "object"` →
   `undefined / resultType "undefined"`。`content` 欠落のケースは前後とも `undefined` で不変。
3. `statusMessage` — `{type:"status"}`（message なし）が `undefined / typeof "undefined"` → `"" / typeof "string"`、
   `{type:"status", message:123}` が `123 / typeof "number"` → `"" / typeof "string"`。
   正常な `"Thinking..."` / `"Working…"` は不変。
4. jsonl（`PERSIST_TOOL_CALLS=1`）— malformed 由来の 3 行が消えた。正常な 3 行はバイト一致。
5. **`published`（pubsub 配信）と `heard`（in-process リスナ受信）は差分ゼロ** ——
   malformed を含む全イベントが従来どおりチャネルとリスナに配信される。
   変わったのは「store が保持する内容」だけで、ワイヤ契約は不変。
6. `pendingGenerations` / `hasUnread` / `isRunning` / storeless generation 経路も差分ゼロ。

検証スクリプトは scratchpad 内の使い捨てで、確認後に削除済み（リポジトリには追加していない）。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Improve session-store event handling by validating string fields instead of using type assertions and tightening type contracts around session event publishing.

Bug Fixes:
- Prevent malformed tool_call events from being stored when toolUseId or toolName are missing or non-string, avoiding unusable history entries.
- Ensure tool_call_result content and status.message never persist non-string values into string-typed fields, falling back to undefined or empty strings instead.

Enhancements:
- Replace unsafe string casts in session-store with a shared hasStringProp guard and allow events with absent or non-string type to be ignored.
- Extract tool_call and tool_call_result handling into dedicated helper functions to clarify session event application logic.
- Restrict publishToSessionChannel to Record<string, unknown> to align with listener expectations and remove the need for runtime casts.

Tests:
- Add tests covering malformed session event payloads for tool_call, tool_call_result, status, and type fields to pin the new validation behavior.