### PR TITLE
fix(accounting): parse the dispatch payload instead of casting it (#2695)

### DIFF
--- a/packages/plugins/accounting-plugin/src/server/accountNormalize.ts
+++ b/packages/plugins/accounting-plugin/src/server/accountNormalize.ts
@@ -1,8 +1,9 @@
-// Pure normalization for the persisted Account record. Lives in its
-// own module so unit tests can exercise the field-whitelist + active-
-// flag policy without spinning up the file system, and so the
-// service-layer `upsertAccount` stays under the repo's 20-line
-// guideline.
+// Pure parsing + normalization for the Account record: `parseAccountInput`
+// narrows a wire payload to an `Account`, `normalizeStoredAccount` decides
+// what of it reaches disk. Lives in its own module so unit tests can
+// exercise the field-whitelist + active-flag policy without spinning up
+// the file system, and so the service-layer `upsertAccount` stays under
+// the repo's 20-line guideline.
 //
 // Policy summary (mirrored in the `upsertAccount` JSDoc):
 //   - whitelist: only `code`, `name`, `type`, optional `note`, and
@@ -21,7 +22,33 @@
 //                          mentioning the active flag — the bug
 //                          coverage that prompted this helper)
 
-import type { Account } from "../shared/types.js";
+import { isRecord } from "@mulmoclaude/common";
+
+import type { Account, AccountType } from "../shared/types.js";
+import { ACCOUNT_TYPES } from "../shared/types.js";
+
+export type AccountParseResult = { ok: true; account: Account } | { ok: false; message: string };
+
+function isAccountType(value: unknown): value is AccountType {
+  return ACCOUNT_TYPES.some((accountType) => accountType === value);
+}
+
+/** Narrow a wire payload to an `Account`. `name` and `type` are as
+ *  required as `code`: an account persisted without a type is invisible
+ *  to every report, which groups rows by it. */
+export function parseAccountInput(raw: unknown): AccountParseResult {
+  if (!isRecord(raw)) return { ok: false, message: "account is required — pass an object with code, name, and type" };
+  const { code, name, type, note, active } = raw;
+  if (typeof code !== "string" || code.length === 0) return { ok: false, message: "account code is required" };
+  if (typeof name !== "string" || name.trim() === "") return { ok: false, message: "account name is required" };
+  if (!isAccountType(type)) return { ok: false, message: `account type ${JSON.stringify(type)} is invalid — must be one of: ${ACCOUNT_TYPES.join(", ")}` };
+  if (note !== undefined && typeof note !== "string") return { ok: false, message: "account note must be a string when supplied" };
+  if (active !== undefined && typeof active !== "boolean") return { ok: false, message: "account active must be a boolean when supplied" };
+  const account: Account = { code, name, type };
+  if (typeof note === "string") account.note = note;
+  if (typeof active === "boolean") account.active = active;
+  return { ok: true, account };
+}
 
 export function normalizeStoredAccount(input: Account, existing?: Account): Account {
   const stored: Account = { code: input.code, name: input.name, type: input.type };

--- a/packages/plugins/accounting-plugin/src/server/accountNormalize.ts
+++ b/packages/plugins/accounting-plugin/src/server/accountNormalize.ts
@@ -1,9 +1,9 @@
 // Pure parsing + normalization for the Account record: `parseAccountInput`
 // narrows a wire payload to an `Account`, `normalizeStoredAccount` decides
-// what of it reaches disk. Lives in its own module so unit tests can
-// exercise the field-whitelist + active-flag policy without spinning up
-// the file system, and so the service-layer `upsertAccount` stays under
-// the repo's 20-line guideline.
+// what of it reaches disk. Both are pure, so unit tests exercise the
+// shape rules + the field-whitelist + the active-flag policy without
+// spinning up a file system, and the service-layer `upsertAccount` is
+// left with only its file-IO and snapshot-invalidation orchestration.
 //
 // Policy summary (mirrored in the `upsertAccount` JSDoc):
 //   - whitelist: only `code`, `name`, `type`, optional `note`, and

--- a/packages/plugins/accounting-plugin/src/server/journal.ts
+++ b/packages/plugins/accounting-plugin/src/server/journal.ts
@@ -11,6 +11,7 @@
 // `addEntries` call for the corrected booking.
 
 import { randomUUID } from "node:crypto";
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
 
 import type { Account, JournalEntry, JournalLine } from "../shared/types.js";
 
@@ -34,10 +35,17 @@ export interface ValidationError {
   message: string;
 }
 
-export interface ValidationResult {
-  ok: boolean;
-  errors: ValidationError[];
+/** The fields `parseEntry` proves about one wire entry. `makeEntry`
+ *  takes this, so an entry can only be built from input something
+ *  actually checked. */
+export interface ParsedEntry {
+  date: string;
+  lines: JournalLine[];
+  memo?: string;
+  replacesEntryId?: string;
 }
+
+export type EntryParseResult = { ok: true; entry: ParsedEntry } | { ok: false; errors: ValidationError[] };
 
 function lineHasExactlyOneSide(line: JournalLine): boolean {
   const hasDebit = typeof line.debit === "number" && line.debit !== 0;
@@ -87,32 +95,75 @@ export function netBalance(lines: readonly JournalLine[]): number {
   return net;
 }
 
-/** Pure validation. Does not throw; returns a list of issues so the
- *  REST handler can return a structured 400 instead of an opaque
- *  500. */
-function validateLine(line: JournalLine, idx: number, accountCodes: ReadonlySet<string>, errors: ValidationError[]): void {
+function checkTaxRegistrationId(value: unknown, idx: number, errors: ValidationError[]): void {
+  if (value === undefined) return;
+  if (typeof value !== "string") {
+    errors.push({ field: `lines[${idx}].taxRegistrationId`, message: "must be a string" });
+    return;
+  }
+  if (value.trim().length > MAX_TAX_REGISTRATION_ID_LENGTH) {
+    errors.push({
+      field: `lines[${idx}].taxRegistrationId`,
+      message: `must be at most ${MAX_TAX_REGISTRATION_ID_LENGTH} characters (got ${value.trim().length})`,
+    });
+  }
+}
+
+/** Narrow one wire value to a `JournalLine`, pushing an issue per bad
+ *  field. Shape only: account existence and the debit/credit-side rule
+ *  belong to the caller, because journal entries and opening balances
+ *  disagree about them. Returns null when nothing usable came out —
+ *  the caller drops the line rather than reading fields off it. */
+export function parseJournalLine(raw: unknown, idx: number, errors: ValidationError[]): JournalLine | null {
+  if (!isRecord(raw)) {
+    errors.push({ field: `lines[${idx}]`, message: "each line must be an object with an accountCode and a debit or credit amount" });
+    return null;
+  }
+  const issuesBefore = errors.length;
+  const { accountCode, debit, credit, memo, taxRegistrationId } = raw;
+  if (typeof accountCode !== "string") errors.push({ field: `lines[${idx}].accountCode`, message: "accountCode must be a string" });
+  if (debit !== undefined && !isNonNegativeNumber(debit)) errors.push({ field: `lines[${idx}].debit`, message: "debit must be a non-negative finite number" });
+  if (credit !== undefined && !isNonNegativeNumber(credit))
+    errors.push({ field: `lines[${idx}].credit`, message: "credit must be a non-negative finite number" });
+  if (memo !== undefined && typeof memo !== "string") errors.push({ field: `lines[${idx}].memo`, message: "memo must be a string" });
+  checkTaxRegistrationId(taxRegistrationId, idx, errors);
+  if (errors.length !== issuesBefore || typeof accountCode !== "string") return null;
+  const line: JournalLine = { accountCode };
+  // Re-tested rather than assigned straight through: the checks above
+  // proved these, but only a `typeof` narrows them for the compiler.
+  if (typeof debit === "number") line.debit = debit;
+  if (typeof credit === "number") line.credit = credit;
+  if (typeof memo === "string") line.memo = memo;
+  if (typeof taxRegistrationId === "string") line.taxRegistrationId = taxRegistrationId;
+  return line;
+}
+
+/** The rules a journal line answers to on top of its shape: the code
+ *  must name a real account, and exactly one side carries an amount. */
+function validateEntryLine(line: JournalLine, idx: number, accountCodes: ReadonlySet<string>, errors: ValidationError[]): void {
   if (!line.accountCode || !accountCodes.has(line.accountCode)) {
     errors.push({ field: `lines[${idx}].accountCode`, message: `unknown account code ${JSON.stringify(line.accountCode)}` });
-  }
-  if (line.debit !== undefined && !isNonNegativeNumber(line.debit)) {
-    errors.push({ field: `lines[${idx}].debit`, message: "debit must be a non-negative finite number" });
-  }
-  if (line.credit !== undefined && !isNonNegativeNumber(line.credit)) {
-    errors.push({ field: `lines[${idx}].credit`, message: "credit must be a non-negative finite number" });
   }
   if (!lineHasExactlyOneSide(line)) {
     errors.push({ field: `lines[${idx}]`, message: "each line must set exactly one of debit or credit (and to a non-zero amount)" });
   }
-  if (line.taxRegistrationId !== undefined) {
-    if (typeof line.taxRegistrationId !== "string") {
-      errors.push({ field: `lines[${idx}].taxRegistrationId`, message: "must be a string" });
-    } else if (line.taxRegistrationId.trim().length > MAX_TAX_REGISTRATION_ID_LENGTH) {
-      errors.push({
-        field: `lines[${idx}].taxRegistrationId`,
-        message: `must be at most ${MAX_TAX_REGISTRATION_ID_LENGTH} characters (got ${line.taxRegistrationId.trim().length})`,
-      });
-    }
-  }
+}
+
+function parseEntryLines(raw: readonly unknown[], accountCodes: ReadonlySet<string>, errors: ValidationError[]): JournalLine[] {
+  const lines: JournalLine[] = [];
+  raw.forEach((rawLine, idx) => {
+    const line = parseJournalLine(rawLine, idx, errors);
+    if (line === null) return;
+    validateEntryLine(line, idx, accountCodes, errors);
+    lines.push(line);
+  });
+  return lines;
+}
+
+function parseOptionalString(value: unknown, field: string, errors: ValidationError[]): string | undefined {
+  if (value === undefined || typeof value === "string") return value;
+  errors.push({ field, message: `${field} must be a string when supplied` });
+  return undefined;
 }
 
 /** Normalize a journal line before persistence: trim string fields
@@ -129,26 +180,35 @@ function normalizeLine(line: JournalLine): JournalLine {
   return out;
 }
 
-export function validateEntry(input: { date: string; lines: readonly JournalLine[]; accounts: readonly Account[] }): ValidationResult {
-  const errors: ValidationError[] = [];
-  if (!isValidCalendarDate(input.date)) {
-    errors.push({ field: "date", message: `expected YYYY-MM-DD calendar date, got ${JSON.stringify(input.date)}` });
+/** Parse one entry off the wire. Does not throw: every rejection comes
+ *  back as a list of issues so the REST handler can return a structured
+ *  400 instead of an opaque 500. Parse rather than validate — the
+ *  narrowed entry rides along on success, so `makeEntry` never has to
+ *  take the caller's word for the shape. */
+export function parseEntry(raw: unknown, accounts: readonly Account[]): EntryParseResult {
+  if (!isRecord(raw)) {
+    return { ok: false, errors: [{ field: "entry", message: "each entry must be an object with a date and a lines array" }] };
   }
-  if (!Array.isArray(input.lines) || input.lines.length < 2) {
+  const errors: ValidationError[] = [];
+  const date = typeof raw.date === "string" && isValidCalendarDate(raw.date) ? raw.date : null;
+  if (date === null) errors.push({ field: "date", message: `expected YYYY-MM-DD calendar date, got ${JSON.stringify(raw.date)}` });
+  if (!isUnknownArray(raw.lines) || raw.lines.length < 2) {
     errors.push({ field: "lines", message: "an entry needs at least two lines (one debit, one credit)" });
     return { ok: false, errors };
   }
-  const accountCodes = new Set(input.accounts.map((account) => account.code));
-  input.lines.forEach((line, idx) => validateLine(line, idx, accountCodes, errors));
-  const net = netBalance(input.lines);
+  const lines = parseEntryLines(raw.lines, new Set(accounts.map((account) => account.code)), errors);
+  const net = netBalance(lines);
   if (Math.abs(net) > EQUALITY_TOLERANCE) {
     errors.push({ field: "lines", message: `Σ debit − Σ credit = ${net.toFixed(4)}; entry must balance` });
   }
-  return { ok: errors.length === 0, errors };
+  const memo = parseOptionalString(raw.memo, "memo", errors);
+  const replacesEntryId = parseOptionalString(raw.replacesEntryId, "replacesEntryId", errors);
+  if (errors.length > 0 || date === null) return { ok: false, errors };
+  return { ok: true, entry: { date, lines, memo, replacesEntryId } };
 }
 
-/** Build a JournalEntry — validation is the caller's responsibility
- *  (it should have called `validateEntry` first). The id is a fresh
+/** Build a JournalEntry from lines something already parsed
+ *  (`parseEntry` / `parseOpening`). The id is a fresh
  *  UUID; createdAt is the wall clock at the moment of creation.
  *  Lines are normalized so optional string fields don't persist as
  *  empty strings. */

--- a/packages/plugins/accounting-plugin/src/server/journal.ts
+++ b/packages/plugins/accounting-plugin/src/server/journal.ts
@@ -109,6 +109,34 @@ function checkTaxRegistrationId(value: unknown, idx: number, errors: ValidationE
   }
 }
 
+/** One issue per bad field, so a caller fixing a line learns about all
+ *  of them at once. Returns whether the line came through clean. */
+function checkLineFields(raw: Record<string, unknown>, idx: number, errors: ValidationError[]): boolean {
+  const issuesBefore = errors.length;
+  const { accountCode, debit, credit, memo, taxRegistrationId } = raw;
+  if (typeof accountCode !== "string") errors.push({ field: `lines[${idx}].accountCode`, message: "accountCode must be a string" });
+  if (debit !== undefined && !isNonNegativeNumber(debit)) errors.push({ field: `lines[${idx}].debit`, message: "debit must be a non-negative finite number" });
+  if (credit !== undefined && !isNonNegativeNumber(credit))
+    errors.push({ field: `lines[${idx}].credit`, message: "credit must be a non-negative finite number" });
+  if (memo !== undefined && typeof memo !== "string") errors.push({ field: `lines[${idx}].memo`, message: "memo must be a string" });
+  checkTaxRegistrationId(taxRegistrationId, idx, errors);
+  return errors.length === issuesBefore;
+}
+
+/** Re-tested rather than assigned straight through: `checkLineFields`
+ *  proved each of these, but only a `typeof` narrows them for the
+ *  compiler. */
+function buildLine(raw: Record<string, unknown>): JournalLine | null {
+  const { accountCode, debit, credit, memo, taxRegistrationId } = raw;
+  if (typeof accountCode !== "string") return null;
+  const line: JournalLine = { accountCode };
+  if (typeof debit === "number") line.debit = debit;
+  if (typeof credit === "number") line.credit = credit;
+  if (typeof memo === "string") line.memo = memo;
+  if (typeof taxRegistrationId === "string") line.taxRegistrationId = taxRegistrationId;
+  return line;
+}
+
 /** Narrow one wire value to a `JournalLine`, pushing an issue per bad
  *  field. Shape only: account existence and the debit/credit-side rule
  *  belong to the caller, because journal entries and opening balances
@@ -119,23 +147,8 @@ export function parseJournalLine(raw: unknown, idx: number, errors: ValidationEr
     errors.push({ field: `lines[${idx}]`, message: "each line must be an object with an accountCode and a debit or credit amount" });
     return null;
   }
-  const issuesBefore = errors.length;
-  const { accountCode, debit, credit, memo, taxRegistrationId } = raw;
-  if (typeof accountCode !== "string") errors.push({ field: `lines[${idx}].accountCode`, message: "accountCode must be a string" });
-  if (debit !== undefined && !isNonNegativeNumber(debit)) errors.push({ field: `lines[${idx}].debit`, message: "debit must be a non-negative finite number" });
-  if (credit !== undefined && !isNonNegativeNumber(credit))
-    errors.push({ field: `lines[${idx}].credit`, message: "credit must be a non-negative finite number" });
-  if (memo !== undefined && typeof memo !== "string") errors.push({ field: `lines[${idx}].memo`, message: "memo must be a string" });
-  checkTaxRegistrationId(taxRegistrationId, idx, errors);
-  if (errors.length !== issuesBefore || typeof accountCode !== "string") return null;
-  const line: JournalLine = { accountCode };
-  // Re-tested rather than assigned straight through: the checks above
-  // proved these, but only a `typeof` narrows them for the compiler.
-  if (typeof debit === "number") line.debit = debit;
-  if (typeof credit === "number") line.credit = credit;
-  if (typeof memo === "string") line.memo = memo;
-  if (typeof taxRegistrationId === "string") line.taxRegistrationId = taxRegistrationId;
-  return line;
+  if (!checkLineFields(raw, idx, errors)) return null;
+  return buildLine(raw);
 }
 
 /** The rules a journal line answers to on top of its shape: the code
@@ -158,6 +171,20 @@ function parseEntryLines(raw: readonly unknown[], accountCodes: ReadonlySet<stri
     lines.push(line);
   });
   return lines;
+}
+
+/** Report the debit = credit imbalance — but only when every line was
+ *  readable. A line that failed to parse contributes nothing to the sum,
+ *  so an entry that balances perfectly would otherwise be told it
+ *  doesn't, sending the caller off to "fix" amounts that were never
+ *  wrong. Naming the unreadable line is the actionable message; the
+ *  balance is worth re-checking once it's a line. */
+export function checkBalances(lines: readonly JournalLine[], expectedLineCount: number, subject: string, errors: ValidationError[]): void {
+  if (lines.length !== expectedLineCount) return;
+  const net = netBalance(lines);
+  if (Math.abs(net) > EQUALITY_TOLERANCE) {
+    errors.push({ field: "lines", message: `Σ debit − Σ credit = ${net.toFixed(4)}; ${subject} must balance` });
+  }
 }
 
 function parseOptionalString(value: unknown, field: string, errors: ValidationError[]): string | undefined {
@@ -197,10 +224,7 @@ export function parseEntry(raw: unknown, accounts: readonly Account[]): EntryPar
     return { ok: false, errors };
   }
   const lines = parseEntryLines(raw.lines, new Set(accounts.map((account) => account.code)), errors);
-  const net = netBalance(lines);
-  if (Math.abs(net) > EQUALITY_TOLERANCE) {
-    errors.push({ field: "lines", message: `Σ debit − Σ credit = ${net.toFixed(4)}; entry must balance` });
-  }
+  checkBalances(lines, raw.lines.length, "entry", errors);
   const memo = parseOptionalString(raw.memo, "memo", errors);
   const replacesEntryId = parseOptionalString(raw.replacesEntryId, "replacesEntryId", errors);
   if (errors.length > 0 || date === null) return { ok: false, errors };

--- a/packages/plugins/accounting-plugin/src/server/openingBalances.ts
+++ b/packages/plugins/accounting-plugin/src/server/openingBalances.ts
@@ -16,9 +16,7 @@ import { isUnknownArray } from "@mulmoclaude/common";
 
 import type { Account, JournalEntry, JournalLine } from "../shared/types.js";
 import { BALANCE_SHEET_ACCOUNT_TYPES } from "../shared/types.js";
-import { isValidCalendarDate, netBalance, parseJournalLine, voidedIdSet } from "./journal.js";
-
-const EQUALITY_TOLERANCE = 0.005;
+import { checkBalances, isValidCalendarDate, parseJournalLine, voidedIdSet } from "./journal.js";
 
 export interface OpeningValidationError {
   field: string;
@@ -118,10 +116,7 @@ export function parseOpening(input: OpeningParseInput): OpeningParseResult {
     return { ok: false, errors };
   }
   const lines = parseOpeningLines(input.lines, input.accounts, errors);
-  const net = netBalance(lines);
-  if (Math.abs(net) > EQUALITY_TOLERANCE) {
-    errors.push({ field: "lines", message: `Σ debit − Σ credit = ${net.toFixed(4)}; opening must balance` });
-  }
+  checkBalances(lines, input.lines.length, "opening", errors);
   validateAsOfPredatesEverything(input, errors);
   if (errors.length > 0) return { ok: false, errors };
   return { ok: true, lines };

--- a/packages/plugins/accounting-plugin/src/server/openingBalances.ts
+++ b/packages/plugins/accounting-plugin/src/server/openingBalances.ts
@@ -12,9 +12,11 @@
 // route handler is responsible for ordering this with snapshot
 // invalidation so the "before" snapshots get dropped.
 
+import { isUnknownArray } from "@mulmoclaude/common";
+
 import type { Account, JournalEntry, JournalLine } from "../shared/types.js";
 import { BALANCE_SHEET_ACCOUNT_TYPES } from "../shared/types.js";
-import { isValidCalendarDate, netBalance, voidedIdSet } from "./journal.js";
+import { isValidCalendarDate, netBalance, parseJournalLine, voidedIdSet } from "./journal.js";
 
 const EQUALITY_TOLERANCE = 0.005;
 
@@ -23,10 +25,7 @@ export interface OpeningValidationError {
   message: string;
 }
 
-export interface OpeningValidationResult {
-  ok: boolean;
-  errors: OpeningValidationError[];
-}
+export type OpeningParseResult = { ok: true; lines: JournalLine[] } | { ok: false; errors: OpeningValidationError[] };
 
 /** Find the existing opening entry for a book, if any. Multiple
  *  openings shouldn't coexist (the route enforces void-then-append),
@@ -43,31 +42,44 @@ export function findActiveOpening(entries: readonly JournalEntry[]): JournalEntr
   return active;
 }
 
-interface OpeningValidationInput {
+interface OpeningParseInput {
   asOfDate: string;
-  lines: readonly JournalLine[];
+  lines: unknown;
   accounts: readonly Account[];
   existingEntries: readonly JournalEntry[];
 }
 
-function validateLineAccountTypes(input: OpeningValidationInput, errors: OpeningValidationError[]): void {
-  const accountByCode = new Map(input.accounts.map((account) => [account.code, account]));
-  input.lines.forEach((line, idx) => {
-    const acct = accountByCode.get(line.accountCode);
-    if (!acct) {
-      errors.push({ field: `lines[${idx}].accountCode`, message: `unknown account code ${JSON.stringify(line.accountCode)}` });
-      return;
-    }
-    if (!BALANCE_SHEET_ACCOUNT_TYPES.includes(acct.type)) {
-      errors.push({
-        field: `lines[${idx}].accountCode`,
-        message: `account ${acct.code} is type ${acct.type}; opening balances may only reference balance-sheet accounts (asset / liability / equity)`,
-      });
-    }
-  });
+function validateOpeningAccount(line: JournalLine, idx: number, accountByCode: ReadonlyMap<string, Account>, errors: OpeningValidationError[]): void {
+  const acct = accountByCode.get(line.accountCode);
+  if (!acct) {
+    errors.push({ field: `lines[${idx}].accountCode`, message: `unknown account code ${JSON.stringify(line.accountCode)}` });
+    return;
+  }
+  if (!BALANCE_SHEET_ACCOUNT_TYPES.includes(acct.type)) {
+    errors.push({
+      field: `lines[${idx}].accountCode`,
+      message: `account ${acct.code} is type ${acct.type}; opening balances may only reference balance-sheet accounts (asset / liability / equity)`,
+    });
+  }
 }
 
-function validateAsOfPredatesEverything(input: OpeningValidationInput, errors: OpeningValidationError[]): void {
+/** Opening lines are narrowed by the same shape parser the journal
+ *  uses, but they answer to different rules afterwards: balance-sheet
+ *  accounts only, and no "exactly one side" requirement — the opening
+ *  form lets a user carry both columns on one account. */
+function parseOpeningLines(raw: readonly unknown[], accounts: readonly Account[], errors: OpeningValidationError[]): JournalLine[] {
+  const accountByCode = new Map(accounts.map((account) => [account.code, account]));
+  const lines: JournalLine[] = [];
+  raw.forEach((rawLine, idx) => {
+    const line = parseJournalLine(rawLine, idx, errors);
+    if (line === null) return;
+    validateOpeningAccount(line, idx, accountByCode, errors);
+    lines.push(line);
+  });
+  return lines;
+}
+
+function validateAsOfPredatesEverything(input: { asOfDate: string; existingEntries: readonly JournalEntry[] }, errors: OpeningValidationError[]): void {
   // The point of the rule is "you can't enter an opening dated
   // 2026-01-01 if you've already booked transactions in December
   // 2025" — that would silently change the meaning of those
@@ -88,27 +100,29 @@ function validateAsOfPredatesEverything(input: OpeningValidationInput, errors: O
   }
 }
 
-/** Validate inputs for `setOpeningBalances`. Caller passes the full
- *  list of journal entries in the book so we can check the
- *  "asOfDate must precede every other entry" rule. An opening with
+/** Parse the inputs for `setOpeningBalances`, returning the narrowed
+ *  lines so the caller can persist what was actually checked. Caller
+ *  passes the full list of journal entries in the book so we can check
+ *  the "asOfDate must precede every other entry" rule. An opening with
  *  zero lines is accepted as a no-op marker — it satisfies the
  *  "book has an opening" gate the UI uses without committing the
  *  user to specific balances on day one (they can replace it
  *  later). */
-export function validateOpening(input: OpeningValidationInput): OpeningValidationResult {
+export function parseOpening(input: OpeningParseInput): OpeningParseResult {
   const errors: OpeningValidationError[] = [];
   if (!isValidCalendarDate(input.asOfDate)) {
     errors.push({ field: "asOfDate", message: `expected YYYY-MM-DD calendar date, got ${JSON.stringify(input.asOfDate)}` });
   }
-  if (!Array.isArray(input.lines)) {
+  if (!isUnknownArray(input.lines)) {
     errors.push({ field: "lines", message: "lines must be an array" });
     return { ok: false, errors };
   }
-  validateLineAccountTypes(input, errors);
-  const net = netBalance(input.lines);
+  const lines = parseOpeningLines(input.lines, input.accounts, errors);
+  const net = netBalance(lines);
   if (Math.abs(net) > EQUALITY_TOLERANCE) {
     errors.push({ field: "lines", message: `Σ debit − Σ credit = ${net.toFixed(4)}; opening must balance` });
   }
   validateAsOfPredatesEverything(input, errors);
-  return { ok: errors.length === 0, errors };
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, lines };
 }

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -71,9 +71,9 @@ type ActionRest = Omit<AccountingActionBody, "action">;
 type ActionHandler = (rest: ActionRest) => Promise<unknown>;
 
 // Each action is a tiny adapter that pulls the typed slice it needs
-// out of the loosely-typed body. Validation of the slice shape
-// itself lives inside the service layer (validateEntry,
-// validateOpening) so the adapters can stay one-liners.
+// out of the loosely-typed body. Parsing of the slice shape itself
+// lives inside the service layer (parseEntry, parseOpening,
+// parseAccountInput) so the adapters can stay one-liners.
 
 async function handleOpenBook(rest: ActionRest): Promise<OpenBookToolResult> {
   // openBook requires an explicit `bookId` that resolves to an
@@ -150,26 +150,12 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
   },
   [ACCOUNTING_ACTIONS.deleteBook]: (rest) => deleteBook({ bookId: typeof rest.bookId === "string" ? rest.bookId : "", confirm: rest.confirm === true }),
   [ACCOUNTING_ACTIONS.getAccounts]: (rest) => listAccounts({ bookId: optionalString(rest.bookId) }),
-  // The three `as never` below are the last casts in this file. Removing
-  // them means making the service signatures honest — `entries` / `lines`
-  // / `account` are declared as validated shapes but arrive raw, and the
-  // validators that were written to turn bad input into a structured 400
-  // read `item.date` / `line.accountCode` off elements that may not be
-  // objects. `entries: [null]` therefore throws a TypeError and 500s
-  // instead. That is a validation-layer fix (journal.ts, openingBalances.ts,
-  // service.ts) with its own tests, tracked on #2692.
-  [ACCOUNTING_ACTIONS.upsertAccount]: (rest) =>
-    upsertAccount({
-      bookId: optionalString(rest.bookId),
-      // Service validates the shape — route doesn't reach into it.
-      account: rest.account as never,
-    }),
-  [ACCOUNTING_ACTIONS.addEntries]: (rest) =>
-    addEntries({
-      bookId: optionalString(rest.bookId),
-      // Service validates each entry's shape — route doesn't reach into it.
-      entries: (rest.entries ?? []) as never,
-    }),
+  // `account` / `entries` / `lines` travel to the service as `unknown`:
+  // the parsers there own the narrowing, so a bad field keeps its own
+  // message ("debit must be a non-negative finite number") instead of
+  // collapsing into a generic shape error the LLM can't repair from.
+  [ACCOUNTING_ACTIONS.upsertAccount]: (rest) => upsertAccount({ bookId: optionalString(rest.bookId), account: rest.account }),
+  [ACCOUNTING_ACTIONS.addEntries]: (rest) => addEntries({ bookId: optionalString(rest.bookId), entries: rest.entries }),
   [ACCOUNTING_ACTIONS.voidEntry]: (rest) =>
     voidEntry({
       bookId: optionalString(rest.bookId),
@@ -189,7 +175,9 @@ const ACTION_HANDLERS: Record<string, ActionHandler> = {
     setOpeningBalances({
       bookId: optionalString(rest.bookId),
       asOfDate: typeof rest.asOfDate === "string" ? rest.asOfDate : "",
-      lines: (rest.lines ?? []) as never,
+      // Omitted `lines` means the zero-line opening marker that unlocks
+      // the View's gate, so it stays an empty array rather than a 400.
+      lines: rest.lines ?? [],
       memo: optionalString(rest.memo),
     }),
   [ACCOUNTING_ACTIONS.getReport]: handleGetReport,

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -15,6 +15,7 @@
 // (enforced by `test/accounting/test_snapshotCache.ts`).
 
 import { randomUUID } from "node:crypto";
+import { isUnknownArray } from "@mulmoclaude/common";
 
 import {
   appendJournal,
@@ -33,9 +34,9 @@ import {
   writeAccounts,
   writeConfig,
 } from "./io.js";
-import { findActiveOpening, validateOpening } from "./openingBalances.js";
-import { normalizeStoredAccount } from "./accountNormalize.js";
-import { isValidCalendarDate, localDateString, makeEntry, makeVoidEntries, validateEntry, voidedIdSet } from "./journal.js";
+import { findActiveOpening, parseOpening } from "./openingBalances.js";
+import { normalizeStoredAccount, parseAccountInput } from "./accountNormalize.js";
+import { isValidCalendarDate, localDateString, makeEntry, makeVoidEntries, parseEntry, voidedIdSet, type ParsedEntry } from "./journal.js";
 import { aggregateBalances, buildBalanceSheet, buildLedger, buildProfitLoss } from "./report.js";
 import {
   bucketize,
@@ -62,7 +63,7 @@ import {
   type FiscalYearEnd,
 } from "../shared";
 import type { AccountingConfig } from "./types.js";
-import type { Account, BookSummary, JournalEntry, JournalLine, ReportPeriod } from "../shared/types.js";
+import type { Account, BookSummary, JournalEntry, ReportPeriod } from "../shared/types.js";
 
 export class AccountingError extends Error {
   constructor(
@@ -319,32 +320,32 @@ export async function listAccounts(input: { bookId?: string }, workspaceRoot?: s
 }
 
 export async function upsertAccount(
-  input: { bookId?: string; account: Account },
+  input: { bookId?: string; account: unknown },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; account: Account; accounts: Account[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
+  const parsed = parseAccountInput(input.account);
+  if (!parsed.ok) throw new AccountingError(400, parsed.message);
+  const { account } = parsed;
   // Account codes starting with `_` are reserved for synthetic
   // rows that the report layer injects (e.g. the
   // `_currentEarnings` row added to the Equity section by
   // buildBalanceSheet). Forbid user accounts in that namespace so
   // a B/S can't display two rows with the same code or
   // accidentally lose a real account behind the synthetic label.
-  if (typeof input.account?.code !== "string" || input.account.code.length === 0) {
-    throw new AccountingError(400, "account code is required");
-  }
-  if (input.account.code.startsWith("_")) {
-    throw new AccountingError(400, `account code ${JSON.stringify(input.account.code)} is reserved (codes starting with _ are used for synthetic report rows)`);
+  if (account.code.startsWith("_")) {
+    throw new AccountingError(400, `account code ${JSON.stringify(account.code)} is reserved (codes starting with _ are used for synthetic report rows)`);
   }
   const accounts = await readAccounts(bookId, workspaceRoot);
-  const existingIdx = accounts.findIndex((account) => account.code === input.account.code);
+  const existingIdx = accounts.findIndex((stored) => stored.code === account.code);
   const next = [...accounts];
   const oldType = existingIdx >= 0 ? accounts[existingIdx].type : null;
   // Whitelist + active-flag policy lives in normalizeStoredAccount
   // (see ./accountNormalize.ts) so the rules are unit-testable in
   // isolation and this service function stays focused on the
   // file-IO + snapshot-invalidation orchestration.
-  const stored = normalizeStoredAccount(input.account, existingIdx >= 0 ? accounts[existingIdx] : undefined);
+  const stored = normalizeStoredAccount(account, existingIdx >= 0 ? accounts[existingIdx] : undefined);
   if (existingIdx >= 0) {
     next[existingIdx] = stored;
   } else {
@@ -354,42 +355,42 @@ export async function upsertAccount(
   // Type changes affect aggregation across periods — drop every
   // snapshot to be safe. Pure name / note changes don't, but
   // distinguishing isn't worth the complexity.
-  if (oldType !== null && oldType !== input.account.type) {
+  if (oldType !== null && oldType !== account.type) {
     scheduleRebuild(bookId, "0000-00", workspaceRoot);
     await invalidateAllSnapshots(bookId, workspaceRoot);
   }
   publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.accounts });
-  return { bookId, account: { ...input.account }, accounts: next };
+  return { bookId, account, accounts: next };
 }
 
 // ── journal entries ────────────────────────────────────────────────
-
-export interface AddEntriesItem {
-  date: string;
-  lines: JournalLine[];
-  memo?: string;
-  replacesEntryId?: string;
-}
 
 interface BatchValidationFailure {
   index: number;
   errors: unknown;
 }
 
-// All-or-nothing validation: collect failures across every entry
-// so the whole batch can be rejected before any write touches disk
-// (a half-applied batch can never end up persisted).
-function collectBatchValidationFailures(items: readonly AddEntriesItem[], accounts: readonly Account[]): BatchValidationFailure[] {
-  const failures: BatchValidationFailure[] = [];
-  for (let idx = 0; idx < items.length; idx++) {
-    const item = items[idx];
-    const validation = validateEntry({ date: item.date, lines: item.lines, accounts });
-    if (!validation.ok) failures.push({ index: idx, errors: validation.errors });
-  }
-  return failures;
+interface BatchParseResult {
+  failures: BatchValidationFailure[];
+  items: ParsedEntry[];
 }
 
-function buildBatchEntries(items: readonly AddEntriesItem[]): JournalEntry[] {
+// All-or-nothing parse: collect failures across every entry so the
+// whole batch can be rejected before any write touches disk (a
+// half-applied batch can never end up persisted). The parsed items
+// ride along so the build step gets a shape something checked.
+function parseBatchEntries(items: readonly unknown[], accounts: readonly Account[]): BatchParseResult {
+  const failures: BatchValidationFailure[] = [];
+  const parsed: ParsedEntry[] = [];
+  items.forEach((item, index) => {
+    const result = parseEntry(item, accounts);
+    if (result.ok) parsed.push(result.entry);
+    else failures.push({ index, errors: result.errors });
+  });
+  return { failures, items: parsed };
+}
+
+function buildBatchEntries(items: readonly ParsedEntry[]): JournalEntry[] {
   return items.map((item) => makeEntry({ date: item.date, lines: item.lines, memo: item.memo, kind: "normal", replacesEntryId: item.replacesEntryId }));
 }
 
@@ -401,19 +402,16 @@ function earliestPeriodOf(entries: readonly JournalEntry[]): string {
   return entries.map((entry) => periodFromDate(entry.date)).reduce((min, period) => (period < min ? period : min));
 }
 
-export async function addEntries(
-  input: { bookId?: string; entries: AddEntriesItem[] },
-  workspaceRoot?: string,
-): Promise<{ bookId: string; entries: JournalEntry[] }> {
+export async function addEntries(input: { bookId?: string; entries: unknown }, workspaceRoot?: string): Promise<{ bookId: string; entries: JournalEntry[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
-  if (!Array.isArray(input.entries) || input.entries.length === 0) {
+  if (!isUnknownArray(input.entries) || input.entries.length === 0) {
     throw new AccountingError(400, "addEntries: entries must be a non-empty array");
   }
   const accounts = await readAccounts(bookId, workspaceRoot);
-  const failures = collectBatchValidationFailures(input.entries, accounts);
+  const { failures, items } = parseBatchEntries(input.entries, accounts);
   if (failures.length > 0) throw new AccountingError(400, "invalid journal entries", failures);
-  const built = buildBatchEntries(input.entries);
+  const built = buildBatchEntries(items);
   // Two-phase batched write: stage every affected month's full new
   // content, then commit all renames at the end. Same-period
   // batches are fully atomic; multi-period failure window is
@@ -511,21 +509,21 @@ export async function getOpeningBalances(input: { bookId?: string }, workspaceRo
 }
 
 export async function setOpeningBalances(
-  input: { bookId?: string; asOfDate: string; lines: JournalLine[]; memo?: string },
+  input: { bookId?: string; asOfDate: string; lines: unknown; memo?: string },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   const accounts = await readAccounts(bookId, workspaceRoot);
   const all = await readAllEntries(bookId, workspaceRoot);
-  const validation = validateOpening({
+  const parsed = parseOpening({
     asOfDate: input.asOfDate,
     lines: input.lines,
     accounts,
     existingEntries: all,
   });
-  if (!validation.ok) {
-    throw new AccountingError(400, "invalid opening balances", validation.errors);
+  if (!parsed.ok) {
+    throw new AccountingError(400, "invalid opening balances", parsed.errors);
   }
   // Replace-mode: void any existing active opening so the new one
   // is unambiguous. The marker is dated today (when the void
@@ -539,7 +537,7 @@ export async function setOpeningBalances(
   }
   const opening = makeEntry({
     date: input.asOfDate,
-    lines: input.lines,
+    lines: parsed.lines,
     memo: input.memo ?? "Opening balances",
     kind: "opening",
   });

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -348,7 +348,11 @@ function applyAccount(accounts: readonly Account[], account: Account): { next: A
   const next = [...accounts];
   if (existingIdx >= 0) next[existingIdx] = stored;
   else next.push(stored);
-  return { next, previousType: existing?.type ?? null };
+  // `existing ? … : null`, not `existing?.type ?? null`: a book written
+  // before the account payload was parsed can hold a record whose `type`
+  // is missing, and collapsing that into "no previous type" would skip
+  // the invalidation below on the very upsert that repairs it.
+  return { next, previousType: existing ? existing.type : null };
 }
 
 export async function upsertAccount(

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -63,7 +63,7 @@ import {
   type FiscalYearEnd,
 } from "../shared";
 import type { AccountingConfig } from "./types.js";
-import type { Account, BookSummary, JournalEntry, ReportPeriod } from "../shared/types.js";
+import type { Account, AccountType, BookSummary, JournalEntry, ReportPeriod } from "../shared/types.js";
 
 export class AccountingError extends Error {
   constructor(
@@ -319,43 +319,51 @@ export async function listAccounts(input: { bookId?: string }, workspaceRoot?: s
   return { bookId, accounts: await readAccounts(bookId, workspaceRoot) };
 }
 
+/** Parse the caller's account, then apply the one rule the chart owns
+ *  rather than the record: codes starting with `_` are reserved for the
+ *  synthetic rows the report layer injects (e.g. `_currentEarnings` in
+ *  the Equity section). A user account there would either duplicate a
+ *  B/S row or hide a real account behind the synthetic label. */
+function parseUpsertAccount(raw: unknown): Account {
+  const parsed = parseAccountInput(raw);
+  if (!parsed.ok) throw new AccountingError(400, parsed.message);
+  if (parsed.account.code.startsWith("_")) {
+    throw new AccountingError(
+      400,
+      `account code ${JSON.stringify(parsed.account.code)} is reserved (codes starting with _ are used for synthetic report rows)`,
+    );
+  }
+  return parsed.account;
+}
+
+/** Insert or replace the account in the chart. The whitelist +
+ *  active-flag policy lives in normalizeStoredAccount (see
+ *  ./accountNormalize.ts) so it stays unit-testable in isolation.
+ *  `previousType` is null for a new code — callers use it to decide
+ *  whether aggregation across periods just changed meaning. */
+function applyAccount(accounts: readonly Account[], account: Account): { next: Account[]; previousType: AccountType | null } {
+  const existingIdx = accounts.findIndex((stored) => stored.code === account.code);
+  const existing = existingIdx >= 0 ? accounts[existingIdx] : undefined;
+  const stored = normalizeStoredAccount(account, existing);
+  const next = [...accounts];
+  if (existingIdx >= 0) next[existingIdx] = stored;
+  else next.push(stored);
+  return { next, previousType: existing?.type ?? null };
+}
+
 export async function upsertAccount(
   input: { bookId?: string; account: unknown },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; account: Account; accounts: Account[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
-  const parsed = parseAccountInput(input.account);
-  if (!parsed.ok) throw new AccountingError(400, parsed.message);
-  const { account } = parsed;
-  // Account codes starting with `_` are reserved for synthetic
-  // rows that the report layer injects (e.g. the
-  // `_currentEarnings` row added to the Equity section by
-  // buildBalanceSheet). Forbid user accounts in that namespace so
-  // a B/S can't display two rows with the same code or
-  // accidentally lose a real account behind the synthetic label.
-  if (account.code.startsWith("_")) {
-    throw new AccountingError(400, `account code ${JSON.stringify(account.code)} is reserved (codes starting with _ are used for synthetic report rows)`);
-  }
-  const accounts = await readAccounts(bookId, workspaceRoot);
-  const existingIdx = accounts.findIndex((stored) => stored.code === account.code);
-  const next = [...accounts];
-  const oldType = existingIdx >= 0 ? accounts[existingIdx].type : null;
-  // Whitelist + active-flag policy lives in normalizeStoredAccount
-  // (see ./accountNormalize.ts) so the rules are unit-testable in
-  // isolation and this service function stays focused on the
-  // file-IO + snapshot-invalidation orchestration.
-  const stored = normalizeStoredAccount(account, existingIdx >= 0 ? accounts[existingIdx] : undefined);
-  if (existingIdx >= 0) {
-    next[existingIdx] = stored;
-  } else {
-    next.push(stored);
-  }
+  const account = parseUpsertAccount(input.account);
+  const { next, previousType } = applyAccount(await readAccounts(bookId, workspaceRoot), account);
   await writeAccounts(bookId, next, workspaceRoot);
   // Type changes affect aggregation across periods — drop every
   // snapshot to be safe. Pure name / note changes don't, but
   // distinguishing isn't worth the complexity.
-  if (oldType !== null && oldType !== account.type) {
+  if (previousType !== null && previousType !== account.type) {
     scheduleRebuild(bookId, "0000-00", workspaceRoot);
     await invalidateAllSnapshots(bookId, workspaceRoot);
   }

--- a/packages/plugins/accounting-plugin/test/accounting/test_journal.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_journal.ts
@@ -251,6 +251,40 @@ describe("parseEntry — non-object input", () => {
     assert.equal(result.ok, false);
     assert.ok(issuesOf(result).some((err) => err.field === "lines[0].accountCode"));
   });
+  it("does not claim an entry is unbalanced when a line was unreadable", () => {
+    // 100 debit against 100 credit — it balances. An unreadable line
+    // contributes nothing to the sum, so reporting the difference would
+    // send the caller off to fix amounts that were never wrong.
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: 1000, debit: 100 },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
+    assert.equal(result.ok, false);
+    assert.equal(
+      issuesOf(result).some((err) => err.message.includes("must balance")),
+      false,
+      JSON.stringify(issuesOf(result)),
+    );
+  });
+  it("still reports a genuine imbalance when every line is readable", () => {
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 100 },
+          { accountCode: "4000", credit: 90 },
+        ],
+      },
+      ACCOUNTS,
+    );
+    assert.ok(issuesOf(result).some((err) => err.message.includes("must balance")));
+  });
 });
 
 describe("makeEntry", () => {

--- a/packages/plugins/accounting-plugin/test/accounting/test_journal.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_journal.ts
@@ -7,10 +7,18 @@ import {
   makeEntry,
   makeVoidEntries,
   netBalance,
-  validateEntry,
+  parseEntry,
   voidedIdSet,
+  type EntryParseResult,
+  type ValidationError,
 } from "../../src/server/journal.js";
 import type { Account, JournalEntry, JournalLine } from "../../src/shared/types.js";
+
+/** Reading issues off a parse result: the ok branch carries the entry,
+ *  not an empty error list, so tests ask for the issues explicitly. */
+function issuesOf(result: EntryParseResult): ValidationError[] {
+  return result.ok ? [] : result.errors;
+}
 
 const ACCOUNTS: Account[] = [
   { code: "1000", name: "Cash", type: "asset" },
@@ -55,107 +63,193 @@ describe("isValidCalendarDate", () => {
   });
 });
 
-describe("validateEntry", () => {
-  it("accepts a balanced entry", () => {
-    const result = validateEntry({ date: "2026-04-01", lines: balancedLines(), accounts: ACCOUNTS });
+describe("parseEntry", () => {
+  it("accepts a balanced entry and returns it narrowed", () => {
+    const result = parseEntry({ date: "2026-04-01", lines: balancedLines(), memo: "Sale" }, ACCOUNTS);
     assert.equal(result.ok, true);
-    assert.deepEqual(result.errors, []);
+    assert.deepEqual(issuesOf(result), []);
+    // The point of parsing over validating: the caller gets a value it
+    // doesn't have to re-assert before handing to makeEntry.
+    assert.ok(result.ok);
+    assert.equal(result.entry.date, "2026-04-01");
+    assert.equal(result.entry.memo, "Sale");
+    assert.deepEqual(result.entry.lines, balancedLines());
   });
   it("rejects malformed dates", () => {
-    const result = validateEntry({ date: "2026/04/01", lines: balancedLines(), accounts: ACCOUNTS });
+    const result = parseEntry({ date: "2026/04/01", lines: balancedLines() }, ACCOUNTS);
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.field === "date"));
+    assert.ok(issuesOf(result).some((err) => err.field === "date"));
   });
   it("rejects unknown account codes", () => {
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "9999", debit: 100 },
-        { accountCode: "4000", credit: 100 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "9999", debit: 100 },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.field.includes("accountCode")));
+    assert.ok(issuesOf(result).some((err) => err.field.includes("accountCode")));
   });
   it("rejects unbalanced entries", () => {
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "1000", debit: 100 },
-        { accountCode: "4000", credit: 90 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 100 },
+          { accountCode: "4000", credit: 90 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.message.includes("must balance")));
+    assert.ok(issuesOf(result).some((err) => err.message.includes("must balance")));
   });
   it("rejects single-line entries", () => {
-    const result = validateEntry({ date: "2026-04-01", lines: [{ accountCode: "1000", debit: 100 }], accounts: ACCOUNTS });
+    const result = parseEntry({ date: "2026-04-01", lines: [{ accountCode: "1000", debit: 100 }] }, ACCOUNTS);
     assert.equal(result.ok, false);
   });
   it("rejects lines with both debit and credit set", () => {
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "1000", debit: 50, credit: 30 },
-        { accountCode: "4000", credit: 20 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 50, credit: 30 },
+          { accountCode: "4000", credit: 20 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, false);
   });
   it("tolerates floating-point noise within ±0.005", () => {
     // 0.1 + 0.2 = 0.30000000000000004 in IEEE-754 — must not flunk
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "1000", debit: 0.1 },
-        { accountCode: "1000", debit: 0.2 },
-        { accountCode: "4000", credit: 0.3 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 0.1 },
+          { accountCode: "1000", debit: 0.2 },
+          { accountCode: "4000", credit: 0.3 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, true);
   });
   it("accepts a line with a taxRegistrationId at the length cap", () => {
     const taxId = "T".repeat(MAX_TAX_REGISTRATION_ID_LENGTH);
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "1000", debit: 100, taxRegistrationId: taxId },
-        { accountCode: "4000", credit: 100 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 100, taxRegistrationId: taxId },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, true);
   });
   it("rejects a taxRegistrationId longer than the length cap (after trim)", () => {
     const tooLong = "T".repeat(MAX_TAX_REGISTRATION_ID_LENGTH + 1);
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "1000", debit: 100, taxRegistrationId: tooLong },
-        { accountCode: "4000", credit: 100 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 100, taxRegistrationId: tooLong },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.field === "lines[0].taxRegistrationId"));
+    assert.ok(issuesOf(result).some((err) => err.field === "lines[0].taxRegistrationId"));
   });
   it("ignores leading/trailing whitespace when checking the length cap", () => {
     // 32 chars padded with whitespace on both sides: trimmed length
     // is at the cap, so the entry should still be accepted.
     const padded = `  ${"T".repeat(MAX_TAX_REGISTRATION_ID_LENGTH)}  `;
-    const result = validateEntry({
-      date: "2026-04-01",
-      lines: [
-        { accountCode: "1000", debit: 100, taxRegistrationId: padded },
-        { accountCode: "4000", credit: 100 },
-      ],
-      accounts: ACCOUNTS,
-    });
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: 100, taxRegistrationId: padded },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
     assert.equal(result.ok, true);
+  });
+});
+
+// #2695: these all used to read `item.date` / `line.accountCode` off a
+// value that isn't an object, so the validator itself threw and the
+// route answered 500 — from the code written to produce a 400.
+describe("parseEntry — non-object input", () => {
+  it("reports a null entry instead of throwing", () => {
+    const result = parseEntry(null, ACCOUNTS);
+    assert.equal(result.ok, false);
+    assert.deepEqual(
+      issuesOf(result).map((err) => err.field),
+      ["entry"],
+    );
+  });
+  it("reports a primitive entry", () => {
+    assert.equal(parseEntry(42, ACCOUNTS).ok, false);
+    assert.equal(parseEntry("nope", ACCOUNTS).ok, false);
+  });
+  it("reports a null line against its own index", () => {
+    const result = parseEntry({ date: "2026-04-01", lines: [null, { accountCode: "4000", credit: 100 }] }, ACCOUNTS);
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.field === "lines[0]"));
+  });
+  it("reports a primitive line against its own index", () => {
+    const result = parseEntry({ date: "2026-04-01", lines: [{ accountCode: "1000", debit: 100 }, "nope"] }, ACCOUNTS);
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.field === "lines[1]"));
+  });
+  it("keeps the specific field message for a mistyped amount", () => {
+    // The anti-degradation check: a shape gate at the route would have
+    // answered "entries are malformed" and left the caller guessing.
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: "1000", debit: "abc" },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
+    assert.equal(result.ok, false);
+    assert.ok(
+      issuesOf(result).some((err) => err.field === "lines[0].debit" && err.message === "debit must be a non-negative finite number"),
+      JSON.stringify(issuesOf(result)),
+    );
+  });
+  it("rejects a non-string memo rather than persisting it raw", () => {
+    const result = parseEntry({ date: "2026-04-01", lines: balancedLines(), memo: 42 }, ACCOUNTS);
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.field === "memo"));
+  });
+  it("rejects a non-string accountCode", () => {
+    const result = parseEntry(
+      {
+        date: "2026-04-01",
+        lines: [
+          { accountCode: 1000, debit: 100 },
+          { accountCode: "4000", credit: 100 },
+        ],
+      },
+      ACCOUNTS,
+    );
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.field === "lines[0].accountCode"));
   });
 });
 

--- a/packages/plugins/accounting-plugin/test/accounting/test_openingBalances.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_openingBalances.ts
@@ -1,9 +1,13 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { findActiveOpening, validateOpening } from "../../src/server/openingBalances.js";
+import { findActiveOpening, parseOpening, type OpeningParseResult, type OpeningValidationError } from "../../src/server/openingBalances.js";
 import { makeEntry, makeVoidEntries } from "../../src/server/journal.js";
 import type { Account, JournalEntry, JournalLine } from "../../src/shared/types.js";
+
+function issuesOf(result: OpeningParseResult): OpeningValidationError[] {
+  return result.ok ? [] : result.errors;
+}
 
 const ACCOUNTS: Account[] = [
   { code: "1000", name: "Cash", type: "asset" },
@@ -19,17 +23,19 @@ const BALANCED: JournalLine[] = [
   { accountCode: "3000", credit: 600 },
 ];
 
-describe("validateOpening", () => {
-  it("accepts a balanced opening over balance-sheet accounts only", () => {
-    const result = validateOpening({ asOfDate: "2026-01-01", lines: BALANCED, accounts: ACCOUNTS, existingEntries: [] });
+describe("parseOpening", () => {
+  it("accepts a balanced opening over balance-sheet accounts only, and returns the lines", () => {
+    const result = parseOpening({ asOfDate: "2026-01-01", lines: BALANCED, accounts: ACCOUNTS, existingEntries: [] });
     assert.equal(result.ok, true);
+    assert.ok(result.ok);
+    assert.deepEqual(result.lines, BALANCED);
   });
   it("accepts an empty opening (zero lines) as a no-op marker", () => {
-    const result = validateOpening({ asOfDate: "2026-01-01", lines: [], accounts: ACCOUNTS, existingEntries: [] });
+    const result = parseOpening({ asOfDate: "2026-01-01", lines: [], accounts: ACCOUNTS, existingEntries: [] });
     assert.equal(result.ok, true);
   });
   it("rejects income / expense accounts", () => {
-    const result = validateOpening({
+    const result = parseOpening({
       asOfDate: "2026-01-01",
       lines: [
         { accountCode: "1000", debit: 1000 },
@@ -39,10 +45,10 @@ describe("validateOpening", () => {
       existingEntries: [],
     });
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.message.includes("balance-sheet")));
+    assert.ok(issuesOf(result).some((err) => err.message.includes("balance-sheet")));
   });
   it("rejects unbalanced opening", () => {
-    const result = validateOpening({
+    const result = parseOpening({
       asOfDate: "2026-01-01",
       lines: [
         { accountCode: "1000", debit: 1000 },
@@ -52,7 +58,7 @@ describe("validateOpening", () => {
       existingEntries: [],
     });
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.message.includes("must balance")));
+    assert.ok(issuesOf(result).some((err) => err.message.includes("must balance")));
   });
   it("rejects asOfDate later than an existing non-voided entry", () => {
     const earlier = makeEntry({
@@ -62,14 +68,14 @@ describe("validateOpening", () => {
         { accountCode: "4000", credit: 50 },
       ],
     });
-    const result = validateOpening({
+    const result = parseOpening({
       asOfDate: "2026-01-01",
       lines: BALANCED,
       accounts: ACCOUNTS,
       existingEntries: [earlier],
     });
     assert.equal(result.ok, false);
-    assert.ok(result.errors.some((err) => err.field === "asOfDate"));
+    assert.ok(issuesOf(result).some((err) => err.field === "asOfDate"));
   });
   it("ignores voided entries when checking the date conflict", () => {
     const earlier = makeEntry({
@@ -80,13 +86,39 @@ describe("validateOpening", () => {
       ],
     });
     const { reverse, marker } = makeVoidEntries(earlier, "x", "2026-01-01");
-    const result = validateOpening({
+    const result = parseOpening({
       asOfDate: "2026-01-01",
       lines: BALANCED,
       accounts: ACCOUNTS,
       existingEntries: [earlier, reverse, marker],
     });
     assert.equal(result.ok, true);
+  });
+});
+
+// #2695: `lines: [null]` reached `accountByCode.get(line.accountCode)`
+// and threw, so the route answered 500. A mistyped amount was worse than
+// that — it balanced to zero, passed, and landed a string in the journal.
+describe("parseOpening — non-object input", () => {
+  it("reports a null line instead of throwing", () => {
+    const result = parseOpening({ asOfDate: "2026-01-01", lines: [null], accounts: ACCOUNTS, existingEntries: [] });
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.field === "lines[0]"));
+  });
+  it("reports a non-array lines value", () => {
+    const result = parseOpening({ asOfDate: "2026-01-01", lines: "nope", accounts: ACCOUNTS, existingEntries: [] });
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.message === "lines must be an array"));
+  });
+  it("rejects a mistyped amount that would otherwise balance to zero", () => {
+    const result = parseOpening({
+      asOfDate: "2026-01-01",
+      lines: [{ accountCode: "1000", debit: "abc" }],
+      accounts: ACCOUNTS,
+      existingEntries: [],
+    });
+    assert.equal(result.ok, false);
+    assert.ok(issuesOf(result).some((err) => err.field === "lines[0].debit" && err.message === "debit must be a non-negative finite number"));
   });
 });
 

--- a/packages/plugins/accounting-plugin/test/accounting/test_openingBalances.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_openingBalances.ts
@@ -110,6 +110,20 @@ describe("parseOpening — non-object input", () => {
     assert.equal(result.ok, false);
     assert.ok(issuesOf(result).some((err) => err.message === "lines must be an array"));
   });
+  it("does not claim an opening is unbalanced when a line was unreadable", () => {
+    const result = parseOpening({
+      asOfDate: "2026-01-01",
+      lines: [null, { accountCode: "1000", debit: 100 }, { accountCode: "3000", credit: 100 }],
+      accounts: ACCOUNTS,
+      existingEntries: [],
+    });
+    assert.equal(result.ok, false);
+    assert.equal(
+      issuesOf(result).some((err) => err.message.includes("must balance")),
+      false,
+      JSON.stringify(issuesOf(result)),
+    );
+  });
   it("rejects a mistyped amount that would otherwise balance to zero", () => {
     const result = parseOpening({
       asOfDate: "2026-01-01",

--- a/packages/plugins/accounting-plugin/test/accounting/test_router.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_router.ts
@@ -143,6 +143,77 @@ describe("getReport period validation", () => {
   });
 });
 
+// #2695: the payloads below reached a validator that assumed its
+// elements were objects, so the TypeError bubbled to the 500 catch-all —
+// out of the code written to turn bad input into a structured 400.
+describe("null elements in entries / lines", () => {
+  it("rejects a null journal entry with a structured 400", async () => {
+    const { status, body } = await dispatch({ action: ACCOUNTING_ACTIONS.addEntries, bookId, entries: [null] });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /invalid journal entries/);
+    // `details` is what lets the LLM repair its own payload — a bare
+    // 400 would be no better than the 500 it replaces.
+    assert.match(JSON.stringify(body.details), /"index":0/);
+  });
+
+  it("rejects a null opening balance line with a structured 400", async () => {
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.setOpeningBalances,
+      bookId,
+      asOfDate: "2026-01-01",
+      lines: [null],
+    });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /invalid opening balances/);
+    assert.match(JSON.stringify(body.details), /lines\[0\]/);
+  });
+
+  it("still rejects a primitive entry and a non-array entries", async () => {
+    const primitive = await dispatch({ action: ACCOUNTING_ACTIONS.addEntries, bookId, entries: [42] });
+    assert.equal(primitive.status, 400);
+    const notArray = await dispatch({ action: ACCOUNTING_ACTIONS.addEntries, bookId, entries: "nope" });
+    assert.equal(notArray.status, 400);
+    assert.match(String(notArray.body.error), /entries must be a non-empty array/);
+  });
+
+  it("keeps the per-field message for a mistyped amount", async () => {
+    // Anti-degradation: narrowing happens inside the validator, so this
+    // stays specific instead of collapsing to "malformed entries".
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.addEntries,
+      bookId,
+      entries: [
+        {
+          date: "2026-01-05",
+          lines: [
+            { accountCode: "1000", debit: "abc" },
+            { accountCode: "3000", credit: 5 },
+          ],
+        },
+      ],
+    });
+    assert.equal(status, 400);
+    assert.match(JSON.stringify(body.details), /debit must be a non-negative finite number/);
+  });
+
+  it("rejects an account payload missing name / type instead of persisting it", async () => {
+    // Previously 200: the account landed on disk with `type` undefined,
+    // and every report groups its rows by type.
+    // 1777 is outside the default chart, so its absence afterwards is
+    // the write not happening rather than a seeded row.
+    const { status, body } = await dispatch({ action: ACCOUNTING_ACTIONS.upsertAccount, bookId, account: { code: "1777" } });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /account name is required/);
+    const accounts = await dispatch({ action: ACCOUNTING_ACTIONS.getAccounts, bookId });
+    assert.doesNotMatch(JSON.stringify(accounts.body), /"1777"/);
+  });
+
+  it("rejects a null account", async () => {
+    const { status } = await dispatch({ action: ACCOUNTING_ACTIONS.upsertAccount, bookId, account: null });
+    assert.equal(status, 400);
+  });
+});
+
 describe("bookId reading", () => {
   it("treats a non-string bookId as absent", async () => {
     // Previously cast to `string | undefined`, so a number reached

--- a/packages/plugins/accounting-plugin/test/accounting/test_service.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_service.ts
@@ -693,6 +693,41 @@ describe("opening balances", () => {
       AccountingError,
     );
   });
+  it("rejects a mistyped amount instead of writing a string into the journal (#2695)", async () => {
+    // A non-number contributed nothing to the debit = credit sum, so a
+    // lone bad line balanced to zero, passed, and persisted verbatim.
+    const root = makeTmp();
+    const book = await createBook({ name: "Test" }, root);
+    const bookId = book.book.id;
+    await assert.rejects(() => setOpeningBalances({ bookId, asOfDate: "2026-01-01", lines: [{ accountCode: "1000", debit: "abc" }] }, root), AccountingError);
+    const opening = await getOpeningBalances({ bookId }, root);
+    assert.equal(opening.opening, null, "a rejected opening must not reach disk");
+  });
+});
+
+describe("upsertAccount input parsing (#2695)", () => {
+  it("rejects an account without a name / type instead of persisting one no report can group", async () => {
+    const root = makeTmp();
+    const book = await createBook({ name: "X" }, root);
+    const bookId = book.book.id;
+    const { listAccounts, upsertAccount } = await import("../../src/server/service.js");
+    // 1777 is outside the default chart, so its absence afterwards is
+    // the write not happening rather than a seeded row.
+    await assert.rejects(() => upsertAccount({ bookId, account: { code: "1777" } }, root), AccountingError);
+    await assert.rejects(() => upsertAccount({ bookId, account: { code: "1777", name: "Equipment" } }, root), AccountingError);
+    await assert.rejects(() => upsertAccount({ bookId, account: { code: "1777", name: "Equipment", type: "nonsense" } }, root), AccountingError);
+    const { accounts } = await listAccounts({ bookId }, root);
+    assert.equal(
+      accounts.some((account) => account.code === "1777"),
+      false,
+    );
+  });
+  it("rejects a null account", async () => {
+    const root = makeTmp();
+    const book = await createBook({ name: "X" }, root);
+    const { upsertAccount } = await import("../../src/server/service.js");
+    await assert.rejects(() => upsertAccount({ bookId: book.book.id, account: null }, root), AccountingError);
+  });
 });
 
 describe("reports end-to-end", () => {

--- a/plans/fix-2692-ban-type-assertions.md
+++ b/plans/fix-2692-ban-type-assertions.md
@@ -52,19 +52,22 @@ Drain order is largest-file-first, so the dominant shapes get a reusable fix
 early.
 
 - [x] `eslint.config.mjs` — rule at `warn`, tests exempt
-- [x] `accounting-plugin/src/server/router.ts` — 30 → 3
-- [ ] 447 casts / 199 files remaining
+- [x] `accounting-plugin/src/server/router.ts` — 30 → 3 → **0**
+- [ ] 413 casts / 197 files remaining (re-measured 2026-08-02, after #2694 / #2697 / #2699 / #2702)
 
-### Deferred: the accounting validation layer
+### Done: the accounting validation layer
 
 The three casts left in `router.ts` (`account` / `entries` / `lines`
-`as never`) can't be removed at the router. The service declares them as
+`as never`) couldn't be removed at the router. The service declared them as
 already-validated shapes (`Account`, `AddEntriesItem[]`, `JournalLine[]`) while
 receiving them raw, and the validators written to turn bad input into a
 structured 400 read `item.date` / `line.accountCode` off elements that may not
-be objects. Fixing it honestly means changing `journal.ts`,
-`openingBalances.ts` and `service.ts` together, with their tests. Reported on
-#2692 with the repro.
+be objects.
+
+Fixed on #2695 by turning those validators into parsers — see
+[`fix-2695-accounting-parse-boundary.md`](./fix-2695-accounting-parse-boundary.md).
+The cast was hiding three live bugs, not just a type mismatch: two 500s and
+three silent 200s that persisted unchecked data.
 
 ## Notes
 

--- a/plans/fix-2695-accounting-parse-boundary.md
+++ b/plans/fix-2695-accounting-parse-boundary.md
@@ -1,0 +1,117 @@
+# fix(accounting): parse the dispatch payload instead of casting it (#2695)
+
+`entries: [null]` and `lines: [null]` return **HTTP 500**. The validators written
+to turn bad input into a structured 400 are themselves throwing:
+
+```
+POST /api/accounting { "action": "addEntries", "entries": [null] }
+  -> 500 TypeError: Cannot read properties of null (reading 'date')
+POST /api/accounting { "action": "setOpeningBalances", "lines": [null] }
+  -> 500 TypeError: Cannot read properties of null (reading 'accountCode')
+```
+
+Root cause: three `as never` casts in `router.ts` hand raw wire data to service
+functions declared as taking already-validated shapes (`Account`,
+`AddEntriesItem[]`, `JournalLine[]`). `as never` is assignable to anything, so
+the mismatch compiles — and the validators read `item.date` / `line.accountCode`
+off elements that may not be objects.
+
+Deferred from #2694 (see the "Deferred" section of
+[`fix-2692-ban-type-assertions.md`](./fix-2692-ban-type-assertions.md)); the
+casts are the last three in that file.
+
+## Measured on `main` before the fix (2026-08-02)
+
+Driving the real Express router. The two 500s are the reported bug; the three
+200s are the same root cause seen from the other side — nothing ever checked
+that a line's `debit` is a number or that an account has a `type`, because the
+type system was told it already had.
+
+| payload | today | persisted |
+|---|---|---|
+| `entries: [null]` | **500** | — |
+| `lines: [null]` | **500** | — |
+| `lines: [{accountCode:"1000",debit:"abc"}]` | 200 | `"debit":"abc"` in the journal jsonl |
+| `entries: [{…, memo: 42}]` | 200 | `"memo":42` |
+| `account: {code:"1500"}` | 200 | account with `name`/`type` **undefined** |
+
+The 200s cannot be fixed at the router: a shape gate there would collapse
+`debit: "abc"` from `"debit must be a non-negative finite number"` into a
+generic message, and the LLM would lose the information it needs to repair its
+own payload. They cannot be left alone either — narrowing `unknown` to
+`JournalLine` / `Account` *is* checking those fields.
+
+## Approach: parse, don't validate
+
+The existing helpers are validators — they answer "any problems?" but return no
+typed value, so a caller still has to assert the shape it just proved. Each one
+becomes a parse: takes `unknown`, narrows internally, returns the narrowed value
+on success and structured issues on failure. Service signatures then become
+honest and the casts have nothing left to hide.
+
+**Every existing error message is preserved verbatim.** Narrowing happens inside
+the validators, per field, so `debit: "abc"` keeps its specific message.
+
+### `src/server/journal.ts`
+
+- `parseJournalLine(raw, idx, errors): JournalLine | null` — shape only:
+  `accountCode` a string, `debit` / `credit` non-negative finite numbers when
+  present, `memo` / `taxRegistrationId` strings, tax-id length cap. A non-object
+  line becomes a structured `lines[i]` error instead of a TypeError.
+  Deliberately does **not** check account existence or the debit/credit-side
+  rule — the journal and the opening balances disagree about those.
+- `validateEntry` → `parseEntry(raw: unknown, accounts)` returning
+  `{ok: true, entry} | {ok: false, errors}`. A non-object entry is its own
+  error; `memo` / `replacesEntryId` are narrowed rather than persisted raw.
+- `netBalance` keeps its typed signature — it now runs on parsed lines, and the
+  old `typeof` guards already skipped non-numbers, so the numbers don't move.
+
+### `src/server/openingBalances.ts`
+
+- `validateOpening` → `parseOpening({asOfDate, lines: unknown, …})` returning the
+  narrowed lines. Reuses `parseJournalLine`; the unknown-account check, the
+  balance-sheet-accounts-only rule and the "asOfDate predates everything" rule
+  are unchanged.
+- Openings deliberately do **not** adopt the entry-level "exactly one of debit
+  or credit" rule. `OpeningBalancesForm` can post a line carrying both today;
+  tightening that is a separate decision, not part of a 500 → 400 fix.
+
+### `src/server/accountNormalize.ts`
+
+- `parseAccountInput(raw: unknown)` — `code` (existing message verbatim), `name`,
+  `type` via an `isAccountType` guard over `ACCOUNT_TYPES`, optional
+  `note` / `active`. Missing `name` / `type` now 400 instead of persisting an
+  account the report layer cannot group. The Vue AccountsModal already always
+  sends all three, so only malformed API / LLM payloads change.
+
+### `src/server/service.ts`
+
+- `addEntries({entries: unknown})`, `setOpeningBalances({lines: unknown})`,
+  `upsertAccount({account: unknown})`.
+- `collectBatchValidationFailures` → one pass returning both the failures and the
+  parsed entries, so `buildBatchEntries` gets typed input.
+- `isUnknownArray` for the non-empty-array check (message unchanged).
+
+### `src/server/router.ts`
+
+Three `as never` gone, deferral comment removed. `lines` keeps its `?? []` — an
+omitted `lines` is the zero-line opening marker the UI's gate relies on, and
+dropping it would turn that into a 400.
+
+## Tests
+
+- `test_journal.ts` / `test_openingBalances.ts` — parse-result shape, plus null
+  elements, primitive elements, non-object lines, non-string memo.
+- `test_router.ts` — endpoint regressions for `entries: [null]` and
+  `lines: [null]` (400 with structured `details`), and an anti-degradation test
+  pinning that `debit: "abc"` still yields
+  `"debit must be a non-negative finite number"` rather than a generic shape
+  error.
+- `test_service.ts` — `upsertAccount` without `name` / `type` rejects; an
+  opening with a string `debit` no longer persists.
+
+## Out of scope
+
+Version bump / npm publish. `@mulmoclaude/accounting-plugin@1.1.0` carries the
+bug; the bump, the launcher dep-range sweep (`packages/mulmoclaude` declares
+`^1.1.0`) and the tagged publish go through the `/publish` skill afterwards.


### PR DESCRIPTION
## Summary

`entries: [null]` / `lines: [null]` on the accounting dispatch returned **HTTP 500** — the validators written to produce a structured 400 were throwing themselves. Root cause: three `as never` casts in `router.ts` handed raw wire data to service functions declared as taking already-validated shapes (`Account`, `AddEntriesItem[]`, `JournalLine[]`), so the mismatch compiled and the validators read `item.date` / `line.accountCode` off elements that may not be objects.

The fix turns those validators into **parsers**: each takes `unknown`, narrows internally, and returns the narrowed value on success. The service signatures become honest, so the three casts have nothing left to hide. **Every existing error message is preserved verbatim** — narrowing happens inside the validators, per field, so `debit: "abc"` keeps `"debit must be a non-negative finite number"`.

The same casts were also hiding **three silent 200s that persisted unchecked data**. All five rows below were measured by driving the real Express router and then reading the journal `.jsonl` on disk:

| payload | before | after |
|---|---|---|
| `entries: [null]` | **500** TypeError | 400 `invalid journal entries`, `details[0].index: 0` |
| `lines: [null]` | **500** TypeError | 400 `invalid opening balances`, field `lines[0]` |
| `lines: [{accountCode:"1000",debit:"abc"}]` | 200, wrote `"debit":"abc"` | 400, field `lines[0].debit`, nothing on disk |
| `entries: [{…, memo: 42}]` | 200, wrote `"memo":42` | 400, field `memo` |
| `account: {code:"1500"}` | 200, wrote `type: undefined` | 400 `account name is required` |

Happy paths re-verified end to end: opening balances, an entry with `taxRegistrationId`, the zero-line opening marker, `upsertAccount`, and a balance-sheet report still returning the real opening cash — with the journal holding only well-formed numeric lines.

## Items to Confirm / Review

1. **`upsertAccount` now requires `code` + `name` + `type`** (agreed with the requester before implementing). Previously `{code:"1500"}` returned 200 and persisted an account with `name`/`type` undefined — invisible to every report, which groups rows by type. The Vue `AccountsModal` always sends all three, so only malformed API / LLM payloads change behaviour. The alternative considered was inheriting `name`/`type` from the stored account on update; that turns upsert into patch, so it was rejected as a separate decision.
2. **Openings deliberately did NOT adopt the entry-level "exactly one of debit or credit" rule.** `OpeningBalancesForm` can post a line carrying both columns today; tightening that would be a behaviour change unrelated to a 500 → 400 fix. Opening lines get shape narrowing only, plus their existing balance-sheet-accounts rule.
3. **`upsertAccount`'s response now echoes the parsed account** rather than the raw payload, so unknown keys no longer bounce back to the caller. Nothing in the frontend reads them, but it is an observable API change.
4. **Existing corrupt data is not repaired.** A book that already holds a string `debit` from the old silent-200 path keeps it; this PR stops new corruption only. Say the word if a migration/repair pass is wanted as a follow-up.
5. **`memo` / `replacesEntryId` / `note` / `active` are now rejected when mistyped** rather than silently dropped or persisted raw. Rejecting keeps the payload repairable by the LLM; dropping would lose data the user meant to send.
6. **Router `lines` keeps its `?? []`.** An omitted `lines` is the zero-line opening marker that unlocks the View's tab gate — dropping the fallback would have turned that into a 400. `entries` lost its `?? []` because both paths produce the same message.

## User Prompt

> GitHub issue #2695: fix(accounting): entries/lines に null 要素を送ると 400 でなく 500 になる — バリデータ自身が落ちている
>
> **何が起きるか**: `accounting` の dispatch に、配列要素が `null` のペイロードを投げると HTTP 500 になります。400 を返すために書かれたバリデータ自身が落ちています。プリミティブなら通ります。`null` だけが落ちます。
>
> **原因**: router がキャスト (`as never`) で service に生のボディを渡しています。service の宣言は検証済みの型です。`as never` は何にでも代入できるので、この不一致がコンパイラを通ります。そして「不正入力を構造化 400 に変換するために書かれた」バリデータが、要素はオブジェクトである前提でフィールドを読みます。
>
> **直し方**: router 側だけでは直せません。バリデータを `unknown` 受け取りにして中で narrow する必要があります。`validateEntry` / `validateLine` / `validateLineAccountTypes` / `netBalance` / `collectBatchValidationFailures`。注意点: 現状の `validateEntry` は validate であって parse ではないので、通過しても型が付きません。`buildBatchEntries` が検証済みの `AddEntriesItem[]` を要求するため、parse 側に寄せる（ok のとき型の付いた値を返す）のが素直です。`test_journal.ts` / `test_openingBalances.ts` の期待値も動きます。
>
> **エラーメッセージの質は落とさないこと。** 例えば `debit: "abc"` は今 `"debit must be a non-negative finite number"` という構造化エラーになります。router 側で雑に shape gate を入れるとこれが汎用エラーに退化し、LLM が自分でペイロードを直せなくなります。narrow はバリデータの中でやるべきです。
>
> **完了条件**: `entries: [null]` / `lines: [null]` が 400（構造化エラー付き）を返す / `router.ts` の `as never` 3件が消える / 既存の構造化エラーメッセージが退化していない / リグレッションテストがある
>
> Let's work on this issue. Read it through first and confirm the approach with me before implementing.

Two decisions taken with the requester before implementing:

- `upsertAccount` with a missing `name` / `type` → **400** (rather than inheriting from the stored account on update).
- **No version bump / publish in this PR** — versioning is handled separately.

## Implementation

### `src/server/journal.ts`

- `parseJournalLine(raw, idx, errors): JournalLine | null` — shape only: `accountCode` a string, `debit`/`credit` non-negative finite numbers when present, `memo`/`taxRegistrationId` strings, tax-id length cap. A non-object line becomes a structured `lines[i]` error instead of a TypeError. Deliberately does **not** check account existence or the debit/credit-side rule — the journal and the opening balances disagree about those, so they stay with each caller.
- `validateEntry` → `parseEntry(raw: unknown, accounts)` returning `{ok: true, entry} | {ok: false, errors}`. A non-object entry is its own error.
- `netBalance` keeps its typed signature: it now runs on parsed lines, and the old `typeof` guards already skipped non-numbers, so the arithmetic is unchanged.

### `src/server/openingBalances.ts`

- `validateOpening` → `parseOpening({asOfDate, lines: unknown, …})` returning the narrowed lines. Reuses `parseJournalLine`; the unknown-account check, the balance-sheet-only rule and the "asOfDate predates everything" rule are untouched.

### `src/server/accountNormalize.ts`

- `parseAccountInput(raw: unknown)` — `code` (message verbatim), `name`, `type` via an `isAccountType` guard over `ACCOUNT_TYPES`, optional `note` / `active`. No `as` cast: the guard is `ACCOUNT_TYPES.some(t => t === value)`.

### `src/server/service.ts`

- `addEntries({entries: unknown})`, `setOpeningBalances({lines: unknown})`, `upsertAccount({account: unknown})`.
- `collectBatchValidationFailures` → `parseBatchEntries`, one pass returning both the failures and the parsed entries, so `buildBatchEntries` gets a shape something checked.
- `isUnknownArray` from `@mulmoclaude/common` for the non-empty-array check (message unchanged; `Array.isArray` on `unknown` narrows to `any[]`).

### `src/server/router.ts`

Three `as never` gone, deferral comment removed.

## Tests

- `test_journal.ts` / `test_openingBalances.ts` — parse-result shape, plus null elements, primitive elements, non-object lines, non-string memo, non-string `accountCode`.
- `test_router.ts` — endpoint regressions for `entries: [null]` and `lines: [null]` (400 **with** structured `details`), and an anti-degradation test pinning that `debit: "abc"` still yields `"debit must be a non-negative finite number"`.
- `test_service.ts` — `upsertAccount` without `name`/`type` rejects and writes nothing; an opening with a string `debit` no longer persists.

269 plugin tests + all 27 root suites pass. `yarn format` / `lint` (0 errors) / `typecheck` / `build` clean, re-run after merging `main`.

## Out of scope

Version bump / npm publish. `@mulmoclaude/accounting-plugin@1.1.0` on npm carries the bug; the bump, the launcher dep-range sweep (`packages/mulmoclaude` declares `^1.1.0`) and the tagged publish go through the `/publish` skill separately.

## Related

- Closes #2695
- Refs #2692 — this clears the last 3 casts from `router.ts`, deferred by #2694. Repo-wide count is now 413 casts / 197 files; the `plans/fix-2692-ban-type-assertions.md` "Deferred" section is updated to Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Parse accounting dispatch payloads at the service layer instead of relying on type assertions, fixing 500s from validators and preventing unchecked data from being persisted while preserving existing structured error messages.

Bug Fixes:
- Return structured 400 errors instead of 500s when journal entries or opening-balance lines contain null or non-object values.
- Prevent mistyped numeric fields (e.g. non-number debit amounts) and invalid opening balances from being silently accepted and written to the journal.
- Reject malformed account payloads, including missing name/type or non-object accounts, so invalid accounts are no longer persisted and hidden from reports.

Enhancements:
- Introduce parsing helpers for journal entries, journal lines, opening balances, and account payloads that narrow unknown input to typed shapes while returning detailed validation issues.
- Update accounting services to accept raw wire payloads as unknown and rely on parsers for narrowing, eliminating unsafe casts and making signatures reflect actual input.
- Ensure upsertAccount responses echo the parsed account payload rather than raw input, so unknown keys are not reflected back to callers.
- Tighten opening-balance and journal handling so only well-formed numeric lines are persisted while keeping per-field error messages specific and repairable by client code.

Documentation:
- Update validation-layer plan documentation to mark the router casts as removed and document the new parse-based boundary for accounting payloads.
- Add a dedicated plan note describing the accounting parse boundary changes and the measured pre-fix behaviour for the affected payloads.

Tests:
- Extend journal and opening-balance unit tests to cover parse results, non-object and primitive inputs, mistyped fields, and preservation of specific error messages.
- Add router tests to assert structured 400 responses and detailed error information for bad entries/lines and malformed account payloads.
- Add service-level tests to ensure mistyped opening balances are rejected without writing corrupt data and that upsertAccount input parsing enforces required fields and types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for accounts, journal entries, and opening balances.
  * Malformed or incomplete accounting data is now rejected with structured, field-specific errors instead of being accepted or causing unexpected failures.
  * Invalid records are prevented from being persisted.
  * Journal entries now validate account codes, dates, line rules, tax IDs, minimum lines, and balance tolerance.
* **Tests**
  * Added regression coverage for invalid and malformed accounting inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->