### PR TITLE
refactor: remove `as Record<string, unknown>` casts (host + relay/line-works, 47 sites)

### DIFF
--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -134,10 +134,9 @@ async function fetchAccessToken(): Promise<TokenCache> {
     throw new Error(`LINE Works token: ${res.status} ${text.slice(0, 200)}`);
   }
   const body: unknown = await res.json();
-  if (!body || typeof body !== "object") throw new Error("LINE Works token: unexpected response");
-  const record = body as Record<string, unknown>;
-  const accessToken = typeof record.access_token === "string" ? record.access_token : "";
-  const expiresIn = typeof record.expires_in === "number" ? record.expires_in : 3_600;
+  if (!isRecord(body)) throw new Error("LINE Works token: unexpected response");
+  const accessToken = typeof body.access_token === "string" ? body.access_token : "";
+  const expiresIn = typeof body.expires_in === "number" ? body.expires_in : 3_600;
   if (!accessToken) throw new Error("LINE Works token: missing access_token");
   return { accessToken, expiresAtMs: Date.now() + (expiresIn - TOKEN_REFRESH_MARGIN_SEC) * 1_000 };
 }

--- a/packages/relay/src/webhooks/jwt.ts
+++ b/packages/relay/src/webhooks/jwt.ts
@@ -6,6 +6,8 @@
 // validation and JWKS fetch/cache — only the parse and the crypto.subtle
 // signature check live here.
 
