### PR TITLE
fix(lint): ratchet the `as` ban to error in the packages already at zero (#2692)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -633,5 +633,33 @@ export default [
       "sonarjs/different-types-comparison": "off",
     },
   },
+  // Per-package ratchet for the `as`-cast ban (#2692). The rule is `warn`
+  // repo-wide while the backlog drains; these packages are already at ZERO,
+  // so a new cast in them is a regression rather than a known debt — and the
+  // only thing that stops the drained set from refilling behind the drain.
+  //
+  // Verified at zero when added; `packages/relay`'s last one went in the same
+  // PR. Extend this list as a directory reaches zero, and delete the block
+  // once the repo-wide setting itself graduates to `error`.
+  {
+    files: [
+      "packages/chat-service/**/*.ts",
+      "packages/client/**/*.ts",
+      "packages/common/**/*.ts",
+      "packages/create-mulmoclaude-plugin/**/*.ts",
+      "packages/mock-server/**/*.ts",
+      "packages/protocol/**/*.ts",
+      "packages/relay/**/*.ts",
+      "packages/scheduler/**/*.ts",
+      "packages/web-push/**/*.ts",
+      "packages/webhook-runtime/**/*.ts",
+    ],
+    // Tests keep the permissive setting the test override below grants them;
+    // this block covers source only, so it must not reach `**/test/**`.
+    ignores: ["packages/*/test/**", "packages/*/**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
+    },
+  },
   eslintConfigPrettier,
 ];

--- a/packages/relay/src/webhooks/teams.ts
+++ b/packages/relay/src/webhooks/teams.ts
@@ -24,7 +24,7 @@
 // — the serviceUrl varies per region and we carry it through via the
 // existing RelayMessage.replyToken channel (opaque to the relay core).
 
-import { isRecord } from "@mulmoclaude/common";
+import { hasNumberProp, hasStringProp, isRecord } from "@mulmoclaude/common";
 import { PLATFORMS, type RelayMessage, type Env } from "../types.js";
 import { registerPlatform, CONNECTION_MODES, type PlatformPlugin } from "../platform.js";
 import { ONE_HOUR_MS, ONE_HOUR_S, TEN_SECONDS_MS } from "../time.js";
@@ -237,11 +237,11 @@ async function getAccessToken(env: Env): Promise<string> {
   if (!res.ok) {
     throw new Error(`Teams token exchange failed: ${res.status}`);
   }
-  const data = (await res.json()) as { access_token?: string; expires_in?: number };
-  if (typeof data.access_token !== "string") {
+  const data: unknown = await res.json();
+  if (!hasStringProp(data, "access_token")) {
     throw new Error("Teams token response missing access_token");
   }
-  const ttlSec = typeof data.expires_in === "number" ? data.expires_in : ONE_HOUR_S;
+  const ttlSec = hasNumberProp(data, "expires_in") ? data.expires_in : ONE_HOUR_S;
   tokenCache = { token: data.access_token, expiresAt: now + ttlSec };
   return data.access_token;
 }


### PR DESCRIPTION
## Summary

`as` 禁止ルールはリポジトリ全体では `warn` のままですが（残り約300件を消化中のため）、**すでに 0 になった10パッケージだけ `error` に固定**します。

drain した先から埋め戻される、という状態を止めるのが目的です。ゼロのパッケージに新しい cast が入るのは「既知の負債」ではなく**回帰**なので、そこだけ先に締めます。

`packages/relay` は残り1件だったので同 PR で直して含めました（`teams.ts` の OAuth トークン応答を検査せずアサートしていた箇所。#2715 が Google 側で直したのと同じ形です）。

## Items to Confirm / Review

1. **gate が本当に効くことを確認しています**（宣言しただけの gate は無意味なので）。

   `packages/common/src/index.ts` に `v as string` を足すと:
   ```
   error  Do not use any type assertions  @typescript-eslint/consistent-type-assertions
   ```
   同じ cast を `packages/*/test/` 配下に足すと **0件**。テストの除外は維持されています。

2. **対象は「測ってゼロだったもの」だけ**です。`packages/core`（49）/ `plugins`（32）/ `bridges`（13）/ `markdown-utils`（10）は未消化なので入れていません。

3. **`ignores` でテストを除外**しています。このブロックは source 専用で、`packages/*/test/**` に届いてはいけません（flat config は後勝ちなので、届くとテスト override を上書きしてしまいます）。

4. リポジトリ全体が `error` に昇格したら、**このブロックごと削除**してください。コメントにもその旨を書いています。

## 実装方針

`eslint.config.mjs` の末尾（`eslintConfigPrettier` の直前）に、対象パッケージだけを `files` に列挙したブロックを追加しました。flat config の last-match-wins で、`warn` の全体設定を上書きします。

対象: `chat-service` / `client` / `common` / `create-mulmoclaude-plugin` / `mock-server` / `protocol` / `relay` / `scheduler` / `web-push` / `webhook-runtime`

`teams.ts` の修正:

```diff
- const data = (await res.json()) as { access_token?: string; expires_in?: number };
- if (typeof data.access_token !== "string") { throw … }
- const ttlSec = typeof data.expires_in === "number" ? data.expires_in : ONE_HOUR_S;
+ const data: unknown = await res.json();
+ if (!hasStringProp(data, "access_token")) { throw … }
+ const ttlSec = hasNumberProp(data, "expires_in") ? data.expires_in : ONE_HOUR_S;
```

検査内容もエラーメッセージも同一です（元から `typeof` で見ていたので、共有ガードに置き換えただけ）。

## 検証

```
npx eslint packages -> assertion ERRORS: 0 / warnings: 104（未消化パッケージのみ）
yarn lint      -> exit 0
yarn typecheck -> exit 0
packages/relay: yarn test -> tests 107 / pass 107 / fail 0
```

gate の実効性テスト（上記 Items 1）は一時的に cast を足して確認し、両方とも元に戻してあります。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Tighten linting around TypeScript `as` assertions for already-clean packages and adjust Teams webhook token handling to comply with the stricter rule.

Enhancements:
- Promote the `@typescript-eslint/consistent-type-assertions` rule from warn to error for a set of packages that have eliminated `as` casts, while keeping tests exempt.
- Refine Teams webhook access token parsing to use shared runtime property guards instead of direct type assertions, preserving behavior while removing casts.