### PR TITLE
docs(build): record the dispatcher.mjs artifact gate and its two traps

### DIFF
--- a/docs/build-orchestration.md
+++ b/docs/build-orchestration.md
@@ -26,6 +26,39 @@ Tiers 3 and 4 are auto-discovered by `scripts/build-workspaces.mjs`. Tiers 0-2 s
 
 NEVER name a non-runtime-plugin package `@mulmoclaude/foo-plugin` (e.g. a helper library). The build driver will try to run its `build` script in tier 4, after every consumer has already been built. Pick a different name (`@mulmoclaude/foo`, `@mulmoclaude/foo-helpers`, …) or fold it into `@mulmoclaude/core`.
 
+## Touching `packages/core` invalidates a committed artifact
+
+`server/build/dispatcher.mjs` is an esbuild bundle **committed to git**, and CI
+gates it (`Verify built hook bundles are up-to-date` runs `yarn build` then
+`git diff --exit-code`). The bundle records core's vite chunk filename as a
+source annotation, so **any** change to `packages/core` — or to what it bundles
+in, i.e. `@mulmoclaude/common` and `@mulmoclaude/markdown-utils` — shifts that
+line and the gate fails with a one-line diff:
+
+```diff
+-// packages/core/dist/dist-Cwk0e12G.js
++// packages/core/dist/dist-DfFWwikm.js
+```
+
+Regenerate and commit it in the same PR:
+
+```bash
+yarn build:packages && yarn build:hooks
+git add server/build/dispatcher.mjs
+```
+
+Two traps, both hit repeatedly during #2692:
+
+- **Verify your tree reproduces the CURRENT artifact before trusting a new
+  hash.** In a git worktree whose `node_modules` is a symlink to another
+  checkout, `@mulmoclaude/*` resolves to _that_ checkout's sources, so the hash
+  you generate describes someone else's tree. Revert to the base commit, build,
+  and confirm `git diff --exit-code` passes before generating the real value.
+- **On a merge conflict here, regenerate — don't pick a side.** When two PRs
+  both touch core, each carries a different hash and neither is correct for the
+  merge result. Resolve by running the two commands above on the merged tree;
+  that is the only value the gate accepts.
+
 ## yarn 4 compatibility
 
 The `yarn4_smoke` workflow verifies the chain still works under yarn 4. Both tiers' driver only spawns `yarn workspace <name> run build` — identical syntax in yarn 1 and 4 — so portability is preserved.

--- a/plans/fix-2692-ban-type-assertions.md
+++ b/plans/fix-2692-ban-type-assertions.md
@@ -2,7 +2,7 @@
 
 `CLAUDE.md` says "NEVER use `as` type casts; MUST use type guards instead", but
 ESLint never enforced it: `@typescript-eslint/consistent-type-assertions` was on