+import { isRecord } from "@mulmoclaude/common";
+
 export interface ParsedJwt {
   header: Record<string, unknown>;
   payload: Record<string, unknown>;
@@ -39,8 +41,11 @@ export function parseJwt(token: string): ParsedJwt | null {
   const parts = token.split(".");
   if (parts.length !== 3) return null;
   try {
-    const header = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[0]))) as Record<string, unknown>;
-    const payload = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[1]))) as Record<string, unknown>;
+    const header: unknown = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[0])));
+    const payload: unknown = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[1])));
+    // A segment that decodes to a bare array / string / number is not a JWT
+    // segment; rejecting here is the same outcome the claim checks would reach.
+    if (!isRecord(header) || !isRecord(payload)) return null;
     return { header, payload, signInput: `${parts[0]}.${parts[1]}`, sig: b64UrlDecode(parts[2]) };
   } catch {
     return null;

--- a/server/api/auth/viewToken.ts
+++ b/server/api/auth/viewToken.ts
@@ -25,6 +25,7 @@ import type { Request, Response, NextFunction } from "express";
 import { getCurrentToken } from "./token.js";
 import { unauthorized } from "../../utils/httpError.js";
 import { ONE_HOUR_MS } from "../../utils/time.js";
+import { isRecord, isUnknownArray } from "../../utils/types.js";
 
 export type ViewCapability = "read" | "write";
 
@@ -94,18 +95,30 @@ export function verifyViewToken(token: string, nowMs: number = Date.now()): View
   const expectedBuf = Buffer.from(expectedSig);
   if (providedBuf.length !== expectedBuf.length) return null;
   if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
-  let parsed: unknown;
+  const payload = decodePayload(payloadB64);
+  if (payload === null || nowMs >= payload.exp) return null;
+  return payload;
+}
+
+/** Decode the (already signature-verified) payload segment. The payload is
+ *  rebuilt field by field from what was actually checked, so a token minted by
+ *  a different version of this file can never smuggle an unvalidated shape
+ *  through. Expiry is the caller's check — this is pure decoding. */
+function decodePayload(payloadB64: string): ViewTokenPayload | null {
+  const parsed = parseJson(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  if (!isRecord(parsed)) return null;
+  const { slug, caps, exp } = parsed;
+  if (typeof slug !== "string" || typeof exp !== "number") return null;
+  if (!isUnknownArray(caps) || !caps.every(isCapability)) return null;
+  return { slug, caps, exp };
+}
+
+function parseJson(text: string): unknown {
   try {
-    parsed = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+    return JSON.parse(text);
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== "object") return null;
-  const candidate = parsed as Record<string, unknown>;
-  if (typeof candidate.slug !== "string" || typeof candidate.exp !== "number") return null;
-  if (!Array.isArray(candidate.caps) || !candidate.caps.every(isCapability)) return null;
-  if (nowMs >= candidate.exp) return null;
-  return { slug: candidate.slug, caps: candidate.caps as ViewCapability[], exp: candidate.exp };
 }
 
 /** Express middleware factory guarding a `view-data` route: require a valid

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -673,7 +673,7 @@ async function handleAgentEvent(event: Awaited<ReturnType<typeof runAgent>> exte
     await setClaudeId(ctx.chatSessionId, event.id);
     return;
   }
-  pushSessionEvent(ctx.chatSessionId, event as Record<string, unknown>);
+  pushSessionEvent(ctx.chatSessionId, event);
 
   if (event.type === EVENT_TYPES.text) {
     // Accumulate text chunks instead of writing each one to jsonl.
@@ -802,12 +802,12 @@ async function writeSkillEntry(ctx: EventContext, skillName: string, body: strin
     skillDescription: resolved.description,
     message: skillPart,
   };
-  pushSessionEvent(ctx.chatSessionId, skillPayload as Record<string, unknown>);
+  pushSessionEvent(ctx.chatSessionId, skillPayload);
   await appendSessionLine(ctx.chatSessionId, JSON.stringify(skillPayload));
 
   if (replyPart) {
     const textPayload = { source: "assistant", type: EVENT_TYPES.text, message: replyPart };
-    pushSessionEvent(ctx.chatSessionId, textPayload as Record<string, unknown>);
+    pushSessionEvent(ctx.chatSessionId, textPayload);
     await appendSessionLine(ctx.chatSessionId, JSON.stringify(textPayload));
   }
 }

--- a/server/events/notifications.ts
+++ b/server/events/notifications.ts
@@ -42,6 +42,7 @@ import { publish as notifierPublish } from "../notifier/engine.js";
 import type { NotifierSeverity } from "../notifier/types.js";
 import { log } from "../system/logger/index.js";
 import { makeUuid } from "../utils/id.js";
+import { isRecord } from "../utils/types.js";
 
 // ── Public types ────────────────────────────────────────────────
 
@@ -83,9 +84,8 @@ export interface LegacyNotifierPluginData {
 }
 
 export function isLegacyNotifierPluginData(value: unknown): value is LegacyNotifierPluginData {
-  if (value === null || typeof value !== "object") return false;
-  const rec = value as Record<string, unknown>;
-  return rec.legacy === true && typeof rec.legacyId === "string" && typeof rec.kind === "string";
+  if (!isRecord(value)) return false;
+  return value.legacy === true && typeof value.legacyId === "string" && typeof value.kind === "string";
 }
 
 // ── Mapping helpers ─────────────────────────────────────────────

--- a/server/events/relay-client-helpers.ts
+++ b/server/events/relay-client-helpers.ts
@@ -6,6 +6,7 @@
 // relay-client.ts.
 
 import type { ChatService } from "@mulmobridge/chat-service";
+import { isRecord } from "../utils/types.js";
 
 export interface RelayMessage {
   id: string;
@@ -50,15 +51,14 @@ export function buildExternalChatId(platform: string, chatId: string): string {
 }
 
 export function isRelayMessage(value: unknown): value is RelayMessage {
-  if (!value || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
+  if (!isRecord(value)) return false;
   return (
-    typeof obj.id === "string" &&
-    typeof obj.platform === "string" &&
-    typeof obj.chatId === "string" &&
-    typeof obj.text === "string" &&
-    obj.text !== "" &&
-    obj.chatId !== ""
+    typeof value.id === "string" &&
+    typeof value.platform === "string" &&
+    typeof value.chatId === "string" &&
+    typeof value.text === "string" &&
+    value.text !== "" &&
+    value.chatId !== ""
   );
 }
 

--- a/server/plugins/dev-loader.ts
+++ b/server/plugins/dev-loader.ts
@@ -26,6 +26,7 @@ import path from "node:path";
 
 import { loadPluginFromCacheDir, type LoaderDeps, type RuntimePlugin } from "./runtime-loader.js";
 import { log } from "../system/logger/index.js";
+import { isRecord } from "../utils/types.js";
 
 const LOG_PREFIX = "plugins/dev";
 
@@ -83,7 +84,7 @@ export async function validateDevPluginPath(absPath: string): Promise<DevPluginV
   try {
     const raw = await readFile(pkgPath, "utf-8");
     const parsed: unknown = JSON.parse(raw);
-    name = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>).name : undefined;
+    name = isRecord(parsed) ? parsed.name : undefined;
   } catch (err) {
     return { ok: false, reason: `package.json unreadable at ${pkgPath}: ${String(err)}` };
   }

--- a/server/services/translation/llm.ts
+++ b/server/services/translation/llm.ts
@@ -53,10 +53,11 @@ export function parseTranslations(stdout: string): string[] {
   if (parsed.is_error) {
     throw new Error(`[translation] claude returned error: ${parsed.result ?? "unknown"}`);
   }
-  if (!isRecord(parsed.structured_output)) {
+  const output = parsed.structured_output;
+  if (!isRecord(output)) {
     throw new Error("[translation] structured_output missing or not an object");
   }
-  const { translations } = parsed.structured_output as Record<string, unknown>;
+  const { translations } = output;
   if (!Array.isArray(translations) || !translations.every((value): value is string => typeof value === "string")) {
     throw new Error("[translation] translations is not a string array");
   }

--- a/server/system/whisper/index.ts
+++ b/server/system/whisper/index.ts
@@ -9,15 +9,23 @@ import { createWhisper, resolveModelName, type ModelStatus, type WhisperModelNam
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 import { depStatus } from "../optionalDeps.js";
 import { log } from "../logger/index.js";
+import { isRecord } from "../../utils/types.js";
 import type { AppSettings } from "../config.js";
 
 export { WHISPER_MODELS, DEFAULT_WHISPER_MODEL, isWhisperModelName, type WhisperModelName } from "@mulmoclaude/core/whisper";
 
+// `WhisperLogger` types its payload as `unknown` while the host sink stores a
+// record, so a non-record gets wrapped rather than dropped on the floor.
+const toLogData = (data: unknown): Record<string, unknown> | undefined => {
+  if (data === undefined) return undefined;
+  return isRecord(data) ? data : { value: data };
+};
+
 // Adapt the host's prefixed logger to the package's minimal logger interface.
 const whisperLogger: WhisperLogger = {
-  info: (message, data) => log.info("whisper", message, data as Record<string, unknown> | undefined),
-  warn: (message, data) => log.warn("whisper", message, data as Record<string, unknown> | undefined),
-  error: (message, data) => log.error("whisper", message, data as Record<string, unknown> | undefined),
+  info: (message, data) => log.info("whisper", message, toLogData(data)),
+  warn: (message, data) => log.warn("whisper", message, toLogData(data)),
+  error: (message, data) => log.error("whisper", message, toLogData(data)),
 };
 
 // One service instance for the process, pointed at the workspace models dir.

--- a/server/utils/exif.ts
+++ b/server/utils/exif.ts
@@ -17,6 +17,7 @@
 
 import { readFile } from "fs/promises";
 import exifr from "exifr";
+import { isRecord } from "./types.js";
 
 /** Extracted, projected EXIF fields. All optional — most photos have
  *  some subset. Persisted as the sidecar JSON shape; consumers can
@@ -171,8 +172,8 @@ export async function readPhotoExif(absPath: string, parser: ExifParser = defaul
     // exists) and exifr "couldn't find any EXIF data" rejections.
     return null;
   }
-  if (!raw || typeof raw !== "object") return null;
-  return projectExif(raw as Record<string, unknown>);
+  if (!isRecord(raw)) return null;
+  return projectExif(raw);
 }
 
 /** Keep finite numbers in a 0…max range; otherwise undefined. Used
@@ -255,9 +256,8 @@ function readFlashFired(value: unknown): boolean | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {
     return (value & 1) === 1;
   }
-  if (typeof value === "object" && value !== null) {
-    const obj = value as Record<string, unknown>;
-    const candidates = [obj.flashfired, obj.fired, obj.flash];
+  if (isRecord(value)) {
+    const candidates = [value.flashfired, value.fired, value.flash];
     for (const candidate of candidates) {
       if (typeof candidate === "boolean") return candidate;
     }

--- a/server/utils/files/content-write-validate.ts
+++ b/server/utils/files/content-write-validate.ts
@@ -3,6 +3,7 @@
 
 import { errorMessage } from "../errors.js";
 import { previewSnippet } from "../logPreview.js";
+import { isRecord } from "../types.js";
 
 /** 1 MB — text content is embedded in a JSON response, so the cap is about
  *  what a payload can carry, not what the filesystem can hold. */
@@ -25,7 +26,7 @@ export type PutContentValidation =
  *  own properties, so this rejects nothing legitimate — it closes the door on a
  *  polluted `Object.prototype` supplying a `path` the caller never sent. */
 function ownField(body: unknown, key: string): unknown {
-  return typeof body === "object" && body !== null && Object.hasOwn(body, key) ? (body as Record<string, unknown>)[key] : undefined;
+  return isRecord(body) && Object.hasOwn(body, key) ? body[key] : undefined;
 }
 
 export function validatePutContentRequest(body: unknown): PutContentValidation {

--- a/server/utils/files/dashboard-io.ts
+++ b/server/utils/files/dashboard-io.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { WORKSPACE_FILES, workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
 import { readTextSafe } from "./safe.js";
+import { isRecord } from "../types.js";
 import type { DashboardTile, DashboardFile } from "../../../src/types/dashboard.js";
 
 function dashboardFilePath(workspaceRoot?: string): string {
@@ -21,9 +22,8 @@ export function normalizeDashboard(input: unknown): DashboardTile[] {
   if (!Array.isArray(input)) return [];
   const out: DashboardTile[] = [];
   for (const raw of input) {
-    if (typeof raw !== "object" || raw === null) continue;
-    const candidate = raw as Record<string, unknown>;
-    const { slug, viewMode } = candidate;
+    if (!isRecord(raw)) continue;
+    const { slug, viewMode } = raw;
     if (typeof slug !== "string" || slug.length === 0) continue;
     if (out.some((existing) => existing.slug === slug)) continue;
     const tile: DashboardTile = { slug };
@@ -50,9 +50,9 @@ function normalizeHeightArray(input: unknown): number[] {
  *  so the 1- and 2-column views never share (and clobber) each other's
  *  row heights. Pure, no IO. */
 export function normalizeRowHeights(input: unknown): Record<string, number[]> {
-  if (!input || typeof input !== "object" || Array.isArray(input)) return {};
+  if (!isRecord(input)) return {};
   const out: Record<string, number[]> = {};
-  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+  for (const [key, value] of Object.entries(input)) {
     const columns = Number(key);
     if (!Number.isInteger(columns) || columns < 1) continue;
     const heights = normalizeHeightArray(value);

--- a/server/utils/files/plugins-io.ts
+++ b/server/utils/files/plugins-io.ts
@@ -18,6 +18,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadJsonFile } from "./json.js";
+import { hasStringProp } from "../types.js";
 import { WORKSPACE_PATHS } from "../../workspace/paths.js";
 
 export interface LedgerEntry {
@@ -32,11 +33,8 @@ export interface LedgerEntry {
   installedAt: string;
 }
 
-const isLedgerEntry = (value: unknown): value is LedgerEntry => {
-  if (typeof value !== "object" || value === null) return false;
-  const obj = value as Record<string, unknown>;
-  return typeof obj.name === "string" && typeof obj.version === "string" && typeof obj.tgz === "string" && typeof obj.installedAt === "string";
-};
+const isLedgerEntry = (value: unknown): value is LedgerEntry =>
+  hasStringProp(value, "name") && hasStringProp(value, "version") && hasStringProp(value, "tgz") && hasStringProp(value, "installedAt");
 
 const sanitiseLedger = (raw: unknown): LedgerEntry[] => {
   if (!Array.isArray(raw)) return [];

--- a/server/utils/files/shortcuts-io.ts
+++ b/server/utils/files/shortcuts-io.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { WORKSPACE_FILES, workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
 import { readTextSafe } from "./safe.js";
+import { isRecord } from "../types.js";
 import { SHORTCUT_KINDS, sameShortcut, type Shortcut, type ShortcutsFile } from "../../../src/types/shortcuts.js";
 
 const KINDS = new Set<string>(SHORTCUT_KINDS);
@@ -22,9 +23,8 @@ export function normalizeShortcuts(input: unknown): Shortcut[] {
   if (!Array.isArray(input)) return [];
   const out: Shortcut[] = [];
   for (const raw of input) {
-    if (typeof raw !== "object" || raw === null) continue;
-    const candidate = raw as Record<string, unknown>;
-    const { kind, slug, title, icon } = candidate;
+    if (!isRecord(raw)) continue;
+    const { kind, slug, title, icon } = raw;
     if (typeof kind !== "string" || !KINDS.has(kind)) continue;
     if (typeof slug !== "string" || slug.length === 0) continue;
     const entry: Shortcut = {

--- a/server/utils/files/translation-io.ts
+++ b/server/utils/files/translation-io.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
 import { loadJsonFile, writeJsonAtomic } from "./json.js";
+import { isRecord, isStringRecord } from "../types.js";
 import { emptyDictionary } from "../../services/translation/cache.js";
 import type { DictionaryFile } from "../../services/translation/types.js";
 
@@ -23,16 +24,8 @@ export function dictionaryPath(namespace: string, workspaceRoot?: string): strin
 // `dict.sentences[sentence]` and turn every request for the namespace
 // into a 500 until the file was repaired.
 function isValidDictionary(value: unknown): value is DictionaryFile {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const { sentences } = value as { sentences?: unknown };
-  if (typeof sentences !== "object" || sentences === null || Array.isArray(sentences)) return false;
-  for (const inner of Object.values(sentences)) {
-    if (typeof inner !== "object" || inner === null || Array.isArray(inner)) return false;
-    for (const translated of Object.values(inner as Record<string, unknown>)) {
-      if (typeof translated !== "string") return false;
-    }
-  }
-  return true;
+  if (!isRecord(value) || !isRecord(value.sentences)) return false;
+  return Object.values(value.sentences).every(isStringRecord);
 }
 
 export function loadDictionary(namespace: string, workspaceRoot?: string): DictionaryFile {

--- a/server/utils/request.ts
+++ b/server/utils/request.ts
@@ -3,17 +3,19 @@
 // Centralizes patterns that were duplicated across route handlers
 // (3+ different ways to read `req.query.session`).
 
+import { isRecord } from "./types.js";
+
 // `query: object` so the helpers work with any Express Request
 // generic — `Request<Params, ResBody, ReqBody, Query>`. A narrow
 // `Query` generic like `{ path?: string }` isn't assignable to
 // `Record<string, unknown>` (no index signature), so we widen to
-// `object` and cast internally when reading a key.
+// `object` and narrow again when reading a key.
 interface HasQuery {
   query: object;
 }
 
 function readQueryKey(queryObj: object, key: string): unknown {
-  return (queryObj as Record<string, unknown>)[key];
+  return isRecord(queryObj) ? queryObj[key] : undefined;
 }
 
 /**

--- a/server/workspace/chat-index/indexer.ts
+++ b/server/workspace/chat-index/indexer.ts
@@ -69,8 +69,7 @@ export async function readManifest(workspaceRoot: string): Promise<ChatIndexMani
 
 function isManifest(raw: unknown): raw is ChatIndexManifest {
   if (!isRecord(raw)) return false;
-  const manifestRecord = raw as Record<string, unknown>;
-  return manifestRecord.version === 1 && Array.isArray(manifestRecord.entries);
+  return raw.version === 1 && Array.isArray(raw.entries);
 }
 
 // In-process mutex serializing the read-modify-write sequence on
@@ -152,7 +151,7 @@ export async function readIndexedAtMs(workspaceRoot: string, sessionId: string):
     const raw = await readFile(indexEntryPathFor(workspaceRoot, safeId), "utf-8");
     const entry: unknown = JSON.parse(raw);
     if (!isRecord(entry)) return null;
-    const { indexedAt } = entry as Record<string, unknown>;
+    const { indexedAt } = entry;
     if (typeof indexedAt !== "string") return null;
     const parsed = Date.parse(indexedAt);
     return Number.isNaN(parsed) ? null : parsed;
@@ -255,11 +254,10 @@ async function readSessionMeta(workspaceRoot: string, sessionId: string): Promis
     const raw = await readFile(sessionMetaPathFor(workspaceRoot, safeId), "utf-8");
     const parsed: unknown = JSON.parse(raw);
     if (!isRecord(parsed)) return {};
-    const metaRecord = parsed as Record<string, unknown>;
     return {
-      roleId: typeof metaRecord.roleId === "string" ? metaRecord.roleId : undefined,
-      startedAt: typeof metaRecord.startedAt === "string" ? metaRecord.startedAt : undefined,
-      origin: typeof metaRecord.origin === "string" ? metaRecord.origin : undefined,
+      roleId: typeof parsed.roleId === "string" ? parsed.roleId : undefined,
+      startedAt: typeof parsed.startedAt === "string" ? parsed.startedAt : undefined,
+      origin: typeof parsed.origin === "string" ? parsed.origin : undefined,
     };
   } catch {
     return {};

--- a/server/workspace/chat-index/summarizer.ts
+++ b/server/workspace/chat-index/summarizer.ts
@@ -185,10 +185,9 @@ export function validateSummaryResult(obj: unknown): SummaryResult {
   if (!isRecord(obj)) {
     throw new Error("[chat-index] summary result is not an object");
   }
-  const record = obj as Record<string, unknown>;
-  const title = typeof record.title === "string" ? record.title : "";
-  const summary = typeof record.summary === "string" ? record.summary : "";
-  const keywords = Array.isArray(record.keywords) ? record.keywords.filter((keyword): keyword is string => typeof keyword === "string") : [];
+  const title = typeof obj.title === "string" ? obj.title : "";
+  const summary = typeof obj.summary === "string" ? obj.summary : "";
+  const keywords = Array.isArray(obj.keywords) ? obj.keywords.filter((keyword): keyword is string => typeof keyword === "string") : [];
   return { title, summary, keywords };
 }
 

--- a/server/workspace/journal/archivist-schemas.ts
+++ b/server/workspace/journal/archivist-schemas.ts
@@ -206,35 +206,31 @@ export { extractJsonObject, findBalancedBraceBlock } from "../../utils/json.js";
 
 export function isDailyArchivistOutput(value: unknown): value is DailyArchivistOutput {
   if (!isRecord(value)) return false;
-  const recordValue = value as Record<string, unknown>;
-  if (typeof recordValue.dailySummaryMarkdown !== "string") return false;
-  if (!Array.isArray(recordValue.topicUpdates)) return false;
-  return recordValue.topicUpdates.every(isTopicUpdate);
+  if (typeof value.dailySummaryMarkdown !== "string") return false;
+  if (!Array.isArray(value.topicUpdates)) return false;
+  return value.topicUpdates.every(isTopicUpdate);
 }
 
 function isTopicUpdate(value: unknown): value is TopicUpdate {
   if (!isRecord(value)) return false;
-  const recordValue = value as Record<string, unknown>;
-  if (typeof recordValue.slug !== "string") return false;
-  if (typeof recordValue.content !== "string") return false;
-  return recordValue.action === "create" || recordValue.action === "append" || recordValue.action === "rewrite";
+  if (typeof value.slug !== "string") return false;
+  if (typeof value.content !== "string") return false;
+  return value.action === "create" || value.action === "append" || value.action === "rewrite";
 }
 
 export function isOptimizationOutput(value: unknown): value is OptimizationOutput {
   if (!isRecord(value)) return false;
-  const recordValue = value as Record<string, unknown>;
-  if (!Array.isArray(recordValue.merges)) return false;
-  if (!Array.isArray(recordValue.archives)) return false;
-  if (!recordValue.merges.every(isTopicMerge)) return false;
-  return recordValue.archives.every((archiveSlug: unknown) => typeof archiveSlug === "string");
+  if (!Array.isArray(value.merges)) return false;
+  if (!Array.isArray(value.archives)) return false;
+  if (!value.merges.every(isTopicMerge)) return false;
+  return value.archives.every((archiveSlug: unknown) => typeof archiveSlug === "string");
 }
 
 function isTopicMerge(value: unknown): value is TopicMerge {
   if (!isRecord(value)) return false;
-  const recordValue = value as Record<string, unknown>;
-  if (!Array.isArray(recordValue.from)) return false;
-  if (!recordValue.from.every((fromSlug: unknown) => typeof fromSlug === "string")) return false;
-  if (typeof recordValue.into !== "string") return false;
-  if (typeof recordValue.newContent !== "string") return false;
+  if (!Array.isArray(value.from)) return false;
+  if (!value.from.every((fromSlug: unknown) => typeof fromSlug === "string")) return false;
+  if (typeof value.into !== "string") return false;
+  if (typeof value.newContent !== "string") return false;
   return true;
 }

--- a/server/workspace/journal/dailyPass.ts
+++ b/server/workspace/journal/dailyPass.ts
@@ -549,7 +549,7 @@ function parseJsonlLine(line: string): Record<string, unknown> | null {
   if (!isRecord(parsed)) {
     return null;
   }
-  return parsed as Record<string, unknown>;
+  return parsed;
 }
 
 function isMetadataEntry(entry: Record<string, unknown>): boolean {
@@ -601,6 +601,7 @@ export function parseEntry(entry: Record<string, unknown>): ParsedEntry | null {
 export function entryToExcerpt(entry: Record<string, unknown>): SessionEventExcerpt | null {
   const source = typeof entry.source === "string" ? entry.source : "unknown";
   const type = typeof entry.type === "string" ? entry.type : "unknown";
+  const { result } = entry;
 
   if (type === EVENT_TYPES.text && typeof entry.message === "string") {
     return {
@@ -609,12 +610,10 @@ export function entryToExcerpt(entry: Record<string, unknown>): SessionEventExce
       content: truncate(entry.message, MAX_EVENT_CONTENT_CHARS),
     };
   }
-  // typeof null === "object", so isRecord must reject null before accessing resultRecord.toolName below.
-  if (type === EVENT_TYPES.toolResult && isRecord(entry.result)) {
-    const resultRecord = entry.result as Record<string, unknown>;
-    const toolName = typeof resultRecord.toolName === "string" ? resultRecord.toolName : "tool";
-    const label =
-      (typeof resultRecord.title === "string" && resultRecord.title) || (typeof resultRecord.message === "string" && resultRecord.message) || "(no message)";
+  // typeof null === "object", so isRecord must reject null before accessing result.toolName below.
+  if (type === EVENT_TYPES.toolResult && isRecord(result)) {
+    const toolName = typeof result.toolName === "string" ? result.toolName : "tool";
+    const label = (typeof result.title === "string" && result.title) || (typeof result.message === "string" && result.message) || "(no message)";
     return {
       source,
       type,
@@ -629,20 +628,18 @@ export function extractArtifactPaths(entry: Record<string, unknown>): string[] {
   if (entry.type !== "tool_result") return [];
   const { result } = entry;
   if (!isRecord(result)) return [];
-  const resultRecord = result as Record<string, unknown>;
-  const { data } = resultRecord;
+  const { data } = result;
   if (!isRecord(data)) return [];
-  const dataRecord = data as Record<string, unknown>;
   const paths: string[] = [];
 
   // presentMulmoScript / presentHtml expose filePath directly.
-  if (typeof dataRecord.filePath === "string" && dataRecord.filePath.length > 0) {
-    paths.push(dataRecord.filePath);
+  if (typeof data.filePath === "string" && data.filePath.length > 0) {
+    paths.push(data.filePath);
   }
 
   // manageWiki only surfaces pageName; synthesise the path from the wiki/pages/<pageName>.md convention.
-  if (resultRecord.toolName === "manageWiki" && typeof dataRecord.pageName === "string") {
-    paths.push(`wiki/pages/${dataRecord.pageName}.md`);
+  if (result.toolName === "manageWiki" && typeof data.pageName === "string") {
+    paths.push(`wiki/pages/${data.pageName}.md`);
   }
 
   return paths.filter(isSafeWorkspacePath);

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -40,13 +40,12 @@ export function defaultState(): JournalState {
 // Forgiving toward partial / hand-edited input — fill defaults instead of throwing.
 export function parseState(raw: unknown): JournalState {
   if (!isRecord(raw)) return defaultState();
-  const obj = raw as Record<string, unknown>;
 
   // Log the version-mismatch reset (#799 PR1) so postmortems can tell
   // it apart from a missing-file first run.
-  if (obj.version !== JOURNAL_STATE_VERSION) {
+  if (raw.version !== JOURNAL_STATE_VERSION) {
     log.info("journal", "state schema version mismatch — resetting", {
-      from: obj.version,
+      from: raw.version,
       to: JOURNAL_STATE_VERSION,
     });
     return defaultState();
@@ -55,22 +54,22 @@ export function parseState(raw: unknown): JournalState {
   const fallback = defaultState();
   return {
     version: JOURNAL_STATE_VERSION,
-    lastDailyRunAt: typeof obj.lastDailyRunAt === "string" ? obj.lastDailyRunAt : null,
-    lastOptimizationRunAt: typeof obj.lastOptimizationRunAt === "string" ? obj.lastOptimizationRunAt : null,
-    dailyIntervalHours: typeof obj.dailyIntervalHours === "number" && obj.dailyIntervalHours > 0 ? obj.dailyIntervalHours : fallback.dailyIntervalHours,
+    lastDailyRunAt: typeof raw.lastDailyRunAt === "string" ? raw.lastDailyRunAt : null,
+    lastOptimizationRunAt: typeof raw.lastOptimizationRunAt === "string" ? raw.lastOptimizationRunAt : null,
+    dailyIntervalHours: typeof raw.dailyIntervalHours === "number" && raw.dailyIntervalHours > 0 ? raw.dailyIntervalHours : fallback.dailyIntervalHours,
     optimizationIntervalDays:
-      typeof obj.optimizationIntervalDays === "number" && obj.optimizationIntervalDays > 0 ? obj.optimizationIntervalDays : fallback.optimizationIntervalDays,
-    processedSessions: parseProcessedSessions(obj.processedSessions),
-    knownTopics: Array.isArray(obj.knownTopics) ? obj.knownTopics.filter((topic): topic is string => typeof topic === "string") : [],
+      typeof raw.optimizationIntervalDays === "number" && raw.optimizationIntervalDays > 0 ? raw.optimizationIntervalDays : fallback.optimizationIntervalDays,
+    processedSessions: parseProcessedSessions(raw.processedSessions),
+    knownTopics: Array.isArray(raw.knownTopics) ? raw.knownTopics.filter((topic): topic is string => typeof topic === "string") : [],
   };
 }
 
 function parseProcessedSessions(raw: unknown): Record<string, ProcessedSessionRecord> {
   if (!isRecord(raw)) return {};
   const out: Record<string, ProcessedSessionRecord> = {};
-  for (const [sessionId, rec] of Object.entries(raw as Record<string, unknown>)) {
+  for (const [sessionId, rec] of Object.entries(raw)) {
     if (!isRecord(rec)) continue;
-    const mtime = (rec as Record<string, unknown>).lastMtimeMs;
+    const mtime = rec.lastMtimeMs;
     if (typeof mtime === "number" && mtime >= 0) {
       out[sessionId] = { lastMtimeMs: mtime };
     }

--- a/server/workspace/memory/topic-cluster.ts
+++ b/server/workspace/memory/topic-cluster.ts
@@ -108,7 +108,7 @@ export function parseClusterMap(raw: string): ClusterMap | null {
   if (!isRecord(parsed)) return null;
   const out: ClusterMap = { preference: [], interest: [], fact: [], reference: [] };
   for (const type of ["preference", "interest", "fact", "reference"] as const) {
-    const list = (parsed as Record<string, unknown>)[type];
+    const list = parsed[type];
     if (!Array.isArray(list)) continue;
     for (const candidate of list) {
       const topic = normaliseTopic(candidate);
@@ -120,11 +120,10 @@ export function parseClusterMap(raw: string): ClusterMap | null {
 
 function normaliseTopic(value: unknown): ClusterTopic | null {
   if (!isRecord(value)) return null;
-  const obj = value as Record<string, unknown>;
-  const slug = resolveTopicSlug(obj.topic);
+  const slug = resolveTopicSlug(value.topic);
   if (!slug) return null;
-  const sections = normaliseSections(obj.sections);
-  const unsectionedBullets = normaliseBulletList(obj.unsectionedBullets);
+  const sections = normaliseSections(value.sections);
+  const unsectionedBullets = normaliseBulletList(value.unsectionedBullets);
   if (sections.length === 0 && unsectionedBullets.length === 0) return null;
   return {
     topic: slug,
@@ -157,11 +156,10 @@ function normaliseBulletList(value: unknown): string[] {
 
 function normaliseSection(value: unknown): ClusterSection | null {
   if (!isRecord(value)) return null;
-  const obj = value as Record<string, unknown>;
-  const heading = typeof obj.heading === "string" ? obj.heading.trim() : "";
+  const heading = typeof value.heading === "string" ? value.heading.trim() : "";
   if (heading.length === 0) return null;
-  if (!Array.isArray(obj.bullets)) return null;
-  const bullets = obj.bullets.filter((bullet): bullet is string => typeof bullet === "string" && bullet.trim().length > 0);
+  if (!Array.isArray(value.bullets)) return null;
+  const bullets = value.bullets.filter((bullet): bullet is string => typeof bullet === "string" && bullet.trim().length > 0);
   if (bullets.length === 0) return null;
   return { heading, bullets };
 }

--- a/server/workspace/reference-dirs.ts
+++ b/server/workspace/reference-dirs.ts
@@ -110,9 +110,8 @@ function hasTraversalSegment(inputPath: string): boolean {
 
 function validateEntry(raw: unknown): ReferenceDirEntry | null {
   if (!isRecord(raw)) return null;
-  const obj = raw as Record<string, unknown>;
 
-  const rawPath = typeof obj.hostPath === "string" ? obj.hostPath : "";
+  const rawPath = typeof raw.hostPath === "string" ? raw.hostPath : "";
   if (!rawPath) return null;
 
   const expanded = expandHome(rawPath);

--- a/server/workspace/skills/external/install.ts
+++ b/server/workspace/skills/external/install.ts
@@ -24,6 +24,7 @@ import { WORKSPACE_DIRS } from "../../paths.js";
 import { parseSkillFrontmatter } from "../parser.js";
 import { log } from "../../../system/logger/index.js";
 import { errorMessage } from "../../../utils/errors.js";
+import { isRecord } from "../../../utils/types.js";
 import { writeFileAtomic } from "../../../utils/files/index.js";
 import { cloneOrUpdate, defaultCacheRoot, type CloneDeps, type CloneResult } from "./clone.js";
 import { canonicalRepoUrl, deriveRepoId, safeRepoId, safeSkillFolder, sanitiseSubpath, urlCacheKey } from "./id.js";
@@ -369,13 +370,12 @@ interface RepoMetadataShape {
 }
 
 function isRepoMetadata(value: unknown): value is RepoMetadataShape {
-  if (!value || typeof value !== "object") return false;
-  const record = value as Record<string, unknown>;
-  if (typeof record.url !== "string") return false;
-  if (typeof record.sha !== "string") return false;
-  if (typeof record.installedAt !== "string") return false;
-  if (record.subpath !== undefined && typeof record.subpath !== "string") return false;
-  if (record.ref !== undefined && typeof record.ref !== "string") return false;
+  if (!isRecord(value)) return false;
+  if (typeof value.url !== "string") return false;
+  if (typeof value.sha !== "string") return false;
+  if (typeof value.installedAt !== "string") return false;
+  if (value.subpath !== undefined && typeof value.subpath !== "string") return false;
+  if (value.ref !== undefined && typeof value.ref !== "string") return false;
   return true;
 }
 

--- a/server/workspace/skills/user-tasks.ts
+++ b/server/workspace/skills/user-tasks.ts
@@ -46,12 +46,11 @@ function isValidDailyTime(value: string): boolean {
 
 function isValidSchedule(scheduleValue: unknown): scheduleValue is LocalTaskSchedule {
   if (!isRecord(scheduleValue)) return false;
-  const scheduleRecord = scheduleValue as Record<string, unknown>;
-  if (scheduleRecord.type === SCHEDULE_TYPES.interval) {
-    return typeof scheduleRecord.intervalMs === "number" && scheduleRecord.intervalMs > 0;
+  if (scheduleValue.type === SCHEDULE_TYPES.interval) {
+    return typeof scheduleValue.intervalMs === "number" && scheduleValue.intervalMs > 0;
   }
-  if (scheduleRecord.type === SCHEDULE_TYPES.daily) {
-    return typeof scheduleRecord.time === "string" && isValidDailyTime(scheduleRecord.time);
+  if (scheduleValue.type === SCHEDULE_TYPES.daily) {
+    return typeof scheduleValue.time === "string" && isValidDailyTime(scheduleValue.time);
   }
   return false;
 }
@@ -66,30 +65,28 @@ export function validateAndCreate(input: unknown): ValidateResult {
   if (!isRecord(input)) {
     return { kind: "error", error: "request body required" };
   }
-  const obj = input as Record<string, unknown>;
-
-  if (typeof obj.name !== "string" || obj.name.trim().length === 0) {
+  if (typeof input.name !== "string" || input.name.trim().length === 0) {
     return { kind: "error", error: "name required" };
   }
-  if (typeof obj.prompt !== "string" || obj.prompt.trim().length === 0) {
+  if (typeof input.prompt !== "string" || input.prompt.trim().length === 0) {
     return { kind: "error", error: "prompt required" };
   }
-  if (!isValidSchedule(obj.schedule)) {
+  if (!isValidSchedule(input.schedule)) {
     return { kind: "error", error: "valid schedule required" };
   }
-  const missedRunPolicy = isValidMissedRunPolicy(obj.missedRunPolicy) ? obj.missedRunPolicy : MISSED_RUN_POLICIES.runOnce;
-  const roleId = typeof obj.roleId === "string" ? obj.roleId : DEFAULT_ROLE_ID;
+  const missedRunPolicy = isValidMissedRunPolicy(input.missedRunPolicy) ? input.missedRunPolicy : MISSED_RUN_POLICIES.runOnce;
+  const roleId = typeof input.roleId === "string" ? input.roleId : DEFAULT_ROLE_ID;
 
   const now = new Date().toISOString();
   const task: PersistedUserTask = {
     id: makeUuid(),
-    name: obj.name.trim(),
-    description: typeof obj.description === "string" ? obj.description.trim() : "",
-    schedule: obj.schedule,
+    name: input.name.trim(),
+    description: typeof input.description === "string" ? input.description.trim() : "",
+    schedule: input.schedule,
     missedRunPolicy,
     enabled: true,
     roleId,
-    prompt: obj.prompt.trim(),
+    prompt: input.prompt.trim(),
     createdAt: now,
     updatedAt: now,
   };

--- a/src/utils/html/previewCsp.ts
+++ b/src/utils/html/previewCsp.ts
@@ -11,6 +11,7 @@
 // audited: every entry is a potential supply-chain surface.
 
 import { SANDBOXED_VIEW_CDN_ALLOWLIST } from "@mulmoclaude/core/remote-view";
+import { isRecord } from "../types";
 
 export const HTML_PREVIEW_CSP_ALLOWED_CDNS: readonly string[] = SANDBOXED_VIEW_CDN_ALLOWLIST;
 
@@ -42,11 +43,10 @@ function isPlainHttpsHost(value: string): boolean {
 }
 
 export function sanitizeCspExtra(raw: unknown): CspExtraHosts {
-  if (raw === null || typeof raw !== "object") return {};
-  const record = raw as Record<string, unknown>;
+  if (!isRecord(raw)) return {};
   const out: CspExtraHosts = {};
   for (const directive of CSP_EXTENDABLE_DIRECTIVES) {
-    const value = record[directive];
+    const value = raw[directive];
     if (!Array.isArray(value)) continue;
     const hosts = value.map((host) => (typeof host === "string" ? host.trim() : "")).filter(isPlainHttpsHost);
     if (hosts.length > 0) out[directive] = [...new Set(hosts)];

--- a/src/utils/tools/result.ts
+++ b/src/utils/tools/result.ts
@@ -95,18 +95,20 @@ export function makeSkillResult(entry: {
   skillDescription: string | null;
   message: string;
 }): ToolResultComplete {
-  const data: SkillResultData = {
+  // `satisfies` rather than an annotation: the envelope's `data` is an index
+  // signature, which an interface-annotated value is not assignable to.
+  const data = {
     skillName: entry.skillName,
     skillScope: entry.skillScope,
     skillPath: entry.skillPath,
     skillDescription: entry.skillDescription,
     body: entry.message,
-  };
+  } satisfies SkillResultData;
   return {
     uuid: uuidv4(),
     toolName: SKILL_TOOL_NAME,
     message: entry.skillDescription ?? entry.skillName,
     title: `Skill: ${entry.skillName}`,
-    data: data as unknown as Record<string, unknown>,
+    data,
   };
 }


### PR DESCRIPTION
## Summary

`x as Record<string, unknown>` 形の型アサーションを **47 箇所削除**（host 側 `server/` 44 + `src/` 2 → **0**、加えて `packages/relay` 2 + `packages/bridges/line-works` 1）。
ほぼ全てが `@mulmoclaude/common` の `isRecord` / `hasStringProp` / `isStringRecord`（`server/utils/types.ts` / `src/utils/types.ts` が re-export）への置き換え、または **既に `isRecord` で絞り込み済みの値に対する冗長なキャストの削除**。新しい型ガードは 1 つも追加していない（`isRecord` の 13 個目のコピーを作らない）。
**スコープ外**: `packages/core`(7) / `packages/markdown-utils`(1) / `packages/plugins/collection-plugin`(3) と、eslint 対象外の `packages/chat-service`・`web-push`・`mock-server`・各 `test/`。理由は「Items to Confirm」に記載。

## Items to Confirm / Review

1. **array を通すか通さないかが変わる箇所（唯一の挙動差、意図的）**
   `isRecord` は配列を弾くが、旧 `typeof x === "object" && x !== null` は通していた。下記 2 つの型ガードだけが「必須プロパティを持つ配列」に対して `true` → `false` に変わる:
   - `server/events/relay-client-helpers.ts` の `isRelayMessage`
   - `server/events/notifications.ts` の `isLegacyNotifierPluginData`

   実プロダクションでは到達不能と判断した。どちらの入力も `JSON.parse` 由来（relay の WebSocket フレーム / notifier の永続化 JSON）で、`JSON.parse` は「名前付きプロパティを持つ配列」を作れない。`Object.assign([], {...})` を渡す差分検証スクリプトで、この 2 件だけが差分として出ることを確認済み（「検証」参照）。**他の全サイトは array を通していても後続の型チェックで確実に落ちるため、差分ゼロ。**

2. **`packages/core` / `markdown-utils` を含めなかった理由（要判断）**
   本 PR は git worktree で作業し、`node_modules` をメイン checkout から symlink している。この構成だと `node_modules/@mulmoclaude/core` は **メイン checkout の `packages/core`** に解決されるため、worktree 内で `yarn build:packages && yarn build:hooks` を回しても `server/build/dispatcher.mjs` が「自分の変更を含まないソース」からビルドされる。CI は `git diff --exit-code` でこれを検査するので、誤ったバンドルを commit する危険がある。よって **意図的に見送り**（別 PR 推奨、通常の checkout で実施すべき）。

3. **`packages/plugins/collection-plugin`(3 箇所) を含めなかった理由**
   このパッケージは `@mulmoclaude/common` に依存していない（`@mulmoclaude/core` を devDependency に持つのみ）。`isRecord` を使うには依存追加が必要で、それは本 PR のスコープ外。ローカルコピーを書くのは `docs/shared-utils.md` が明示的に禁じている。

4. **既存の「不正直な型述語」はそのまま残した（意図的）**
   `isRelayMessage` は `value is RelayMessage` を名乗るが `senderId` / `receivedAt` を検査していない。`isLegacyNotifierPluginData` も `priority` / `action` を検査していない。どちらも本 PR 以前からの状態で、**厳格化すると外部由来メッセージを落としうる挙動変更になる**ため、検査内容は 1 バイトも変えていない。別 issue 候補。

5. **同一ファイル内に残した別形状のキャスト**（本 PR の対象外、`refs #2692` の別バケット）
   `exif.ts:195-196` (`as number`)、`dashboard-io.ts:70` / `shortcuts-io.ts:31,48` (`as Partial<…>` / `as Shortcut["kind"]`)、`viewToken.ts:61`、`agent.ts:1137`、`install.ts:217,336`。ベースラインの eslint 出力と突き合わせ、**新規警告 0** を確認済み。

6. **`server/utils/files/translation-io.ts`** — `isValidDictionary` を書き換えた際、同じ式にあった `value as { sentences?: unknown }`（別形状）も自然に消えた。検査内容は等価（record → record → 全値 string）で、`isStringRecord` を使って 11 行 → 3 行。

7. **`src/utils/tools/result.ts`** — `data as unknown as Record<string, unknown>` は二重キャスト。`SkillResultData` が `interface` のため implicit index signature が付かないのが原因なので、注釈をやめて `satisfies SkillResultData` にした（型検査は維持したままオブジェクトリテラル型を保つ）。`interface` 宣言自体は変更していない。

8. **`packages/relay/src/webhooks/jwt.ts`（認証境界）** — header/payload が record でない場合、旧コードは「Record を名乗る非オブジェクト」を返し、呼び出し側の claim 検査で落ちていた。今は `parseJwt` が `null` を返す。呼び出し側は 2 箇所とも `if (!jwt) return false;` なので**最終的な拒否という結果は同一**、より早く安全に落ちるだけ。

## 実装方針

- **既存ヘルパー優先**: `docs/shared-utils.md` に従い `@mulmoclaude/common` の `isRecord` / `hasStringProp` / `isStringRecord` / `isUnknownArray` のみを使用。新規ガードは追加しない。
- **冗長キャストの削除が最多**: 47 件のうち相当数は `if (!isRecord(raw)) return …;` の直後に `const obj = raw as Record<string, unknown>;` と書かれていたもの。エイリアス変数を消して narrowing 済みの値をそのまま使うだけで、型も挙動も変わらない（`archivist-schemas.ts` の 4 件、`state.ts` 3 件、`dailyPass.ts` 4 件、`indexer.ts` 3 件、`topic-cluster.ts` 3 件 など）。
- **失敗パスは既存に合わせる**: `null` を返す関数は `null`、`{}` を返す関数は `{}`、`continue` する関数は `continue`。新しい throw は増やしていない。
- **`server/api/routes/agent.ts` の 3 件は最初から不要だった**: `AgentEvent` は匿名オブジェクト型の union、`skillPayload` / `textPayload` はオブジェクトリテラルなので、TypeScript の implicit index signature で `Record<string, unknown>` にそのまま代入できる。キャストを消すだけで型が通る（SSE ブロードキャスト経路には一切手を入れていない）。
- **`viewToken.ts`**: 「検査した値からペイロードを組み立て直す」方針に変更。`decodePayload` を切り出し、`slug` / `exp` / `caps` を個別に検査した上で `{ slug, caps, exp }` を新規構築して返す。`caps.every(isCapability)` の `this is S[]` narrowing により `caps as ViewCapability[]` も不要になった。`let parsed` も解消。
- **`server/system/whisper/index.ts`**: `WhisperLogger` の `data?: unknown` を host の `data?: Record<string, unknown>` に橋渡しする 3 つのキャストを、1 つの `toLogData` ヘルパーに集約（DRY）。record でない値は捨てずに `{ value: data }` で包む。現行の呼び出し側は全てオブジェクトリテラルを渡しているため実質差分なし。
- **`let` の扱い**: 既存の `let`（`dev-loader.ts` の `name`、`exif.ts` の `raw` など）は本 PR の対象外なのでそのまま。新たな `let` は 1 つも増やしていない。

## 検証

すべて worktree `mc3-wt-asrecord`（`origin/main` = 7413b0fbf から分岐）で実行。

```
npx prettier --write <touched 27 files>   → 全て (unchanged)
npx eslint <touched 27 files>             → 0 errors / 11 warnings
```
11 warnings は全て **ベースラインにも存在する別形状のキャスト** と `no-unsafe-assignment`。`origin/main` の eslint JSON 出力と 1 件ずつ突き合わせ、行番号のズレ以外に新規なしを確認（`as Record<string, unknown>` 由来の警告はこの 27 ファイルから全消滅）。

```
npx tsc -p server/tsconfig.json --noEmit  → exit 0
npx vue-tsc --noEmit                      → exit 0
npx tsc -p test/tsconfig.json --noEmit    → exit 0
npx tsc -p e2e/tsconfig.json  --noEmit    → exit 0
cd packages/relay && npx tsc --noEmit     → exit 0
cd packages/relay && npx tsx --test test/test_*.ts  → tests 107 / pass 107 / fail 0
cd packages/bridges/line-works && npx tsc --noEmit  → exit 0
```

ユニットテスト（リポジトリルート全量）:
```
npx tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts
→ tests 8898 / suites 1966 / pass 8884 / fail 0 / skipped 14
```

E2E（`src/` に触れているため両リビジョンで実施）:
```
npx playwright test --config e2e/playwright.config.ts --reporter=line
  本ブランチ : 441 passed / 7 failed  (5.9m)
  origin/main: 441 passed / 7 failed  (4.9m)
```
**pass/fail 件数は同一**。かつ失敗したテスト名が 2 回の実行で異なる（本ブランチ: accounting×2, chat-flow×2, right-sidebar×2, stack-sticky×1 / main: chat-flow×2, collection-state-persist×1, right-sidebar×3, stack-sticky×1）ため、変更起因ではなく既存の flaky。

### 外部 ground truth による差分検証（リスクの高いサイト）

永続状態・リクエストボディ・レンダリング経路に触れる関数を、**同一の敵対的入力コーパス**に対して両リビジョンで実行し、出力 JSON を diff した（スクリプトは scratch ディレクトリで実行し削除済み）。

対象: `verifyViewToken`（署名済みペイロード 16 ケース: 配列/文字列/数値/null ペイロード、caps 欠落・非配列・不正 cap・空 caps、slug/exp 型違い、`__proto__` 汚染、改竄、期限切れ）、`parseState`(7)、`normalizeDashboard`/`normalizeShortcuts`(4)、`normalizeRowHeights`(4)、`entryToExcerpt`/`extractArtifactPaths`(9、`result` が配列/null/文字列、`data` が配列、パストラバーサルを含む)、`sanitizeCspExtra`/`buildHtmlPreviewCsp`(8)、`validatePutContentRequest`(6)、`isRelayMessage`/`isLegacyNotifierPluginData`(7)、`validateAndCreate`(7)、`validateSummaryResult`(4)、`getSessionQuery`/`getOptionalStringQuery`(4)。

**diff 結果 — 差分は 2 行のみ**:
```
< "isRelayMessage.arrayWithProps":            { "ok": true }
> "isRelayMessage.arrayWithProps":            { "ok": false }
< "isLegacyNotifierPluginData.arrayWithProps":{ "ok": true }
> "isLegacyNotifierPluginData.arrayWithProps":{ "ok": false }
```
（`arrayWithProps` = `Object.assign([], { id, platform, chatId, text, legacy, legacyId, kind })`。Items to Confirm #1 の意図的な変更そのもので、それ以外は完全一致。CSP 文字列も viewToken のペイロードもバイト一致。）

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Remove unsafe Record<string, unknown> type assertions by relying on existing type guards and narrowing throughout server, relay, and bridge modules.

Bug Fixes:
- Tighten JWT and LINE Works token parsing to reject non-object payloads and return null on invalid structures.
- Ensure view-token, content validation, and translation parsing rebuild or validate payloads using safe record checks, preventing prototype pollution and malformed inputs from slipping through.

Enhancements:
- Refine multiple server-side validators and normalizers (journal, chat index, shortcuts, dashboard, user tasks, reference dirs) to operate directly on values narrowed by shared type guards instead of re-casting.
- Introduce safer logging for Whisper by wrapping non-record metadata in a structured envelope instead of casting blindly.
- Use shared isRecord/hasStringProp/isStringRecord helpers across host and relay code to centralize object-shape validation and reduce duplication.
- Simplify skill result construction by using TypeScript's satisfies to keep strong typing without unsafe casts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of authentication tokens and JWT data, rejecting malformed payloads more reliably.
  - Strengthened handling of malformed or unexpected data across configuration, file, translation, workspace, and integration workflows.
  - Improved logging resilience when diagnostic payloads contain unsupported value types.

- **Refactor**
  - Consolidated data validation to provide more consistent and predictable behavior without changing supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->