### PR TITLE
refactor: remove `x as unknown as T` double casts (25 -> 10)

### DIFF
--- a/packages/core/src/collection/server/csvQuery.ts
+++ b/packages/core/src/collection/server/csvQuery.ts
@@ -59,7 +59,10 @@ function whereFragment(cond: CollectionQueryWhere): { sql: string; params: CsvQu
     const lhs = textual ? asText : column;
     return { sql: `${lhs} IN (${values.map(() => "?").join(", ")})`, params: values };
   }
-  if (cond.op === "contains") return { sql: `contains(${asText}, ?)`, params: [String(cond.value)] };
+  // `String()` stays — `contains` matches against text, so a numeric needle is
+  // searched by its text form — but an array must fail here like it does on
+  // every other scalar op, not silently become the needle "1,2".
+  if (cond.op === "contains") return { sql: `contains(${asText}, ?)`, params: [String(scalarValue(cond))] };
   const operator = { eq: "=", ne: "<>", gt: ">", gte: ">=", lt: "<", lte: "<=" }[cond.op];
   const lhs = typeof cond.value === "string" && (cond.op === "eq" || cond.op === "ne") ? asText : column;
   return { sql: `${lhs} ${operator} ?`, params: [scalarValue(cond)] };

--- a/packages/core/src/collection/server/csvQuery.ts
+++ b/packages/core/src/collection/server/csvQuery.ts
@@ -10,6 +10,12 @@
 import type { CollectionQuery, CollectionQueryAggregate, CollectionQueryWhere } from "../core/queryZ";
 import { DEFAULT_QUERY_ROWS } from "../core/queryZ";
 
