### PR TITLE
chore(release): @mulmoclaude/collection-plugin@1.2.3

### DIFF
--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -37,7 +37,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^1.2.1",
     "@mulmoclaude/chart-plugin": "^1.0.4",
-    "@mulmoclaude/collection-plugin": "^1.2.2",
+    "@mulmoclaude/collection-plugin": "^1.2.3",
     "@mulmoclaude/common": "^1.1.1",
     "@mulmoclaude/core": "^1.13.0",
     "@mulmoclaude/form-plugin": "^1.0.2",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/collection-plugin",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Schema-driven Collections plugin (presentCollection) — the Vue surfaces (chat View/Preview, embeds, calendar, record modal, i18n) for MulmoClaude and MulmoTerminal. The isomorphic engine + node storage engine now live in @mulmoclaude/core/collection and @mulmoclaude/core/collection/server.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

`@mulmoclaude/collection-plugin` を **1.2.3** に上げ、publish できる状態にします。

**#2721 は 1.2.2 を publish した後にマージされた**ので、`modalTeleportTarget` が ShadowRoot を返せるようにする修正は main にはあるが npm には無い状態です。レンジ更新ではなく **code drift**（`src/vue/uiContext.ts` は `dist` に入る同梱ソース）。

1.2.2 以降このパッケージに入った変更は **#2721 の1ファイルだけ**です。

## Items to Confirm / Review

1. **他に code drift が3件残っています**（`@mulmoclaude/core` #2700 / `@mulmoclaude/accounting-plugin` #2714 / `@mulmobridge/relay` google-chat 検証）。**今回は対象外**で、それらの修正は npm 利用者に届かないままになります。まとめて出す場合はお知らせください。
2. launcher の宣言レンジのみ追随（`^1.2.2` → `^1.2.3`）。**自身の version は 1.9.0 のまま**です。

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/2721/changes の更新だけを反映して。
> あ、まざってもよいよ / collection-plugin だけってこと

## 検証（実 exit code）

`check:launcher-sync` OK / `build:packages` 0 / `format --check` 0 / `lint` 0 / `typecheck` 0 / `build` 0 / `test` 0（**10938 pass / 0 fail**）

work in mulmoclaude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the collection plugin to version 1.2.3.
  * Refreshed the related package dependency to ensure compatibility with the latest plugin release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->