### PR TITLE
refactor(dashboard): narrow DOM event targets instead of asserting them (#2692)

### DIFF
--- a/e2e/tests/dashboard-tile-interactions.spec.ts
+++ b/e2e/tests/dashboard-tile-interactions.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+// The dashboard's three pointer/select handlers had no e2e coverage at all,
+// so a broken narrowing in any of them type-checked and shipped silently:
+// the tile would simply stop dragging, resizing, or switching view. These
+// drive the real handlers and assert the persisted layout that results.
+
+const TILE_SLUGS = ["tasks", "notes"] as const;
+
+const collectionDetail = (slug: string, title: string) => ({
+  collection: {
+    slug,
+    title,
+    icon: "checklist",
+    source: "user",
+    schema: {
+      title,
+      icon: "checklist",
+      dataPath: `data/${slug}/items`,
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true },
+        title: { type: "string", label: "Title", required: true },
+        status: { type: "enum", label: "Status", values: ["todo", "done"] },
+      },
+    },
+  },
+  items: [{ id: "a", title: `${title} item`, status: "todo" }],
+});
+
+/** Layout PUTs the component makes, newest last. */
+interface SavedLayout {
+  tiles: { slug: string; viewMode?: string }[];
+  rowHeights?: Record<string, number[]>;
+}
+
+async function setup(page: Page): Promise<SavedLayout[]> {
+  const saved: SavedLayout[] = [];
+  await mockAllApis(page);
+
+  for (const slug of TILE_SLUGS) {
+    await page.route(
+      (url) => url.pathname === `/api/collections/${slug}`,
+      (route) => route.fulfill({ json: collectionDetail(slug, slug === "tasks" ? "Tasks" : "Notes") }),
+    );
+  }
+
+  // Membership derives from pinned collection shortcuts.
+  await page.route(
+    (url) => url.pathname === "/api/shortcuts",
+    (route) =>
+      route.fulfill({
+        json: { shortcuts: TILE_SLUGS.map((slug) => ({ kind: "collection", slug, title: slug === "tasks" ? "Tasks" : "Notes", icon: "checklist" })) },
+      }),
+  );
+
+  // Stateful: the component replaces the layout wholesale, and later reads
+  // must see what the earlier write stored.
+  const state: SavedLayout = { tiles: TILE_SLUGS.map((slug) => ({ slug })), rowHeights: {} };
+  await page.route(
+    (url) => url.pathname === "/api/dashboard",
+    (route) => {
+      if (route.request().method() === "PUT") {
+        const body: SavedLayout = JSON.parse(route.request().postData() ?? "{}");
+        state.tiles = body.tiles ?? state.tiles;
+        state.rowHeights = body.rowHeights ?? state.rowHeights;
+        saved.push(JSON.parse(JSON.stringify(state)));
+        return route.fulfill({ json: state });
+      }
+      return route.fulfill({ json: state });
+    },
+  );
+
+  await page.goto("/dashboard");
+  await expect(page.getByTestId("dashboard-grid")).toBeVisible();
+  return saved;
+}
+
+test.describe("DashboardView — tile interactions", () => {
+  test("the view picker persists the chosen mode for that tile", async ({ page }) => {
+    const saved = await setup(page);
+    const picker = page.getByTestId("dashboard-tile-view-tasks");
+    await expect(picker).toBeVisible();
+
+    // `onPickView` reads `event.target`; if that narrowing fails the handler
+    // returns early and nothing is ever persisted.
+    await picker.selectOption("kanban");
+    await expect.poll(() => saved.at(-1)?.tiles.find((tile) => tile.slug === "tasks")?.viewMode).toBe("kanban");
+  });
+
+  test("dragging the handle reorders the tiles", async ({ page }) => {
+    const saved = await setup(page);
+    const handles = page.getByTestId("dashboard-tile-drag");
+    await expect(handles).toHaveCount(TILE_SLUGS.length);
+
+    const source = await handles.nth(0).boundingBox();
+    const destination = await handles.nth(1).boundingBox();
+    expect(source).not.toBeNull();
+    expect(destination).not.toBeNull();
+    if (!source || !destination) return;
+
+    // `onReorderStart` captures the pointer to `event.currentTarget`; a failed
+    // narrowing means no drag ever starts.
+    await page.mouse.move(source.x + source.width / 2, source.y + source.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(destination.x + destination.width / 2, destination.y + destination.height / 2, { steps: 12 });
+    await page.mouse.up();
+
+    await expect.poll(() => saved.at(-1)?.tiles.map((tile) => tile.slug)).toEqual(["notes", "tasks"]);
+  });
+
+  test("dragging the resize handle stores a row height", async ({ page }) => {
+    const saved = await setup(page);
+    const handle = page.getByTestId("dashboard-tile-resize-tasks");
+    await expect(handle).toBeVisible();
+
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+
+    // `onResizeStart` captures the pointer the same way.
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 120, { steps: 12 });
+    await page.mouse.up();
+
+    await expect
+      .poll(() =>
+        Object.values(saved.at(-1)?.rowHeights ?? {})
+          .flat()
+          .some((height) => height > 0),
+      )
+      .toBe(true);
+  });
+});

