### PR TITLE
refactor(accounting): drop every `as` cast from the compact preview

### DIFF
--- a/packages/plugins/accounting-plugin/src/vue/Preview.vue
+++ b/packages/plugins/accounting-plugin/src/vue/Preview.vue
@@ -11,93 +11,14 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { isRecord, isUnknownArray } from "@mulmoclaude/common";
 import { useAccountingI18n } from "./lang";
-import { formatAmountNumeric } from "../shared";
+import { summarisePreview } from "./previewSummary";
 
 const { t } = useAccountingI18n();
 
+// Some renderers carry the payload on `data`, others on `jsonData`;
+// `summarisePreview` merges whichever arrived and picks the branch.
 const props = defineProps<{ data?: unknown; jsonData?: Record<string, unknown> }>();
 
-// Readers, not predicates: everything below the payload root arrives as
-// `unknown`, so a field is a string / number only once one of these has
-// looked. Twins of the server's `bodyFields.ts` readers, duplicated here
-// because a browser bundle must not import the server surface.
-const optionalString = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined);
-const optionalNumber = (value: unknown): number | undefined => (typeof value === "number" ? value : undefined);
-
-// Each summarise* helper returns null when its branch doesn't apply,
-// keeping the dispatch in `summary` linear (no nested if-trees).
-
-function summariseError(json: Record<string, unknown>): string | null {
-  const error = optionalString(json.error);
-  if (error === undefined) return null;
-  return t("pluginAccounting.previewError", { error });
-}
-
-function summariseEntry(json: Record<string, unknown>): string | null {
-  // addEntries returns `{ entries: [...] }`. The compact preview
-  // card shows one date — use the first entry's so single-entry
-  // batches (the common case from the manual UI) read naturally
-  // and multi-entry batches still anchor to a meaningful date.
-  const [first] = isUnknownArray(json.entries) ? json.entries : [];
-  const entry = isRecord(first) ? first : undefined;
-  const entryId = optionalString(entry?.id);
-  const date = optionalString(entry?.date);
-  if (!entryId || !date) return null;
-  return t("pluginAccounting.preview.entry", { date });
-}
-
-function summarisePl(json: Record<string, unknown>): string | null {
-  const { profitLoss } = json;
-  if (!isRecord(profitLoss)) return null;
-  const netIncome = optionalNumber(profitLoss.netIncome);
-  if (netIncome === undefined) return null;
-  return t("pluginAccounting.preview.pl", {
-    from: optionalString(profitLoss.from) ?? "?",
-    to: optionalString(profitLoss.to) ?? "?",
-    net: formatAmountNumeric(netIncome),
-  });
-}
-
-function summariseBs(json: Record<string, unknown>): string | null {
-  const { balanceSheet } = json;
-  if (!isRecord(balanceSheet)) return null;
-  const date = optionalString(balanceSheet.asOf);
-  const sections = isUnknownArray(balanceSheet.sections) ? balanceSheet.sections : undefined;
-  if (!date || !sections) return null;
-  const assets = sections.find((section) => isRecord(section) && section.type === "asset");
-  return t("pluginAccounting.preview.bs", {
-    date,
-    assets: isRecord(assets) ? formatAmountNumeric(optionalNumber(assets.total) ?? 0) : "?",
-  });
-}
-
-function summariseBook(json: Record<string, unknown>): string | null {
-  const { book } = json;
-  if (!isRecord(book)) return null;
-  const bookId = optionalString(book.id);
-  const name = optionalString(book.name);
-  if (!bookId || !name) return null;
-  return t("pluginAccounting.preview.bookCreated", { name, id: bookId });
-}
-
-function summariseFallback(json: Record<string, unknown>): string {
-  const bookId = optionalString(json.bookId);
-  if (bookId !== undefined) return t("pluginAccounting.previewSummary", { bookId });
-  return t("pluginAccounting.previewGeneric");
-}
-
-function asObject(value: unknown): Record<string, unknown> {
-  // Some renderers pass the structured payload via `data`, others
-  // via `jsonData`. Accept either so a tool-result like
-  // `{ entry: ... }` resolves to the right summariser regardless
-  // of which prop the host harness picks.
-  return isRecord(value) ? value : {};
-}
-
-const summary = computed<string>(() => {
-  const json = { ...asObject(props.data), ...asObject(props.jsonData) };
-  return summariseError(json) ?? summariseEntry(json) ?? summarisePl(json) ?? summariseBs(json) ?? summariseBook(json) ?? summariseFallback(json);
-});
+const summary = computed<string>(() => summarisePreview(props.data, props.jsonData, t));
 </script>

