### PR TITLE
refactor: narrow errors with isErrorWithCode instead of casting (22→0, #2692)

### DIFF
--- a/packages/bridges/nostr/src/index.ts
+++ b/packages/bridges/nostr/src/index.ts
@@ -29,7 +29,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { SimplePool, finalizeEvent, getPublicKey, nip04, nip19, type Event } from "nostr-tools";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { parseCsvSet, parseCsvList } from "@mulmoclaude/common";
+import { isErrorWithCode, parseCsvList, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "nostr";
 const MAX_DM_LEN = 50_000;
@@ -227,7 +227,7 @@ async function loadCursor(): Promise<void> {
   } catch (err) {
     // ENOENT on first run is expected; anything else is worth surfacing
     // but not fatal — we fall back to the lookback window.
-    const code = typeof err === "object" && err !== null && "code" in err ? (err as { code: unknown }).code : undefined;
+    const code = isErrorWithCode(err) ? err.code : undefined;
     if (code !== "ENOENT") {
       console.warn(`[nostr] cursor load failed (${cursorFile}): ${err}`);
     }

--- a/packages/core/src/collection/server/csvStore.ts
+++ b/packages/core/src/collection/server/csvStore.ts
@@ -38,6 +38,7 @@ import type { CollectionQuery } from "../core/queryZ";
 import { compileCsvQuery, quoteIdent, readCsvArgs } from "./csvQuery";
 import { getWorkspaceRoot, log } from "./host";
 import { isContainedInRoot, safeRecordId } from "./paths";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 /** `list()` row cap. Over-cap files are truncated with a warn — the v1
  *  contract is "browse + per-record views", not full-table analytics. */
@@ -251,7 +252,7 @@ async function safeCsvStat(absPath: string, workspaceRoot: string): Promise<{ mt
   try {
     info = await lstat(absPath);
   } catch (err) {
-    if ((err as { code?: string }).code === "ENOENT") return null;
+    if (isErrorWithCode(err) && err.code === "ENOENT") return null;
     throw err;
   }
   if (!info.isFile()) {

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -16,6 +16,7 @@ import { CollectionSchemaZ } from "../core/schemaZ";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 // Re-exported for the existing `collection/server` importers (manageCollection's
 // putSchema, the registry importWriter) that validate schemas the same way
@@ -115,8 +116,7 @@ async function loadOneCollection(skillsRoot: string, slug: string, source: Colle
     if (!fileStat.isFile()) return null;
     raw = await readFile(schemaPath, "utf-8");
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code !== "ENOENT") {
+    if (!isErrorWithCode(err) || err.code !== "ENOENT") {
       log.warn("collections", "failed to read schema.json, skipping", { slug: safeName, path: schemaPath, error: String(err) });
     }
     return null;
@@ -165,8 +165,7 @@ async function collectFromDir(skillsRoot: string, source: CollectionSource, work
   try {
     entries = await readdir(skillsRoot);
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code === "ENOENT") return [];
+    if (isErrorWithCode(err) && err.code === "ENOENT") return [];
     log.warn("collections", "failed to list skills dir, returning empty", { root: skillsRoot, error: String(err) });
     return [];
   }

--- a/packages/core/src/collection/server/io.ts
+++ b/packages/core/src/collection/server/io.ts
@@ -10,6 +10,7 @@ import { getWorkspaceRoot, log, publishCollectionChange } from "./host";
 import { writeFileAtomic } from "../../files/atomic.js";
 import { isContainedInRoot, itemFilePath, safeRecordId } from "./paths";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 export interface IoOptions {
   /** Override the workspace root for containment checks. Default:
@@ -83,8 +84,7 @@ export async function listItems(dataDir: string, opts: IoOptions = {}): Promise<
   try {
     entries = await readdir(dataDir);
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code === "ENOENT") return [];
+    if (isErrorWithCode(err) && err.code === "ENOENT") return [];
     throw err;
   }
   const results: CollectionItem[] = [];
@@ -116,8 +116,7 @@ export async function readItem(dataDir: string, itemId: string, opts: IoOptions 
   try {
     return parseRecordJson(await readFile(filePath, "utf-8"));
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code === "ENOENT") return null;
+    if (isErrorWithCode(err) && err.code === "ENOENT") return null;
     throw err;
   }
 }
@@ -195,8 +194,7 @@ export async function writeItem(dataDir: string, itemId: string, item: Collectio
     try {
       handle = await open(filePath, "wx");
     } catch (err) {
-      const error = err as { code?: string };
-      if (error.code === "EEXIST") return { kind: "conflict", itemId: safeId };
+      if (isErrorWithCode(err) && err.code === "EEXIST") return { kind: "conflict", itemId: safeId };
       throw err;
     }
     try {
@@ -227,8 +225,7 @@ export async function deleteItem(dataDir: string, itemId: string, opts: IoOption
     if (opts.slug) publishCollectionChange({ slug: opts.slug, ids: [safeId], op: "delete" });
     return { kind: "ok", itemId: safeId };
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code === "ENOENT") return { kind: "not-found", itemId: safeId };
+    if (isErrorWithCode(err) && err.code === "ENOENT") return { kind: "not-found", itemId: safeId };
     throw err;
   }
 }

--- a/packages/core/src/collection/server/jsonlQuery.ts
+++ b/packages/core/src/collection/server/jsonlQuery.ts
@@ -27,6 +27,7 @@ import type { CollectionQuery, CollectionQueryAggregate } from "../core/queryZ";
 import { compileJsonlQuery } from "./csvQuery";
 import { cacheDir, normalizeCsvValue, queryCsv } from "./csvStore";
 import { log } from "./host";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 /** SQL semantics for an aggregate-only query over ZERO rows: one scalar
  *  row (`count` = 0, everything else NULL) — the same shape the CSV path
@@ -95,7 +96,7 @@ export async function runQueryOverRows(rows: CollectionItem[], query: Collection
     // (other than "never created") is only logged: throwing here would
     // mask the query's own error.
     await unlink(jsonlPath).catch((err: unknown) => {
-      if ((err as { code?: string }).code !== "ENOENT") log.warn("collections", "temp JSONL cleanup failed", { path: jsonlPath, error: String(err) });
+      if (!isErrorWithCode(err) || err.code !== "ENOENT") log.warn("collections", "temp JSONL cleanup failed", { path: jsonlPath, error: String(err) });
     });
   }
 }

--- a/packages/core/src/collection/server/paths.ts
+++ b/packages/core/src/collection/server/paths.ts
@@ -8,6 +8,7 @@ import { getWorkspaceRoot } from "./host";
 // The character rules live in ../core/ids so the isomorphic schema validator
 // (../core/schemaZ) gates on the SAME patterns these sanitisers do.
 import { SAFE_SLUG_PATTERN, SAFE_RECORD_ID_PATTERN } from "../core/ids";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 export const SCHEMA_FILE = "schema.json";
 
@@ -49,8 +50,7 @@ function realpathClosestAncestor(absPath: string): string | null {
     try {
       return realpathSync(cursor);
     } catch (err) {
-      const error = err as { code?: string };
-      if (error.code === "ENOENT") {
+      if (isErrorWithCode(err) && err.code === "ENOENT") {
         cursor = path.dirname(cursor);
         continue;
       }

--- a/packages/core/src/collection/server/skillAssets.ts
+++ b/packages/core/src/collection/server/skillAssets.ts
@@ -15,6 +15,7 @@ import { isRegularFile, type IoOptions } from "./io";
 import { resolveTemplatePath, safeSlugName } from "./paths";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
 import type { LoadedCollection } from "./discoveredCollection";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 /** The shape `readSourceAwareFile` (and its public callers
  *  `readCustomViewHtml` / `readCustomViewI18n`) need from a loaded collection:
@@ -62,8 +63,8 @@ async function readSourceAwareFile(collection: SourceAwareReadTarget, relPath: s
       // permission denial / disk error must propagate — silently falling back
       // would mask a real failure as a stale-from-other-base success or a
       // misleading 404 (CodeRabbit review on #1836).
-      const { code } = err as { code?: string };
-      if (code !== "ENOENT" && code !== "ENOTDIR") throw err;
+      if (!isErrorWithCode(err)) throw err;
+      if (err.code !== "ENOENT" && err.code !== "ENOTDIR") throw err;
     }
   }
   return null;

--- a/packages/core/src/collection/server/validate.ts
+++ b/packages/core/src/collection/server/validate.ts
@@ -15,6 +15,7 @@ import { storeFor } from "./store";
 import { firstRecordProblem, type RecordCheckTier } from "../core/recordZ";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 // The compiled record validators (and COMPUTED_TYPES, which moved next to
 // them) live in the isomorphic ../core/recordZ; re-exported here so the
@@ -47,8 +48,7 @@ async function listRecordFilenames(dataDir: string, workspaceRoot: string): Prom
   try {
     return await readdir(dataDir);
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code === "ENOENT") return []; // no dir yet = no records
+    if (isErrorWithCode(err) && err.code === "ENOENT") return []; // no dir yet = no records
     throw err; // surface permission / I/O faults instead of silently passing
   }
 }

--- a/packages/core/src/collection/server/views.ts
+++ b/packages/core/src/collection/server/views.ts
@@ -26,6 +26,7 @@ import { getWorkspaceRoot, isPresetSlug, skillsStagingDir } from "./host";
 import { resolveTemplatePath, safeSlugName, SCHEMA_FILE } from "./paths";
 import type { IoOptions } from "./io";
 import type { LoadedCollection } from "./discoveredCollection";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 export type DeleteViewResult =
   | { kind: "ok"; viewId: string }
@@ -39,8 +40,8 @@ async function fileExists(target: string): Promise<boolean> {
     await stat(target);
     return true;
   } catch (err) {
-    const { code } = err as { code?: string };
-    if (code === "ENOENT" || code === "ENOTDIR") return false;
+    if (!isErrorWithCode(err)) throw err;
+    if (err.code === "ENOENT" || err.code === "ENOTDIR") return false;
     throw err;
   }
 }
@@ -79,7 +80,7 @@ async function unlinkIfPresent(target: string): Promise<void> {
   try {
     await unlink(target);
   } catch (err) {
-    if ((err as { code?: string }).code !== "ENOENT") throw err;
+    if (!isErrorWithCode(err) || err.code !== "ENOENT") throw err;
   }
 }
 

--- a/packages/core/src/feeds/server/state.ts
+++ b/packages/core/src/feeds/server/state.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 import type { CollectionSource } from "../../collection/index.js";
 import { log, requireFeedsHost } from "./host.js";
 import { feedStatePath, ingestStatePath } from "../paths.js";
+import { isErrorWithCode } from "@mulmoclaude/common";
 
 /** Minimal shape needed to locate a collection's state file. `LoadedCollection`
  *  satisfies it. */
@@ -66,8 +67,7 @@ export async function readFeedState(workspaceRoot: string, target: StateTarget):
     const raw = await readFile(stateFilePath(target, workspaceRoot), "utf-8");
     return normalizeState(slug, JSON.parse(raw) as Partial<FeedState>);
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code !== "ENOENT") {
+    if (!isErrorWithCode(err) || err.code !== "ENOENT") {
       log.warn("feeds", "failed to read feed state, using default", { slug, error: String(err) });
     }
     return defaultFeedState(slug);

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -21,6 +21,7 @@ import { log } from "../../system/logger/index.js";
 import { previewSnippet } from "../../utils/logPreview.js";
 import { publishFileChange } from "../../events/file-change.js";
 import { spawn } from "node:child_process";
+import { isErrorWithCode } from "../../utils/types.js";
 
 // Cross-platform "open this file with the host's default handler" that
 // never lets the path travel through a shell parser. Windows earlier
@@ -1009,7 +1010,7 @@ async function performCreateWrite(
       await writeFile(resolved.absPath, content, { flag: "wx" });
     }
   } catch (err) {
-    const { code } = err as { code?: string };
+    const code = isErrorWithCode(err) ? err.code : undefined;
     if (code === "EEXIST") {
       log.warn("files", "POST create: conflict", { pathPreview: previewSnippet(relPath) });
       sendError(res, 409, "File already exists");
@@ -1115,8 +1116,7 @@ export async function writeUploadWithRename(
       // the wrong file (or nothing).
       return { ok: true, relPath, absPath: resolved.absPath };
     } catch (err) {
-      const { code } = err as { code?: string };
-      if (code !== "EEXIST") return { ok: false, status: 500, message: errorMessage(err) };
+      if (!isErrorWithCode(err) || err.code !== "EEXIST") return { ok: false, status: 500, message: errorMessage(err) };
     }
   }
   return { ok: false, status: 409, message: "Could not find an unused filename" };

--- a/server/workspace/skills/discovery.ts
+++ b/server/workspace/skills/discovery.ts
@@ -9,6 +9,7 @@ import { log } from "../../system/logger/index.js";
 import { parseSkillFrontmatter } from "./parser.js";
 import { SKILL_FILE, USER_SKILLS_DIR, projectSkillsDir } from "./paths.js";
 import type { Skill, SkillSource } from "./types.js";
+import { isErrorWithCode } from "../../utils/types.js";
 
 // One directory entry → a parsed Skill, or null when the entry is
 // not a valid skill (no SKILL.md, malformed frontmatter, I/O error).
@@ -41,8 +42,7 @@ async function readSkillDir(skillDir: string, name: string, source: SkillSource)
     // ENOENT = SKILL.md missing. Anything else is logged so a
     // permissions issue is findable; we still treat the slot as
     // "not a skill" rather than failing the whole list.
-    const error = err as { code?: string };
-    if (error.code !== "ENOENT") {
+    if (!isErrorWithCode(err) || err.code !== "ENOENT") {
       log.warn("skills", "failed to read SKILL.md, skipping", {
         name,
         path: skillPath,
@@ -64,8 +64,7 @@ export async function collectSkillsFromDir(root: string, source: SkillSource): P
   try {
     entries = await readdir(root);
   } catch (err) {
-    const error = err as { code?: string };
-    if (error.code === "ENOENT") return [];
+    if (isErrorWithCode(err) && err.code === "ENOENT") return [];
     log.warn("skills", "failed to list skills dir, returning empty", {
       root,
       error: String(err),

--- a/server/workspace/skills/writer.ts
+++ b/server/workspace/skills/writer.ts
@@ -17,6 +17,7 @@ import { projectSkillDir, projectSkillPath } from "./paths.js";
 import { isValidSlug } from "../../utils/slug.js";
 import { log } from "../../system/logger/index.js";
 import { writeFileAtomic } from "../../utils/files/index.js";
+import { isErrorWithCode } from "../../utils/types.js";
 
 export interface SaveSkillInput {
   /** Workspace root (typically `~/mulmoclaude`). */
@@ -159,8 +160,7 @@ export async function deleteProjectSkill(input: DeleteSkillInput): Promise<Delet
   } catch (err) {
     // ENOENT is fine — discovery may be stale. Anything else is
     // surfaced so the caller knows the delete didn't fully work.
-    const error = err as { code?: string };
-    if (error.code !== "ENOENT") throw err;
+    if (!isErrorWithCode(err) || err.code !== "ENOENT") throw err;
   }
   await rmdir(dir).catch(() => {
     // Dir may contain user-added files (e.g. the user dropped a

--- a/server/workspace/wiki-pages/snapshot.ts
+++ b/server/workspace/wiki-pages/snapshot.ts
@@ -26,6 +26,7 @@ import { shortId } from "../../utils/id.js";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { WORKSPACE_DIRS } from "../paths.js";
 import type { WikiPageEditor, WikiWriteMeta } from "./io.js";
+import { isErrorWithCode } from "../../utils/types.js";
 
 export const SNAPSHOT_RETAIN_COUNT = 100;
 export const SNAPSHOT_RETAIN_DAYS = 180;
@@ -164,7 +165,7 @@ async function historyDirIsSafe(dir: string): Promise<boolean> {
 }
 
 function isErrnoCode(err: unknown, code: string): boolean {
-  return typeof err === "object" && err !== null && (err as { code?: unknown }).code === code;
+  return isErrorWithCode(err) && err.code === code;
 }
 
 /** Write a snapshot file for a page that just changed. The

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -56,7 +56,7 @@ export const lastBackendError: Ref<string | null> = ref(null);
  *  "AbortError"`). Normal flow — must NOT flip `backendReachable`. */
 function isAbortError(err: unknown): boolean {
   if (typeof DOMException !== "undefined" && err instanceof DOMException && err.name === "AbortError") return true;
-  return typeof err === "object" && err !== null && "name" in err && (err as { name: unknown }).name === "AbortError";
+  return hasStringProp(err, "name") && err.name === "AbortError";
 }
 
 // ── Auth token (populated by bootstrap; consumed by every call) ─────


### PR DESCRIPTION
## Summary

エラーの narrowing という**1つの形**を15ファイル横断で掃除しました。**22 → 0**。

`err as { code?: string }` → `@mulmoclaude/common` の `isErrorWithCode`。`docs/shared-utils.md` の重複表どおり、新しいガードは1つも作っていません。

残っていた cast の裾野は「158ファイルに1〜2個ずつ」なので、ファイル単位ではなく**形ごとの横断掃除**に切り替えた最初の1本です。

## Items to Confirm / Review

1. **`code` を持たないエラーの分岐が唯一の意味的な差**です。ここを取り違えると挙動が変わります。

   `const { code } = err as {…}` は `undefined` を返し、その `undefined` が**どの分岐に落ちるか**が元の意味です。「`isErrorWithCode` でなければ throw」と機械的に訳すと、元がフォールバックに落ちていた場所で throw になります。全サイトを元の分岐と突き合わせました。

   | サイト | code なしエラーの挙動（修正前 → 修正後） |
   |---|---|
   | `views.ts` / `skillAssets.ts` | throw → throw（同一） |
   | `files.ts` 2箇所 | フォールバック → **フォールバック**（当初 throw にしてしまい、既存テストが検出） |
   | その他11箇所 | ENOENT 判定に落ちない → 同一 |

2. **潜在クラッシュが1件消えます。** `(err as {…}).code` は `err` が `null` のとき TypeError を投げます（`throw null` や `Promise.reject(null)` で発生）。`isErrorWithCode` は `false` を返します。挙動が変わるのはこのケースだけで、改善方向です。

3. `src/utils/api.ts` の1件だけ `.name === "AbortError"` を見ているので `hasStringProp(err, "name")` を使っています。

4. `packages/bridges/nostr` の1件は `code: unknown` を読んでいたので、`isErrorWithCode` 経由の `string | undefined` に変わります。比較対象が `"ENOENT"` なので結果は同一です。

## 実装方針

| 元の形 | 置換後 |
|---|---|
| `const error = err as { code?: string };` + `if (error.code === "ENOENT")` | `if (isErrorWithCode(err) && err.code === "ENOENT")` |
| `if ((err as { code?: string }).code !== "ENOENT") throw err;` | `if (!isErrorWithCode(err) \|\| err.code !== "ENOENT") throw err;` |
| `const { code } = err as { code?: string };`（複数分岐で使用） | `const code = isErrorWithCode(err) ? err.code : undefined;` |
| `typeof err === "object" && err !== null && (err as {…}).code === code` | `isErrorWithCode(err) && err.code === code` |
| `… && (err as { name: unknown }).name === "AbortError"` | `hasStringProp(err, "name") && err.name === "AbortError"` |

## 検証

### 既存テストが回帰を検出しました（重要）

最初、`files.ts` の2箇所を「code なし → throw」と訳しました。既存テストが落ちました。

```
✖ stops on a non-EEXIST write failure rather than renaming around it
```

`writeUploadWithRename` は code なしの書き込み失敗に対して **500 の結果を返す**必要があり、throw してはいけません。元の分岐に合わせ直して 75/75 pass です。

**この1件が、機械的な一括置換をそのまま出さなかった理由です。**

### ゲート

```
npx eslint <15ファイル>          -> 0 errors（consistent-type-assertions 22 → 0）
yarn typecheck:server            -> exit 0
packages/core: yarn typecheck    -> exit 0
packages/core: yarn test         -> tests 710 / pass 710 / fail 0
host 全体スイート                -> tests 8898 / pass 8884 / fail 0
```

### ビルド artifact

`packages/core` を触っていますが、`yarn build:packages && yarn build:hooks` 後に `server/build/dispatcher.mjs` は**バイト単位で不変**でした（`git status` に出ない）。dispatcher が束ねるのは skill-bridge / wiki paths 系で、今回触った collection io を含まないためです。

なお worktree（`node_modules` が main への symlink）で生成すると `@mulmoclaude/core` が**main チェックアウト側に解決**され、`../mulmoclaude3/packages/core/dist/…` という偽の差分が出ます。`docs/build-orchestration.md` に記録済みの罠で、実際に踏んだのでメインチェックアウトで生成し直しています。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Replace manual error.code casts with shared error type guards across filesystem-related modules.

Enhancements:
- Adopt isErrorWithCode helper for errno-based control flow instead of inline type assertions.
- Use hasStringProp for AbortError detection in API utilities to avoid unsafe name property access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of filesystem errors across file, collection, feed, skill, and workspace operations.
  - Missing files and directories continue to be handled gracefully, while unexpected errors are preserved and reported correctly.
  - Improved reliability when detecting canceled API requests and file-operation conflicts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->