### PR TITLE
fix(plugins): make wrapWithScope's return type honest, dropping 15 casts (#2692)

### DIFF
--- a/src/plugins/chart/index.ts
+++ b/src/plugins/chart/index.ts
@@ -1,4 +1,3 @@
-import type { Component } from "vue";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
 import { View, Preview, TOOL_DEFINITION, type PresentChartData } from "@mulmoclaude/chart-plugin/vue";
 // The package's component scoped styles are compiled into a standalone
@@ -16,16 +15,14 @@ import { wrapWithScope } from "../scope";
 // components in MulmoClaude's scoped runtime provider (wrapWithScope) so the
 // package's useT()/locale resolves to the host.
 const chartPlugin: ToolPlugin<PresentChartData> = {
-  // gui-chat-protocol type is externalized but yarn-4's dual-@vue can make the
-  // package's nominal types distinct; coerce once here.
-  toolDefinition: TOOL_DEFINITION as ToolPlugin<PresentChartData>["toolDefinition"],
+  toolDefinition: TOOL_DEFINITION,
 
   execute: makeRouteExecute<ChartEndpoints, PresentChartData>("chart", "create", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Rendering chart…",
-  viewComponent: wrapWithScope("chart", View as unknown as Component),
-  previewComponent: wrapWithScope("chart", Preview as unknown as Component),
+  viewComponent: wrapWithScope("chart", View),
+  previewComponent: wrapWithScope("chart", Preview),
 };
 export { TOOL_NAME };
 

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -5,7 +5,6 @@
 // (server/plugins/markdown-builtin.ts). This adapter keeps MulmoClaude's
 // existing client-side create path (POST /api/markdown) rather than the
 // package's context.app create, so the legacy create route is untouched.
-import type { Component } from "vue";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
 import { View, Preview, TOOL_DEFINITION, TOOL_NAME, type MarkdownToolData } from "@mulmoclaude/markdown-plugin/vue";
 // The package's component scoped styles (incl. the flex/overflow layout
@@ -22,16 +21,14 @@ import type { ResolvedRoute } from "../meta-types";
 type DocumentEndpoints = { readonly [K in keyof typeof META.apiRoutes]: ResolvedRoute };
 
 const markdownPlugin: ToolPlugin<MarkdownToolData> = {
-  // gui-chat-protocol type is externalized but yarn-4's dual-@vue can
-  // make the package's nominal types distinct; coerce once here.
-  toolDefinition: TOOL_DEFINITION as ToolPlugin<MarkdownToolData>["toolDefinition"],
+  toolDefinition: TOOL_DEFINITION,
 
   execute: makeRouteExecute<DocumentEndpoints, MarkdownToolData>("markdown", "create", TOOL_NAME),
 
   isEnabled: () => true,
   generatingMessage: "Creating document...",
-  viewComponent: wrapWithScope("markdown", View as unknown as Component),
-  previewComponent: wrapWithScope("markdown", Preview as unknown as Component),
+  viewComponent: wrapWithScope("markdown", View),
+  previewComponent: wrapWithScope("markdown", Preview),
 };
 export { TOOL_NAME };
 

--- a/src/plugins/presentHtml/index.ts
+++ b/src/plugins/presentHtml/index.ts
@@ -1,4 +1,3 @@
-import type { Component } from "vue";
 import type { PluginRegistration, ToolPlugin } from "../../tools/types";
 import type { ToolResult } from "gui-chat-protocol";
 import { View, Preview, type PresentHtmlData } from "@mulmoclaude/html-plugin/vue";
@@ -47,10 +46,8 @@ const presentHtmlPlugin: ToolPlugin<PresentHtmlData> = {
 
   isEnabled: () => true,
   generatingMessage: "Presenting HTML page…",
-  // gui-chat-protocol's Component type is externalized but yarn-4's dual-@vue can
-  // make the package's nominal types distinct; coerce once here (same as chart).
-  viewComponent: wrapWithScope("html", View as unknown as Component),
-  previewComponent: wrapWithScope("html", Preview as unknown as Component),
+  viewComponent: wrapWithScope("html", View),
+  previewComponent: wrapWithScope("html", Preview),
 };
 export { TOOL_NAME };
 

--- a/src/plugins/scope.ts
+++ b/src/plugins/scope.ts
@@ -38,7 +38,9 @@ import { pluginEndpoints } from "./api";
  *  @param scope    plugin scope name (matches the install registry
  *                  key, e.g. `"todos"`, `"wiki"`, `"mulmoScript"`).
  *  @param inner    the plugin's raw View / Preview component. */
-export function wrapWithScope<TInner extends Component | undefined>(scope: string, inner: TInner): TInner {
+export function wrapWithScope(scope: string, inner: Component): Component;
+export function wrapWithScope(scope: string, inner: Component | undefined): Component | undefined;
+export function wrapWithScope(scope: string, inner: Component | undefined): Component | undefined {
   if (!inner) return inner;
   // `markRaw` so reactive containers don't try to proxy this
   // component object — Vue warns + the proxy can interfere with
@@ -53,5 +55,5 @@ export function wrapWithScope<TInner extends Component | undefined>(scope: strin
         return () => h(PluginScopedRoot, { pkgName: scope, endpoints }, () => h(inner, attrs, slots));
       },
     }),
-  ) as TInner;
+  );
 }