--- a/packages/plugins/accounting-plugin/src/vue/Preview.vue
+++ b/packages/plugins/accounting-plugin/src/vue/Preview.vue
@@ -11,6 +11,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
 import { useAccountingI18n } from "./lang";
 import { formatAmountNumeric } from "../shared";
 
@@ -18,29 +19,19 @@ const { t } = useAccountingI18n();
 
 const props = defineProps<{ data?: unknown; jsonData?: Record<string, unknown> }>();
 
-interface BalanceSheetSection {
-  type: string;
-  total?: number;
-}
-interface BalanceSheetLike {
-  balanceSheet?: { asOf?: string; sections?: BalanceSheetSection[]; imbalance?: number };
-}
-interface ProfitLossLike {
-  profitLoss?: { from?: string; to?: string; netIncome?: number };
-}
-interface EntriesLike {
-  entries?: { id?: string; date?: string }[];
-}
-interface BookLike {
-  book?: { id?: string; name?: string };
-}
+// Readers, not predicates: everything below the payload root arrives as
+// `unknown`, so a field is a string / number only once one of these has
+// looked. Twins of the server's `bodyFields.ts` readers, duplicated here
+// because a browser bundle must not import the server surface.
+const optionalString = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined);
+const optionalNumber = (value: unknown): number | undefined => (typeof value === "number" ? value : undefined);
 
 // Each summarise* helper returns null when its branch doesn't apply,
 // keeping the dispatch in `summary` linear (no nested if-trees).
 
 function summariseError(json: Record<string, unknown>): string | null {
-  const { error } = json as { error?: unknown };
-  if (typeof error !== "string") return null;
+  const error = optionalString(json.error);
+  if (error === undefined) return null;
   return t("pluginAccounting.previewError", { error });
 }
 
@@ -49,42 +40,51 @@ function summariseEntry(json: Record<string, unknown>): string | null {
   // card shows one date — use the first entry's so single-entry
   // batches (the common case from the manual UI) read naturally
   // and multi-entry batches still anchor to a meaningful date.
-  const { entries } = json as EntriesLike;
-  if (!Array.isArray(entries) || entries.length === 0) return null;
-  const [first] = entries;
-  if (!first?.id || !first?.date) return null;
-  return t("pluginAccounting.preview.entry", { date: first.date });
+  const [first] = isUnknownArray(json.entries) ? json.entries : [];
+  const entry = isRecord(first) ? first : undefined;
+  const entryId = optionalString(entry?.id);
+  const date = optionalString(entry?.date);
+  if (!entryId || !date) return null;
+  return t("pluginAccounting.preview.entry", { date });
 }
 
 function summarisePl(json: Record<string, unknown>): string | null {
-  const { profitLoss } = json as ProfitLossLike;
-  if (!profitLoss || typeof profitLoss.netIncome !== "number") return null;
+  const { profitLoss } = json;
+  if (!isRecord(profitLoss)) return null;
+  const netIncome = optionalNumber(profitLoss.netIncome);
+  if (netIncome === undefined) return null;
   return t("pluginAccounting.preview.pl", {
-    from: profitLoss.from ?? "?",
-    to: profitLoss.to ?? "?",
-    net: formatAmountNumeric(profitLoss.netIncome),
+    from: optionalString(profitLoss.from) ?? "?",
+    to: optionalString(profitLoss.to) ?? "?",
+    net: formatAmountNumeric(netIncome),
   });
 }
 
 function summariseBs(json: Record<string, unknown>): string | null {
-  const { balanceSheet } = json as BalanceSheetLike;
-  if (!balanceSheet?.asOf || !balanceSheet.sections) return null;
-  const assets = balanceSheet.sections.find((section) => section.type === "asset");
+  const { balanceSheet } = json;
+  if (!isRecord(balanceSheet)) return null;
+  const date = optionalString(balanceSheet.asOf);
+  const sections = isUnknownArray(balanceSheet.sections) ? balanceSheet.sections : undefined;
+  if (!date || !sections) return null;
+  const assets = sections.find((section) => isRecord(section) && section.type === "asset");
   return t("pluginAccounting.preview.bs", {
-    date: balanceSheet.asOf,
-    assets: assets ? formatAmountNumeric(assets.total ?? 0) : "?",
+    date,
+    assets: isRecord(assets) ? formatAmountNumeric(optionalNumber(assets.total) ?? 0) : "?",
   });
 }
 
 function summariseBook(json: Record<string, unknown>): string | null {
-  const { book } = json as BookLike;
-  if (!book?.id || !book?.name) return null;
-  return t("pluginAccounting.preview.bookCreated", { name: book.name, id: book.id });
+  const { book } = json;
+  if (!isRecord(book)) return null;
+  const bookId = optionalString(book.id);
+  const name = optionalString(book.name);
+  if (!bookId || !name) return null;
+  return t("pluginAccounting.preview.bookCreated", { name, id: bookId });
 }
 
 function summariseFallback(json: Record<string, unknown>): string {
-  const { bookId } = json as { bookId?: unknown };
-  if (typeof bookId === "string") return t("pluginAccounting.previewSummary", { bookId });
+  const bookId = optionalString(json.bookId);
+  if (bookId !== undefined) return t("pluginAccounting.previewSummary", { bookId });
   return t("pluginAccounting.previewGeneric");
 }
 