-at its default `assertionStyle: "as"`, which only polices the *syntax* (`as T`
+at its default `assertionStyle: "as"`, which only polices the _syntax_ (`as T`
 over `<T>x`). The written ban was therefore unmachined, and casts accumulated.
 
 Follows the approach established in
@@ -16,17 +16,17 @@ files**. The issue's headline number (187) counted `src/` + `server/` only;
 
 By shape:
 
-| count | shape | intended treatment |
-|---|---|---|
-| 218 | other | case by case |
-| 68 | `as unknown as T` (double cast) | **fix** — the most dangerous kind |
-| 64 | `as Record<…>` | usually a typed reader / guard |
-| 35 | `as string \| undefined` | typed field reader |
-| 25 | error narrowing (`err as NodeJS.ErrnoException`) | shared guard helper |
-| 25 | `JSON.parse(…) as T` | **fix** — parse + validate |
-| 18 | DOM element (`$event.target as HTMLInputElement`) | allowlist candidate |
-| 11 | `as never` | fix — hides a real type mismatch |
-| 10 | `Object.fromEntries(…) as …` | TS inference limit — allowlist candidate |
+| count | shape                                             | intended treatment                       |
+| ----- | ------------------------------------------------- | ---------------------------------------- |
+| 218   | other                                             | case by case                             |
+| 68    | `as unknown as T` (double cast)                   | **fix** — the most dangerous kind        |
+| 64    | `as Record<…>`                                    | usually a typed reader / guard           |
+| 35    | `as string \| undefined`                          | typed field reader                       |
+| 25    | error narrowing (`err as NodeJS.ErrnoException`)  | shared guard helper                      |
+| 25    | `JSON.parse(…) as T`                              | **fix** — parse + validate               |
+| 18    | DOM element (`$event.target as HTMLInputElement`) | allowlist candidate                      |
+| 11    | `as never`                                        | fix — hides a real type mismatch         |
+| 10    | `Object.fromEntries(…) as …`                      | TS inference limit — allowlist candidate |
 
 ## Approach
 
@@ -36,7 +36,7 @@ By shape:
    constructing input the types call impossible so a runtime guard has
    something to reject, and handing partial mocks to code wanting a full
    interface. The exemption lives in the existing test override and spells out
-   its options — flat config *keeps* the previous match's options when an
+   its options — flat config _keeps_ the previous match's options when an
    override supplies only a severity, so a bare `"error"` there would have
    inherited `never` and banned `as` in tests too.
 3. **Drain file by file.** One file per commit, each one a real fix (type
@@ -53,7 +53,25 @@ early.
 
 - [x] `eslint.config.mjs` — rule at `warn`, tests exempt
 - [x] `accounting-plugin/src/server/router.ts` — 30 → 3 → **0**
-- [ ] 413 casts / 197 files remaining (re-measured 2026-08-02, after #2694 / #2697 / #2699 / #2702)
+- [x] `server/plugins/runtime-loader.ts` (#2697) · `server/api/routes/collections.ts` (#2699)
+- [x] `src/plugins/presentMulmoScript/index.ts` (#2702) · `packages/core/src/notifier/store.ts` (#2703)
+- [x] `server/api/routes/plugins.ts` (#2705) · `server/events/session-store/index.ts` (#2706)
+- [x] `server/workspace/photo-locations/list.ts` (#2701) · `server/plugins/runtime.ts` (#2698)
+- [x] `src/plugins/scope.ts` + chart / markdown / presentHtml (#2710) — 15 in one go
+- [ ] 368 casts / 188 files remaining (re-measured 2026-08-02, after #2698)
+
+### Two shapes worth copying
+
+**Fix the signature, not the call site.** `wrapWithScope` and `withHostAdapter`
+both declared `<TInner> (…): TInner` while returning a brand-new wrapper
+component; `as TInner` laundered it. Correcting the two signatures deleted 15
+casts across four files, because every one of them existed only to satisfy the
+lie. When several files cast the same call, suspect the callee.
+
+**A stale comment outlives its reason.** Fourteen of those casts carried
+"yarn-4's dual-@vue can make the package's nominal types distinct". The tree
+resolves one `vue` today, so the direct assignment type-checks. Re-test the
+premise before preserving a workaround.
 
 ### Done: the accounting validation layer
 


### PR DESCRIPTION
## Summary

`packages/core` を触る PR が **3本連続で同じ CI 失敗**を踏んだので、その運用知識を人が読む場所に移しました。

`server/build/dispatcher.mjs` は git にコミットされた esbuild バンドルで、CI が `git diff --exit-code` で新鮮さを強制しています。バンドルは core の vite チャンク名をソース注釈として抱えているため、`packages/core`（および core がバンドルする `@mulmoclaude/common` / `@mulmoclaude/markdown-utils`）を触ると必ず陳腐化します。

```diff
-// packages/core/dist/dist-Cwk0e12G.js
+// packages/core/dist/dist-DfFWwikm.js
```

このルールは**クローズ済みの plan ファイル1つ**（`refactor-2483-known-dupes-sweep.md`）にしか書かれておらず、誰も見に行かない場所でした。CLAUDE.md が「workspace のビルド周り」の参照先に指定している `docs/build-orchestration.md` に移しています。

## Items to Confirm / Review

1. **配置場所** — `docs/build-orchestration.md` でよいか。CLAUDE.md の "Add a workspace package, debug a tier order issue" の参照先なので選びました。
2. **記録した2つの罠**は、いずれも今回の #2692 作業で実際に踏んだものです。推測ではありません。
   - worktree の `node_modules` が別チェックアウトへの symlink だと `@mulmoclaude/*` が**そちらのソース**に解決されるので、生成したハッシュが他人のツリーを表す
   - コンフリクト時はどちらのハッシュもマージ結果に対して正しくないので、**片側を選ばず再生成する**
3. plan ファイルの進捗を実測値（368 casts / 188 files）に更新し、一般化した2パターンを追記しました。

## 実装方針

ドキュメントのみ。コード変更なし。

`docs/build-orchestration.md` に「Touching `packages/core` invalidates a committed artifact」節を追加（再生成コマンド + 2つの罠）。`plans/fix-2692-ban-type-assertions.md` の進捗リストを更新し、他PRに効いた2つの知見を追記:

- **呼び出し側ではなく署名を直す** — `wrapWithScope` / `withHostAdapter` はどちらも `<TInner>(…): TInner` と宣言しながら新しいラッパを返しており、`as TInner` がそれを洗浄していました。署名2つを正すだけで**4ファイル15箇所**のキャストが消えました。同じ呼び出しを複数ファイルがキャストしているときは、呼ばれる側を疑うべきです。
- **理由が消えてもコメントは残る** — うち14箇所が「yarn-4 の dual-@vue で nominal type が別物になる」というコメント付きでした。今のツリーは `vue` を1つしか解決しないので前提が成立していません。回避策を残す前に前提を測り直すべきでした。

## 検証

```
yarn format --check -> exit 0
yarn lint           -> exit 0
yarn typecheck      -> exit 0
```

なお `yarn typecheck` が最初 79 errors を出しましたが、**ローカルの `packages/*/dist` が別ブランチのビルド結果で古かった**だけで、`yarn build:packages` 後は exit 0 です。main の状態ではありません（この現象自体が、本 PR が記録している罠の一種です）。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Document the dispatcher.mjs build artifact gate and its failure modes, and update the type-assertion cleanup plan with current progress and two generalized refactoring patterns.

Documentation:
- Add guidance on how changes to packages/core invalidate the committed dispatcher.mjs bundle and how to correctly regenerate it, including two common traps to avoid.

Chores:
- Refresh the fix-2692 type-assertion plan with updated cast/file counts and note two reusable strategies for eliminating casts encountered in related PRs.