### PR DESCRIPTION
## Summary

`wrapWithScope` が「返していない型」を名乗っていたのを直し、その嘘を満たすためだけに存在していた3プラグインのキャストを削除しました。**15 → 0**。

#2702 で `withHostAdapter` に見つかったのと**同じ**バグです（そちらのレビューで「`scope.ts` にも同型がある」と報告済み）。

| ファイル | cast |
|---|---|
| `src/plugins/scope.ts` | 1 → 0 |
| `src/plugins/chart/index.ts` | 5 → 0 |
| `src/plugins/markdown/index.ts` | 5 → 0 |
| `src/plugins/presentHtml/index.ts` | 4 → 0 |

## Items to Confirm / Review

1. **`wrapWithScope` のシグネチャ変更**が本 PR の中心です。ジェネリクスを捨ててオーバーロード2本にしました。**実行時の挙動は変わりません**（元から wrapper を返していた）。呼び出し側は本 PR 内の3ファイル + 既存の全ビルトインプラグインで、いずれも `Component` を渡して `Component` を受け取る形なので影響ありません。
2. **`undefined` の扱いを保持しています。** `viewComponent` / `previewComponent` は optional なので、`undefined` を渡したら `undefined` が返る必要があります。2本目のオーバーロードがそれです。
3. **3プラグインのコメント削除**について。「yarn-4 の dual-@vue で nominal type が別物になる」という理由が書かれていましたが、**現在のツリーは `vue` を1つしか解決しません**。素直に代入して 0 エラーなので、前提が消えたコメントごと削除しました。もし将来 dual-@vue が復活する可能性を残したいなら、そこは判断をお願いします。
4. **`toolDefinition` のキャストも同時に消えています**（chart / markdown）。同じ「dual-@vue」コメントの下にあり、同じく直接代入で通ります。

## 実装方針

```ts
// before — 返していない型を名乗る
export function wrapWithScope<TInner extends Component | undefined>(scope: string, inner: TInner): TInner {
  if (!inner) return inner;
  return markRaw(defineComponent({ /* 新しいラッパ */ })) as TInner;
}

// after — 実際に返すものを宣言する
export function wrapWithScope(scope: string, inner: Component): Component;
export function wrapWithScope(scope: string, inner: Component | undefined): Component | undefined;
export function wrapWithScope(scope: string, inner: Component | undefined): Component | undefined {
  if (!inner) return inner;
  return markRaw(defineComponent({ /* 新しいラッパ */ }));
}
```

`TInner` は呼び出し側が決める型変数なので、`markRaw(defineComponent(...))` がそれに代入できる保証はどこにもありません。`as TInner` はその指摘を消していただけです。

呼び出し側は素直になります。

```ts
- viewComponent: wrapWithScope("chart", View as unknown as Component),
- previewComponent: wrapWithScope("chart", Preview as unknown as Component),
+ viewComponent: wrapWithScope("chart", View),
+ previewComponent: wrapWithScope("chart", Preview),
```

なお `presentForm` は `pkg.viewComponent` を渡していて元からキャスト不要でした。これが本来の形です。

## 検証

**コンポーネント登録はビルドが通っても実行時に落ちます**（white screen / view が mount しない）。なので実アプリで確認しました。

### mock e2e スイート全体（444テスト）

| | 本ブランチ | 同一コミットで変更なし |
|---|---|---|
| passed | **444** | 444 |
| failed | 1 | 1 |

**両方で同じ1件だけが落ちます** — `stack-sticky-bottom-scroll.spec.ts`。単体で実行すると**両方の revision で pass** するので、フルスイート負荷時の flaky です。本 PR とは無関係です。

対象3プラグインを直接カバーする spec も個別に確認しました。

```
npx playwright test --config e2e/playwright.config.ts chart-plugin markdown-frontmatter files-html-preview
  -> 9 passed
```

`chart-plugin.spec.ts` は canvas に実際にチャートが2つ描画されることと PNG エクスポートを、`markdown-frontmatter.spec.ts` は frontmatter パネル + 本文の描画を、`files-html-preview.spec.ts` は HTML プレビューの iframe / CSP / 画像パス書き換えを見ています。

### その他のゲート

```
yarn lint      -> exit 0
yarn typecheck -> exit 0
yarn build     -> exit 0
yarn test      -> 8862 tests / 8855 pass / 0 fail（+ 全 workspace 0 fail）
npx eslint <4ファイル> --rule consistent-type-assertions:never -> 0
```

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Clarify the wrapWithScope API to return the actual wrapped Component (or undefined) and clean up plugin usages accordingly.

Bug Fixes:
- Fix wrapWithScope’s return type so it accurately reflects the wrapped Component or undefined, avoiding unsafe generic-based casting.

Enhancements:
- Simplify chart, markdown, and presentHtml plugins by removing unnecessary Component imports, type casts, and dual-@vue related comments.
- Use direct TOOL_DEFINITION assignment in chart and markdown plugins instead of casting to the ToolPlugin toolDefinition type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal plugin component registration and typing.
  * Improved handling of optional components during scoped wrapping.
  * No user-facing behavior or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->