@@ -93,7 +93,7 @@ function asObject(value: unknown): Record<string, unknown> {
   // via `jsonData`. Accept either so a tool-result like
   // `{ entry: ... }` resolves to the right summariser regardless
   // of which prop the host harness picks.
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return isRecord(value) ? value : {};
 }
 
 const summary = computed<string>(() => {

--- a/packages/plugins/accounting-plugin/src/vue/previewSummary.ts
+++ b/packages/plugins/accounting-plugin/src/vue/previewSummary.ts
@@ -1,0 +1,97 @@
+// The line of text the compact preview card shows for a non-openBook tool
+// result. Pure and Vue-free: `Preview.vue` is the template plus a `computed`
+// that calls `summarisePreview`, so these branches are reachable from
+// `tsx --test` (which cannot load an SFC).
+//
+// Everything below the payload root arrives as `unknown` — the dispatch
+// envelope is built server-side and replayed from the chat log — so a field is
+// a string or a number only once one of the readers below has looked.
+
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
+
+import { formatAmountNumeric } from "../shared";
+
+/** The subset of the plugin's i18n surface these summaries need, injected so
+ *  the module stays free of Vue and of the locale wiring. */
+export type TranslateFn = (key: string, named?: Record<string, unknown>) => string;
+
+const optionalString = (value: unknown): string | undefined => (typeof value === "string" ? value : undefined);
+const optionalNumber = (value: unknown): number | undefined => (typeof value === "number" ? value : undefined);
+
+// Each summarise* helper returns null when its branch doesn't apply, keeping
+// the dispatch below linear (no nested if-trees).
+
+export function summariseError(json: Record<string, unknown>, translate: TranslateFn): string | null {
+  const error = optionalString(json.error);
+  if (error === undefined) return null;
+  return translate("pluginAccounting.previewError", { error });
+}
+
+export function summariseEntry(json: Record<string, unknown>, translate: TranslateFn): string | null {
+  // addEntries returns `{ entries: [...] }`. The card shows one date — the
+  // first entry's, so single-entry batches (the common case from the manual
+  // UI) read naturally and multi-entry batches still anchor to a real date.
+  const [first] = isUnknownArray(json.entries) ? json.entries : [];
+  const entry = isRecord(first) ? first : undefined;
+  const entryId = optionalString(entry?.id);
+  const date = optionalString(entry?.date);
+  if (!entryId || !date) return null;
+  return translate("pluginAccounting.preview.entry", { date });
+}
+
+export function summarisePl(json: Record<string, unknown>, translate: TranslateFn): string | null {
+  const { profitLoss } = json;
+  if (!isRecord(profitLoss)) return null;
+  const netIncome = optionalNumber(profitLoss.netIncome);
+  if (netIncome === undefined) return null;
+  return translate("pluginAccounting.preview.pl", {
+    from: optionalString(profitLoss.from) ?? "?",
+    to: optionalString(profitLoss.to) ?? "?",
+    net: formatAmountNumeric(netIncome),
+  });
+}
+
+export function summariseBs(json: Record<string, unknown>, translate: TranslateFn): string | null {
+  const { balanceSheet } = json;
+  if (!isRecord(balanceSheet)) return null;
+  const date = optionalString(balanceSheet.asOf);
+  const sections = isUnknownArray(balanceSheet.sections) ? balanceSheet.sections : undefined;
+  if (!date || !sections) return null;
+  const assets = sections.find((section) => isRecord(section) && section.type === "asset");
+  return translate("pluginAccounting.preview.bs", {
+    date,
+    assets: isRecord(assets) ? formatAmountNumeric(optionalNumber(assets.total) ?? 0) : "?",
+  });
+}
+
+export function summariseBook(json: Record<string, unknown>, translate: TranslateFn): string | null {
+  const { book } = json;
+  if (!isRecord(book)) return null;
+  const bookId = optionalString(book.id);
+  const name = optionalString(book.name);
+  if (!bookId || !name) return null;
+  return translate("pluginAccounting.preview.bookCreated", { name, id: bookId });
+}
+
+export function summariseFallback(json: Record<string, unknown>, translate: TranslateFn): string {
+  const bookId = optionalString(json.bookId);
+  if (bookId !== undefined) return translate("pluginAccounting.previewSummary", { bookId });
+  return translate("pluginAccounting.previewGeneric");
+}
+
+/** Merge the two props a host might carry the payload on. `isRecord` rejects
+ *  arrays, which the old `typeof value === "object"` check spread into the
+ *  payload. */
+export const asPayload = (value: unknown): Record<string, unknown> => (isRecord(value) ? value : {});
+
+export function summarisePreview(data: unknown, jsonData: unknown, translate: TranslateFn): string {
+  const json = { ...asPayload(data), ...asPayload(jsonData) };
+  return (
+    summariseError(json, translate) ??
+    summariseEntry(json, translate) ??
+    summarisePl(json, translate) ??
+    summariseBs(json, translate) ??
+    summariseBook(json, translate) ??
+    summariseFallback(json, translate)
+  );
+}

--- a/packages/plugins/accounting-plugin/test/accounting/test_previewSummary.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_previewSummary.ts
@@ -1,0 +1,206 @@
+// Branch + boundary coverage for the compact preview summary.
+//
+// Every payload here is the real shape `router.ts` returns for that action
+// (see test_router.ts, which drives the same responses over HTTP), plus the
+// malformed variants the readers exist to survive.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  asPayload,
+  summariseBook,
+  summariseBs,
+  summariseEntry,
+  summariseError,
+  summariseFallback,
+  summarisePl,
+  summarisePreview,
+} from "../../src/vue/previewSummary.js";
+
+/** Echoes the key and its interpolations, so a test asserts which branch ran
+ *  and what it read — not the wording of a translation. */
+const translate = (key: string, named?: Record<string, unknown>): string => (named === undefined ? key : `${key} ${JSON.stringify(named)}`);
+
+describe("summariseError", () => {
+  it("reports a string error", () => {
+    assert.match(summariseError({ error: "bookId is required" }, translate) ?? "", /previewError.*bookId is required/);
+  });
+
+  it("declines when error is absent or not a string", () => {
+    assert.equal(summariseError({}, translate), null);
+    assert.equal(summariseError({ error: 500 }, translate), null);
+    assert.equal(summariseError({ error: null }, translate), null);
+  });
+});
+
+describe("summariseEntry", () => {
+  const entries = [
+    { id: "e1", date: "2026-02-01" },
+    { id: "e2", date: "2026-02-02" },
+  ];
+
+  it("anchors to the first entry's date", () => {
+    assert.match(summariseEntry({ entries }, translate) ?? "", /preview\.entry.*2026-02-01/);
+  });
+
+  it("declines when the entry lacks an id or a date", () => {
+    assert.equal(summariseEntry({ entries: [{ date: "2026-02-01" }] }, translate), null);
+    assert.equal(summariseEntry({ entries: [{ id: "e1" }] }, translate), null);
+  });
+
+  it("declines on a non-object element rather than throwing", () => {
+    // `entries: [null]` is the shape that used to crash the accounting
+    // validators (#2695); the preview must degrade, not throw.
+    assert.equal(summariseEntry({ entries: [null] }, translate), null);
+    assert.equal(summariseEntry({ entries: ["e1"] }, translate), null);
+  });
+
+  it("declines when entries is empty or not an array", () => {
+    assert.equal(summariseEntry({ entries: [] }, translate), null);
+    assert.equal(summariseEntry({ entries: "e1" }, translate), null);
+    assert.equal(summariseEntry({}, translate), null);
+  });
+
+  it("declines on a non-string id or date", () => {
+    assert.equal(summariseEntry({ entries: [{ id: 7, date: "2026-02-01" }] }, translate), null);
+    assert.equal(summariseEntry({ entries: [{ id: "e1", date: 20260201 }] }, translate), null);
+  });
+});
+
+describe("summarisePl", () => {
+  const profitLoss = { from: "2026-01-01", to: "2026-12-31", netIncome: 50 };
+
+  it("reports the period and net income", () => {
+    const summary = summarisePl({ profitLoss }, translate) ?? "";
+    assert.match(summary, /preview\.pl/);
+    assert.match(summary, /2026-01-01/);
+    assert.match(summary, /2026-12-31/);
+  });
+
+  it("keeps a zero net income — it is a real answer, not a missing one", () => {
+    assert.match(summarisePl({ profitLoss: { ...profitLoss, netIncome: 0 } }, translate) ?? "", /preview\.pl/);
+  });
+
+  it("falls back to ? for a non-string from/to rather than rendering the number", () => {
+    const summary = summarisePl({ profitLoss: { from: 1, to: 2, netIncome: 50 } }, translate) ?? "";
+    assert.match(summary, /"from":"\?"/);
+    assert.match(summary, /"to":"\?"/);
+  });
+
+  it("declines when netIncome is absent or not a number", () => {
+    assert.equal(summarisePl({ profitLoss: { from: "a", to: "b" } }, translate), null);
+    assert.equal(summarisePl({ profitLoss: { ...profitLoss, netIncome: "50" } }, translate), null);
+  });
+
+  it("declines when profitLoss is not a plain object", () => {
+    assert.equal(summarisePl({ profitLoss: [profitLoss] }, translate), null);
+    assert.equal(summarisePl({ profitLoss: null }, translate), null);
+    assert.equal(summarisePl({}, translate), null);
+  });
+});
+
+describe("summariseBs", () => {
+  const balanceSheet = {
+    asOf: "2026-02-28",
+    sections: [
+      { type: "asset", total: 160 },
+      { type: "liability", total: 0 },
+    ],
+  };
+
+  it("reports the date and the asset total", () => {
+    const summary = summariseBs({ balanceSheet }, translate) ?? "";
+    assert.match(summary, /preview\.bs/);
+    assert.match(summary, /2026-02-28/);
+    assert.match(summary, /160/);
+  });
+
+  it("renders ? when there is no asset section", () => {
+    const sections = [{ type: "liability", total: 0 }];
+    assert.match(summariseBs({ balanceSheet: { ...balanceSheet, sections } }, translate) ?? "", /"assets":"\?"/);
+  });
+
+  it("treats a non-numeric total as zero rather than rendering the raw value", () => {
+    const sections = [{ type: "asset", total: "9" }];
+    assert.match(summariseBs({ balanceSheet: { ...balanceSheet, sections } }, translate) ?? "", /"assets":"0/);
+  });
+
+  it("survives a null section instead of throwing", () => {
+    // The old `sections.find(...)` reached into whatever the array held.
+    assert.doesNotThrow(() => summariseBs({ balanceSheet: { ...balanceSheet, sections: [null] } }, translate));
+    assert.match(summariseBs({ balanceSheet: { ...balanceSheet, sections: [null] } }, translate) ?? "", /"assets":"\?"/);
+  });
+
+  it("declines when sections is not an array or asOf is not a string", () => {
+    assert.equal(summariseBs({ balanceSheet: { ...balanceSheet, sections: "x" } }, translate), null);
+    assert.equal(summariseBs({ balanceSheet: { ...balanceSheet, asOf: 20260228 } }, translate), null);
+  });
+});
+
+describe("summariseBook", () => {
+  it("reports the created book's name and id", () => {
+    const summary = summariseBook({ book: { id: "book-1", name: "Probe Co" } }, translate) ?? "";
+    assert.match(summary, /preview\.bookCreated/);
+    assert.match(summary, /Probe Co/);
+    assert.match(summary, /book-1/);
+  });
+
+  it("declines when id or name is missing or not a string", () => {
+    assert.equal(summariseBook({ book: { id: "book-1" } }, translate), null);
+    assert.equal(summariseBook({ book: { name: "Probe Co" } }, translate), null);
+    assert.equal(summariseBook({ book: { id: 1, name: "Probe Co" } }, translate), null);
+  });
+
+  it("declines when book is not a plain object", () => {
+    assert.equal(summariseBook({ book: null }, translate), null);
+    assert.equal(summariseBook({ book: ["book-1"] }, translate), null);
+  });
+});
+
+describe("summariseFallback", () => {
+  it("names the book when the payload carries a bookId", () => {
+    assert.match(summariseFallback({ bookId: "book-1" }, translate), /previewSummary.*book-1/);
+  });
+
+  it("returns the generic line for a non-string bookId", () => {
+    assert.equal(summariseFallback({ bookId: 42 }, translate), "pluginAccounting.previewGeneric");
+    assert.equal(summariseFallback({}, translate), "pluginAccounting.previewGeneric");
+  });
+});
+
+describe("asPayload", () => {
+  it("passes a plain object through", () => {
+    const value = { bookId: "b1" };
+    assert.equal(asPayload(value), value);
+  });
+
+  it("reads an array as empty — the old typeof check spread it into the payload", () => {
+    assert.deepEqual(asPayload([1, 2]), {});
+    assert.deepEqual(asPayload(null), {});
+    assert.deepEqual(asPayload("b1"), {});
+  });
+});
+
+describe("summarisePreview dispatch", () => {
+  it("prefers error over every other branch", () => {
+    const json = { error: "boom", entries: [{ id: "e1", date: "2026-02-01" }] };
+    assert.match(summarisePreview(json, undefined, translate), /previewError/);
+  });
+
+  it("picks each branch in turn", () => {
+    assert.match(summarisePreview({ entries: [{ id: "e1", date: "2026-02-01" }] }, undefined, translate), /preview\.entry/);
+    assert.match(summarisePreview({ profitLoss: { from: "a", to: "b", netIncome: 1 } }, undefined, translate), /preview\.pl/);
+    assert.match(summarisePreview({ balanceSheet: { asOf: "2026-02-28", sections: [] } }, undefined, translate), /preview\.bs/);
+    assert.match(summarisePreview({ book: { id: "b1", name: "Co" } }, undefined, translate), /preview\.bookCreated/);
+  });
+
+  it("merges jsonData over data", () => {
+    assert.match(summarisePreview({ bookId: "from-data" }, { bookId: "from-json" }, translate), /from-json/);
+  });
+
+  it("falls back to the generic line for an unrecognised payload", () => {
+    assert.equal(summarisePreview({ rebuilt: true }, undefined, translate), "pluginAccounting.previewGeneric");
+    assert.equal(summarisePreview(undefined, undefined, translate), "pluginAccounting.previewGeneric");
+  });
+});


### PR DESCRIPTION
## Summary

`packages/plugins/accounting-plugin/src/vue/Preview.vue` の `as` キャスト **7 個すべて** を削除しました（`eslint` の `consistent-type-assertions` 警告 7 → 0）。
キャストが主張していた `EntriesLike` / `ProfitLossLike` / `BalanceSheetLike` / `BookLike` は「誰も検査していない入れ子形状」の宣言だったため、型定義ごと削除し、**テンプレートが実際に描画するフィールドだけを検査して返す reader** に置き換えています。
narrowing は `@mulmoclaude/common` の共有ガード `isRecord` / `isUnknownArray` を使用（本パッケージの既存依存）。
**実サーバが返す全ペイロードの描画結果は変更前後で完全に一致**。差分は「サーバが生成し得ない不正ペイロード」のみです。

## Items to Confirm / Review

### 1. `asObject` を `isRecord` に置き換えた件（配列の扱いが変わります）

旧: `value && typeof value === "object"` → `typeof [] === "object"` が true なので **配列も record として通過** していました。
新: `isRecord` は配列を弾きます（`!Array.isArray`）。**意図的な変更**です。

- 実害の有無: router 側は `const handlerFields = isRecord(result) ? result : { value: result }`（`router.ts:333`）で既に配列を弾いており、`data` は必ず record です。`jsonData` は accounting router が一切セットしません。よって**実ペイロードでは差が出ません**。
- 唯一差が出るのは「配列に `bookId` などの own property が生えている」病的なケース（検証ケース `arrayWithBookId`）で、旧 `Accounting · b1` → 新 `Accounting result`。

### 2. 各 reader がどこまで検証しているか（＝キャストとの差）

| 分岐 | 新しい reader が実際に検査するもの | テンプレートが読むもの |
| --- | --- | --- |
| `summariseError` | `json.error` が string | `error` |
| `summariseEntry` | `json.entries` が配列 / `[0]` が record / `id`・`date` が空でない string | `date` のみ（`id` は「本物のエントリか」の存在判定） |
| `summarisePl` | `profitLoss` が record / `netIncome` が number（`from`・`to` は string なら採用、それ以外は `"?"`） | `from` / `to` / `netIncome` |
| `summariseBs` | `balanceSheet` が record / `asOf` が空でない string / `sections` が配列 / 該当 section が record / `total` が number（無ければ 0） | `asOf` と asset section の `total` |
| `summariseBook` | `book` が record / `id`・`name` が空でない string | `id` / `name` |
| `summariseFallback` | `json.bookId` が string | `bookId` |

いずれも「全体形状を true と主張する述語（type predicate）」は書いていません。**証明した値だけを返す reader** です。`imbalance` など描画に使われないフィールドは読みません（旧 `BalanceSheetLike` は宣言だけしていました）。

### 3. 挙動が変わり得る箇所（すべて不正ペイロード限定）

| ケース | 変更前 | 変更後 |
| --- | --- | --- |
| `balanceSheet.sections` が配列でない (`"x"` / `"abc"`) | **`TypeError: sections.find is not a function` で render が例外** → `PluginScopedRoot` のエラーバウンダリで「プラグインがクラッシュしました」パネル | 分岐が成立せず汎用サマリへフォールバック |
| `sections: [null]` | **`Cannot read properties of null (reading 'type')` で例外** | `Balance sheet as of … · assets ?` |
| `entries[0].id` が number (`7`) | `Posted entry on 2026-01-01` | 汎用サマリ |
| `entries[0].date` が number (`20260101`) | `Posted entry on 20260101` | 汎用サマリ |
| `profitLoss.from/to` が number | `P&L 1 → 2: net 5.00` | `P&L ? → ?: net 5.00` |
| `balanceSheet.asOf` が number | `Balance sheet as of 20260131 …` | 汎用サマリ |
| `sections[].total` が string (`"9"`) | `assets 9`（`formatAmountNumeric(value: number)` に string を渡していた＝キャストが隠していた型不整合） | `assets 0.00`（旧 `total ?? 0` の意味を維持） |
| `book.id` が number | `Created book "N" (1)` | 汎用サマリ |

空文字 (`""`) の扱いは旧実装の truthy 判定と**完全に同一**にしてあります（`""` は分岐不成立、`profitLoss.from: ""` は `""` のまま）。

### 4. 残したキャスト

**なし**。7/7 削除しました。

### 5. 別件で見つかったバグ（このPRでは修正していません）

**このコンポーネントは、現在ホスト上では常に汎用サマリ (`previewGeneric` = "Accounting result") しか表示していません。**

- `Preview.vue` が宣言する props は `{ data?, jsonData? }`。
- 唯一のレンダリング箇所 `src/components/SessionSidebar.vue:58` は `:result="result"` しか渡しません（他プラグインの Preview は `result: ToolResult` を受け取る形になっている）。
- したがって `props.data` / `props.jsonData` は常に `undefined` → `summary` は必ず `summariseFallback({})` に落ちます。初出コミット `cd441febb`（"Stub compact preview"）からこの形のままです。

再現コマンドと出力は「検証」節に記載しました。修正は props 契約の変更＝描画結果が大きく変わるため、キャスト除去とは別 PR が適切と判断しています。

## 実装方針

- 共有ガードを優先（`docs/shared-utils.md`）: `@mulmoclaude/common` の `isRecord` / `isUnknownArray` を使用。同パッケージの `src/shared/errors.ts` も同じ leaf パッケージを import しており、ブラウザ安全・vite でバンドルされます。
- ローカル reader は `optionalString` / `optionalNumber` の 2 本のみ。サーバ側の双子 (`src/server/bodyFields.ts` の `optionalString` / `optionalRecord`) は **ブラウザバンドルがサーバ面を import してはならない** ため共有せず、その理由を 1 行コメントで残しています（`src/shared/` への昇格は公開 API (`@mulmoclaude/accounting-plugin/shared`) を広げるため見送り）。
- `record` 用の reader は作らず `isRecord` をそのまま `if` で使い、`optionalRecord` の重複実装を避けました。
- `<style>` ブロックの追加なし、Tailwind ユーティリティのみ、テンプレート無変更、i18n キー無変更。
- `id` は `eslint` の `id-length` に触れるため `entryId` / `bookId` に改名（i18n の placeholder 名 `id` は維持）。

## 検証

### 静的ゲート

```
$ npx prettier --write packages/plugins/accounting-plugin/src/vue/Preview.vue
  → unchanged

$ npx eslint packages/plugins/accounting-plugin/src/vue/Preview.vue
  → 0 errors, 0 warnings
     （main の同ファイル: ✖ 7 problems (0 errors, 7 warnings) — すべて
       @typescript-eslint/consistent-type-assertions）

$ cd packages/plugins/accounting-plugin && yarn typecheck   # vue-tsc --noEmit  → OK
$ cd packages/plugins/accounting-plugin && yarn test        # tests 272 / pass 272 / fail 0
$ cd packages/plugins/accounting-plugin && yarn lint        # 0 errors（残る 19 warning は他ファイル）
$ cd packages/plugins/accounting-plugin && yarn build       # ✓ built in 1.51s
$ yarn typecheck:vue                                        # ルート vue-tsc --noEmit → OK
```

### 実描画による before/after 比較（build 成功≠描画される、の担保）

使い捨てハーネス（検証後に削除済み）で、**実際の Express router を起動**して各 action を dispatch し、その生のレスポンスを `Preview.vue` に流して SSR 描画した文字列を、変更前後で比較しました。

- ハーネス: `test/accounting/test_router.ts` と同じ express + `configureAccountingServer` 構成 → `vite.ssrLoadModule("…/Preview.vue")` → `vue/server-renderer#renderToString`。
- 実 action: `createBook` / `upsertAccount` / `setOpeningBalances` / `addEntries`(1件・2件) / `voidEntry` / `getReport` balance・pl・ledger / `openBook` / エラー2種（unknown action・不正 period）。
- props の形も 4 通り（`{result}` / `{data}` / `{jsonData}` / `{data,jsonData}`）で描画。
- さらに不正ペイロード 40 種（null / undefined / 配列 / 文字列 / 数値 / 各フィールドの型違い / 分岐の優先順位 / `__proto__` キー）。

結果 (`diff before after`、book id はマスク):

- **実 action 12 件 × props 4 形 = 48 パターンすべて差分ゼロ。**
- 差分は不正ペイロード 9 件のみ（上記「Items to Confirm」§3 の表がその全量）。うち 3 件は **変更前は例外を投げていたケース**。

`{result}` で描画した列は before/after とも全ケースで `Accounting result` になり、これが §5 のバグの根拠です:

```
### real createBook (HTTP 200)
  props{result}       : Accounting result
  props{data}         : Created book "Harness Co" (book-XXXX)
### real addEntries(1) (HTTP 200)
  props{result}       : Accounting result
  props{data}         : Posted entry on 2026-02-01
### real getReport(pl) (HTTP 200)
  props{result}       : Accounting result
  props{jsonData}     : P&L 2026-02-01 → 2026-02-28: net 130.00
```

### 未実施

`Preview.vue` の単体テストは追加していません。本パッケージの `test` script は `tsx --test`（`.vue` をロードできない）で、SFC を描画するには vite ベースのテスト基盤の新設が必要なためです。上記ハーネスと同等のものを常設する価値はあると考えており、必要なら別 PR で対応します。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Replace accounting compact preview type assertions with field-level readers and shared guards to validate only rendered payload fields while preserving behavior for valid server responses.

Bug Fixes:
- Avoid runtime errors in the accounting preview when balance sheet sections or other payload fields have unexpected shapes or types.
- Stop rendering misleading summaries for malformed accounting payloads by falling back to a generic summary when required fields are invalid.

Enhancements:
- Remove all TypeScript `as` casts from the accounting preview component and rely on shared runtime guards for safer payload narrowing.
- Constrain preview summarisers to read only the fields actually used in the template, tightening validation of accounting router responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accounting preview summaries for errors, entries, profit and loss, balance sheets, and newly created books.
  * Safely combines preview data from multiple sources and provides clearer fallback messages when details are unavailable.

* **Bug Fixes**
  * Prevented malformed or incomplete accounting data from causing preview failures.
  * Improved handling of invalid values and unexpected payload structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->