### PR TITLE
docs(helps): make the calendar and feeds record losses findable (#2693)

### DIFF
--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -461,6 +461,104 @@ Repair pass reports schema violations by record id, but has no
 "malformed file" classification), and the completion/spawn watcher
 reconciles the WHOLE collection per db change (no per-record events).
 
+## A record the user edited came back with the source's value
+
+### Symptoms
+
+Nothing fails — the user reports it. Any of:
+
+- A Google Calendar collection record they edited shows Google's value
+  again after a sync.
+- A feed record lost the column they had added beside it, or the whole
+  record disappeared once the item aged past `ingest.maxItems`.
+- The edit is simply gone, and no conflict was ever reported.
+
+### Cause
+
+Records are written WHOLE (`writeItem`), so anything that mirrors a
+remote source into a collection has to lay its values OVER the stored
+record rather than replace it — and has to refuse when the record holds
+an edit the source has not seen. Four separate places got that wrong:
+
+- `#2683` — a calendar collection without `autoPush` was never in the
+  pull's protected set at all.
+- `#2684` — the protected set was a snapshot taken when the push
+  finished, so an edit made while the window was in flight (minutes of
+  it, on a full re-walk) was invisible to it.
+- `#2688` — a cancellation in Google deleted the record without asking
+  whether it held an unsent edit.
+- `#2696` — the feeds ingest replaced the record whole, and the
+  `maxItems` prune deleted annotated records once they aged out.
+
+### Fix
+
+All four are fixed as of `@mulmoclaude/core` 1.13.0. **Check the host's
+version first** — if it is older, that is the whole answer.
+
+If it happens on 1.13.0 or later, it is a new bug, not one of these:
+capture which collection, whether it declares `googleCalendar` or
+`ingest`, and what the record looked like before and after. Do NOT
+suggest re-editing and hoping — the point of these fixes is that the
+loss is no longer silent.
+
+## A calendar conflict is reported on every Push and will not clear
+
+### Symptoms
+
+Push reports a conflict for a record that already matches Google. It
+comes back on every attempt; nothing the user does in the record clears
+it.
+
+### Cause
+
+The conflict check compares Google against the BASELINE in
+`<workspace>/data/calendar/.push-state.json`, not against the record.
+A baseline older than both sides reports a conflict forever.
+
+Before `#2679` that happened whenever two hosts pointed at the same
+workspace: both read the same snapshot and the later write dropped the
+earlier one's entry. The state files are now serialised across
+processes with a lock file.
+
+**It can still happen when the workspace lives in a sync folder**
+(Dropbox, iCloud, Google Drive). Exclusive file creation gives no
+exclusion there — the file is replicated after the fact, so both hosts
+believe they hold the lock. No mechanism in the app can fix that.
+
+### Fix
+
+Move the workspace onto a real filesystem. A network mount is fine
+(`O_EXCL` is atomic on NFSv3+); a consumer sync folder is not.
+
+Nothing is lost while it persists: the push REFUSES rather than
+overwrites, which is exactly what the conflict report means. If the
+workspace is already on a real filesystem and a conflict still will not
+clear, that is a new bug — report it with the calendar id and the
+record.
+
+## `proceeding without the calendar state lock` in the logs
+
+### Symptoms
+
+A `google` warning naming a `.lock` path, during a calendar sync.
+
+### Cause
+
+The lock guards one read-modify-write of a calendar state file, and it
+fails OPEN: a host that cannot take it does its work anyway, because
+the lock removes a race rather than being a precondition for syncing
+correctly.
+
+A single occurrence is normal — another host held the file for the few
+milliseconds the mutation takes.
+
+### Fix
+
+Nothing, if it is occasional. If it is constant, either another host is
+hammering the same workspace, or the lock file cannot be created at all
+(a read-only mount, a missing `data/calendar` directory, a full disk) —
+check those before treating it as a calendar problem.
+
 ## Fallback
 
 If none of the above matches the failing tool output:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^1.0.3",
     "@mulmoclaude/collection-plugin": "^1.2.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.1",
     "@mulmoclaude/html-plugin": "^1.2.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.12.0"
+    "@mulmoclaude/core": "^1.13.0"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.12.0"
+    "@mulmoclaude/core": "^1.13.0"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^1.12.0"
+    "@mulmoclaude/core": "^1.13.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^1.2.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.12.0"
+    "@mulmoclaude/core": "^1.13.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,20 +37,20 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "@mulmoclaude/markdown-utils": "^1.3.2",
     "js-yaml": "^5.2.2",
     "marked": "^18.0.7",
     "mermaid": "^11.16.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "gui-chat-protocol": "^1.2.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^1.12.0",
