### PR TITLE
refactor: 永続 JSON を assert せず parse する（JSON.parse の as キャスト 21→2, #2692）

### DIFF
--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -54,7 +54,6 @@ import {
   type LoadedCollection,
   type StoreChange,
 } from "../collection/server";
-import type { CollectionSchema } from "../collection";
 import { errMsg, log } from "./config.js";
 import { evalNow } from "./clock.js";
 import { reconcileAllItems, reconcileItem, sweepStaleActiveEntries } from "./reconciler.js";
@@ -80,15 +79,18 @@ interface CollectionWatcher {
    *  are detected (which paths, which filenames are noise, how an atomic
    *  replace is debounced); this module only holds the handle. */
   unsubscribe: () => void;
-  /** Last-seen serialized schema for change detection. When a rediscovery
-   *  tick observes a different value, the watcher's items are reconciled
-   *  and the cache is refreshed — this catches schema-only edits (e.g.
-   *  flipping `completionField` on or off) that don't touch any record
-   *  file and would otherwise leave bell state stale indefinitely. */
+  /** Last-seen serialized schema, used ONLY as a change-detection
+   *  fingerprint. When a rediscovery tick observes a different value, the
+   *  watcher's items are reconciled and the cache is refreshed — this catches
+   *  schema-only edits (e.g. flipping `completionField` on or off) that don't
+   *  touch any record file and would otherwise leave bell state stale
+   *  indefinitely. Never parsed back: `collection.schema` below is the same
+   *  schema, already typed. */
   schemaJson: string;
   /** The discovered collection this watcher was mounted for — what the
    *  reconciler needs to pick the right STORE (file records vs a sqlite
-   *  `storage` db). Refreshed whenever `schemaJson` is. */
+   *  `storage` db), and the typed schema every other read here goes through.
+   *  Refreshed whenever `schemaJson` is. */
   collection: LoadedCollection;
 }
 
