### PR TITLE
fix(collection-plugin): modalTeleportTarget が ShadowRoot を返せるようにする

### DIFF
--- a/packages/plugins/collection-plugin/src/vue/uiContext.ts
+++ b/packages/plugins/collection-plugin/src/vue/uiContext.ts
@@ -340,8 +340,13 @@ export interface CollectionUi {
   // ── optional host overrides ──
   /** Where the record modal teleports. Defaults to `"body"`; a Shadow-DOM host
    *  (e.g. MulmoTerminal) points it at an in-shadow node so the injected styles
-   *  still apply to the teleported modal. */
-  modalTeleportTarget?: () => string | HTMLElement;
+   *  still apply to the teleported modal.
+   *
+   *  `ShadowRoot` is in the union because that in-shadow node IS one: Vue's own
+   *  `TeleportProps.to` is `string | RendererElement`, which accepts it, and the
+   *  modal passes this value straight through. Without it a Shadow-DOM host — the
+   *  case this option exists for — cannot satisfy the type without a cast. */
+  modalTeleportTarget?: () => string | HTMLElement | ShadowRoot;
   /** Translate a batch of UI strings into the active locale via the host's
    *  `/api/translation` route (host: `apiPost`, global bearer attached). The
    *  contract is host-agnostic (`@mulmoclaude/core/translation/client`); the LLM


### PR DESCRIPTION
## Summary

`modalTeleportTarget` の型を `() => string | HTMLElement` から `() => string | HTMLElement | ShadowRoot` へ広げます。

**宣言のコメント自身が、型が禁じている使い方を指定していました。**

```ts
/** Where the record modal teleports. Defaults to `"body"`; a Shadow-DOM host
 *  (e.g. MulmoTerminal) points it at an in-shadow node so the injected styles
 *  still apply to the teleported modal. */
modalTeleportTarget?: () => string | HTMLElement;
```

「Shadow-DOM ホストが in-shadow ノードを指す」と書いてありますが、その in-shadow ノードは `ShadowRoot` であって `HTMLElement` ではありません。

## Items to Confirm / Review

1. **runtime は最初から動いています。型だけが狭すぎました。** 受け手の `CollectionRecordModal.vue:45` はこの値を Teleport の `to` にそのまま渡します。Vue 自身の `TeleportProps.to` は `string | RendererElement | null | undefined` で ShadowRoot を受けるので、実行時の挙動は変わりません。

2. **後方互換です。** union を広げるだけなので、既存の `string` / `HTMLElement` を返すホストはそのまま通ります。破壊的変更はありません。

3. **これが無いと Shadow-DOM ホストは cast なしで実装できません。** MulmoTerminal は二段キャストで通していました。

   ```ts
   modalTeleportTarget: () => (teleportStack[teleportStack.length - 1] ?? "body") as unknown as string | HTMLElement,
   ```

   receptron/mulmoterminal#1231（`as` を ESLint で全面禁止する作業）で、**ホスト側の型付けでは消せない数少ない箇所**として残っていました。module augmentation も試しましたが、既存プロパティの型は TS の仕様上広げられません。

## 検証

- `packages/plugins/collection-plugin`: `yarn typecheck` **0 error** / `yarn lint` **0 error**
- **ホスト側での実証**: この型を当てた `d.ts` を MulmoTerminal の `node_modules` に入れ、上記の二段キャストを削除したところ、ホストの `yarn typecheck` が通ることを確認しました。つまりこの 1 行で MulmoTerminal 側のキャストが 1 つ消えます。

作業コピー（`~/ss/llm/mulmoclaude`）が別ブランチで作業中だったため、`origin` からのクリーンクローンで作業しています。

## リリース後

`@mulmoclaude/collection-plugin` が publish されたら、MulmoTerminal 側でキャストを削除する PR を出します（#1231 の一部）。

work in mulmoterminal3

## Summary by Sourcery

Broaden the collection plugin UI context’s modalTeleportTarget option type to support ShadowRoot for Shadow DOM hosts.

Bug Fixes:
- Allow Shadow-DOM hosts to provide a ShadowRoot to modalTeleportTarget without unsafe casts by widening its union type.

Documentation:
- Clarify the modalTeleportTarget documentation to explain ShadowRoot support and its relation to Vue TeleportProps.to.