+    "@mulmoclaude/core": "^1.13.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^1.12.0"
+    "@mulmoclaude/core": "^1.13.0"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",


### PR DESCRIPTION
## Summary

このセッションで入った4件（#2683 / #2684 / #2688 / #2696）は、**エージェントからは見えない**状態でした。知見が PR 本文にしか無く、しかもどれも**ツール出力の失敗として現れません**。ユーザーが言うのは「編集が Google の値に戻った」「この conflict が消えない」で、これは `error-recovery.md` が持つ**2つ目の入口**（ツール出力に何も出ず、症状だけが語られるケース）そのものです。

エラー文字列ではなく**ユーザーの言い方**をキーにした3セクションを追加しました。

| 見出し | 扱う症状 |
|---|---|
| A record the user edited came back with the source's value | カレンダー / feed の編集・列が消えた |
| A calendar conflict is reported on every Push and will not clear | 一致しているのに conflict が出続ける |
| `proceeding without the calendar state lock` in the logs | ロックの fail-open 警告 |

`assets/helps/*` は npm に出るので、`@mulmoclaude/core` を **1.13.0** に上げ、**同じコミットで宣言レンジを13箇所（9 manifest）掃いて** launcher-sync のラチェットを green に保っています。

## Items to Confirm / Review

1. **launcher の OWN version は意図的に触っていません。** CLAUDE.md の規約どおり、あのフィールドは `/publish-mulmoclaude` フローのものです。上げたのは core の version と、各 consumer の**依存レンジ**だけです。`yarn check:launcher-sync` は OK。

2. **バージョンを本文に書いています**（"fixed as of `@mulmoclaude/core` 1.13.0"）。これにより「まずホストのバージョンを見る」が実際の第一手になり、**1.13.0 以降での再発は『これらのいずれか』ではなく新規バグとして扱われます**。バージョンを書かないと、この区別ができません。

3. **conflict のセクションで、直せない限界を明記しました。** ワークスペースが Dropbox / iCloud / Drive にある場合、排他的ファイル作成が排他になりません（ファイルが事後に複製されるため）。アプリ側のどの機構でも直せないので、**「ワークスペースを実 FS へ移す」**を fix にしています。

4. **意図的に「復旧レシピ」を書いていません。** 詰まった conflict を消す手順（baseline を消す等）を書きたくなりますが、**baseline を消すと pull 側の保護も消える**ので、間に sync が挟まるとローカル編集が上書きされます。検証していない手順を help に書くのは危険なので、代わりに「**push は上書きせず拒否するので失われるものは無い**」という事実と、実 FS でも消えないなら新規バグとして報告、を書きました。

5. **feeds も含めました。** issue のタイトルは「カレンダー同期の症状」ですが、#2696 は同じ波で出た**同一クラス**（レコードが丸ごと置換される）で、ユーザーは同じ場所を引きます。分けるほうが不親切だと判断しました。**分離すべきならお知らせください。**

6. **`error-recovery.md` 自身が「自分で編集するな、メンテナ管理」と書いています**（`## When you discover a new common error`）。これはその**メンテナ側の追加**として、canonical な `packages/core/assets/helps/` に対して行っています。

## User Prompt

> #2693を！

（#2693 は PR #2690 の CodeRabbit レビューから切り出した follow-up。release 連動になるためバグ修正PRから分離していたもの）

## 検証（実 exit code）

- `yarn check:launcher-sync` — ✅ `OK — root ↔ launcher deps in sync, no peer-dep violations.`
- `yarn build:packages` 0 / `yarn format --check` 0 / `yarn lint` 0 / `yarn typecheck` 0 / `yarn build` 0
- `yarn test` 0 — **10852 pass / 0 fail**
- `yarn.lock` は**変化なし**（レンジのみの変更で、解決先は workspace のまま）

**npm publish はしていません。** このPRは version と本文を揃えるところまでで、公開は `/publish` フローの仕事です。

refs #2693, #2683, #2684, #2688, #2696, #2679

work in mulmoclaude

## Summary by Sourcery

Document calendar and feed record loss scenarios in error recovery help and align core and plugin packages to @mulmoclaude/core 1.13.0.

Enhancements:
- Bump @mulmoclaude/core to version 1.13.0 and update dependency/peer ranges across host and plugin packages to keep launcher sync green.

Documentation:
- Expand error-recovery help with user-symptom-based sections for silent calendar/feed record loss, persistent calendar conflicts, and calendar state lock warnings.