### PR TITLE
fix(relay): verify Google Chat JWK and OAuth token instead of asserting them

### DIFF
--- a/packages/relay/src/webhooks/google-chat.ts
+++ b/packages/relay/src/webhooks/google-chat.ts
@@ -12,7 +12,7 @@
 // the message but cannot send replies back.
 
 import { chunkText } from "@mulmobridge/client/text";
-import { isRecord } from "@mulmoclaude/common";
+import { hasStringProp, isRecord } from "@mulmoclaude/common";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS, FIFTEEN_SECONDS_MS } from "../time.js";
@@ -29,15 +29,20 @@ const MAX_CHAT_TEXT = 4000;
 
 // ── JWKS cache ──────────────────────────────────────────────────
 
+// Only the fields the guard below actually proves — the JWKS entry reaches crypto.subtle verbatim, extra fields (`alg`, `use`) included.
 interface JwkKey {
   kid: string;
   kty: string;
   n: string;
   e: string;
-  alg?: string;
 }
 let cachedKeys: JwkKey[] = [];
 let cacheExpiresAt = 0;
+
+// Every field of JwkKey is checked here, so nothing is asserted; `e` and `kty`
+// are what crypto.subtle needs to build an RSA public key.
+export const isJwk = (key: unknown): key is JwkKey =>
+  hasStringProp(key, "kid") && hasStringProp(key, "kty") && hasStringProp(key, "n") && hasStringProp(key, "e");
 
 async function getJwks(): Promise<JwkKey[]> {
   if (Date.now() < cacheExpiresAt && cachedKeys.length > 0) return cachedKeys;
@@ -45,8 +50,6 @@ async function getJwks(): Promise<JwkKey[]> {
   if (!res.ok) return cachedKeys;
   const data: { keys?: unknown[] } = await res.json();
   if (!Array.isArray(data.keys)) return cachedKeys;
-  const isJwk = (key: unknown): key is JwkKey =>
-    typeof key === "object" && key !== null && typeof (key as JwkKey).kid === "string" && typeof (key as JwkKey).n === "string";
   cachedKeys = data.keys.filter(isJwk);
   cacheExpiresAt = Date.now() + JWKS_CACHE_TTL_MS;
   return cachedKeys;
@@ -104,7 +107,7 @@ interface ServiceAccount {
 
 function parseServiceAccount(raw: string): ServiceAccount | null {
   try {
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed: unknown = JSON.parse(raw);
     if (!isRecord(parsed) || typeof parsed.client_email !== "string" || typeof parsed.private_key !== "string") return null;
     return { client_email: parsed.client_email, private_key: parsed.private_key };
   } catch {
@@ -132,6 +135,15 @@ async function makeServiceAccountJwt(account: ServiceAccount): Promise<string> {
   return `${header}.${claims}.${sig}`;
 }
 
+// OAuth can answer 200 with an error body; asserting the shape instead of
+// checking it would send the literal string "Bearer undefined" to the Chat API.
+export function readAccessToken(data: unknown, status: number): string {
+  if (!hasStringProp(data, "access_token") || !data.access_token) {
+    throw new Error(`Google token exchange returned no access_token (${GOOGLE_TOKEN_URL}, status ${status})`);
+  }
+  return data.access_token;
+}
+
 async function getGoogleAccessToken(account: ServiceAccount): Promise<string> {
   const jwt = await makeServiceAccountJwt(account);
   const res = await fetch(GOOGLE_TOKEN_URL, {
@@ -141,8 +153,7 @@ async function getGoogleAccessToken(account: ServiceAccount): Promise<string> {
     signal: AbortSignal.timeout(TEN_SECONDS_MS),
   });
   if (!res.ok) throw new Error(`Google token exchange failed: ${res.status}`);
-  const data = (await res.json()) as { access_token: string };
-  return data.access_token;
+  return readAccessToken(await res.json(), res.status);
 }
 
 // ── Plugin ──────────────────────────────────────────────────────

--- a/packages/relay/test/test_google_chat_webhook.ts
+++ b/packages/relay/test/test_google_chat_webhook.ts
@@ -9,7 +9,7 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { validateGoogleChatClaims } from "../src/webhooks/google-chat.js";
+import { isJwk, readAccessToken, validateGoogleChatClaims } from "../src/webhooks/google-chat.js";
 
 const GOOGLE_CHAT_ISSUER = "chat@system.gserviceaccount.com";
 const PROJECT_NUMBER = "123456789012";
@@ -60,4 +60,63 @@ describe("validateGoogleChatClaims", () => {
   it("rejects when exp claim is null (fail-closed)", () => {
     assert.equal(validateGoogleChatClaims(basePayload({ exp: null }), PROJECT_NUMBER, NOW_SEC), false);
   });
+});
+
+function baseJwk(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { kid: "abc123", kty: "RSA", n: "0vx7ag...", e: "AQAB", alg: "RS256", ...overrides };
+}
+
+describe("isJwk", () => {
+  it("accepts a well-formed RSA JWKS entry", () => {
+    assert.equal(isJwk(baseJwk()), true);
+  });
+
+  it("accepts an entry carrying extra fields", () => {
+    assert.equal(isJwk(baseJwk({ use: "sig" })), true);
+  });
+
+  for (const field of ["kid", "kty", "n", "e"]) {
+    it(`rejects an entry missing ${field}`, () => {
+      const key = Object.fromEntries(Object.entries(baseJwk()).filter(([name]) => name !== field));
+      assert.equal(isJwk(key), false);
+    });
+
+    it(`rejects an entry whose ${field} is not a string`, () => {
+      assert.equal(isJwk(baseJwk({ [field]: 42 })), false);
+    });
+  }
+
+  for (const [label, value] of [
+    ["null", null],
+    ["undefined", undefined],
+    ["an array", [baseJwk()]],
+    ["a string", "not a jwk"],
+    ["a number", 7],
+  ] as const) {
+    it(`rejects ${label}`, () => {
+      assert.equal(isJwk(value), false);
+    });
+  }
+});
+
+describe("readAccessToken", () => {
+  it("returns the token from a well-formed response", () => {
+    assert.equal(readAccessToken({ access_token: "ya29.abc", expires_in: 3599 }, 200), "ya29.abc");
+  });
+
+  it("throws on an OAuth error body served with a 2xx status", () => {
+    assert.throws(() => readAccessToken({ error: "invalid_grant" }, 200), /no access_token.*status 200/s);
+  });
+
+  for (const [label, data] of [
+    ["an empty token", { access_token: "" }],
+    ["a non-string token", { access_token: 12345 }],
+    ["a null body", null],
+    ["an array body", []],
+    ["a string body", "ya29.abc"],
+  ] as const) {
+    it(`throws on ${label}`, () => {
+      assert.throws(() => readAccessToken(data, 200), /no access_token/);
+    });
+  }
 });


### PR DESCRIPTION
## Summary

`packages/relay/src/webhooks/google-chat.ts` の `as` キャスト 4 箇所（3 行）を全て除去した。ここは Google Chat からの inbound webhook の JWT 署名を検証するセキュリティ境界なので、「型を主張する」コードを「実際に検証して値を返す」コードに置き換えている。
JWKS ガードは `kid` / `n` しか見ていないのに `JwkKey`（`kty` / `e` / `alg` も宣言）へキャストしていた。OAuth トークン応答は `{ access_token: string }` と断定されており、エラーボディが返ると `undefined` が `string` 型のまま `Bearer undefined` として送出されていた。
`eslint` の `consistent-type-assertions` 警告はこのファイルで 4 → 0。relay パッケージのテストは 85 → 107 件（全 pass）。

## Items to Confirm / Review

- **accept/reject 境界（inbound 認証）**: 実プラグインを RSA 署名済み JWT + スタブ JWKS で end-to-end に駆動する検証ハーネスを書き、**変更前後の両リビジョンで 19 ケースを実行して diff を取った**。判定が変わったのは **1 ケースのみ**で、それ以外の 18 ケースは変更前が拒否したものを変更後も全て拒否している（下記マトリクス参照）。
  - 唯一の差分: `dup-kid-malformed-first` = **JWKS に同じ `kid` が 2 エントリあり、先頭が壊れている（`e` 欠落）、2 番目が本物の署名鍵** というケース。
    - 変更前: `find` が壊れた先頭を掴み `crypto.subtle.importKey` が `DOMException: Invalid keyData` を投げて拒否。
    - 変更後: 壊れたエントリが `isJwk` で落ち、本物の鍵が見つかり **署名検証が実際に成功して受理**。
    - つまり受理されるのは「Google が公開している本物の鍵で正しく署名されたトークン」だけであり、偽造トークンが通るようになったわけではない。変更前の拒否は認証判断ではなく、壊れた同名エントリが本物の鍵を隠していた堅牢性の欠陥。**ここは人間の判断を仰ぎたい唯一の点。**
- **トークン経路がエラーボディで何をするか**: 変更前は 200 + `{"error":"invalid_grant"}` で **`Authorization: Bearer undefined` を Chat API に送っていた**（ハーネスで実測、下記）。変更後は `readAccessToken` がエンドポイントと status を添えて throw する。空文字トークン（`Bearer ` になる）も同様に throw。これは outbound（返信送信）側なので inbound 認証の境界には影響しない。
- **`res.ok` / timeout**: トークン交換 fetch は変更前から **両方とも既に存在**（`if (!res.ok) throw` と `AbortSignal.timeout(TEN_SECONDS_MS)`）。JWKS fetch・Chat API fetch も同様。ここに欠落は無かった。
- **残したキャスト**: 無し（4/4 除去）。
- **スコープ外として残した観察点（このPRでは触っていない）**: 同ファイル 51 行目の `const data: { keys?: unknown[] } = await res.json();` は `as` ではないが、型注釈による同種の未検証アサーション。ここを `unknown` + ガードに直すと、JWKS 応答が `null` のときだけ「変更前は TypeError で拒否 / 変更後は stale キャッシュへフォールバック」という accept/reject 差分が出るため、境界を動かさない方針で**あえて据え置いた**。`packages/relay/src/webhooks/jwt.ts`（2件）と `teams.ts`（1件）の警告も別ファイルにつき対象外。

## 実装方針

1. **JWK ガード（旧 49 行目、2 キャスト）** — `hasStringProp`（`@mulmoclaude/common`）で `kid` / `kty` / `n` / `e` の 4 つを全て検証する述語 `isJwk` に置き換え、トップレベルに export（単体テスト可能にするため）。
   - `JwkKey` は `kty` / `e` を必須で宣言しているのに旧ガードは検証していなかった → **検証する側に倒した**（`crypto.subtle.importKey` が RSA 公開鍵を組むのに実際必要なフィールドのため）。
   - 逆に `alg?: string` は誰も検証せず、このファイルでも読んでいないので **宣言から削除**（証明していないことを型で主張しない）。実行時オブジェクトはそのまま `crypto.subtle` へ渡るので、Web Crypto 側の `alg` / `use` 検査は変更前と同一に効く（`use-enc` / `alg-hs256` ケースで実測確認済み）。
   - 「フィルタを通した後に既定値で `kty` / `e` を埋める」（`teams.ts` 方式）は**採らなかった**。それだと `use: "enc"` / `alg: "HS256"` の鍵が落ちて Web Crypto の拒否をすり抜け、**変更前が拒否していたものを受理してしまう**ため。
2. **`JSON.parse(raw) as unknown`（旧 107 行目）** — `const parsed: unknown = JSON.parse(raw);` に。後続の `isRecord` + `typeof` チェックは元から本物の検証なのでそのまま。
3. **OAuth トークン読み取り（旧 144 行目）** — 純粋関数 `readAccessToken(data: unknown, status: number): string` を切り出して export。`hasStringProp(data, "access_token")` が false、または空文字なら、エンドポイントと status を添えて throw する。

## 検証

すべて worktree `/Users/isamu/ss/llm/mc3-wt-google-chat`（base = `243fdb38c`）で実行。

```
npx prettier --write packages/relay/src/webhooks/google-chat.ts packages/relay/test/test_google_chat_webhook.ts
  → unchanged (both)
npx eslint packages/relay/src/webhooks/google-chat.ts packages/relay/test/test_google_chat_webhook.ts
  → exit 0 / 0 errors / 0 warnings   (変更前は同ファイルで consistent-type-assertions 警告 4 件)
npx eslint packages/relay/src packages/relay/test
  → exit 0（残る警告 6 件はいずれも他ファイル: jwt.ts, teams.ts, durable-object.ts, line.ts, telegram.ts）
cd packages/relay && yarn typecheck   → exit 0
cd packages/relay && yarn test        → tests 107 / pass 107 / fail 0   (base は 85 件、+22 件が本PRの追加分)
```

`consistent-type-assertions` が変更前に確かに発火していたことの実測（base のファイルを一時的に書き戻して実行）:

```
packages/relay/src/webhooks/google-chat.ts
   49:56  warning  Do not use any type assertions  @typescript-eslint/consistent-type-assertions
   49:99  warning  Do not use any type assertions  @typescript-eslint/consistent-type-assertions
  107:20  warning  Do not use any type assertions  @typescript-eslint/consistent-type-assertions
  144:16  warning  Do not use any type assertions  @typescript-eslint/consistent-type-assertions
✖ 4 problems (0 errors, 4 warnings)
```

### accept/reject マトリクス（変更前 / 変更後）

外部 ground truth として、**実際の `googleChatPlugin.handleWebhook` / `sendResponse` を呼ぶ**ハーネスを用意した（`crypto.subtle.generateKey` で RSA 鍵ペアを生成 → 本物の RS256 署名 JWT を作成 → `globalThis.fetch` をスタブして JWKS / トークン応答を差し替え）。JWKS キャッシュはモジュールレベルなので **1 ケース = 1 プロセス**で実行し、変更前・変更後の両リビジョンで同一ケース集合を流して diff を取った。

| ケース | 変更前 | 変更後 | 備考 |
|---|---|---|---|
| `valid`（正常な JWKS エントリ） | ACCEPT | ACCEPT | |
| `valid-with-use`（`use: "sig"` 付き） | ACCEPT | ACCEPT | |
| `extra-unknown-field`（未知フィールド付き） | ACCEPT | ACCEPT | |
| `use-enc`（`use: "enc"`） | REJECT | REJECT | Web Crypto の `Invalid JWK "use" Parameter`（両者同一） |
| `alg-hs256`（`alg: "HS256"`） | REJECT | REJECT | Web Crypto の alg 不一致（両者同一） |
| `missing-kid` | REJECT | REJECT | |
| `missing-n` | REJECT | REJECT | |
| `missing-kty` | REJECT | REJECT | 変更前は `Invalid keyData`、変更後はガードで除外 |
| `missing-e` | REJECT | REJECT | 同上 |
| `nonstring-kid` / `nonstring-n` / `nonstring-kty` / `nonstring-e` | REJECT | REJECT | |
| `null-entry` / `array-entry` / `primitive-entry`（不正エントリ + 本物） | ACCEPT | ACCEPT | 不正エントリは両者とも除外され本物で検証 |
| `empty-keys` | REJECT | REJECT | |
| `dup-kid-good-first`（本物が先、壊れたのが後） | ACCEPT | ACCEPT | |
| **`dup-kid-malformed-first`（壊れたのが先、本物が後）** | **REJECT** | **ACCEPT** | **唯一の差分。上記 Items to Confirm 参照** |

outbound（返信送信）側:

| ケース | 変更前 | 変更後 |
|---|---|---|
| `token-valid` | 送信 `Bearer ya29.real` | 送信 `Bearer ya29.real` |
| `token-oauth-error`（200 + `{"error":"invalid_grant"}`） | **送信 `Bearer undefined`** | throw `Google token exchange returned no access_token (https://oauth2.googleapis.com/token, status 200)` |
| `token-empty-string`（`{"access_token":""}`） | **送信 `Bearer`** | 同上 throw |
| `token-non-2xx`（400） | throw `Google token exchange failed: 400` | 同（変更なし） |
| `token-malformed-json` | `SyntaxError` | 同（変更なし） |
| `sa-valid` / `sa-missing-email` / `sa-missing-key` / `sa-null` / `sa-array` / `sa-primitive` / `sa-malformed` / `sa-nonstring-email` | 全て同一 | 全て同一（`parseServiceAccount` の判定は不変） |

まとめ: **inbound 19 ケース中 18 ケースで判定は完全一致し、変更前が拒否した入力は変更後も全て拒否される**（唯一の例外は上記の重複 `kid` ケースで、そこで受理されるのは署名が本当に有効なトークンのみ）。outbound は 13 ケース中 2 ケースが「壊れた bearer トークンを送る」→「文脈付き例外」へ変わる強化のみ。

検証スクリプトは scratchpad 配下で実行し、確認後に削除した（リポジトリには追加していない）。マトリクスのうち JWKS ガードとトークン読み取りに相当する部分は、リポジトリの `packages/relay/test/test_google_chat_webhook.ts` に `describe("isJwk")` / `describe("readAccessToken")` として恒久的な単体テスト（22 件）で残してある。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Strengthen Google Chat relay security by validating JWKS entries and OAuth token responses instead of relying on type assertions.

New Features:
- Expose reusable helpers for validating Google Chat JWKS entries and OAuth token responses.

Bug Fixes:
- Prevent sending malformed bearer tokens (e.g., `Bearer undefined`) to the Google Chat API when the OAuth response body does not contain a valid access token.

Enhancements:
- Tighten JWKS validation so only keys with all required RSA fields are cached and used for signature verification.
- Remove unsafe type assertions in Google Chat webhook handling in favor of explicit runtime checks.
- Expand Google Chat webhook tests to cover JWKS validation and OAuth token parsing edge cases.

Tests:
- Add unit tests for JWKS entry validation and OAuth access token parsing, including malformed and edge-case responses.