--- a/src/components/DashboardView.vue
+++ b/src/components/DashboardView.vue
@@ -125,7 +125,7 @@ function modesFor(slug: string): CollectionViewMode[] {
  *  the first available mode (table). */
 function effectiveView(tile: DashboardTile): CollectionViewMode {
   const modes = modesFor(tile.slug);
-  return tile.viewMode && modes.includes(tile.viewMode as CollectionViewMode) ? (tile.viewMode as CollectionViewMode) : (modes[0] ?? "table");
+  return modes.find((mode) => mode === tile.viewMode) ?? modes[0] ?? "table";
 }
 
 const BUILTIN_LABEL_KEYS: Record<string, string> = {
@@ -143,8 +143,9 @@ function modeLabel(slug: string, mode: CollectionViewMode): string {
 }
 
 function onPickView(slug: string, event: Event): void {
-  const { value } = event.target as HTMLSelectElement;
-  void setViewMode(slug, value);
+  const { target } = event;
+  if (!(target instanceof HTMLSelectElement)) return;
+  void setViewMode(slug, target.value);
 }
 
 function openFull(slug: string): void {
@@ -158,6 +159,21 @@ function openFull(slug: string): void {
 // double-click does (the requested pointer UX).
 function onTitleActivate(event: MouseEvent, slug: string): void {
   if (event.detail === 0) openFull(slug);
+}
+
+// The element a drag started on, with the pointer captured to it. Capture
+// routes every subsequent move/up to the handle even when the cursor passes
+// over an embedded view (incl. iframes), which is what made the drag drop
+// events and feel unstable.
+function captureDragHandle(event: PointerEvent): HTMLElement | null {
+  const { currentTarget } = event;
+  if (!(currentTarget instanceof HTMLElement)) return null;
+  try {
+    currentTarget.setPointerCapture(event.pointerId);
+  } catch {
+    // Pointer capture unsupported — fall back to plain window listeners.
+  }
+  return currentTarget;
 }
 
 // ── Drag-to-reorder via pointer events. Native HTML5 DnD conflicted with
@@ -211,12 +227,8 @@ function onReorderEnd(): void {
 }
 
 function onReorderStart(index: number, event: PointerEvent): void {
-  const handle = event.currentTarget as HTMLElement;
-  try {
-    handle.setPointerCapture(event.pointerId);
-  } catch {
-    // Pointer capture unsupported — fall back to plain window listeners.
-  }
+  const handle = captureDragHandle(event);
+  if (!handle) return;
   reorder = { startIndex: index, handle, pointerId: event.pointerId };
   dragIndex.value = index;
   isReordering.value = true;
@@ -331,15 +343,8 @@ function onResizeEnd(): void {
 }
 
 function onResizeStart(index: number, event: PointerEvent): void {
-  const handle = event.currentTarget as HTMLElement;
-  // Pointer capture routes every subsequent move/up to the handle even
-  // when the cursor passes over the embedded view (incl. iframes), which
-  // is what made the drag drop events and feel unstable.
-  try {
-    handle.setPointerCapture(event.pointerId);
-  } catch {
-    // Pointer capture unsupported — fall back to plain window listeners.
-  }
+  const handle = captureDragHandle(event);
+  if (!handle) return;
   resize = { cols: columns.value, row: rowOf(index), startY: event.clientY, startHeight: rowHeight(index), handle, pointerId: event.pointerId };
   isResizing.value = true;
   window.addEventListener("pointermove", onResizeMove);


### PR DESCRIPTION
## Summary

`src/components/DashboardView.vue` の `as` を **5 → 0** にしました（#2692、1ファイル1PR）。

DOM の narrowing 3箇所を `instanceof` の**本物の実行時チェック**に、`viewMode` の union 判定を `find` に置き換えています。あわせて、この3箇所を実際に駆動する e2e を追加しました（**このファイルには e2e が1件も無かった**ため）。

## Items to Confirm / Review

1. **チェックが失敗したときの挙動**を確認してください。3箇所とも**早期 return** です。
   - `onPickView`: `event.target` が `HTMLSelectElement` でなければ何もしない
   - `onReorderStart` / `onResizeStart`: `event.currentTarget` が `HTMLElement` でなければドラッグを開始しない

   いずれも実際には起こりません（`@change` は `<select>`、`@pointerdown` は `currentTarget` が常にそのハンドル要素）。ただし「起こらないはず」を握りつぶさないよう、e2e で3経路とも駆動しています。
2. **`captureDragHandle` に共通化**しました。reorder と resize が同じ pointer-capture 処理を重複して持っていたためです。
3. **e2e を新規追加**しています（`e2e/tests/dashboard-tile-interactions.spec.ts`）。本 PR のスコープを少し超えますが、**変更したのが操作ハンドラで、既存カバレッジがゼロ**だったので付けています。不要なら外します。
4. バグは見つかりませんでした。5件とも「嘘だが今のところ無害」なキャストです。

## 実装方針

| 元 | 置換後 |
|---|---|
| `modes.includes(tile.viewMode as CollectionViewMode) ? (tile.viewMode as CollectionViewMode) : …` | `modes.find((mode) => mode === tile.viewMode) ?? modes[0] ?? "table"` |
| `event.target as HTMLSelectElement` | `if (!(target instanceof HTMLSelectElement)) return;` |
| `event.currentTarget as HTMLElement` ×2 | `captureDragHandle(event)`（`instanceof HTMLElement` + pointer capture を共通化） |

`viewMode` の方は「`includes` で確かめてからアサート」という**逆さま**の書き方でした。`find` は確かめた値そのものを返すので、アサートが不要になります。

## 検証

### 追加した e2e が回帰を本当に捕まえるか

narrowing を両方とも壊して（`if (true) return`）実行しました。

```
3 failed
  › the view picker persists the chosen mode for that tile
  › dragging the handle reorders the tiles
  › dragging the resize handle stores a row height
```

本来の実装では **3 passed** です。「通るけれど壊れても通る」テストではありません。

各テストは実際の PUT ペイロードを見ています（`viewMode` が永続化されるか、タイル順が入れ替わるか、`rowHeights` が入るか）。描画の有無ではなく**操作の結果**を検証しています。

### その他

```
npx eslint src/components/DashboardView.vue e2e/tests/dashboard-tile-interactions.spec.ts
  -> 0 errors, 0 warnings（consistent-type-assertions も 0。5 → 0）
yarn typecheck:vue -> エラーなし
yarn typecheck:e2e -> exit 0
npx playwright test --config e2e/playwright.config.ts dashboard-tile-interactions -> 3 passed
npx playwright test --config e2e/playwright.config.ts collection-view-dashboard-removed -> 2 passed
```

なお本ブランチは古い main から分岐していたため、`origin/main` をマージ済みです（#2698 / #2707 の変更を打ち消さないため）。差分は `DashboardView.vue` と新規 spec の2ファイルです。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Refine dashboard tile interaction handlers to use runtime DOM type checks and improve safety while adding end-to-end coverage for their behavior.

Enhancements:
- Simplify effective view selection to avoid unsafe type assertions when resolving a tile's CollectionViewMode.
- Introduce a shared helper for pointer capture on drag handles, consolidating reorder and resize drag-start logic and guarding against invalid event targets.

Tests:
- Add Playwright e2e tests that exercise dashboard tile view selection, reordering, and resizing, asserting the persisted dashboard layout and row heights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard tile view selection validation and persistence.
  * Improved drag-and-drop behavior when pointer capture is unavailable.
  * Prevented invalid event targets from affecting selected tile views.

* **Tests**
  * Added end-to-end coverage for tile view persistence, reordering, and resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->