@@ -239,17 +241,11 @@ export async function _tickTimeTriggersForTesting(now?: Date): Promise<void> {
 /** Re-reconcile every watched collection that depends on the clock — i.e.
  *  declares `triggerField` (a bell that fires at a date) and/or `spawn`
  *  (recurrence whose successors come due over time). Collections with
- *  neither are skipped. Idempotent. The schema is parsed back from the
- *  watcher's cached `schemaJson` to avoid a per-tick disk read. */
+ *  neither are skipped. Idempotent. Reads the watcher's cached
+ *  `collection.schema` to avoid a per-tick disk read. */
 async function tickTimeTriggers(now: Date = evalNow()): Promise<void> {
   for (const entry of watchers.values()) {
-    let schema: CollectionSchema;
-    try {
-      schema = JSON.parse(entry.schemaJson) as CollectionSchema;
-    } catch (err) {
-      log().warn("trigger tick: bad cached schema", { slug: entry.slug, error: errMsg(err) });
-      continue;
-    }
+    const { schema } = entry.collection;
     // dataSource is NOT excluded. Its rows are read-only, but `triggerField`
     // is not among the keys zod forbids on it, and a trigger date fires from
     // the CLOCK — the one state change that arrives without the file moving.
@@ -305,13 +301,7 @@ function stopVanishedWatchers(liveSlugs: Set<string>): boolean {
  *  `dataSource.path`, a different `dataPath`, or a flip between the two
  *  modes. The mounted fs.watch is bound to the OLD location, so it must
  *  be remounted, not just re-reconciled. */
-function storagePathChanged(previousJson: string, next: LoadedCollection["schema"]): boolean {
-  let previous: LoadedCollection["schema"];
-  try {
-    previous = JSON.parse(previousJson) as LoadedCollection["schema"];
-  } catch {
-    return true; // unreadable cache — remount to be safe
-  }
+function storagePathChanged(previous: LoadedCollection["schema"], next: LoadedCollection["schema"]): boolean {
   return previous.dataSource?.path !== next.dataSource?.path || previous.dataPath !== next.dataPath || previous.storage?.path !== next.storage?.path;
 }
 
@@ -324,7 +314,7 @@ async function reconcileChangedSchemas(collections: readonly LoadedCollection[])
     if (!existing) continue;
     const nextJson = JSON.stringify(collection.schema);
     if (existing.schemaJson === nextJson) continue;
-    if (storagePathChanged(existing.schemaJson, collection.schema)) {
+    if (storagePathChanged(existing.collection.schema, collection.schema)) {
       // Drop the stale mount; `startNewWatchers` (which runs right after
       // this pass in syncWatchers) remounts on the new location. A
       // dataSource collection also gets a change ping so open views

--- a/packages/core/src/collection/server/views.ts
+++ b/packages/core/src/collection/server/views.ts
@@ -19,6 +19,7 @@
 // Custom-view HTML is staging-only for project collections (never mirrored —
 // rendering is host-side), so only the canonical base's copy is unlinked.
 
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
 import { readFile, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { writeFileAtomic } from "../../files/atomic.js";
@@ -90,9 +91,13 @@ async function unlinkIfPresent(target: string): Promise<void> {
 async function removeViewFromSchemas(collection: LoadedCollection, viewId: string, workspaceRoot: string, safeSlug: string): Promise<void> {
   const base = await canonicalBase(collection, workspaceRoot, safeSlug);
   const canonical = path.join(base, SCHEMA_FILE);
-  const parsed = JSON.parse(await readFile(canonical, "utf-8")) as { views?: { id?: unknown }[] };
-  if (Array.isArray(parsed.views)) parsed.views = parsed.views.filter((entry) => entry?.id !== viewId);
-  const serialized = `${JSON.stringify(parsed, null, 2)}\n`;
+  const parsed: unknown = JSON.parse(await readFile(canonical, "utf-8"));
+  // Anything that isn't an object with a `views` array is written back
+  // byte-identical — this function only ever removes one entry, so a schema
+  // it can't recognise must survive the round-trip untouched.
+  const next =
+    isRecord(parsed) && isUnknownArray(parsed.views) ? { ...parsed, views: parsed.views.filter((entry) => !isRecord(entry) || entry.id !== viewId) } : parsed;
+  const serialized = `${JSON.stringify(next, null, 2)}\n`;
   for (const target of await schemaWriteTargets(collection, workspaceRoot, safeSlug)) {
     await writeFileAtomic(target, serialized);
   }

--- a/packages/core/src/collection/server/views.ts
+++ b/packages/core/src/collection/server/views.ts
@@ -19,7 +19,7 @@
 // Custom-view HTML is staging-only for project collections (never mirrored —
 // rendering is host-side), so only the canonical base's copy is unlinked.
 
-import { isRecord, isUnknownArray } from "@mulmoclaude/common";
+import { isErrorWithCode, isRecord, isUnknownArray } from "@mulmoclaude/common";
 import { readFile, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { writeFileAtomic } from "../../files/atomic.js";
@@ -27,7 +27,6 @@ import { getWorkspaceRoot, isPresetSlug, skillsStagingDir } from "./host";
 import { resolveTemplatePath, safeSlugName, SCHEMA_FILE } from "./paths";
 import type { IoOptions } from "./io";
 import type { LoadedCollection } from "./discoveredCollection";
-import { isErrorWithCode } from "@mulmoclaude/common";
 
 export type DeleteViewResult =
   | { kind: "ok"; viewId: string }

--- a/packages/core/src/feeds/server/state.ts
+++ b/packages/core/src/feeds/server/state.ts
@@ -9,13 +9,12 @@
 // Deliberately minimal: the legacy `sources` tree carries richer backoff
 // state, but the engine starts simple and grows on real need.
 
-import { isRecord } from "@mulmoclaude/common";
+import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { CollectionSource } from "../../collection/index.js";
 import { log, requireFeedsHost } from "./host.js";
 import { feedStatePath, ingestStatePath } from "../paths.js";
-import { isErrorWithCode } from "@mulmoclaude/common";
 
 /** Minimal shape needed to locate a collection's state file. `LoadedCollection`
  *  satisfies it. */

--- a/packages/core/src/feeds/server/state.ts
+++ b/packages/core/src/feeds/server/state.ts
@@ -9,6 +9,7 @@
 // Deliberately minimal: the legacy `sources` tree carries richer backoff
 // state, but the engine starts simple and grows on real need.
 
+import { isRecord } from "@mulmoclaude/common";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { CollectionSource } from "../../collection/index.js";
@@ -46,7 +47,7 @@ export function defaultFeedState(slug: string): FeedState {
   return { slug, lastFetchedAt: null, cursor: {}, consecutiveFailures: 0 };
 }
 
-function normalizeState(slug: string, parsed: Partial<FeedState>): FeedState {
+function normalizeState(slug: string, parsed: Record<string, unknown>): FeedState {
   const base = defaultFeedState(slug);
   const cursor = parsed.cursor && typeof parsed.cursor === "object" ? (parsed.cursor as Record<string, string>) : base.cursor;
   return {
@@ -64,7 +65,10 @@ export async function readFeedState(workspaceRoot: string, target: StateTarget):
   const { slug } = target;
   try {
     const raw = await readFile(stateFilePath(target, workspaceRoot), "utf-8");
-    return normalizeState(slug, JSON.parse(raw) as Partial<FeedState>);
+    const parsed: unknown = JSON.parse(raw);
+    // A non-object state file has no fields to read, so it normalises to the
+    // same default `normalizeState` would produce from an empty record.
+    return normalizeState(slug, isRecord(parsed) ? parsed : {});
   } catch (err) {
     const error = err as { code?: string };
     if (error.code !== "ENOENT") {

--- a/packages/plugins/accounting-plugin/src/server/io.ts
+++ b/packages/plugins/accounting-plugin/src/server/io.ts
@@ -13,6 +13,7 @@ import { promises as fsPromises } from "node:fs";
 import path from "node:path";
 
 import { defaultWorkspaceRoot } from "./context.js";
+import { isJournalEntry } from "./journal.js";
 import { ACCOUNTING_DIRS as WORKSPACE_DIRS, resolveFiscalYearEnd } from "../shared";
 import { writeJsonAtomic, isEnoent } from "@mulmoclaude/core/files";
 import type { AccountingConfig, MonthSnapshot } from "./types.js";
@@ -91,6 +92,11 @@ async function fileExists(filePath: string): Promise<boolean> {
 async function readJsonStrict<T>(filePath: string): Promise<T | null> {
   try {
     const raw = await fsPromises.readFile(filePath, "utf-8");
+    // Cast kept (#2692): the persisted shapes are deliberately looser than
+    // their types — `BookSummary.fiscalYearEnd` is typed as a month number but
+    // legacy books hold "Q1".."Q4" on disk (`normalizeBookFiscalYearEnd`
+    // absorbs it on read). A predicate written against the type would reject
+    // those files and lock the user out of their books.
     return JSON.parse(raw) as T;
   } catch (err) {
     if (isEnoent(err)) return null;
@@ -200,6 +206,18 @@ export async function appendJournalBatch(bookId: string, entries: readonly Journ
   }
 }
 
+/** One JSONL line, or null when it isn't a journal entry — unparseable JSON
+ *  and JSON of the wrong shape are the same failure to a caller that can only
+ *  skip the line. */
+function parseJournalLine(line: string): JournalEntry | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    return isJournalEntry(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Read a single month's JSONL. Malformed lines are skipped (logged
  *  by the caller; this layer just returns the parseable subset) so
  *  one bad line doesn't lock the user out of their book. */
@@ -212,17 +230,12 @@ export async function readJournalMonth(bookId: string, period: string, workspace
     if (isEnoent(err)) return { entries: [], skipped: 0 };
     throw err;
   }
-  const entries: JournalEntry[] = [];
-  let skipped = 0;
-  for (const line of raw.split("\n")) {
-    if (line.trim() === "") continue;
-    try {
-      entries.push(JSON.parse(line) as JournalEntry);
-    } catch {
-      skipped += 1;
-    }
-  }
-  return { entries, skipped };
+  const parsed = raw
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map(parseJournalLine);
+  const entries = parsed.filter((entry): entry is JournalEntry => entry !== null);
+  return { entries, skipped: parsed.length - entries.length };
 }
 
 /** List the YYYY-MM periods that have a journal file on disk, sorted

--- a/packages/plugins/accounting-plugin/src/server/journal.ts
+++ b/packages/plugins/accounting-plugin/src/server/journal.ts
@@ -11,8 +11,9 @@
 // `addEntries` call for the corrected booking.
 
 import { randomUUID } from "node:crypto";
-import { isRecord, isUnknownArray } from "@mulmoclaude/common";
+import { hasStringProp, isRecord, isUnknownArray } from "@mulmoclaude/common";
 
+import { JOURNAL_ENTRY_KINDS } from "../shared/types.js";
 import type { Account, JournalEntry, JournalLine } from "../shared/types.js";
 
 /** Floating-point tolerance for the debit = credit check. Currency
@@ -191,6 +192,40 @@ function parseOptionalString(value: unknown, field: string, errors: ValidationEr
   if (value === undefined || typeof value === "string") return value;
   errors.push({ field, message: `${field} must be a string when supplied` });
   return undefined;
+}
+
+const isOptionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
+const isOptionalNumber = (value: unknown): boolean => value === undefined || typeof value === "number";
+
+function isJournalLine(value: unknown): value is JournalLine {
+  return (
+    hasStringProp(value, "accountCode") &&
+    isOptionalNumber(value.debit) &&
+    isOptionalNumber(value.credit) &&
+    isOptionalString(value.memo) &&
+    isOptionalString(value.taxRegistrationId)
+  );
+}
+
+/** Checks every field `JournalEntry` and `JournalLine` declare, so a value
+ *  that passes really is one. Used when reading the journal JSONL back:
+ *  everything this module ever wrote satisfies it (`id` / `date` / `kind` /
+ *  `lines` / `createdAt` have been required since the plugin's first
+ *  release), while a line that doesn't is exactly the line that takes the
+ *  whole book down — `report.ts` iterates `entry.lines` unguarded. */
+export function isJournalEntry(value: unknown): value is JournalEntry {
+  return (
+    hasStringProp(value, "id") &&
+    hasStringProp(value, "date") &&
+    hasStringProp(value, "createdAt") &&
+    JOURNAL_ENTRY_KINDS.some((kind) => kind === value.kind) &&
+    isUnknownArray(value.lines) &&
+    value.lines.every(isJournalLine) &&
+    isOptionalString(value.memo) &&
+    isOptionalString(value.voidedEntryId) &&
+    isOptionalString(value.voidReason) &&
+    isOptionalString(value.replacesEntryId)
+  );
 }
 
 /** Normalize a journal line before persistence: trim string fields

--- a/packages/plugins/accounting-plugin/src/shared/types.ts
+++ b/packages/plugins/accounting-plugin/src/shared/types.ts
@@ -68,7 +68,8 @@ export interface BookSummary {
   createdAt: string;
 }
 
-export type JournalEntryKind = "normal" | "opening" | "void" | "void-marker";
+export const JOURNAL_ENTRY_KINDS = ["normal", "opening", "void", "void-marker"] as const;
+export type JournalEntryKind = (typeof JOURNAL_ENTRY_KINDS)[number];
 
 export interface JournalLine {
   accountCode: string;

--- a/packages/plugins/accounting-plugin/test/accounting/test_io.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_io.ts
@@ -131,6 +131,57 @@ describe("journal append + read", () => {
     assert.equal(result.entries.length, 1);
     assert.equal(result.skipped, 1);
   });
+  it("skips lines that parse as JSON but aren't journal entries", async () => {
+    const root = makeTmp();
+    await ensureBookDir("default", root);
+    await appendJournal("default", sampleEntry("2026-04-01", "good"), root);
+    const fsModule = await import("node:fs/promises");
+    const file = path.join(root, "data/accounting/books/default/journal/2026-04.jsonl");
+    const existing = await fsModule.readFile(file, "utf-8");
+    // Each of these used to be admitted as a `JournalEntry`, and the one
+    // without `lines` then crashed `aggregateBalances` with "entry.lines is
+    // not iterable" — taking the whole book's reports down over one bad line.
+    const bogus = [
+      "null",
+      "[1,2,3]",
+      '"hello"',
+      JSON.stringify({ id: "x", date: "2026-04-02", kind: "normal", createdAt: "t" }),
+      JSON.stringify({ ...sampleEntry("2026-04-03", "y"), kind: "weird" }),
+    ];
+    await fsModule.writeFile(file, existing + bogus.map((line) => `${line}\n`).join(""));
+    const result = await readJournalMonth("default", "2026-04", root);
+    assert.deepEqual(
+      result.entries.map((entry) => entry.id),
+      ["good"],
+    );
+    assert.equal(result.skipped, bogus.length);
+  });
+  it("keeps every entry shape the plugin itself writes", async () => {
+    const root = makeTmp();
+    await ensureBookDir("default", root);
+    const fsModule = await import("node:fs/promises");
+    const file = path.join(root, "data/accounting/books/default/journal/2026-04.jsonl");
+    await fsModule.mkdir(path.dirname(file), { recursive: true });
+    const kept = [
+      { id: "marker", date: "2026-04-02", kind: "void-marker", lines: [], createdAt: "t", voidedEntryId: "a", voidReason: "typo" },
+      { id: "opening", date: "2026-04-03", kind: "opening", lines: [{ accountCode: "1000", debit: 1 }], createdAt: "t" },
+      {
+        id: "taxed",
+        date: "2026-04-04",
+        kind: "normal",
+        lines: [{ accountCode: "1400", credit: 1, memo: "m", taxRegistrationId: "T1" }],
+        createdAt: "t",
+        replacesEntryId: "opening",
+      },
+    ];
+    await fsModule.writeFile(file, kept.map((entry) => `${JSON.stringify(entry)}\n`).join(""));
+    const result = await readJournalMonth("default", "2026-04", root);
+    assert.deepEqual(
+      result.entries.map((entry) => entry.id),
+      ["marker", "opening", "taxed"],
+    );
+    assert.equal(result.skipped, 0);
+  });
   it("listJournalPeriods returns sorted YYYY-MM list", async () => {
     const root = makeTmp();
     await ensureBookDir("default", root);

--- a/packages/relay/src/webhooks/jwt.ts
+++ b/packages/relay/src/webhooks/jwt.ts
@@ -6,6 +6,8 @@
 // validation and JWKS fetch/cache — only the parse and the crypto.subtle
 // signature check live here.
 
+import { isRecord } from "@mulmoclaude/common";
+
 export interface ParsedJwt {
   header: Record<string, unknown>;
   payload: Record<string, unknown>;
@@ -34,13 +36,21 @@ export function b64UrlDecode(str: string): Uint8Array {
   return Uint8Array.from(atob(padded), (chr) => chr.charCodeAt(0));
 }
 
+function decodeSegment(segment: string): unknown {
+  return JSON.parse(new TextDecoder().decode(b64UrlDecode(segment)));
+}
+
 // null means "not a well-formed JWT" — callers treat that as a rejection.
 export function parseJwt(token: string): ParsedJwt | null {
   const parts = token.split(".");
   if (parts.length !== 3) return null;
   try {
-    const header = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[0]))) as Record<string, unknown>;
-    const payload = JSON.parse(new TextDecoder().decode(b64UrlDecode(parts[1]))) as Record<string, unknown>;
+    const header = decodeSegment(parts[0]);
+    const payload = decodeSegment(parts[1]);
+    // RFC 7519 requires both segments to be JSON objects. A scalar or array
+    // would read as "every claim absent" in the per-platform validators —
+    // a rejection either way, just a later and less obvious one.
+    if (!isRecord(header) || !isRecord(payload)) return null;
     return { header, payload, signInput: `${parts[0]}.${parts[1]}`, sig: b64UrlDecode(parts[2]) };
   } catch {
     return null;

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -15,6 +15,7 @@ import type { Attachment } from "@mulmobridge/protocol";
 import { isImageMime, isNativeAttachmentMime } from "@mulmobridge/client";
 import { convertAttachment } from "./attachmentConverter.js";
 import { log } from "../system/logger/index.js";
+import { isRecord } from "../utils/types.js";
 import { preflightUserServers, logPreflightResult } from "./mcpPreflight.js";
 
 export const CONTAINER_WORKSPACE_PATH = "/home/node/mulmoclaude";
@@ -752,7 +753,8 @@ function workspacePackageDirs(packageRoot: string): string[] {
 // `@mulmobridge/protocol` unmounted (#2052).
 function scopedPackageName(pkgDir: string): string | null {
   try {
-    const { name } = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8")) as { name?: unknown };
+    const parsed: unknown = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf-8"));
+    const name = isRecord(parsed) ? parsed.name : undefined;
     return typeof name === "string" && name.startsWith("@") ? name : null;
   } catch {
     return null;

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -81,7 +81,16 @@ async function serverLog(namespace, message, options = {}) {
   await safePost(req, LOG_TIMEOUT_MS);
 }
 
+// ../mulmoclaude3/packages/common/dist/index.js
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 // server/workspace/hooks/shared/stdin.ts
+var isOptionalRecord = (value) => value === void 0 || isRecord(value);
+function isHookPayload(value) {
+  return isRecord(value) && isOptionalRecord(value.tool_input) && isOptionalRecord(value.tool_response);
+}
 async function readHookPayload() {
   const chunks = [];
   for await (const chunk of process.stdin) {
@@ -90,7 +99,8 @@ async function readHookPayload() {
   const raw = Buffer.concat(chunks).toString("utf-8");
   if (!raw.trim()) return null;
   try {
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+    return isHookPayload(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -126,7 +136,7 @@ async function handleConfigRefresh(payload) {
   await safePost(req);
 }
 
-// packages/core/dist/templatePath-k_WNbL_Q.js
+// ../mulmoclaude3/packages/core/dist/templatePath-k_WNbL_Q.js
 var TEMPLATES_PREFIX = "templates/";
 function isSafeTemplatePath(value) {
   if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
@@ -136,7 +146,7 @@ function isSafeActionTemplatePath(value) {
   return value.startsWith(TEMPLATES_PREFIX) && isSafeTemplatePath(value);
 }
 
-// packages/core/dist/skill-bridge/index.js
+// ../mulmoclaude3/packages/core/dist/skill-bridge/index.js
 import { mkdirSync, readFileSync as readFileSync2, renameSync, rmSync, writeFileSync } from "node:fs";
 import path3 from "node:path";
 var DATA_SKILLS_DIR = path3.join("data", "skills");
@@ -201,12 +211,12 @@ function mirrorSkillDelete(workspaceRoot2, slug) {
   return { dest };
 }
 
-// packages/core/dist/dist-HC-r8qQi.js
-function isRecord(value) {
+// ../mulmoclaude3/packages/core/dist/dist-HC-r8qQi.js
+function isRecord2(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function hasStringProp(value, key) {
-  return isRecord(value) && typeof value[key] === "string";
+  return isRecord2(value) && typeof value[key] === "string";
 }
 function errorMessage(err, fallback) {
   if (err instanceof Error) return err.message;
@@ -269,7 +279,7 @@ async function handleSkillBridge(payload) {
 // server/workspace/hooks/handlers/wikiSnapshot.ts
 import path5 from "node:path";
 
-// packages/core/dist/slug-CdN-pQX1.js
+// ../mulmoclaude3/packages/core/dist/slug-CdN-pQX1.js
 function isSafeSlug(slug) {
   if (slug.length === 0) return false;
   if (slug === "." || slug === "..") return false;
@@ -278,7 +288,7 @@ function isSafeSlug(slug) {
   return true;
 }
 
-// packages/core/dist/wiki/paths.js
+// ../mulmoclaude3/packages/core/dist/wiki/paths.js
 import path4 from "node:path";
 function wikiSlugFromAbsPath(absPath, pagesDir) {
   const rel = path4.relative(pagesDir, absPath);

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -81,7 +81,7 @@ async function serverLog(namespace, message, options = {}) {
   await safePost(req, LOG_TIMEOUT_MS);
 }
 
-// ../mulmoclaude3/packages/common/dist/index.js
+// packages/common/dist/index.js
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -136,7 +136,7 @@ async function handleConfigRefresh(payload) {
   await safePost(req);
 }
 
-// ../mulmoclaude3/packages/core/dist/templatePath-k_WNbL_Q.js
+// packages/core/dist/templatePath-k_WNbL_Q.js
 var TEMPLATES_PREFIX = "templates/";
 function isSafeTemplatePath(value) {
   if (value.length === 0 || value.includes("\\") || value.startsWith("/")) return false;
@@ -146,7 +146,7 @@ function isSafeActionTemplatePath(value) {
   return value.startsWith(TEMPLATES_PREFIX) && isSafeTemplatePath(value);
 }
 
-// ../mulmoclaude3/packages/core/dist/skill-bridge/index.js
+// packages/core/dist/skill-bridge/index.js
 import { mkdirSync, readFileSync as readFileSync2, renameSync, rmSync, writeFileSync } from "node:fs";
 import path3 from "node:path";
 var DATA_SKILLS_DIR = path3.join("data", "skills");
@@ -211,7 +211,7 @@ function mirrorSkillDelete(workspaceRoot2, slug) {
   return { dest };
 }
 
-// ../mulmoclaude3/packages/core/dist/dist-HC-r8qQi.js
+// packages/core/dist/dist-HC-r8qQi.js
 function isRecord2(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -279,7 +279,7 @@ async function handleSkillBridge(payload) {
 // server/workspace/hooks/handlers/wikiSnapshot.ts
 import path5 from "node:path";
 
-// ../mulmoclaude3/packages/core/dist/slug-CdN-pQX1.js
+// packages/core/dist/slug-CdN-pQX1.js
 function isSafeSlug(slug) {
   if (slug.length === 0) return false;
   if (slug === "." || slug === "..") return false;
@@ -288,7 +288,7 @@ function isSafeSlug(slug) {
   return true;
 }
 
-// ../mulmoclaude3/packages/core/dist/wiki/paths.js
+// packages/core/dist/wiki/paths.js
 import path4 from "node:path";
 function wikiSlugFromAbsPath(absPath, pagesDir) {
   const rel = path4.relative(pagesDir, absPath);

--- a/server/plugins/preset-loader.ts
+++ b/server/plugins/preset-loader.ts
@@ -39,13 +39,28 @@ import { PRESET_PLUGINS, type PresetPlugin } from "./preset-list.js";
 import { resolvePresetRoot } from "./resolvePresetRoot.js";
 import { loadPluginFromCacheDir, type LoaderDeps, type RuntimePlugin } from "./runtime-loader.js";
 import { log } from "../system/logger/index.js";
+import { isRecord } from "../utils/types.js";
 
 export { resolvePresetRoot };
 
 const LOG_PREFIX = "plugins/preset";
 
-interface PackageJsonShape {
-  version?: string;
+/** The preset's declared version, or null when the package.json is
+ *  unreadable / malformed / versionless — a broken preset is skipped, never
+ *  fatal. */
+function readPresetVersion(pkgJsonPath: string, packageName: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    const version = isRecord(parsed) ? parsed.version : undefined;
+    if (typeof version !== "string" || version.length === 0) {
+      log.warn(LOG_PREFIX, "preset package has no version", { packageName });
+      return null;
+    }
+    return version;
+  } catch (err) {
+    log.warn(LOG_PREFIX, "preset package.json read/parse failed", { packageName, error: String(err) });
+    return null;
+  }
 }
 
 async function loadOnePreset(entry: PresetPlugin, deps: LoaderDeps = {}): Promise<RuntimePlugin | null> {
@@ -61,19 +76,8 @@ async function loadOnePreset(entry: PresetPlugin, deps: LoaderDeps = {}): Promis
     }
     return null;
   }
-  const pkgJsonPath = path.join(cachePath, "package.json");
-  let pkg: PackageJsonShape;
-  try {
-    pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8")) as PackageJsonShape;
-  } catch (err) {
-    log.warn(LOG_PREFIX, "preset package.json read/parse failed", { packageName, error: String(err) });
-    return null;
-  }
-  const { version } = pkg;
-  if (typeof version !== "string" || version.length === 0) {
-    log.warn(LOG_PREFIX, "preset package has no version", { packageName });
-    return null;
-  }
+  const version = readPresetVersion(path.join(cachePath, "package.json"), packageName);
+  if (version === null) return null;
   return loadPluginFromCacheDir(packageName, version, cachePath, deps);
 }
 

--- a/server/utils/files/dashboard-io.ts
+++ b/server/utils/files/dashboard-io.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { WORKSPACE_FILES, workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
 import { readTextSafe } from "./safe.js";
+import { isRecord } from "../types.js";
 import type { DashboardTile, DashboardFile } from "../../../src/types/dashboard.js";
 
 function dashboardFilePath(workspaceRoot?: string): string {
@@ -67,8 +68,9 @@ export async function readDashboard(workspaceRoot?: string): Promise<DashboardFi
   const text = await readTextSafe(dashboardFilePath(workspaceRoot));
   if (text === null) return { tiles: [], rowHeights: {} };
   try {
-    const parsed = JSON.parse(text) as Partial<DashboardFile>;
-    return { tiles: normalizeDashboard(parsed?.tiles), rowHeights: normalizeRowHeights(parsed?.rowHeights) };
+    const parsed: unknown = JSON.parse(text);
+    const file = isRecord(parsed) ? parsed : {};
+    return { tiles: normalizeDashboard(file.tiles), rowHeights: normalizeRowHeights(file.rowHeights) };
   } catch {
     return { tiles: [], rowHeights: {} };
   }

--- a/server/utils/files/journal-io.ts
+++ b/server/utils/files/journal-io.ts
@@ -9,10 +9,12 @@ import { summariesRoot, dailyPathFor, topicPathFor, TOPICS_DIR, INDEX_FILE, STAT
 
 const root = (rootOverride?: string) => rootOverride ?? workspacePath;
 
-export async function readJournalState<T>(fallback: T, rootOverride?: string): Promise<T> {
+// Returns whatever the state file holds; `parseState` in
+// `workspace/journal/state.ts` is what turns it into a `JournalState`.
+export async function readJournalState(fallback: unknown, rootOverride?: string): Promise<unknown> {
   const filePath = path.join(summariesRoot(root(rootOverride)), STATE_FILE);
   try {
-    return JSON.parse(await fsp.readFile(filePath, "utf-8")) as T;
+    return JSON.parse(await fsp.readFile(filePath, "utf-8"));
   } catch (err) {
     if (isEnoent(err)) return fallback;
     log.error("journal-io", "readJournalState failed", { error: String(err) });

--- a/server/utils/files/json.ts
+++ b/server/utils/files/json.ts
@@ -17,6 +17,10 @@ export function loadJsonFile<T>(filePath: string, defaultValue: T): T {
     throw err;
   }
   try {
+    // Cast kept (#2692): `loadSchedulerItems` / `loadUserTasks` propagate this
+    // `T` into files the same request rewrites, so filtering unrecognised
+    // entries here would delete the user's data. Removing it needs those two
+    // persistence paths to gain real per-entry validation first.
     return JSON.parse(raw) as T;
   } catch (err) {
     log.error("json", "loadJsonFile parse failed, using default", {

--- a/server/utils/files/session-io.ts
+++ b/server/utils/files/session-io.ts
@@ -2,7 +2,8 @@ import { appendFile, rm } from "fs/promises";
 import path from "node:path";
 import { WORKSPACE_DIRS, workspacePath } from "../../workspace/paths.js";
 import { readTextUnder, writeTextUnder, resolvePath, ensureWorkspaceDir } from "./workspace-io.js";
-import type { SessionOrigin } from "../../../src/types/session.js";
+import { isRecord } from "../types.js";
+import { isSessionOrigin, type SessionOrigin } from "../../../src/types/session.js";
 
 const CHAT = WORKSPACE_DIRS.chat;
 const root = (rootOverride?: string) => rootOverride ?? workspacePath;
@@ -36,13 +37,44 @@ export interface SessionMeta {
 
 export type ReadMetaResult = { kind: "missing" } | { kind: "ok"; meta: SessionMeta } | { kind: "corrupt"; raw: string };
 
+const isOptionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
+const isOptionalBoolean = (value: unknown): boolean => value === undefined || typeof value === "boolean";
+
+// Checks every field `SessionMeta` declares. The trailing index signature
+// accepts anything, so the extra keys older builds may have written ride
+// along untouched — nothing is dropped and nothing is left unverified.
+function isSessionMeta(value: unknown): value is SessionMeta {
+  return (
+    isRecord(value) &&
+    isOptionalString(value.roleId) &&
+    isOptionalString(value.startedAt) &&
+    isOptionalString(value.firstUserMessage) &&
+    isOptionalString(value.claudeSessionId) &&
+    isOptionalBoolean(value.hasUnread) &&
+    isOptionalBoolean(value.isBookmarked) &&
+    (value.origin === undefined || isSessionOrigin(value.origin)) &&
+    (value.userQueryCount === undefined || typeof value.userQueryCount === "number")
+  );
+}
+
 export async function readSessionMetaFull(sessionId: string, rootOverride?: string): Promise<ReadMetaResult> {
   const raw = await readTextUnder(root(rootOverride), metaRel(sessionId));
   if (raw === null) return { kind: "missing" };
+  // A file whose fields don't match the declared types joins the existing
+  // "corrupt" branch rather than getting a new one: the caller's contract is
+  // already "warn, treat as existing, never clobber", which is exactly the
+  // right handling for a meta file we can't trust.
+  const parsed: unknown = tryParseJson(raw);
+  return isSessionMeta(parsed) ? { kind: "ok", meta: parsed } : { kind: "corrupt", raw };
+}
+
+/** `undefined` on unparseable input — no JSON document parses to `undefined`,
+ *  so it is unambiguous as a sentinel. */
+function tryParseJson(raw: string): unknown {
   try {
-    return { kind: "ok", meta: JSON.parse(raw) as SessionMeta };
+    return JSON.parse(raw);
   } catch {
-    return { kind: "corrupt", raw };
+    return undefined;
   }
 }
 

--- a/server/utils/files/shortcuts-io.ts
+++ b/server/utils/files/shortcuts-io.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { WORKSPACE_FILES, workspacePath } from "../../workspace/paths.js";
 import { writeFileAtomic } from "./atomic.js";
 import { readTextSafe } from "./safe.js";
+import { isRecord } from "../types.js";
 import { SHORTCUT_KINDS, sameShortcut, type Shortcut, type ShortcutsFile } from "../../../src/types/shortcuts.js";
 
 const KINDS = new Set<string>(SHORTCUT_KINDS);
@@ -45,8 +46,8 @@ export async function readShortcuts(workspaceRoot?: string): Promise<Shortcut[]>
   const text = await readTextSafe(shortcutsFilePath(workspaceRoot));
   if (text === null) return [];
   try {
-    const parsed = JSON.parse(text) as Partial<ShortcutsFile>;
-    return normalizeShortcuts(parsed?.shortcuts);
+    const parsed: unknown = JSON.parse(text);
+    return normalizeShortcuts(isRecord(parsed) ? parsed.shortcuts : undefined);
   } catch {
     return [];
   }

--- a/server/utils/files/workspace-io.ts
+++ b/server/utils/files/workspace-io.ts
@@ -34,21 +34,23 @@ export function readWorkspaceTextSync(relPath: string): string | null {
   }
 }
 
-export async function readWorkspaceJson<T>(relPath: string, fallback: T): Promise<T> {
+// Returns whatever the file happens to hold; narrowing is the caller's job,
+// because only the caller knows which shape it asked for.
+export async function readWorkspaceJson(relPath: string, fallback: unknown): Promise<unknown> {
   const text = await readWorkspaceText(relPath);
   if (text === null) return fallback;
   try {
-    return JSON.parse(text) as T;
+    return JSON.parse(text);
   } catch {
     return fallback;
   }
 }
 
-export function readWorkspaceJsonSync<T>(relPath: string, fallback: T): T {
+export function readWorkspaceJsonSync(relPath: string, fallback: unknown): unknown {
   const text = readWorkspaceTextSync(relPath);
   if (text === null) return fallback;
   try {
-    return JSON.parse(text) as T;
+    return JSON.parse(text);
   } catch {
     return fallback;
   }

--- a/server/workspace/hooks/shared/stdin.ts
+++ b/server/workspace/hooks/shared/stdin.ts
@@ -3,6 +3,8 @@
 // malformed — the dispatcher treats null as a fast no-op so a hook
 // fired with no body never crashes the user's tool turn.
 
+import { isRecord } from "../../../utils/types.js";
+
 export interface HookPayload {
   tool_name?: unknown;
   tool_input?: {
@@ -18,6 +20,15 @@ export interface HookPayload {
   [key: string]: unknown;
 }
 
+const isOptionalRecord = (value: unknown): boolean => value === undefined || isRecord(value);
+
+// `tool_name` / `session_id` are declared `unknown`, so any value satisfies
+// them; only the two nested objects carry a shape. Together with the trailing
+// index signature that covers every field the interface declares.
+function isHookPayload(value: unknown): value is HookPayload {
+  return isRecord(value) && isOptionalRecord(value.tool_input) && isOptionalRecord(value.tool_response);
+}
+
 export async function readHookPayload(): Promise<HookPayload | null> {
   const chunks: Buffer[] = [];
   for await (const chunk of process.stdin) {
@@ -26,7 +37,8 @@ export async function readHookPayload(): Promise<HookPayload | null> {
   const raw = Buffer.concat(chunks).toString("utf-8");
   if (!raw.trim()) return null;
   try {
-    return JSON.parse(raw) as HookPayload;
+    const parsed: unknown = JSON.parse(raw);
+    return isHookPayload(parsed) ? parsed : null;
   } catch {
     return null;
   }

--- a/server/workspace/journal/state.ts
+++ b/server/workspace/journal/state.ts
@@ -95,7 +95,7 @@ export function isOptimizationDue(state: JournalState, nowMs: number): boolean {
 }
 
 export async function readState(workspaceRoot: string): Promise<JournalState> {
-  const raw = await readJournalStateRaw<unknown>(null, workspaceRoot);
+  const raw = await readJournalStateRaw(null, workspaceRoot);
   return parseState(raw);
 }
 

--- a/server/workspace/skills/external/catalog.ts
+++ b/server/workspace/skills/external/catalog.ts
@@ -21,7 +21,7 @@ import { WORKSPACE_DIRS } from "../../paths.js";
 import { parseSkillFrontmatter } from "../parser.js";
 import { log } from "../../../system/logger/index.js";
 import { deriveActiveId, isSafeRepoId, safeSkillFolder } from "./id.js";
-import { listInstalledRepos, type InstalledRepo } from "./install.js";
+import { listInstalledRepos, readSourceUrl, type InstalledRepo } from "./install.js";
 
 const SOURCE_METADATA_FILE = ".source.json";
 
@@ -168,34 +168,23 @@ interface ResolvedSource {
   url: string;
 }
 
-async function readRepoMetadata(repoDir: string): Promise<{ url: string } | null> {
-  try {
-    const raw = await readFile(path.join(repoDir, SOURCE_METADATA_FILE), "utf-8");
-    const parsed = JSON.parse(raw) as { url?: unknown };
-    if (typeof parsed.url !== "string") return null;
-    return { url: parsed.url };
-  } catch {
-    return null;
-  }
-}
-
 async function resolveSource(repoIdRaw: string, skillFolderRaw: string, workspaceRoot: string): Promise<ResolvedSource | null> {
   if (!isSafeRepoId(repoIdRaw)) return null;
   const repoId = path.basename(repoIdRaw);
   if (repoId !== repoIdRaw) return null;
   const repoDir = path.join(externalRoot(workspaceRoot), repoId);
   if (!(await isDirectory(repoDir))) return null;
-  const meta = await readRepoMetadata(repoDir);
-  if (!meta) return null;
+  const url = await readSourceUrl(path.join(repoDir, SOURCE_METADATA_FILE));
+  if (url === null) return null;
   if (skillFolderRaw === ".") {
     if (!(await isFile(path.join(repoDir, "SKILL.md")))) return null;
-    return { repoId, skillFolder: ".", sourceDir: repoDir, url: meta.url };
+    return { repoId, skillFolder: ".", sourceDir: repoDir, url };
   }
   const skillFolder = safeFolderName(skillFolderRaw);
   if (skillFolder === null) return null;
   const sourceDir = path.join(repoDir, skillFolder);
   if (!(await isDirectory(sourceDir))) return null;
-  return { repoId, skillFolder, sourceDir, url: meta.url };
+  return { repoId, skillFolder, sourceDir, url };
 }
 
 // Resolve a catalog source, or classify why it failed: a bad-shape id

--- a/server/workspace/skills/external/install.ts
+++ b/server/workspace/skills/external/install.ts
@@ -24,6 +24,7 @@ import { WORKSPACE_DIRS } from "../../paths.js";
 import { parseSkillFrontmatter } from "../parser.js";
 import { log } from "../../../system/logger/index.js";
 import { errorMessage } from "../../../utils/errors.js";
+import { isRecord } from "../../../utils/types.js";
 import { writeFileAtomic } from "../../../utils/files/index.js";
 import { cloneOrUpdate, defaultCacheRoot, type CloneDeps, type CloneResult } from "./clone.js";
 import { canonicalRepoUrl, deriveRepoId, safeRepoId, safeSkillFolder, sanitiseSubpath, urlCacheKey } from "./id.js";
@@ -206,18 +207,27 @@ export type InstallExternalRepoResult =
   | { kind: "id-collision"; repoId: string; existingUrl: string }
   | { kind: "error"; reason: string };
 
+/** The `url` recorded in a repo's `.source.json`, or null when the file is
+ *  missing / unparseable / carries no string url. Shared with the catalog
+ *  reader so both sides agree on what a usable metadata file looks like. */
+export async function readSourceUrl(metadataPath: string): Promise<string | null> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(metadataPath, "utf-8"));
+    const url = isRecord(parsed) ? parsed.url : undefined;
+    return typeof url === "string" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
 /** When `repoDir` already holds an install, return its recorded
  *  canonical URL. `repoId` is a lossy punctuation-normalised slug, so
  *  two different repos (`foo/a.b`, `foo/a-b`) can map to the same dir;
  *  the canonical URL in `.source.json` is what actually identifies
  *  the occupant. */
 async function existingCanonicalUrl(metadataPath: string): Promise<string | null> {
-  try {
-    const parsed = JSON.parse(await readFile(metadataPath, "utf-8")) as { url?: unknown };
-    return typeof parsed.url === "string" ? canonicalRepoUrl(parsed.url) : null;
-  } catch {
-    return null;
-  }
+  const url = await readSourceUrl(metadataPath);
+  return url === null ? null : canonicalRepoUrl(url);
 }
 
 /** Install an external skill repo into the catalog. */
@@ -327,17 +337,9 @@ export async function uninstallExternalRepo(repoIdRaw: string, deps: ExternalIns
   if (!(await isDirectory(repoDir))) return { kind: "not-found", repoId };
 
   // Read URL from metadata BEFORE removing so we can also drop the
-  // scratch clone. Missing metadata isn't fatal — uninstall the
+  // scratch clone. Missing / corrupt metadata isn't fatal — uninstall the
   // catalog dir regardless.
-  let url: string | null = null;
-  try {
-    const raw = await readFile(metadataPath, "utf-8");
-    const parsed = JSON.parse(raw) as { url?: unknown };
-    const { url: parsedUrl } = parsed;
-    if (typeof parsedUrl === "string") url = parsedUrl;
-  } catch {
-    /* missing or corrupt metadata — proceed with catalog cleanup */
-  }
+  const url = await readSourceUrl(metadataPath);
 
   await rm(repoDir, { recursive: true, force: true });
   if (url) {

--- a/test/utils/files/test_session_io.ts
+++ b/test/utils/files/test_session_io.ts
@@ -1,6 +1,6 @@
 import { after, before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -44,6 +44,25 @@ describe("readSessionMeta", () => {
     await writeSessionMeta("rw-test", { roleId: "general" }, root);
     const meta = await readSessionMeta("rw-test", root);
     assert.equal(meta?.roleId, "general");
+  });
+
+  it("returns null for JSON whose declared fields have the wrong types", async () => {
+    const chatDir = path.join(root, WORKSPACE_DIRS.chat);
+    const body = JSON.stringify({ roleId: 5, hasUnread: "yes", origin: "martian" });
+    writeFileSync(path.join(chatDir, "bad-shape.json"), body);
+    assert.equal(await readSessionMeta("bad-shape", root), null);
+    // Every mutator early-returns on null, so an unreadable meta file must
+    // stay on disk intact rather than being replaced by a partial rewrite.
+    await updateHasUnread("bad-shape", true, root);
+    assert.equal(readFileSync(path.join(chatDir, "bad-shape.json"), "utf-8"), body);
+  });
+
+  it("keeps keys the type doesn't model, and accepts a plugin origin", async () => {
+    const chatDir = path.join(root, WORKSPACE_DIRS.chat);
+    writeFileSync(path.join(chatDir, "extra.json"), JSON.stringify({ roleId: "general", origin: "plugin:@scope/pkg", futureField: [1, 2] }));
+    const meta = await readSessionMeta("extra", root);
+    assert.equal(meta?.origin, "plugin:@scope/pkg");
+    assert.deepEqual(meta?.futureField, [1, 2]);
   });
 });
 


### PR DESCRIPTION
## Summary

`JSON.parse(...) as T` 形の `as` キャストを **21 件 → 2 件** に削減しました（#2692 のうち「ファイル/ワイヤ由来の JSON を無検査で型付けする」形だけを担当）。
各サイトは「そのファイルが元々持っている失敗経路」（null / デフォルト値 / corrupt / skip）にそのまま合流させており、新しい throw は一切足していません。
途中で **実バグを 1 件発見・修正**しました: 会計仕訳 JSONL に `lines` の無い行が 1 行でもあると、その帳簿のレポート生成全体が `TypeError: entry.lines is not iterable` で落ちていました。
残した 2 件は「正直に外せない」と判断したもので、それぞれ 1 行のコメントで理由を残しています。

## Items to Confirm / Review

壊れたファイルの扱いが変わりうる箇所を先に挙げます。**ここだけ人間の判断が要ります。**

1. **`server/utils/files/session-io.ts` — セッション meta の型違反が `corrupt` 扱いに変わります**
   - 変更前: `{"roleId": 5, "hasUnread": "yes"}` のような**宣言型と食い違う JSON** も `{kind:"ok"}` として通り、そのまま `{...meta, hasUnread}` で書き戻されていました。
   - 変更後: `isSessionMeta` が全宣言フィールドを検査し、外れたら既存の `{kind:"corrupt", raw}` に合流します。
   - **データ損失は起きません**: `readSessionMeta` が null を返すと `updateHasUnread` / `setClaudeSessionId` などの全ミューテータは早期 return するため、**壊れたファイルは上書きされずディスクに残ります**（テストで固定しました）。`agent.ts` 側は元々 `corrupt` を「warn して既存扱い」で処理済みです。
   - `origin` は `isSessionOrigin`（`plugin:<pkg>` 形式も許可）で検査。書き込み側 `agent.ts:273` が既に同じ関数で絞っているので、自分で書いた値が弾かれることはありません。
   - 型が持つ index signature (`[key: string]: unknown`) のおかげで、**未知の追加キーはそのまま保持されます**（テスト済み）。

2. **`packages/plugins/accounting-plugin` — 仕訳行の shape 検査を追加（実バグ修正）**
   - 変更前: `JSON.parse(line) as JournalEntry` なので、`null` / `[1,2,3]` / `{"id":..., "lines"なし}` が「仕訳」として `entries` に混入していました。
   - `report.ts:34` の `for (const line of entry.lines)` は無防備なので、**1 行壊れているだけで帳簿全体のレポートが 500 で落ちます**（下の「検証」に再現手順）。
   - 変更後: `isJournalEntry` で弾き、既存の `skipped` カウンタ（= 元々「JSON として壊れた行」を数えていた場所）に合流。挙動としては「1 行の破損で帳簿がロックされない」という**既存のドキュメント方針そのまま**です。
   - **既存データが落ちない根拠**: 必須 5 フィールド (`id` / `date` / `kind` / `lines` / `createdAt`) はプラグイン初回コミット `cd441febb` から一貫して必須で、後から増えた `replacesEntryId` / `taxRegistrationId` はすべて optional として検査しています。`void-marker`（`lines: []`）/ `opening` / タックス ID 付き行が通ることをテストで固定しました。

3. **`packages/core/src/feeds/server/state.ts` — `null` の state ファイルで warn ログが 1 本消えます**
   - 変更前: `JSON.parse("null")` → `normalizeState(slug, null)` が `TypeError` を投げ、catch されて warn ログ + デフォルト state。
   - 変更後: `isRecord` で弾いて `{}` を渡す → 同じデフォルト state（ログは出ない）。返り値は同一です。

4. **`packages/core/src/collection-watchers/watcher.ts` — parse 自体を廃止しました**
   - `entry.schemaJson` は常に `JSON.stringify(entry.collection.schema)` で（mount 時 L410 と更新時 L343-344 の 2 箇所でのみ同時に代入、interface のコメントにも「Refreshed whenever `schemaJson` is」と明記）、**parse し直す必要がありません**。`entry.collection.schema` を直接読むよう変更し、`as CollectionSchema` / `let schema` / try-catch / 毎分の JSON round-trip がまとめて消えました。
   - `storagePathChanged` も引数を JSON 文字列から schema オブジェクトに変更（同じ不変条件）。`schemaJson` は変更検知のフィンガープリント専用になった旨をコメントに反映しています。
   - **確認してほしい点**: 「`schemaJson` と `collection` は必ず同時に更新される」という不変条件に依存しています。将来どちらか片方だけ代入するコードが入ると壊れます。

5. **`server/workspace/hooks/shared/stdin.ts` — dispatcher バンドルに `@mulmoclaude/common` が入ります**
   - `isRecord` を使うため `server/build/dispatcher.mjs` が 11,208 → 11,716 bytes（+508B）。tree-shake 済みで `isRecord` のみ。CI の `git diff --exit-code` ゲート用に再ビルド済み成果物をコミットに含めています。

6. **外せなかったキャスト 2 件**（それぞれコード内に 1 行の理由コメント）
   - `server/utils/files/json.ts:24` `loadJsonFile<T>` — `T` が `loadSchedulerItems` / `loadUserTasks` を経由して**同じリクエストが書き戻すファイル**に流れます。ここで検証して弾くと、`loadItems() → push → saveItems()` の往復でユーザーのスケジュール項目を**恒久的に削除**します。外すには先にその 2 経路へ per-entry バリデーションを入れる設計判断が要ります。
   - `packages/plugins/accounting-plugin/src/server/io.ts:100` `readJsonStrict<T>` — 永続シェイプが宣言型より**意図的にゆるい**（`BookSummary.fiscalYearEnd` は月番号型だが、旧 book はディスク上に `"Q1".."Q4"` を持ち、読み出し時に `normalizeBookFiscalYearEnd` が吸収する。既存テスト `test_io.ts` にも固定されています）。型どおりの述語を書くと**旧 book が丸ごと読めなくなります**。

7. 触ったファイルに残る `consistent-type-assertions` warning は、すべて**別形状**のキャスト（`as Record<string, unknown>` / `err as { code?: string }`）で、他の #2692 ブランチの担当範囲です（`views.ts:43,83` / `state.ts:52,73` / `dashboard-io.ts:26,56` / `shortcuts-io.ts:27,32` / `install.ts:375`）。本 PR では触っていません。

## 実装方針

| 元の形 | 置き換え | 該当サイト |
|---|---|---|
| `as { url?: unknown }` / `as { name?: unknown }` | `const parsed: unknown = JSON.parse(...)` + `isRecord` でフィールドを読む | `external/catalog.ts:174`, `external/install.ts:216,335`, `agent/config.ts:755` |
| `as Record<string, unknown>` (JWT ヘッダ/ペイロード) | `isRecord` で弾いて既存の `null`（= JWT 不正）へ | `relay/webhooks/jwt.ts:42,43` |
| `as Partial<X>`（この後 normalize 関数に渡すだけ） | `isRecord(parsed) ? parsed : {}` を normalize に渡す（引数型を `Record<string, unknown>` へ） | `dashboard-io.ts:70`, `shortcuts-io.ts:48`, `feeds/server/state.ts:67` |
| `as PackageJsonShape`（`version` しか読まない） | `readPresetVersion()` に切り出し、`isRecord` + 既存の 2 本の warn ログを維持。`let pkg` と使われなくなった interface も削除 | `plugins/preset-loader.ts:67` |
| `as T`（呼び出し側が実際は `unknown` を渡している汎用ローダ） | 戻り値を `unknown` にして narrowing を呼び出し側へ | `workspace-io.ts:41,51`（本番呼び出し 0 件）, `journal-io.ts:15`（唯一の呼び出しが既に `<unknown>` + `parseState`） |
| `as CollectionSchema` / `as LoadedCollection["schema"]`（自分で stringify した文字列の parse） | **parse をやめて** `entry.collection.schema` を直接読む | `collection-watchers/watcher.ts:248,311` |
| `as { views?: { id?: unknown }[] }`（schema.json を書き戻す） | `isRecord` + `isUnknownArray` で分岐、認識できない形は**バイト等価で書き戻し** | `collection/server/views.ts:93` |
| `as HookPayload` | 全宣言フィールドを検査する `isHookPayload`（`tool_input` / `tool_response` が object か。他は `unknown` 宣言なので無条件成立）→ 既存の `null` へ | `hooks/shared/stdin.ts:29` |
| `as SessionMeta` | 全宣言フィールドを検査する `isSessionMeta` → 既存の `{kind:"corrupt"}` へ | `session-io.ts:43` |
| `as JournalEntry` | 全宣言フィールドを検査する `isJournalEntry` / `isJournalLine`（`journal.ts` に配置）→ 既存の `skipped` へ | `accounting-plugin/src/server/io.ts:220` |
| 外せない 2 件 | キャスト維持 + 理由 1 行コメント | `files/json.ts:24`, `accounting-plugin/src/server/io.ts:100` |

副次的な整理（同じサイトで発生したもの）:
- `.source.json` の url 読み出しが 3 箇所に重複していたので `readSourceUrl()` に集約（`install.ts` から export し `catalog.ts` が利用）。`uninstallExternalRepo` の `let url` も消えました。
- `JournalEntryKind` を `JOURNAL_ENTRY_KINDS` (`as const`) から導出（同ファイルの `ACCOUNT_TYPES` と同じ形）。型は完全に等価です。
- 新しい `isRecord` は 1 つも足していません。すべて `@mulmoclaude/common`（host は `server/utils/types.ts` 経由）を使っています。

## 検証

### 静的チェック

```
npx eslint <touched files>   → 0 errors / 残 warning は全て別形状のキャスト（上記 7）
yarn format --check          → All matched files use Prettier code style!
yarn lint                    → 0 errors, 350 warnings（main と同じ既存 warning 群）
yarn typecheck               → 0 errors（全 workspace）
yarn build                   → OK
```

`JSON.parse` 形のキャスト数（eslint の JSON 出力を機械集計）: **21 → 2**。

### テスト

```
npx tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts
  → tests 8900 / pass 8893 / fail 0 / skipped 7
packages/core          yarn test → 710 pass / 0 fail
accounting-plugin      yarn test → 302 pass / 0 fail（新規 2 件を含む）
packages/relay         yarn test → 107 pass / 0 fail
```

追加したテスト:
- `test/utils/files/test_session_io.ts` — 型違反の meta は null で返り、**その後のミューテータがファイルを上書きしない**こと / 未知キーと `plugin:` origin が保持されること。
- `packages/plugins/accounting-plugin/test/accounting/test_io.ts` — JSON としては読めるが仕訳でない 5 パターンが `skipped` に入ること / プラグイン自身が書く 3 形状（`void-marker` / `opening` / taxRegistrationId 付き）は必ず残ること。

### 外部 ground truth との突き合わせ（before/after 差分）

一時プローブを書き、**同一の壊れ方フィクスチャ**（正常 / 途中で切れたファイル / 不正 JSON / JSON としては正しいが型違い（array・scalar・null・フィールド型違い）/ ファイル無し）を、`git stash` した **origin/main 実装**と本 PR 実装の両方に流して出力を diff しました（プローブは検証後に削除済み）。

差分が出たのは**意図した 3 グループだけ**で、他は 1 バイトも変わりませんでした。

```
# 差分なし（全ケースで完全一致）
dashboard/{good,truncated,invalid,shape-array,shape-scalar,shape-null,bad-field-types,missing}
shortcuts/{同上}
journalState/{good,truncated,invalid,shape-array,shape-null,missing}
feedState/{good,truncated,invalid,shape-array,shape-scalar,shape-null,bad-field-types,missing}
views/{good,views-not-array,views-with-scalars,top-level-array,top-level-scalar}
  ↑ deleteCustomView の書き戻し後の schema.json を**文字列比較**。
    モデル外フィールド (`unmodelledExtra`) もキー順も完全に同一。

# 意図した差分 1: セッション meta（型違反 → corrupt。ファイルは上書きされない）
- sessionMeta/shape-array:      {"kind":"ok","meta":[1,2,3]}
+ sessionMeta/shape-array:      {"kind":"corrupt","raw":"[1,2,3]"}
- sessionMeta/shape-scalar:     {"kind":"ok","meta":"hello"}
+ sessionMeta/shape-scalar:     {"kind":"corrupt","raw":"\"hello\""}
- sessionMeta/shape-null:       {"kind":"ok","meta":null}
+ sessionMeta/shape-null:       {"kind":"corrupt","raw":"null"}
- sessionMeta/bad-field-types:  {"kind":"ok","meta":{"roleId":5,"hasUnread":"yes","origin":"martian"}}
+ sessionMeta/bad-field-types:  {"kind":"corrupt","raw":"..."}
（good / unknown-extra-keys / plugin-origin / truncated / invalid / missing は変化なし）

# 意図した差分 2: 会計仕訳（仕訳でない行 → skipped に計上）
- journalMonth/shape-array:   entries=[good, [1,2,3]]            skipped=0
+ journalMonth/shape-array:   entries=[good]                     skipped=1
- journalMonth/shape-scalar:  entries=[good, "hello"]            skipped=0
+ journalMonth/shape-scalar:  entries=[good]                     skipped=1
- journalMonth/shape-null:    entries=[good, null]               skipped=0
+ journalMonth/shape-null:    entries=[good]                     skipped=1
- journalMonth/missing-lines: entries=[good, {lines なし}]        skipped=0
+ journalMonth/missing-lines: entries=[good]                     skipped=1
- journalMonth/missing-kind:  entries=[{kind なし}]               skipped=0
+ journalMonth/missing-kind:  entries=[]                         skipped=1
（good / truncated / invalid / void-marker / opening / line-with-tax-id / missing は変化なし）

# 意図した差分 3: フックペイロード（object でない → null = dispatcher の no-op）
- hookPayload/shape-array:       [1,2,3]                        → + null
- hookPayload/shape-scalar:      "hello"                        → + null
- hookPayload/tool-input-scalar: {"tool_name":"Bash","tool_input":"ls"} → + null
（good / empty / invalid / shape-null / proto-pollution は変化なし。
  変更前も `payload.tool_input?.file_path` は undefined になり結局 no-op だったため、実質同値）
```

### 発見したバグの再現（root cause + 実行した再現手順）

**Root cause**: `readJournalMonth` の `JSON.parse(line) as JournalEntry` が、JSON として読めさえすれば何でも仕訳として通す。`report.ts:34` の `for (const line of entry.lines)` は `lines` の存在を確認していない。

**再現**（一時スクリプトを両リビジョンで実行。tmpdir に 2 行の JSONL を書き、`readJournalMonth` → `aggregateBalances` を呼ぶだけ）:

```
書いた JSONL（2行目に lines が無い = 手編集や書き込み中断で起こりうる形）:
{"id":"a","date":"2026-01-05","kind":"normal","lines":[{"accountCode":"1000","debit":10}],"createdAt":"..."}
{"id":"b","date":"2026-01-06","kind":"normal","createdAt":"..."}

### BASE (origin/main)
readJournalMonth: entries=2 skipped=0
aggregateBalances THREW: TypeError: entry.lines is not iterable

### 本 PR
readJournalMonth: entries=1 skipped=1
aggregateBalances: [{"accountCode":"1000","netDebit":10}]
```

`aggregateBalances` は残高表 / B/S / P/L の共通土台なので、**1 行の破損で帳簿全体のレポートが 500 になる**状態でした。修正後は既存方針どおり該当行だけ skip し、`readAllEntries` が `skipped > 0` を warn ログに出します。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Reduce unsafe JSON.parse type assertions by validating parsed data and routing invalid shapes into existing error or skip paths, while preserving existing persistence behavior and fixing a crash in accounting reports.

Bug Fixes:
- Prevent accounting journal reports from crashing when JSONL includes lines without valid journal entries by validating entry shape and skipping invalid lines.
- Treat malformed session metadata files as corrupt without overwriting them, avoiding partial rewrites of unreadable files.

Enhancements:
- Replace several JSON.parse-as casting sites with runtime shape checks using shared helpers, returning defaults or null for malformed JSON instead of trusting types.
- Simplify collection watcher behavior by relying on the in-memory collection.schema instead of reparsing cached schemaJson strings and adjusting storage path change detection accordingly.
- Preserve unknown fields and plugin origins when reading session metadata and custom view schemas, ensuring round-trips do not drop unmodelled data.
- Refactor preset loader and external skill repo metadata readers to share JSON parsing logic that tolerates missing or malformed metadata and logs appropriately.
- Loosen generic workspace JSON readers to return unknown and delegate narrowing to callers, reducing unsafe generic casts.
- Validate JWT header and payload segments as JSON objects before use, rejecting tokens with non-object segments.
- Constrain hook stdin payloads to expected shapes so malformed inputs become dispatcher no-ops instead of flowing through unchecked.
- Derive JournalEntryKind from a const array to keep type and value lists aligned.

Tests:
- Add accounting plugin tests ensuring non-journal JSONL lines are skipped while all plugin-emitted journal entry shapes are preserved.
- Extend session meta tests to cover type-mismatched JSON being treated as unreadable without file overwrite and to verify preservation of extra keys and plugin origins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for imported journals, session metadata, dashboards, shortcuts, workspace data, feeds, presets, and hook payloads.
  * Invalid or malformed JSON is now rejected safely or replaced with appropriate empty/default values.
  * Journal files continue loading supported entry types while skipping and counting malformed entries.
  * Improved JWT and package metadata handling prevents invalid data from being accepted.
  * Preserved non-standard collection schemas and view data during updates.
* **Tests**
  * Added coverage for malformed data and supported journal entry formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->