+/** One value bound to a `?` placeholder. The DSL only ever compares
+ *  against JSON scalars, and these are exactly the `DuckDBValue`s the
+ *  driver accepts — typing the chain end-to-end is what lets `queryCsv`
+ *  hand them to `runAndReadAll` without coercion. */
+export type CsvQueryParam = string | number | boolean;
+
 /** Double-quote a SQL identifier (CSV column name / result alias). */
 export function quoteIdent(name: string): string {
   return `"${name.replaceAll('"', '""')}"`;
@@ -44,7 +50,7 @@ function aggregateExpr(aggregate: CollectionQueryAggregate): string {
  *  equality compares against `CAST(col AS VARCHAR)` so a sniffer-typed
  *  column still matches its textual value; numeric/boolean values compare
  *  natively (DuckDB coerces the column side). */
-function whereFragment(cond: CollectionQueryWhere): { sql: string; params: unknown[] } {
+function whereFragment(cond: CollectionQueryWhere): { sql: string; params: CsvQueryParam[] } {
   const column = quoteIdent(cond.field);
   const asText = `CAST(${column} AS VARCHAR)`;
   if (cond.op === "in") {
@@ -56,7 +62,17 @@ function whereFragment(cond: CollectionQueryWhere): { sql: string; params: unkno
   if (cond.op === "contains") return { sql: `contains(${asText}, ?)`, params: [String(cond.value)] };
   const operator = { eq: "=", ne: "<>", gt: ">", gte: ">=", lt: "<", lte: "<=" }[cond.op];
   const lhs = typeof cond.value === "string" && (cond.op === "eq" || cond.op === "ne") ? asText : column;
-  return { sql: `${lhs} ${operator} ?`, params: [cond.value] };
+  return { sql: `${lhs} ${operator} ?`, params: [scalarValue(cond)] };
+}
+
+/** `CollectionQueryZ` refines "`in` ⇔ array value", so an array reaching a
+ *  scalar op means the query was compiled without being validated first —
+ *  binding it would send an array to a single `?`. */
+function scalarValue(cond: CollectionQueryWhere): CsvQueryParam {
+  if (Array.isArray(cond.value)) {
+    throw new Error(`where condition on '${cond.field}' uses op '${cond.op}', which requires a scalar value, not an array`);
+  }
+  return cond.value;
 }
 
 /** Compile a validated query against `fromSql` (a table-function call
@@ -65,7 +81,7 @@ function whereFragment(cond: CollectionQueryWhere): { sql: string; params: unkno
  *  Callers MUST have run `CollectionQueryZ` first; this function trusts
  *  the shape (aliases already charset-checked, orderBy membership already
  *  enforced). */
-function compileQuery(query: CollectionQuery, fromSql: string): { sql: string; params: unknown[] } {
+function compileQuery(query: CollectionQuery, fromSql: string): { sql: string; params: CsvQueryParam[] } {
   const groupBy = query.groupBy ?? [];
   const aggregates = Object.entries(query.aggregates ?? {});
   const selectList = [...groupBy.map(quoteIdent), ...aggregates.map(([alias, aggregate]) => `${aggregateExpr(aggregate)} AS ${quoteIdent(alias)}`)];
@@ -80,7 +96,7 @@ function compileQuery(query: CollectionQuery, fromSql: string): { sql: string; p
 }
 
 /** Compile against a CSV file (the dataSource store's engine). */
-export function compileCsvQuery(query: CollectionQuery, primaryKey: string): { sql: string; params: unknown[] } {
+export function compileCsvQuery(query: CollectionQuery, primaryKey: string): { sql: string; params: CsvQueryParam[] } {
   return compileQuery(query, `read_csv(${readCsvArgs(primaryKey)})`);
 }
 
@@ -92,6 +108,6 @@ export function compileCsvQuery(query: CollectionQuery, primaryKey: string): { s
  *  inferred as a column and the query would binder-error on it (Codex P2
  *  on #2165). The full scan costs nothing extra here: aggregation reads
  *  the whole file anyway. */
-export function compileJsonlQuery(query: CollectionQuery): { sql: string; params: unknown[] } {
+export function compileJsonlQuery(query: CollectionQuery): { sql: string; params: CsvQueryParam[] } {
   return compileQuery(query, `read_json(?, format='newline_delimited', sample_size=-1)`);
 }

--- a/packages/core/src/collection/server/csvStore.ts
+++ b/packages/core/src/collection/server/csvStore.ts
@@ -35,7 +35,8 @@ import path from "node:path";
 import iconv from "iconv-lite";
 import type { CollectionItem } from "../core/schema";
 import type { CollectionQuery } from "../core/queryZ";
-import { compileCsvQuery, quoteIdent, readCsvArgs } from "./csvQuery";
+import type { DuckDBInstance } from "@duckdb/node-api";
+import { compileCsvQuery, quoteIdent, readCsvArgs, type CsvQueryParam } from "./csvQuery";
 import { getWorkspaceRoot, log } from "./host";
 import { isContainedInRoot, safeRecordId } from "./paths";
 
@@ -282,27 +283,16 @@ async function ensureUtf8CsvPath(absPath: string, workspaceRoot: string): Promis
 // DuckDB plumbing
 // ---------------------------------------------------------------------------
 
-interface DuckDbModule {
-  DuckDBInstance: {
-    create: (dbPath?: string) => Promise<{
-      connect: () => Promise<{
-        runAndReadAll: (sql: string, values?: unknown[]) => Promise<{ getRowObjectsJS: () => Record<string, unknown>[] }>;
-        disconnectSync: () => void;
-      }>;
-    }>;
-  };
-}
-
-let instancePromise: ReturnType<DuckDbModule["DuckDBInstance"]["create"]> | null = null;
+let instancePromise: Promise<DuckDBInstance> | null = null;
 
 /** Lazily create one shared in-memory DuckDB instance. The dynamic import
  *  keeps the native module OUT of core's load path — a platform where the
  *  prebuilt binding is missing degrades to a per-query error on dataSource
  *  collections only, never a broken core. A failed init is retried on the
  *  next call (the promise is reset). */
-async function duckDbInstance(): ReturnType<DuckDbModule["DuckDBInstance"]["create"]> {
+async function duckDbInstance(): Promise<DuckDBInstance> {
   if (instancePromise === null) {
-    instancePromise = import("@duckdb/node-api").then((mod) => (mod as unknown as DuckDbModule).DuckDBInstance.create(":memory:"));
+    instancePromise = import("@duckdb/node-api").then((mod) => mod.DuckDBInstance.create(":memory:"));
   }
   try {
     return await instancePromise;
@@ -314,7 +304,7 @@ async function duckDbInstance(): ReturnType<DuckDbModule["DuckDBInstance"]["crea
   }
 }
 
-export async function queryCsv(sql: string, params: unknown[]): Promise<Record<string, unknown>[]> {
+export async function queryCsv(sql: string, params: CsvQueryParam[]): Promise<Record<string, unknown>[]> {
   const instance = await duckDbInstance();
   const connection = await instance.connect();
   try {

--- a/packages/core/src/plugin-vue/sanitizeMarkdownHtml.ts
+++ b/packages/core/src/plugin-vue/sanitizeMarkdownHtml.ts
@@ -49,10 +49,12 @@ const SANITIZE_CONFIG = {
  *  normally strip; additionally permits the one YouTube-embed iframe shape. */
 export function sanitizeMarkdownHtml(html: string): string {
   ensureHook();
-  // DOMPurify's typed return is `string | TrustedHTML` depending on config
-  // flags; `RETURN_TRUSTED_TYPE` is never enabled here, so it is always a
-  // string. The double cast is the documented way to narrow through the union.
-  return DOMPurify.sanitize(html, SANITIZE_CONFIG) as unknown as string;
+  // `SANITIZE_CONFIG` is deliberately left un-annotated: every DOMPurify
+  // overload that returns something other than a string requires an explicit
+  // flag (`RETURN_TRUSTED_TYPE` / `RETURN_DOM` / `RETURN_DOM_FRAGMENT` /
+  // `IN_PLACE`), so keeping the literal type is what makes adding one a compile
+  // error here instead of a silent change of return shape.
+  return DOMPurify.sanitize(html, SANITIZE_CONFIG);
 }
 
 /** Test seam — undoes the global DOMPurify hook so an isolated test can verify

--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -14,6 +14,7 @@
 // every host's own Firebase init. The hostId is host-specific ("mulmoclaude",
 // "mulmoterminal") and is supplied by each host — there is no discovery.
 import { CollectionReference, DocumentData, DocumentReference, Firestore, collection, doc } from "firebase/firestore";
+import { isRecord } from "@mulmoclaude/common";
 
 // JSON payloads carried by the command channel. Explicit JSON types keep the
 // channel typed without resorting to any/unknown.
@@ -53,6 +54,49 @@ export type Jsonify<T> = T extends JsonValue
  *  with the justification re-argued in eight slightly different comments —
  *  which is how a rule stops being reviewable. */
 export const toJsonObject = <T extends object>(payload: Jsonify<T>): JsonObject => payload as JsonObject;
+
+const describeNonJson = (value: unknown): string => {
+  if (typeof value === "number") return String(value);
+  if (typeof value === "object") return "a non-plain object";
+  return `a ${typeof value}`;
+};
+
+/** Rebuild `value` as JSON, or throw naming the property that cannot be. */
+function toJsonValue(value: unknown, path: string): JsonValue {
+  if (Array.isArray(value)) return toJsonItems(value, path);
+  if (isRecord(value)) return toJsonEntries(value, path);
+  return toJsonScalar(value, path);
+}
+
+/** JSON's four scalar forms. Anything else — a function, a class instance, a
+ *  non-finite number — is what the channel cannot carry. */
+function toJsonScalar(value: unknown, path: string): JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  throw new Error(`${path} is ${describeNonJson(value)}, which JSON cannot represent`);
+}
+
+function toJsonItems(items: unknown[], path: string): JsonValue[] {
+  // An absent element becomes `null`, matching `JSON.stringify` — an array has
+  // to keep its length, so a hole cannot simply be dropped the way a key is.
+  return items.map((entry, index) => (entry === undefined ? null : toJsonValue(entry, `${path}[${index}]`)));
+}
+
+function toJsonEntries(record: Record<string, unknown>, path: string): JsonObject {
+  const usable = Object.entries(record).filter(([, value]) => value !== undefined);
+  return Object.fromEntries(usable.map(([key, value]) => [key, toJsonValue(value, `${path}.${key}`)]));
+}
+
+/** Runtime counterpart to `toJsonObject`, for payloads whose values are typed
+ *  `unknown` — a collection record, a projected view row — so no amount of
+ *  mapped-type work can PROVE them JSON.
+ *
+ *  Walks the payload and rebuilds it from the values it actually inspected, so
+ *  the returned `JsonObject` is earned rather than asserted. Absent (`undefined`)
+ *  properties are dropped exactly as `JSON.stringify` drops them; anything the
+ *  channel could not carry — a function, a class instance, `NaN` — throws
+ *  naming its path, instead of reaching Firestore as a silently mangled write. */
+export const coerceJsonObject = (payload: Record<string, unknown>): JsonObject => toJsonEntries(payload, "payload");
 
 // A channel routes commands to one specific host. Both sides agree on a
 // hardcoded hostId per use case (e.g. "mulmoclaude", "mulmoterminal"); there is

--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -91,7 +91,10 @@ function toJsonScalar(value: unknown, path: string): JsonValue {
 function toJsonItems(items: unknown[], path: string): JsonValue[] {
   // An absent element becomes `null`, matching `JSON.stringify` — an array has
   // to keep its length, so a hole cannot simply be dropped the way a key is.
-  return items.map((entry, index) => (entry === undefined ? null : toJsonValue(entry, `${path}[${index}]`)));
+  // `Array.from` rather than `map`, which SKIPS holes and would leave them in
+  // the result: `JSON.stringify` renders a hole as null and hides that, but
+  // `1 in arr` / `Object.keys` / `forEach` all still see the gap.
+  return Array.from(items, (entry, index) => (entry === undefined ? null : toJsonValue(entry, `${path}[${index}]`)));
 }
 
 function toJsonEntries(record: Record<string, unknown>, path: string): JsonObject {

--- a/packages/core/src/remote-host/index.ts
+++ b/packages/core/src/remote-host/index.ts
@@ -61,10 +61,22 @@ const describeNonJson = (value: unknown): string => {
   return `a ${typeof value}`;
 };
 
+/** Anything carrying its own JSON form — `Date` above all — must be asked for
+ *  it rather than walked, because walking a `Date`'s own enumerable keys finds
+ *  none and flattens the timestamp to `{}`. This is the step `JSON.stringify`
+ *  performs before it recurses, and the channel used to get it for free. */
+const hasToJson = (value: object): value is { toJSON: () => unknown } => "toJSON" in value && typeof value.toJSON === "function";
+
+const jsonRepresentationOf = (value: object): unknown => (hasToJson(value) ? value.toJSON() : value);
+
 /** Rebuild `value` as JSON, or throw naming the property that cannot be. */
 function toJsonValue(value: unknown, path: string): JsonValue {
   if (Array.isArray(value)) return toJsonItems(value, path);
-  if (isRecord(value)) return toJsonEntries(value, path);
+  if (isRecord(value)) {
+    const represented = jsonRepresentationOf(value);
+    if (represented !== value) return toJsonValue(represented, path);
+    return toJsonEntries(value, path);
+  }
   return toJsonScalar(value, path);
 }
 

--- a/packages/markdown-utils/src/markdown/mermaidRender.ts
+++ b/packages/markdown-utils/src/markdown/mermaidRender.ts
@@ -94,7 +94,7 @@ export function adoptSvg(svgMarkup: string): SVGElement | null {
   // `<svg>` at the top level lands under `body` in HTML5 parsing.
   const svgEl = parsed.body.querySelector("svg");
   if (!svgEl) return null;
-  return document.importNode(svgEl, true) as unknown as SVGElement;
+  return document.importNode(svgEl, true);
 }
 
 async function renderOne(node: HTMLElement, mermaid: MermaidRuntime, labels: MermaidRenderLabels, idPrefix: string): Promise<void> {

--- a/packages/plugins/form-plugin/src/core/index.ts
+++ b/packages/plugins/form-plugin/src/core/index.ts
@@ -13,6 +13,7 @@ export type {
   FormData,
   FormArgs,
 } from "./types";
+export { toFormViewState, type FormViewState } from "./viewState";
 export { TOOL_NAME, TOOL_DEFINITION } from "./definition";
 export { pluginCore, executeForm } from "./plugin";
 export { samples } from "./samples";

--- a/packages/plugins/form-plugin/src/core/viewState.ts
+++ b/packages/plugins/form-plugin/src/core/viewState.ts
@@ -1,0 +1,34 @@
+// Per-result UI state the host round-trips through `ToolResult.viewState`.
+//
+// The protocol types that field `Record<string, unknown>` — the host cannot
+// know any plugin's shape — so the blob coming back is only as trustworthy as
+// whatever wrote it (a previous app version, a restored session, another host).
+// View and Preview both used to re-declare this interface and assert the blob
+// into it, which claimed `userResponses` / `touched` were present when nothing
+// had checked. One definition, one parser, both earned at runtime.
+
+/** The shape this plugin stores under `ToolResult.viewState`. */
+export interface FormViewState {
+  userResponses: Record<string, unknown>;
+  touched: string[];
+  submitted?: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Rebuild a `FormViewState` from a stored blob, keeping only the parts that
+ *  really are the declared shape — a missing or malformed member degrades to
+ *  its empty default rather than surfacing as a present-but-wrong field.
+ *  Returns null when the blob is not an object at all, which is what a result
+ *  that never carried view state looks like. */
+export function toFormViewState(value: unknown): FormViewState | null {
+  if (!isRecord(value)) return null;
+  const touchedItems: unknown[] = Array.isArray(value.touched) ? value.touched : [];
+  return {
+    userResponses: isRecord(value.userResponses) ? value.userResponses : {},
+    touched: touchedItems.filter((fieldId) => typeof fieldId === "string"),
+    submitted: typeof value.submitted === "boolean" ? value.submitted : undefined,
+  };
+}

--- a/packages/plugins/form-plugin/src/vue/Preview.vue
+++ b/packages/plugins/form-plugin/src/vue/Preview.vue
@@ -41,15 +41,10 @@
 import { computed } from "vue";
 import type { ToolResult } from "gui-chat-protocol";
 import type { FormData } from "../core/types";
+import { toFormViewState, type FormViewState } from "../core/viewState";
 import { useT } from "../lang";
 
 const t = useT();
-
-interface FormViewState {
-  userResponses: Record<string, unknown>;
-  touched: string[];
-  submitted?: boolean;
-}
 
 const props = defineProps<{
   result: ToolResult;
@@ -62,7 +57,7 @@ const formData = computed<FormData | null>(() => {
   return null;
 });
 
-const viewState = computed<FormViewState | null>(() => (props.result?.viewState as unknown as FormViewState) || null);
+const viewState = computed<FormViewState | null>(() => toFormViewState(props.result?.viewState));
 
 const fieldCount = computed(() => formData.value?.fields.length || 0);
 

--- a/packages/plugins/form-plugin/src/vue/View.vue
+++ b/packages/plugins/form-plugin/src/vue/View.vue
@@ -272,6 +272,7 @@
 import { ref, watch, computed } from "vue";
 import type { ToolResult } from "gui-chat-protocol";
 import type { FormData, FormField, TextField, TextareaField, NumberField, DateField, CheckboxField } from "../core/types";
+import { toFormViewState, type FormViewState } from "../core/viewState";
 import { useT } from "../lang";
 
 const t = useT();
@@ -280,13 +281,6 @@ interface FieldError {
   fieldId: string;
   message: string;
   type: "required" | "format" | "range" | "pattern" | "custom";
-}
-
-interface FormViewState {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userResponses: Record<string, any>;
-  touched: string[];
-  submitted?: boolean;
 }
 
 const props = defineProps<{
@@ -312,11 +306,9 @@ function isFreshResult(newResult: ToolResult, oldResult: ToolResult | null | und
 }
 
 function restoreViewState(state: FormViewState): void {
-  if (state.userResponses) Object.assign(formValues.value, state.userResponses);
-  if (state.touched) {
-    touched.value = new Set(state.touched);
-    state.touched.forEach((fieldId) => validateField(fieldId));
-  }
+  Object.assign(formValues.value, state.userResponses);
+  touched.value = new Set(state.touched);
+  state.touched.forEach((fieldId) => validateField(fieldId));
   if (state.submitted !== undefined) submitted.value = state.submitted;
 }
 
@@ -327,7 +319,8 @@ function applyNewResult(newResult: ToolResult): void {
   formData.value.fields.forEach((field) => {
     formValues.value[field.id] = getDefaultValue(field);
   });
-  if (newResult.viewState) restoreViewState(newResult.viewState as unknown as FormViewState);
+  const viewState = toFormViewState(newResult.viewState);
+  if (viewState) restoreViewState(viewState);
   isRestoring.value = false;
 }
 

--- a/server/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/remoteHost/handlers/getRemoteViewItems.ts
@@ -13,6 +13,7 @@
 import { clampLimit, clampOffset, normalizeFields, readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { remoteViewItems, remoteViewItemsFailureMessage } from "../../workspace/collections/remoteView.js";
+import { coerceJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface GetRemoteViewItemsDeps {
@@ -31,10 +32,9 @@ export const createGetRemoteViewItems =
     const result = await deps.remoteViewItems(collection, viewId, request);
     if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
     // Not `toJsonObject`: `RemoteViewPage.items` is `RemoteViewItem[]`, whose
-    // values are `unknown`, so the payload cannot be PROVEN JSON — same
-    // irreducible gap as `pageResult` in collectionPage.ts, and for the same
-    // reason (record values are JSON by loader invariant, not by type).
-    return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
+    // values are `unknown`, so no mapped type can prove the payload is JSON.
+    // `coerceJsonObject` establishes it by walking the value instead.
+    return coerceJsonObject({ page: result.page, inlined: result.inlined, omitted: result.omitted });
   };
 
 export const getRemoteViewItems = createGetRemoteViewItems({ loadCollection, remoteViewItems });

--- a/server/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/remoteHost/handlers/mutateRemoteView.ts
@@ -14,7 +14,7 @@
 import { normalizeMutate, readIdParam } from "@mulmoclaude/core/remote-view";
 import { loadCollection } from "../../workspace/collections/index.js";
 import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../workspace/collections/remoteView.js";
-import { toJsonObject } from "../commandChannel.js";
+import { coerceJsonObject, toJsonObject } from "../commandChannel.js";
 import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface MutateRemoteViewHandlerDeps {
@@ -33,13 +33,11 @@ export const createMutateRemoteViewHandler =
     if (!collection) throw new Error(`collection '${slug}' not found`);
     const result = await deps.mutateRemoteView(collection, viewId, request);
     if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
-    // The delete branch is all strings, so it type-checks. The update branch
-    // carries a `CollectionItem`, whose values are `unknown` — JSON by the
-    // record loader's invariant, but not provably so. Same irreducible gap as
-    // `pageResult` / `getRemoteViewItems`, kept visible per branch rather than
-    // blanketing both.
+    // The delete branch is all strings, so the compile-time widen suffices. The
+    // update branch carries a `CollectionItem`, whose values are `unknown`, so
+    // it has to earn its JSON at runtime instead.
     if (result.op === "delete") return toJsonObject({ op: "delete", id: result.id });
-    return { op: "update", item: result.item } as unknown as JsonObject;
+    return coerceJsonObject({ op: "update", item: result.item });
   };
 
 export const mutateRemoteViewItem = createMutateRemoteViewHandler({ loadCollection, mutateRemoteView });

--- a/server/utils/router.ts
+++ b/server/utils/router.ts
@@ -10,14 +10,19 @@
 // string }>, res: Response) => void` binds with no coercion.
 
 import type { IRouter, RequestHandler } from "express";
-import type { ParamsDictionary, Query } from "express-serve-static-core";
 import type { ResolvedRoute } from "../../src/plugins/meta-types.js";
+
+// `RequestHandler`'s own defaults, read off Express's public type rather than
+// imported from `express-serve-static-core` — that sub-package is a transitive
+// type-only dep, and naming it makes the launcher's dependency scan fail.
+type DefaultParams = RequestHandler extends RequestHandler<infer P, infer __R, infer __B, infer __Q> ? P : never;
+type DefaultQuery = RequestHandler extends RequestHandler<infer __P, infer __R, infer __B, infer Q> ? Q : never;
 
 /** Register `handlers` on `router` using the verb + URL declared by
  *  `route`. The generics let callers keep their own `params` / `body` /
  *  `query` shapes; every handler in one call must agree on them, which
  *  is the same constraint Express itself imposes. */
-export function bindRoute<P = ParamsDictionary, ResBody = unknown, ReqBody = unknown, ReqQuery = Query>(
+export function bindRoute<P = DefaultParams, ResBody = unknown, ReqBody = unknown, ReqQuery = DefaultQuery>(
   router: IRouter,
   route: ResolvedRoute,
   ...handlers: RequestHandler<P, ResBody, ReqBody, ReqQuery>[]

--- a/server/utils/router.ts
+++ b/server/utils/router.ts
@@ -4,38 +4,39 @@
 // `bindRoute(router, API_ROUTES.todos.itemsCreate, handler)` instead
 // of branching on the verb at the call site.
 //
-// Handler typing matches Express's own loose `RouteParameters`
-// inference: a handler typed as `(req: Request<{ id: string }>, res:
-// Response) => void` is forwarded as-is — the underlying
-// `router[method](url, handler)` call accepts any handler shape, so
-// we cast through `unknown` once here rather than at every site.
+// Handler typing mirrors Express's own: the generics travel through to
+// `router[method]`, whose matching overload is itself generic over
+// params / body / query, so a handler declared as `(req: Request<{ id:
+// string }>, res: Response) => void` binds with no coercion.
 
 import type { IRouter, RequestHandler } from "express";
+import type { ParamsDictionary, Query } from "express-serve-static-core";
 import type { ResolvedRoute } from "../../src/plugins/meta-types.js";
 
-/** Register `handler` on `router` using the verb + URL declared by
- *  `route`. The generic on `handler` lets callers pass an Express
- *  handler typed against their own `params` / `body` / `query`
- *  generics; the cast hides the variance from Express's
- *  `RequestHandler<ParamsDictionary, …>` default. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function bindRoute<H extends (...args: any[]) => unknown>(router: IRouter, route: ResolvedRoute, ...handlers: H[]): void {
-  const cast = handlers as unknown as RequestHandler[];
+/** Register `handlers` on `router` using the verb + URL declared by
+ *  `route`. The generics let callers keep their own `params` / `body` /
+ *  `query` shapes; every handler in one call must agree on them, which
+ *  is the same constraint Express itself imposes. */
+export function bindRoute<P = ParamsDictionary, ResBody = unknown, ReqBody = unknown, ReqQuery = Query>(
+  router: IRouter,
+  route: ResolvedRoute,
+  ...handlers: RequestHandler<P, ResBody, ReqBody, ReqQuery>[]
+): void {
   switch (route.method) {
     case "GET":
-      router.get(route.url, ...cast);
+      router.get<P, ResBody, ReqBody, ReqQuery>(route.url, ...handlers);
       break;
     case "POST":
-      router.post(route.url, ...cast);
+      router.post<P, ResBody, ReqBody, ReqQuery>(route.url, ...handlers);
       break;
     case "PUT":
-      router.put(route.url, ...cast);
+      router.put<P, ResBody, ReqBody, ReqQuery>(route.url, ...handlers);
       break;
     case "PATCH":
-      router.patch(route.url, ...cast);
+      router.patch<P, ResBody, ReqBody, ReqQuery>(route.url, ...handlers);
       break;
     case "DELETE":
-      router.delete(route.url, ...cast);
+      router.delete<P, ResBody, ReqBody, ReqQuery>(route.url, ...handlers);
       break;
   }
 }

--- a/src/components/FileContentRenderer.vue
+++ b/src/components/FileContentRenderer.vue
@@ -259,7 +259,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, ref, watch, type Component } from "vue";
+import { computed, defineAsyncComponent, ref, toRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import TextResponseView from "../plugins/textResponse/View.vue";
 import SystemFileBanner from "./SystemFileBanner.vue";
@@ -273,7 +273,6 @@ import { rewriteMarkdownImageRefs } from "@mulmoclaude/markdown-utils/image/rewr
 import { API_ROUTES } from "../config/apiRoutes";
 import { useSharePack } from "../composables/useSharePack";
 import { useOpenInOs } from "../composables/useOpenInOs";
-import { toRef } from "vue";
 import { descriptorForPath, jsonEditableByPolicy } from "../config/systemFileDescriptors";
 import { isMarpDocument } from "@mulmoclaude/markdown-utils/markdown/marpDetect";
 import { buildPdfFilename } from "@mulmoclaude/markdown-utils/files/filename";
@@ -283,8 +282,8 @@ import { wrapWithScope } from "../plugins/scope";
 // export via dispatch), so they must mount inside a markdown scope
 // provider — same scope the plugin canvas uses, so both reach the
 // built-in "markdown" dispatch handler (task #6).
-const MarpView = wrapWithScope("markdown", MarpViewRaw as unknown as Component);
-const MarpSplitEditor = wrapWithScope("markdown", MarpSplitEditorRaw as unknown as Component);
+const MarpView = wrapWithScope("markdown", MarpViewRaw);
+const MarpSplitEditor = wrapWithScope("markdown", MarpSplitEditorRaw);
 // Lazy: CodeMirror (~390 KB raw) is only fetched when a user actually
 // opens the inline JSON editor, keeping it out of the initial bundle.
 const JsonEditor = defineAsyncComponent(() => import("./JsonEditor.vue"));

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -21,7 +21,7 @@ import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useNotifications, type NotifierEntry, type NotifierHistoryEntry } from "../composables/useNotifications";
 import { formatRelativeTime } from "../utils/format/date";
-import type { NotificationI18n, NotificationKind, NotificationPriority } from "../types/notification";
+import type { NotificationI18n } from "../types/notification";
 import { isRecord } from "../utils/types";
 
 const { t } = useI18n();
@@ -101,39 +101,58 @@ watch(open, (nowOpen: boolean) => {
 // ── Legacy pluginData typing ────────────────────────────────
 //
 // `publishNotification()` stashes legacy fields under
-// `pluginData.legacy = true`. The bell type-narrows here so it can
-// preserve i18n localization for entries that came through the
-// wrapper. Future direct callers of `notifier.publish()` don't set
-// this shape; their entries fall back to the engine-level
-// `entry.title` / `entry.body`.
+// `pluginData.legacy = true`. The bell reads back only the localization
+// payload, so that is all this rebuilds — the sibling `legacyId` / `kind` /
+// `priority` fields the wrapper also stashes are unused here and therefore
+// not claimed. Direct `notifier.publish()` callers set no such blob; their
+// entries fall back to the engine-level `entry.title` / `entry.body`.
 
-interface LegacyPluginDataShape {
-  legacy: true;
-  legacyId: string;
-  kind: NotificationKind;
-  priority: NotificationPriority;
-  i18n?: NotificationI18n;
+type NotificationI18nParams = NonNullable<NotificationI18n["titleParams"]>;
+
+/** One vue-i18n named param: a scalar, or the string list the
+ *  `NotificationI18n` contract allows for list-style keys. */
+function toI18nParam(value: unknown): string | number | readonly string[] | undefined {
+  if (typeof value === "string" || typeof value === "number") return value;
+  if (!Array.isArray(value)) return undefined;
+  const items: unknown[] = value;
+  return items.every((item) => typeof item === "string") ? items.filter((item) => typeof item === "string") : undefined;
 }
 
-function asLegacy(entry: { pluginData?: unknown }): LegacyPluginDataShape | null {
+function toI18nParams(value: unknown): NotificationI18nParams | undefined {
+  if (!isRecord(value)) return undefined;
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, param]) => {
+      const usable = toI18nParam(param);
+      return usable === undefined ? [] : [[key, usable] as const];
+    }),
+  );
+}
+
+/** The stashed localization payload, rebuilt from the fields this actually
+ *  verified. A blob whose `i18n` carries no string `titleKey` now falls back to
+ *  the engine-level text instead of reaching `t()` with an undefined key. */
+function legacyI18n(entry: { pluginData?: unknown }): NotificationI18n | null {
   const data = entry.pluginData;
-  if (!isRecord(data)) return null;
-  if (data.legacy !== true) return null;
-  if (typeof data.legacyId !== "string") return null;
-  if (typeof data.kind !== "string") return null;
-  if (typeof data.priority !== "string") return null;
-  return data as unknown as LegacyPluginDataShape;
+  if (!isRecord(data) || data.legacy !== true) return null;
+  const { i18n } = data;
+  if (!isRecord(i18n) || typeof i18n.titleKey !== "string") return null;
+  return {
+    titleKey: i18n.titleKey,
+    titleParams: toI18nParams(i18n.titleParams),
+    bodyKey: typeof i18n.bodyKey === "string" ? i18n.bodyKey : undefined,
+    bodyParams: toI18nParams(i18n.bodyParams),
+  };
 }
 
 function localizeTitle(entry: NotifierEntry | NotifierHistoryEntry): string {
-  const legacy = asLegacy(entry);
-  if (legacy?.i18n) return t(legacy.i18n.titleKey, legacy.i18n.titleParams ?? {});
+  const i18n = legacyI18n(entry);
+  if (i18n) return t(i18n.titleKey, i18n.titleParams ?? {});
   return entry.title;
 }
 
 function localizeBody(entry: NotifierEntry | NotifierHistoryEntry): string | undefined {
-  const legacy = asLegacy(entry);
-  if (legacy?.i18n?.bodyKey) return t(legacy.i18n.bodyKey, legacy.i18n.bodyParams ?? {});
+  const i18n = legacyI18n(entry);
+  if (i18n?.bodyKey) return t(i18n.bodyKey, i18n.bodyParams ?? {});
   return entry.body;
 }
 

--- a/src/plugins/presentForm/index.ts
+++ b/src/plugins/presentForm/index.ts
@@ -11,13 +11,11 @@ import { TOOL_NAME } from "./definition";
 // runtime provider (wrapWithScope) so the package's useRuntime()/locale resolves
 // to the host — which is what drives the package's bundled i18n.
 //
-// Coerce the package's plugin to the host's ToolPlugin type. The package is built
-// with its own `vue` dep, so under yarn 4 it resolves a second @vue/runtime-core
-// whose `Component` type is nominally distinct from the host's (identical at
-// runtime — the built app bundles a single Vue). Without this bridge, passing the
-// package's Component into the host-typed wrapWithScope makes tsc compare two giant
-// equivalent Component types and blow the stack (TS2321).
-const pkg = formPlugin as unknown as ToolPlugin<FormData, FormData, FormArgs>;
+// Annotated rather than coerced: the package already declares `plugin` as this
+// exact type, so a plain assignment checks it. Should the install ever hoist a
+// second `@vue/runtime-core` again, this reports the divergence instead of
+// hiding it.
+const pkg: ToolPlugin<FormData, FormData, FormArgs> = formPlugin;
 
 const presentFormPlugin: ToolPlugin<FormData, FormData, FormArgs> = {
   ...pkg,

--- a/src/plugins/server-bindings-types.ts
+++ b/src/plugins/server-bindings-types.ts
@@ -7,8 +7,9 @@
 // `meta-types.ts`. Imported from server-side code via tsx.
 
 import type { ToolDefinition } from "gui-chat-protocol";
+import { isRecord } from "@mulmoclaude/common";
 import { API_ROUTES } from "../config/apiRoutes";
-import type { PluginMeta, ResolvedRoute } from "./meta-types";
+import type { PluginMeta } from "./meta-types";
 
 export interface ServerPluginBinding {
   /** ToolDefinition object — the plugin's MCP-facing schema. The
@@ -29,10 +30,21 @@ export function mcpEndpoint(meta: PluginMeta): string {
   if (!meta.apiNamespace || !meta.mcpDispatch) {
     throw new Error(`Plugin "${meta.toolName}" cannot register MCP binding: missing apiNamespace or mcpDispatch in META`);
   }
-  const namespaceRecord = (API_ROUTES as unknown as Record<string, Record<string, ResolvedRoute>>)[meta.apiNamespace];
-  const route = namespaceRecord?.[meta.mcpDispatch];
-  if (!route) {
+  const url = findRouteUrl(meta.apiNamespace, meta.mcpDispatch);
+  if (url === undefined) {
     throw new Error(`Plugin "${meta.toolName}" mcpDispatch route "${meta.mcpDispatch}" not found under API_ROUTES.${meta.apiNamespace}`);
   }
-  return route.url;
+  return url;
+}
+
+/** `API_ROUTES` is an intersection of literal-typed records, so it carries no
+ *  index signature and a namespace known only at runtime cannot be used to
+ *  subscript it. Walk the entries instead and read back only the one field this
+ *  module consumes. */
+function findRouteUrl(namespace: string, routeKey: string): string | undefined {
+  const namespaces: [string, unknown][] = Object.entries(API_ROUTES);
+  const namespaceValue = namespaces.find(([key]) => key === namespace)?.[1];
+  if (!isRecord(namespaceValue)) return undefined;
+  const route = namespaceValue[routeKey];
+  return isRecord(route) && typeof route.url === "string" ? route.url : undefined;
 }

--- a/src/utils/image/imageRepairInlineScript.ts
+++ b/src/utils/image/imageRepairInlineScript.ts
@@ -85,11 +85,11 @@ export function findRepairTarget(src: string): string | null {
  *  closes over no module-scope identifiers, so `Function.toString()`
  *  produces a self-contained body that runs unchanged in the iframe.
  *
- *  The shapes used inside (`HTMLImageElement`, `HTMLSourceElement`,
- *  `dataset`, `closest`, `querySelectorAll`) are all browser-native;
- *  the function is cast through unknown-shape probes rather than
- *  assuming a structurally-typed mock so the same body works in any
- *  iframe context. */
+ *  The shapes used inside (`dataset`, `src`, `closest`,
+ *  `querySelectorAll`) are described by the duck type `ElLike` below,
+ *  which real `HTMLImageElement` / `HTMLSourceElement` satisfy and a
+ *  plain test object can too — so the same body works in any iframe
+ *  context without assuming a particular DOM implementation. */
 // Duck-typed element shape the repair logic touches. Real `Element` /
 // `HTMLImageElement` / `HTMLSourceElement` etc. all satisfy this; tests
 // pass a plain object that does too.
@@ -163,23 +163,28 @@ function repairSource(src: ElLike, pattern: RegExp, patternEncoded: RegExp): voi
 // Public entry point: dispatch by tagName onto the right helper.
 // Pure (no module-scope closures); patterns come in by argument so the
 // stringified form runs unchanged inside the iframe's null-origin scope.
-export function repairImageErrorTarget(target: EventTarget | null, pattern: RegExp, patternEncoded: RegExp): void {
+// Declared against `ElLike`, not `EventTarget`: the only untyped caller is the
+// installer inside `IMAGE_REPAIR_INLINE_SCRIPT`, which is a template string the
+// compiler never sees, so typing this as `EventTarget` bought nothing and forced
+// every typed caller to coerce an element-shaped value into `EventTarget` and
+// back out again. A `target` that turns out not to be element-like simply fails
+// the `tagName` comparisons below and falls through.
+export function repairImageErrorTarget(target: ElLike | null, pattern: RegExp, patternEncoded: RegExp): void {
   if (!target) return;
-  const element = target as unknown as ElLike;
-  if (element.tagName === "IMG") {
-    repairImg(element, pattern, patternEncoded);
-    const pic = element.closest ? element.closest("picture") : null;
+  if (target.tagName === "IMG") {
+    repairImg(target, pattern, patternEncoded);
+    const pic = target.closest ? target.closest("picture") : null;
     if (pic && pic.querySelectorAll) {
       for (const source of pic.querySelectorAll("source")) repairSource(source, pattern, patternEncoded);
     }
     return;
   }
-  if (element.tagName === "SOURCE") {
-    repairSource(element, pattern, patternEncoded);
+  if (target.tagName === "SOURCE") {
+    repairSource(target, pattern, patternEncoded);
     return;
   }
-  if ((element.tagName === "AUDIO" || element.tagName === "VIDEO") && element.querySelectorAll) {
-    for (const source of element.querySelectorAll(":scope > source")) repairSource(source, pattern, patternEncoded);
+  if ((target.tagName === "AUDIO" || target.tagName === "VIDEO") && target.querySelectorAll) {
+    for (const source of target.querySelectorAll(":scope > source")) repairSource(source, pattern, patternEncoded);
   }
 }
 

--- a/src/utils/tools/result.ts
+++ b/src/utils/tools/result.ts
@@ -94,7 +94,7 @@ export function makeSkillResult(entry: {
   skillPath: string | null;
   skillDescription: string | null;
   message: string;
-}): ToolResultComplete {
+}): ToolResultComplete<SkillResultData> {
   const data: SkillResultData = {
     skillName: entry.skillName,
     skillScope: entry.skillScope,
@@ -107,6 +107,6 @@ export function makeSkillResult(entry: {
     toolName: SKILL_TOOL_NAME,
     message: entry.skillDescription ?? entry.skillName,
     title: `Skill: ${entry.skillName}`,
-    data: data as unknown as Record<string, unknown>,
+    data,
   };
 }

--- a/test/utils/image/test_imageRepairInlineScript.ts
+++ b/test/utils/image/test_imageRepairInlineScript.ts
@@ -189,31 +189,31 @@ describe("injectImageRepairScript", () => {
 describe("repairImageErrorTarget — runtime behavior", () => {
   it("rewrites <img>.src when the URL carries a recognisable artifacts/images segment", () => {
     const img = makeElement("IMG", { src: "/wrong/prefix/artifacts/images/2026/05/foo.png" });
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(img.src, "/artifacts/images/2026/05/foo.png");
     assert.equal(img.dataset.imageRepairTried, "1");
   });
 
   it("rewrites the encoded form via decodeURIComponent (issue #1102)", () => {
     const img = makeElement("IMG", { src: "/api/files/raw?path=artifacts%2Fimages%2F2026%2F05%2Ffoo.png" });
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(img.src, "/artifacts/images/2026/05/foo.png");
   });
 
   it("is a one-shot per element — second invocation is a no-op", () => {
     const img = makeElement("IMG", { src: "/wrong/artifacts/images/foo.png" });
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(img.src, "/artifacts/images/foo.png");
     // Even if a follow-up rewrite would change the path again, the
     // dataset flag stops it.
     img.src = "/wrong/again/artifacts/images/bar.png";
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(img.src, "/wrong/again/artifacts/images/bar.png");
   });
 
   it("leaves <img>.src alone when no pattern matches", () => {
     const img = makeElement("IMG", { src: "/some/other/path.png" });
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(img.src, "/some/other/path.png");
     assert.equal(img.dataset.imageRepairTried, undefined);
   });
@@ -224,7 +224,7 @@ describe("repairImageErrorTarget — runtime behavior", () => {
 
   it("rewrites a <source> element via getAttribute / setAttribute", () => {
     const src = makeElement("SOURCE", { attrs: { src: "/wrong/artifacts/images/x.webp" } });
-    repairImageErrorTarget(src as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(src, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(src.attrs.src, "/artifacts/images/x.webp");
     assert.equal(src.dataset.imageRepairTried, "1");
   });
@@ -233,7 +233,7 @@ describe("repairImageErrorTarget — runtime behavior", () => {
     const src = makeElement("SOURCE", {
       srcset: "/wrong/artifacts/images/a.png 1x, /wrong/artifacts/images/b.png 2x, /unrelated.png 3x",
     });
-    repairImageErrorTarget(src as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(src, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(src.srcset, "/artifacts/images/a.png 1x, /artifacts/images/b.png 2x, /unrelated.png 3x");
     assert.equal(src.dataset.imageRepairTried, "1");
   });
@@ -245,7 +245,7 @@ describe("repairImageErrorTarget — runtime behavior", () => {
     const picture = makeElement("PICTURE", { children: [sourceA, sourceB, img] });
     img.parentPicture = picture;
 
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
 
     assert.equal(img.src, "/artifacts/images/main.png");
     assert.equal(sourceA.attrs.src, "/artifacts/images/a.webp");
@@ -257,7 +257,7 @@ describe("repairImageErrorTarget — runtime behavior", () => {
     const sourceB = makeElement("SOURCE", { attrs: { src: "/wrong/artifacts/images/b.ogg" } });
     const audio = makeElement("AUDIO", { children: [sourceA, sourceB] });
 
-    repairImageErrorTarget(audio as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(audio, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
 
     assert.equal(sourceA.attrs.src, "/artifacts/images/a.mp3");
     assert.equal(sourceB.attrs.src, "/artifacts/images/b.ogg");
@@ -268,14 +268,14 @@ describe("repairImageErrorTarget — runtime behavior", () => {
     // throw URIError. The handler must swallow that and leave src alone,
     // not crash the iframe.
     const img = makeElement("IMG", { src: "/api/files/raw?path=artifacts%2Fimages%2F%E0%A4" });
-    repairImageErrorTarget(img as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(img, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(img.src, "/api/files/raw?path=artifacts%2Fimages%2F%E0%A4");
     assert.equal(img.dataset.imageRepairTried, undefined);
   });
 
   it("ignores tags outside the IMG/SOURCE/AUDIO/VIDEO whitelist", () => {
     const div = makeElement("DIV", { src: "/wrong/artifacts/images/foo.png" });
-    repairImageErrorTarget(div as unknown as EventTarget, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
+    repairImageErrorTarget(div, IMAGE_REPAIR_PATTERN, IMAGE_REPAIR_PATTERN_ENCODED);
     assert.equal(div.src, "/wrong/artifacts/images/foo.png");
     assert.equal(div.dataset.imageRepairTried, undefined);
   });


### PR DESCRIPTION
## Summary

`x as unknown as T` の二重キャストを **25 → 10** に削減（テストが強制されていた 14 件も併せて除去、計 29 件）。二重キャストは「TypeScript が直接のキャストを拒否した」印なので、全サイトでキャストを削除して型エラーを読み、その**エラー自体を診断結果**として扱った。

宣言の誤りが 4 件（うち 1 件は実バグ）、未検証の断定が 4 件、単なる残骸が 5 件。残る 10 件は設計判断が必要なため、診断結果を添えて据え置いた（下記）。

## Items to Confirm / Review

**要確認（挙動が変わりうる箇所）**

1. **`csvStore.ts` — DuckDB シムが型で嘘をついていた（実バグ）**
   手書きの `DuckDbModule` が `runAndReadAll(sql, values?: unknown[])` と宣言していたが、実ドライバは `DuckDBValue[]` しか受けない。`@duckdb/node-api` は core の**実依存**なので本物の型が最初から使えた。実機で確認：`unknown[]` が約束していた値のうち plain object / array / function / undefined は **`Error: Cannot create values of type ANY`** で落ちる。現行の呼び出し経路は zod 検証済みスカラーのみなので**顕在化はしていない潜在バグ**。→ バインド値の型を `CsvQueryParam` で通し、シムを削除。
   *レビュー観点*: `whereFragment` のスカラー分岐に `scalarValue()` ガードを追加（`in` 以外に配列が来たら throw）。zod の refine と同じ不変条件なので到達しない想定。

2. **`NotificationBell.vue` — 述語が未検証のフィールドを断定していた**
   旧 `asLegacy` は `legacy`/`legacyId`/`kind`/`priority` を確認しつつ、`kind: NotificationKind`（string ではなく union）と **`i18n` 全体**を無検証で断定していた。`localizeTitle` は直後に `t(legacy.i18n.titleKey, …)` を呼ぶため、`i18n` が `{}` なら `t(undefined)` に到達しうる。
   *挙動変更*: `titleKey` が string でない場合、`t()` に渡さず `entry.title` へフォールバックする。実際に `i18n` を書くのは host 側のみで必ず `titleKey` を入れるため、実運用では差分なしのはず。

3. **`form-plugin` の `viewState`** — View/Preview が同じ `FormViewState` を各自宣言して断定していたのを、共有 `toFormViewState()` パーサに統合。
   *挙動変更（到達しない想定）*: `viewState` はあるが `touched` を欠く「新しい結果」の場合、旧コードは `if (state.touched)` で素通りし前のフォームの touched を残していた。新実装は `[]` にリセットする。`viewState` を書くのはこのプラグイン自身だけで常に `touched` を含むため実際には起きない。ラウンドトリップ検証済み（下記）。

4. **`presentForm/index.ts` のキャスト削除**
   元コメントは「yarn 4 で 2 つ目の `@vue/runtime-core` が解決され TS2321 でスタックが溢れる」と説明していた。現在の install には `@vue/runtime-core` が 1 つしかなく（`packages/**/node_modules` はどれも `.bin` のみ）、キャストを消しても `vue-tsc` は通る。パッケージ側は `plugin` を**まったく同じ型**で export しているので、キャストではなく注釈付き代入にした（将来また二重解決が起きたら隠さずエラーになる）。**CI の install レイアウトで再確認したい点。**

5. **`repairImageErrorTarget` の引数型変更**
   `EventTarget | null` → `ElLike | null`。型付きの呼び出し元はテストのみで、全員が `img as unknown as EventTarget` を書かされていた（＝シグネチャが嘘）。唯一の実行時呼び出し元は `IMAGE_REPAIR_INLINE_SCRIPT` 内のテンプレート文字列で、**コンパイラからは見えない**ため型を変えても影響しない。関数本体は `Function.toString()` で iframe に送られるので、モジュールスコープのヘルパーは一切追加していない（追加すると iframe で `ReferenceError`）。

**据え置いた 10 件（着手しなかった理由）**

| サイト | 診断 | 直すのに必要なこと |
|---|---|---|
| `src/config/apiRoutes.ts:499`, `toolNames.ts:113`, `pubsubChannels.ts:185`, `server/workspace/paths.ts:268` | キャストを外すと**下流が大量に崩れる**（例: `Property 'internal' does not exist on type 'ApiRoutesAggregateValue'` / `Property 'internal' does not exist on type '"/api/health"'`）。`defineHostAggregate` は実行時に `Record<string, V>` を作り、型側は `PluginApiRoutesMap<BuiltInPluginMetas>` という**別経路のマップ型**で表現している。実行時のマージ結果をコンパイル時の射影に結び付ける行為そのもの | `defineHostAggregate` を meta 型でジェネリックにし、マージ結果の型を推論させる設計変更。`WORKSPACE_DIRS` はアプリ全体が依存するため特に影響大 |
| `chart-plugin/plugin.ts:84`, `html-plugin/plugin.ts:140`, `mulmoscript-plugin/plugin.ts:186` | `Type '(context: ChartExecuteContext, …)' is not assignable to '(context: ToolContext, …)'` → `Property 'files' is missing in type 'ToolContext'`。上流 `gui-chat-protocol` の `ToolContext` は `{ currentResult?, app? }` だけで、host が実際に注入する `files.artifacts` を宣言していない | 上流の型を直すか、各プラグインで `FileOps` のうち使用メンバーを検証するガード＋明示 throw を書く。`files.artifacts` は `FileOps` ごと他関数に渡されるため、部分検証で述語を名乗るのは避けたく、別 PR が妥当 |
| `markdown-plugin/plugin.ts:92` | `Argument of type 'ToolContext' is not assignable to 'MarkdownExecuteContext'` → `ToolContextApp` に `loadDoc, saveDoc, saveNewDoc, marpThemes` ほか 2 つが無い | 同上。検証すべき host メソッドが 6 つあり範囲が大きい |
| `mulmoscript-plugin/useDeckEditor.ts:25,55` | ローカル `DeckScriptShape` と mulmocast の `MulmoScript` が**構造的に食い違う**。25 行目: `Type 'Beat' is not assignable to 'DeckBeatShape'`（index signature 不足）。55 行目: `image.type` が `DeckScriptShape` では省略可・`Beat` では**必須**。つまり `type` を持たない deck の beat を保存すると、スキーマ違反の `MulmoScript` を書きうる | どちらの形が正なのかの設計判断が必要（潜在バグの可能性あり）。**別途調査を推奨** |

**その他**

- `packages/core/src/remote-host/index.ts` に `sonarjs/function-return-type` の warning が 2 件残る。JSON ウォーカーが `JsonValue`（union）を返す以上避けられず、同ルールは `packages/core/src` + `server/utils` + `server/workspace` だけで既に 8 件の既存 warning がある。可読性を損ねてまで潰すのは不適当と判断。
- `eslint.config.mjs` は変更していない。他の形の `as` キャストにも手を付けていない（`csvQuery.ts:57` の `cond.value as (…)[]` は別形なので残置）。

## 実装方針

| サイト | キャストを外した時の型エラー | 対応 |
|---|---|---|
| `src/utils/image/imageRepairInlineScript.ts:168` | `TS2339: Property 'tagName' does not exist on type 'EventTarget'`（ほか計 10 件） | 引数を `ElLike \| null` に修正。テスト側 14 件の `as unknown as EventTarget` も不要になり削除 |
| `packages/core/src/collection/server/csvStore.ts:305` | `TS2322: 'DuckDBInstance' is not assignable to …` → `Type 'unknown[]' is not assignable to 'DuckDBValue[]'` | `DuckDbModule` シムを削除し `@duckdb/node-api` の実型を使用。`CsvQueryParam` をバインド値チェーンに導入 |
| `server/remoteHost/handlers/getRemoteViewItems.ts:37` | `TS2322: Type 'RemoteViewPage' is not assignable to 'JsonValue'` → `Index signature for type 'string' is missing` | 新 `coerceJsonObject()` で実行時に JSON を再構築 |
| `server/remoteHost/handlers/mutateRemoteView.ts:42` | `TS2322: Type 'CollectionItem' is not assignable to 'JsonValue'` | 同上（delete 分岐は従来どおり `toJsonObject`） |
| `src/components/NotificationBell.vue:125` | `TS2739: Type 'Record<string, unknown>' is missing the following properties …: legacy, legacyId, kind, priority` | 実際に使う `i18n` だけを検証済みフィールドから再構築 |
| `src/plugins/server-bindings-types.ts:32` | `TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type …` | `Object.entries` を走査し、使用する `url` のみ読み戻す |
| `packages/plugins/form-plugin/src/vue/Preview.vue:65` | `TS2769: Type 'Record<string, unknown>' is missing … userResponses, touched` | 共有 `toFormViewState()` パーサ |
| `packages/plugins/form-plugin/src/vue/View.vue:330` | `TS2345`（同上） | 同上。重複していた `FormViewState` 宣言も統合 |
| `server/utils/router.ts:23` | **エラーなし**（`H extends (...args: any[])` の `any` 経由で通っていただけ） | Express のジェネリクスをそのまま伝播。`any` と `eslint-disable` も削除 |
| `src/utils/tools/result.ts:110` | **エラーなし**（`ToolResultComplete` の `data` は `unknown`） | 戻り値を `ToolResultComplete<SkillResultData>` に |
| `src/plugins/presentForm/index.ts:20` | **エラーなし** | 注釈付き代入に変更 |
| `src/components/FileContentRenderer.vue:286,287` | **エラーなし**（`wrapWithScope` は既に `Component` を受ける） | 削除。未使用になった `type Component` import も整理 |
| `packages/core/src/plugin-vue/sanitizeMarkdownHtml.ts:55` | **エラーなし**。dompurify 3.4.12 では string 以外を返す overload が全て明示フラグ必須 | 削除。`SANITIZE_CONFIG` は**あえて無注釈のまま**にし、将来 `RETURN_DOM` 等を足したらここでコンパイルエラーになるようにした |
| `packages/markdown-utils/src/markdown/mermaidRender.ts:97` | **エラーなし**（`importNode<T>` は `SVGSVGElement` を返す） | 削除 |

## 検証

すべて worktree `mc3-wt-double` 内で実行（`node_modules` はワークスペースパッケージが worktree 側を指すようミラーを作成。共有シンボリックリンクのままだと本チェックアウトの `packages/*` を解決してしまい**偽の合格**になるため）。

```
npx prettier --write <touched files>          # 全て unchanged
npx eslint <touched files>                    # 0 errors / consistent-type-assertions 0 件（残りは既存の別形）
npx vue-tsc --noEmit                          # クリーン
npx tsc -p server/tsconfig.json --noEmit      # クリーン
npx tsc -p test/tsconfig.json --noEmit        # クリーン
npx tsc -p e2e/tsconfig.json --noEmit         # クリーン
npx tsc -p e2e-live/tsconfig.json --noEmit    # クリーン
yarn workspaces run typecheck                 # exit 0
yarn build:packages && yarn build:hooks       # exit 0（`server/build/dispatcher.mjs` に差分なし）
yarn build                                    # exit 0
npx tsx --test ./test/*/test_*.ts …           # tests 8898 / pass 8891 / fail 0
yarn workspaces run test                      # exit 0
```

**外部 ground truth との突き合わせ（before / after 差分）**

- **DuckDB バインド値**（実ドライバに直接投入）:
  ```
  string: OK  number: OK  boolean: OK
  plainObj : THREW -> Error: Cannot create values of type ANY. Specify a specific type.
  array    : THREW -> 同上      function : THREW -> 同上      undefined: THREW -> 同上
  ```
  → 旧シムの `unknown[]` が実在しない契約だったことの確認。
- **`mcpEndpoint`**: 全 16 プラグイン META で before/after を出力し `diff` → **完全一致**（`presentChart -> /api/chart` 等 13 件の URL と、META 不備 3 件の同一 throw メッセージ）。
- **サニタイザ**: XSS 込み 9 ケース（`img onerror` / `<script>` / `javascript:` href / `svg onload` / 非許可 iframe / YouTube 埋め込み / クエリ付き YouTube / form / plain）を JSDOM 上で実行し、返り値が全て `typeof "string"`・想定どおり除去/通過することを確認。加えて **esbuild で before/after の出力 JS を diff → 完全一致**（型アサーション削除のみで実行時コードは不変）。`test_sanitizeCoreMarkdownHtml.ts` + `test_sanitize.ts` = 15 tests pass。
- **`mermaidRender`**: 同様に出力 JS を diff → **完全一致**。
- **`coerceJsonObject`**: 実際の 2 ハンドラ相当ペイロード（ネスト・配列・null・data: URL 文字列を含む）で `JSON.stringify(coerced) === JSON.stringify(raw)` を確認 → **一致**。非 JSON 値はパス付きで throw（`payload.item.cb is a function, which JSON cannot represent` 等）。remoteHost ハンドラのテスト 38 件 pass。
- **`toFormViewState`**: View が書く形をそのまま入力してラウンドトリップ一致を確認。`undefined → null`、壊れた入力（`userResponses: "nope"`, `touched: [1,"ok"]`, `submitted: "yes"`）は `{userResponses:{}, touched:["ok"]}` に安全に劣化。
- **`repairImageErrorTarget`**: 該当テスト 25 件 pass。

**E2E（`--config e2e/playwright.config.ts` 付きで実行）**

| 実行 | 結果 |
|---|---|
| 本ブランチ（フル、1 回目） | **443 passed / 5 failed** |
| 本ブランチ（フル、2 回目） | **443 passed / 5 failed** |
| `src/` のみ `origin/main` に戻して該当 2 spec | **8 passed / 4 failed** |

失敗の内訳: `chat-flow.spec.ts:264,281` と `right-sidebar-toggle.spec.ts:14,32` の **4 件は main の `src/` でも同一に再現**（＝既存の失敗）。5 件目は実行ごとに入れ替わり（1 回目 `right-sidebar-toggle.spec.ts:48` → 2 回目 `files-path-url.spec.ts:211`）で、`right-sidebar-toggle.spec.ts` を単体 `--repeat-each=3` で回すと **main / 本ブランチどちらでも `:14`/`:32` が 3/3 失敗、`:48` は 3/3 成功**。よって 5 件目は並列実行由来の flake であり本変更とは無関係。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Tighten type safety by replacing unknown-to-target double casts with validated conversions across notifications, CSV DuckDB querying, remote host JSON handling, image repair utilities, form-plugin view state, and Vue wrappers, while keeping runtime behavior unchanged.

Bug Fixes:
- Align CSV DuckDB query parameter typing with the actual driver contract to prevent invalid value bindings.
- Prevent notification localization from calling i18n with undefined or malformed keys by reconstructing `NotificationI18n` from checked fields.
- Ensure remote host command payloads are valid JSON by walking unknown-typed objects and rejecting non-JSON values instead of asserting.
- Fix image repair handler typing to match the element-like shape actually used at runtime, avoiding incorrect EventTarget assertions.

Enhancements:
- Introduce a shared `FormViewState` parser for the form plugin and use it in both View and Preview, replacing duplicate interfaces and unchecked casts.
- Propagate Express generics through `bindRoute` so handlers retain precise params/body/query types without any casting.
- Resolve MCP endpoint URLs by iterating `API_ROUTES` entries instead of indexing with a runtime string, avoiding unsafe record casts.
- Rely on DOMPurify’s typed return value and keep the sanitize config literal so future non-string-returning flags surface as compile-time errors.
- Simplify Vue component wrapping by passing raw components into `wrapWithScope` without unnecessary casting.
- Use DOM importNode’s existing typing in mermaid SVG adoption instead of coercing the return type.
- Specialize tool result construction for skills to return `ToolResultComplete<SkillResultData>` without casting its data field.

Documentation:
- Add inline comments to clarify JSON coercion behavior, CSV query parameter constraints, image repair duck typing, form view state validation, and route binding generics.

Tests:
- Update image repair tests to call `repairImageErrorTarget` with element-like objects directly, matching the new function signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of CSV and JSONL query values, including clearer handling of invalid array predicates.
  - Added safer handling of remote data, rejecting unsupported values and preventing malformed responses.
  - Improved restoration of saved form state with sensible defaults for incomplete or invalid data.
  - Enhanced notification handling for legacy payloads and invalid localization parameters.
  - Improved route resolution, image repair behavior, and media rendering reliability.

- **New Features**
  - Added shared form state conversion utilities for consistent preview and submission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->