### PR TITLE
refactor: drain `as` casts from packages/core (#2692)

### DIFF
--- a/packages/core/src/collection/core/backlinks.ts
+++ b/packages/core/src/collection/core/backlinks.ts
@@ -6,6 +6,8 @@
 // single-implementation rule `deriveAll` follows for formulas. No zod,
 // no I/O; safe for the browser barrel.
 
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
+
 import { whenMatches } from "./actionVisible";
 import { fieldTextOrNull } from "./fieldText";
 import type { CollectionFieldSpec, CollectionItem } from "./schema";
@@ -43,8 +45,8 @@ export function viaMatches(via: string, item: CollectionItem, recordId: string):
   const tableField = via.slice(0, dot);
   const refColumn = via.slice(dot + 1);
   const rows = item[tableField];
-  if (!Array.isArray(rows)) return false;
-  return rows.some((row) => fieldTextOrNull((row as CollectionItem)?.[refColumn]) === recordId);
+  if (!isUnknownArray(rows)) return false;
+  return rows.some((row) => isRecord(row) && fieldTextOrNull(row[refColumn]) === recordId);
 }
 
 /** The SOURCE records whose `via` field stores `recordId` (compared as

--- a/packages/core/src/collection/core/calendarGrid.ts
+++ b/packages/core/src/collection/core/calendarGrid.ts
@@ -255,20 +255,21 @@ export interface DaySlice {
  *  null when the span doesn't cover that day. */
 export function daySlice<T>(span: RecordSpan<T>, day: Ymd): DaySlice | null {
   if (!spanCoversDay(span, day)) return null;
-  const hasStart = span.startMin !== null;
-  const hasEnd = span.endMin !== null;
-  if (!hasStart && !hasEnd) {
+  // Destructured so the `!== null` tests narrow the clocks where they are used;
+  // reading them back off `span` each time would not.
+  const { startMin: spanStart, endMin: spanEnd } = span;
+  if (spanStart === null && spanEnd === null) {
     return { kind: "allDay", startMin: 0, endMin: MINUTES_PER_DAY, bleedsBefore: false, bleedsAfter: false };
   }
   const singleDay = compareYmd(span.start, span.end) === 0;
   const isStartDay = compareYmd(day, span.start) === 0;
   const isEndDay = compareYmd(day, span.end) === 0;
   // A point in time: a start clock with no end, all on one day.
-  if (singleDay && hasStart && !hasEnd) {
-    return { kind: "line", startMin: span.startMin as number, endMin: span.startMin as number, bleedsBefore: false, bleedsAfter: false };
+  if (singleDay && spanStart !== null && spanEnd === null) {
+    return { kind: "line", startMin: spanStart, endMin: spanStart, bleedsBefore: false, bleedsAfter: false };
   }
-  const startMin = isStartDay && hasStart ? (span.startMin as number) : 0;
-  const endMin = isEndDay && hasEnd ? (span.endMin as number) : MINUTES_PER_DAY;
+  const startMin = isStartDay && spanStart !== null ? spanStart : 0;
+  const endMin = isEndDay && spanEnd !== null ? spanEnd : MINUTES_PER_DAY;
   // Zero-length or inverted same-day range → degrade to a line.
   if (singleDay && endMin <= startMin) {
     return { kind: "line", startMin, endMin: startMin, bleedsBefore: false, bleedsAfter: false };

--- a/packages/core/src/collection/core/project.ts
+++ b/packages/core/src/collection/core/project.ts
@@ -6,10 +6,13 @@
 
 //  Pruning a shallow copy keeps the caller's record type; rebuilding the object
 //  from `Object.entries` would only ever be a `Record<string, unknown>`.
+//  `Reflect.ownKeys` rather than `Object.keys` because the spread also copies
+//  enumerable SYMBOL keys, and a symbol can never be one of the requested
+//  `fields` — leaving it would return data the caller did not select.
 function withOnlyKeys<T extends Record<string, unknown>>(item: T, keep: Set<string>): T {
   const pruned = { ...item };
-  Object.keys(pruned)
-    .filter((key) => !keep.has(key))
+  Reflect.ownKeys(pruned)
+    .filter((key) => typeof key !== "string" || !keep.has(key))
     .forEach((key) => Reflect.deleteProperty(pruned, key));
   return pruned;
 }

--- a/packages/core/src/collection/core/project.ts
+++ b/packages/core/src/collection/core/project.ts
@@ -4,12 +4,22 @@
 // dependency-free so either side can import it; extracted to kill the
 // jscpd duplicate the two copies were.
 
+//  Pruning a shallow copy keeps the caller's record type; rebuilding the object
+//  from `Object.entries` would only ever be a `Record<string, unknown>`.
+function withOnlyKeys<T extends Record<string, unknown>>(item: T, keep: Set<string>): T {
+  const pruned = { ...item };
+  Object.keys(pruned)
+    .filter((key) => !keep.has(key))
+    .forEach((key) => Reflect.deleteProperty(pruned, key));
+  return pruned;
+}
+
 /** Keep only `fields` (+ `primaryKey`, always) on each record. No `fields`
  *  ⇒ records pass through untouched. */
 export function projectRecordFields<T extends Record<string, unknown>>(items: T[], fields: readonly string[] | undefined, primaryKey: string): T[] {
   if (!fields) return items;
   const keep = new Set([primaryKey, ...fields]);
-  return items.map((item) => Object.fromEntries(Object.entries(item).filter(([key]) => keep.has(key))) as T);
+  return items.map((item) => withOnlyKeys(item, keep));
 }
 
 /** Retrieved values laid over whatever the record already holds.

--- a/packages/core/src/collection/core/recordZ.ts
+++ b/packages/core/src/collection/core/recordZ.ts
@@ -26,6 +26,7 @@
 // deliberately NOT exported through the browser barrel; the server surface
 // re-exports it via `../server/validate`.
 
+import { isRecord } from "@mulmoclaude/common";
 import { z } from "zod";
 import { coerceNumeric } from "./backlinks";
 import { parseIsoDate, parseIsoDateTime } from "./calendarGrid";
@@ -91,9 +92,9 @@ function strictTableProblem(key: string, spec: Extract<CollectionFieldSpec, { ty
   if (!Array.isArray(value)) return `'${key}' = '${String(value)}' is not an array of rows (a 'table' field stores an array of row objects)`;
   for (let index = 0; index < value.length; index++) {
     const row: unknown = value[index];
-    if (!row || typeof row !== "object" || Array.isArray(row)) return `'${key}' row ${index + 1} is not an object`;
+    if (!isRecord(row)) return `'${key}' row ${index + 1} is not an object`;
     for (const [subKey, subSpec] of Object.entries(spec.of)) {
-      const subValue = (row as Record<string, unknown>)[subKey];
+      const subValue = row[subKey];
       // Typed checks apply to PRESENT sub-values only — an empty optional
       // cell is fine, mirroring the top-level gate in `recordFieldProblem`.
       const problem = enforcedProblem(subKey, subSpec, subValue) ?? (isEmptyValue(subValue) ? null : strictTypeProblem(subKey, subSpec, subValue));

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -16,6 +16,7 @@
 // `CollectionSchemaZ`). Runtime imports here point only at `./schema`'s
 // consts, so the module graph stays acyclic: schemaZ → schema.
 
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
 import { z } from "zod";
 import { isSafeSlug } from "./ids";
 import { isSafeActionTemplatePath, isSafeCustomViewI18nPath, isSafeCustomViewPath } from "./templatePath";
@@ -1115,28 +1116,46 @@ function ownPrototypeKey(value: unknown): string | null {
   return null;
 }
 
-/** Dotted path of the first prototype-sensitive field name in the raw
- *  schema input — top-level `fields`, each table field's `of`, and each
- *  action's `params` (the three records that DEFINE names) — or null. */
-function prototypeFieldKeyPath(input: unknown): string | null {
-  if (input === null || typeof input !== "object") return null;
-  const schema = input as { fields?: unknown; actions?: unknown; collectionActions?: unknown };
-  const bad = ownPrototypeKey(schema.fields);
-  if (bad !== null) return `fields.${bad}`;
-  for (const [key, spec] of Object.entries(schema.fields ?? {})) {
-    const badSub = ownPrototypeKey((spec as { of?: unknown } | null)?.of);
-    if (badSub !== null) return `fields.${key}.of.${badSub}`;
-  }
+/** Own enumerable entries of an object (arrays keyed by index), none for
+ *  anything else — the raw input is unvalidated, so `fields` may be junk. */
+function ownEntries(value: unknown): [string, unknown][] {
+  if (isUnknownArray(value)) return value.map((entry, index): [string, unknown] => [String(index), entry]);
+  return isRecord(value) ? Object.entries(value) : [];
+}
+
+/** The name-defining sub-record a raw field spec (`of`) or action (`params`)
+ *  carries, or undefined when the holder isn't an object at all. */
+function nameDefiningSubRecord(holder: unknown, key: "of" | "params"): unknown {
+  return isRecord(holder) ? holder[key] : undefined;
+}
+
+/** Dotted path of the first prototype-sensitive `params` name across both
+ *  action lists, or null. */
+function prototypeActionParamPath(input: Record<string, unknown>): string | null {
   for (const [listName, list] of [
-    ["actions", schema.actions],
-    ["collectionActions", schema.collectionActions],
+    ["actions", input.actions],
+    ["collectionActions", input.collectionActions],
   ] as const) {
-    for (const action of Array.isArray(list) ? list : []) {
-      const badParam = ownPrototypeKey((action as { params?: unknown } | null)?.params);
+    for (const action of isUnknownArray(list) ? list : []) {
+      const badParam = ownPrototypeKey(nameDefiningSubRecord(action, "params"));
       if (badParam !== null) return `${listName}.params.${badParam}`;
     }
   }
   return null;
+}
+
+/** Dotted path of the first prototype-sensitive field name in the raw
+ *  schema input — top-level `fields`, each table field's `of`, and each
+ *  action's `params` (the three records that DEFINE names) — or null. */
+function prototypeFieldKeyPath(input: unknown): string | null {
+  if (!isRecord(input)) return null;
+  const bad = ownPrototypeKey(input.fields);
+  if (bad !== null) return `fields.${bad}`;
+  for (const [key, spec] of ownEntries(input.fields)) {
+    const badSub = ownPrototypeKey(nameDefiningSubRecord(spec, "of"));
+    if (badSub !== null) return `fields.${key}.of.${badSub}`;
+  }
+  return prototypeActionParamPath(input);
 }
 
 export const CollectionSchemaZ = z.preprocess((input, ctx) => {

--- a/packages/core/src/collection/registry/server/importWriter.ts
+++ b/packages/core/src/collection/registry/server/importWriter.ts
@@ -133,7 +133,7 @@ function isRenameOf(name: string, slug: string): boolean {
 // (even if an earlier slug freed up). An authored skill without `.origin.json`
 // is invisible to this scan and so never collides with an update.
 async function findMatchingInstall(skillsDir: string, registry: string, entry: RegistryEntry): Promise<string | null> {
-  const names = await readdir(skillsDir).catch(() => [] as string[]);
+  const names = await readdir(skillsDir).catch((): string[] => []);
   for (const name of names) {
     if (!isRenameOf(name, entry.slug)) continue;
     const dir = path.join(skillsDir, name);
@@ -253,7 +253,7 @@ function bridgeAllowlistFiles(bundle: Map<string, string>): Set<string> {
  *  writing the new ones. */
 async function listFilesRecursive(root: string, prefix = ""): Promise<string[]> {
   const dir = prefix ? path.join(root, ...prefix.split("/")) : root;
-  const entries: Dirent[] = await readdir(dir, { withFileTypes: true }).catch(() => [] as Dirent[]);
+  const entries: Dirent[] = await readdir(dir, { withFileTypes: true }).catch((): Dirent[] => []);
   const out: string[] = [];
   for (const entry of entries) {
     const rel = prefix ? `${prefix}/${entry.name}` : entry.name;

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -16,7 +16,7 @@ import { CollectionSchemaZ } from "../core/schemaZ";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
-import { isErrorWithCode } from "@mulmoclaude/common";
+import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
 
 // Re-exported for the existing `collection/server` importers (manageCollection's
 // putSchema, the registry importWriter) that validate schemas the same way
@@ -34,10 +34,9 @@ export { CollectionSchemaZ };
 // its own folder, never another app's data (e.g. `data/wiki`). Non-object
 // input passes through so the Zod error stays clear.
 function applyFeedSchemaDefaults(parsed: unknown, slug: string): unknown {
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return parsed;
-  const obj = parsed as Record<string, unknown>;
-  const icon = typeof obj.icon === "string" && obj.icon.trim().length > 0 ? obj.icon : "dynamic_feed";
-  return { ...obj, icon, dataPath: `data/feeds/${slug}` };
+  if (!isRecord(parsed)) return parsed;
+  const icon = typeof parsed.icon === "string" && parsed.icon.trim().length > 0 ? parsed.icon : "dynamic_feed";
+  return { ...parsed, icon, dataPath: `data/feeds/${slug}` };
 }
 
 /** Result of the post-Zod acceptance gates: the resolved record dir (and,

--- a/packages/core/src/collection/server/io.ts
+++ b/packages/core/src/collection/server/io.ts
@@ -10,7 +10,7 @@ import { getWorkspaceRoot, log, publishCollectionChange } from "./host";
 import { writeFileAtomic } from "../../files/atomic.js";
 import { isContainedInRoot, itemFilePath, safeRecordId } from "./paths";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
-import { isErrorWithCode } from "@mulmoclaude/common";
+import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
 
 export interface IoOptions {
   /** Override the workspace root for containment checks. Default:
@@ -53,10 +53,7 @@ export async function isRegularFile(filePath: string): Promise<boolean> {
  *  null when it isn't a JSON object (array / scalar / null). */
 function parseRecordJson(raw: string): CollectionItem | null {
   const parsed: unknown = JSON.parse(raw);
-  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-    return parsed as CollectionItem;
-  }
-  return null;
+  return isRecord(parsed) ? parsed : null;
 }
 
 async function tryReadRecord(filePath: string): Promise<CollectionItem | null> {

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -43,6 +43,7 @@
 // evaluation-only validation ablation are injected, and tests point the
 // whole tool at a tmpdir workspace via the same deps.
 
+import { isRecord, isStringArray, isUnknownArray } from "@mulmoclaude/common";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { COMPUTED_TYPES } from "../core/schema";
@@ -134,10 +135,10 @@ interface PutItemsArgs {
 
 function optionalStringArray(value: unknown, name: string): { ok: true; value?: string[] } | { ok: false; error: string } {
   if (value === undefined) return { ok: true };
-  if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string" && entry.length > 0)) {
+  if (!isStringArray(value) || !value.every((entry) => entry.length > 0)) {
     return { ok: false, error: `manageCollection: \`${name}\` must be an array of non-empty strings when present.` };
   }
-  return { ok: true, value: value as string[] };
+  return { ok: true, value };
 }
 
 /** Project a record down to the requested fields. The primary key is
@@ -193,17 +194,18 @@ async function loadRequestedItems(
 }
 
 async function handleGetItems(collection: LoadedCollection, args: GetItemsArgs, deps: ManageCollectionDeps): Promise<string> {
-  const { items, missing } = await loadRequestedItems(collection, args.ids, deps);
-  if (!args.ids && !args.fields && items.length > MAX_UNSELECTIVE_ITEMS) {
+  const { ids, fields } = args;
+  const { items, missing } = await loadRequestedItems(collection, ids, deps);
+  if (!ids && !fields && items.length > MAX_UNSELECTIVE_ITEMS) {
     return `manageCollection: refused — '${collection.slug}' has ${items.length} records, over the unselective limit of ${MAX_UNSELECTIVE_ITEMS}. Pass \`ids\` for specific records or \`fields\` to project only the columns you need.`;
   }
   const enriched = await enrichItems(collection, items, deps);
-  const projected = args.fields ? enriched.map((item) => projectFields(item, args.fields as string[], collection.schema.primaryKey)) : enriched;
+  const projected = fields ? enriched.map((item) => projectFields(item, fields, collection.schema.primaryKey)) : enriched;
   // The warning scan reads every record file, so don't pay it on a
   // selective read that found everything it asked for — only a full
   // listing (where a malformed file silently looks absent) or a missing
   // requested id (where the scan explains WHY it's missing) needs it.
-  const warning = !args.ids || missing.length > 0 ? await recordIssuesWarning(collection, deps) : undefined;
+  const warning = !ids || missing.length > 0 ? await recordIssuesWarning(collection, deps) : undefined;
   return JSON.stringify({
     collection: collection.slug,
     count: projected.length,
@@ -378,19 +380,30 @@ async function deleteOneItem(removeItem: NonNullable<CollectionStore["delete"]>,
 
 function parseDeleteIds(args: Record<string, unknown>): string[] | string {
   const { ids } = args;
-  const valid = Array.isArray(ids) && ids.length > 0 && ids.every((entry) => typeof entry === "string" && entry.trim().length > 0);
+  const valid = isStringArray(ids) && ids.length > 0 && ids.every((entry) => entry.trim().length > 0);
   if (!valid) return "manageCollection: `ids` is required for deleteItems — a non-empty array of record ids.";
-  return ids as string[];
+  return ids;
+}
+
+const PUT_MODES: readonly PutMode[] = ["upsert", "create", "merge"];
+
+/** The requested write mode, defaulting when absent, or null when the caller
+ *  named a mode that doesn't exist. */
+function parsePutMode(mode: unknown): PutMode | null {
+  if (mode === undefined) return "upsert";
+  return PUT_MODES.find((candidate) => candidate === mode) ?? null;
+}
+
+function isRecordArray(value: unknown): value is CollectionItem[] {
+  return isUnknownArray(value) && value.every(isRecord);
 }
 
 function parsePutItems(args: Record<string, unknown>, slug: string): PutItemsArgs | string {
   const { items, mode } = args;
-  const validItems = Array.isArray(items) && items.length > 0 && items.every((entry) => Boolean(entry) && typeof entry === "object" && !Array.isArray(entry));
-  if (!validItems) return "manageCollection: `items` is required for putItems — a non-empty array of record objects.";
-  if (mode !== undefined && mode !== "upsert" && mode !== "create" && mode !== "merge") {
-    return 'manageCollection: `mode` must be "upsert" (default), "create", or "merge".';
-  }
-  return { slug, items: items as CollectionItem[], mode: (mode as PutItemsArgs["mode"] | undefined) ?? "upsert" };
+  if (!isRecordArray(items) || items.length === 0) return "manageCollection: `items` is required for putItems — a non-empty array of record objects.";
+  const putMode = parsePutMode(mode);
+  if (putMode === null) return 'manageCollection: `mode` must be "upsert" (default), "create", or "merge".';
+  return { slug, items, mode: putMode };
 }
 
 /** The machine-readable workspace ontology: every collection with its

--- a/packages/core/src/collection/server/skillAssets.ts
+++ b/packages/core/src/collection/server/skillAssets.ts
@@ -15,7 +15,7 @@ import { isRegularFile, type IoOptions } from "./io";
 import { resolveTemplatePath, safeSlugName } from "./paths";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
 import type { LoadedCollection } from "./discoveredCollection";
-import { isErrorWithCode } from "@mulmoclaude/common";
+import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
 
 /** The shape `readSourceAwareFile` (and its public callers
  *  `readCustomViewHtml` / `readCustomViewI18n`) need from a loaded collection:
@@ -87,8 +87,8 @@ const EMPTY_I18N: CustomViewI18nResult = { locale: "", dict: {} };
 
 function pickLocaleBlock(parsed: Record<string, unknown>, locale: string): Record<string, string> | null {
   const block = parsed[locale];
-  if (!block || typeof block !== "object" || Array.isArray(block)) return null;
-  const entries = Object.entries(block as Record<string, unknown>).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  if (!isRecord(block)) return null;
+  const entries = Object.entries(block).filter((entry): entry is [string, string] => typeof entry[1] === "string");
   return Object.fromEntries(entries);
 }
 
@@ -113,8 +113,8 @@ export async function readCustomViewI18n(
   } catch {
     return EMPTY_I18N;
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return EMPTY_I18N;
-  const obj = parsed as Record<string, unknown>;
+  if (!isRecord(parsed)) return EMPTY_I18N;
+  const obj = parsed;
   const primary = pickLocaleBlock(obj, locale);
   if (primary !== null && Object.keys(primary).length > 0) return { locale, dict: primary };
   if (locale !== I18N_FALLBACK_LOCALE) {

--- a/packages/core/src/collection/server/validate.ts
+++ b/packages/core/src/collection/server/validate.ts
@@ -15,7 +15,7 @@ import { storeFor } from "./store";
 import { firstRecordProblem, type RecordCheckTier } from "../core/recordZ";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionItem, CollectionSchema } from "../core/schema";
-import { isErrorWithCode } from "@mulmoclaude/common";
+import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
 
 // The compiled record validators (and COMPUTED_TYPES, which moved next to
 // them) live in the isomorphic ../core/recordZ; re-exported here so the
@@ -124,14 +124,14 @@ async function inspectRecord(fullPath: string, name: string, schema: CollectionS
       problem: `invalid JSON (${reason}) — SKIPPED, won't appear. Usual cause: an unescaped " inside a string value; use 「」/『』 or write \\" instead.`,
     };
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     return { file: name, problem: "not a JSON object — skipped, won't appear" };
   }
   // "strict" tier: the file scan is REPORT-ONLY (surfaced through
   // presentCollection / the detail response), so it lints the per-type
   // rules the write gate does not yet enforce — legacy records written
   // under the loose rules get reported here, never rejected on write.
-  const problem = validateRecordObject(parsed as CollectionItem, name.replace(/\.json$/, ""), schema, "strict");
+  const problem = validateRecordObject(parsed, name.replace(/\.json$/, ""), schema, "strict");
   return problem ? { file: name, problem } : null;
 }
 

--- a/packages/core/src/feeds/server/agentIngest.ts
+++ b/packages/core/src/feeds/server/agentIngest.ts
@@ -14,7 +14,7 @@ import { listItems, promptPathsFor, readSkillTemplate, buildCollectionActionSeed
 import { publish as publishNotifier, clear as clearNotifier } from "../../notifier/index.js";
 import { log, requireFeedsHost, type AgentWorkerResult, type AgentWorkerRunner } from "./host.js";
 import { readFeedState, writeFeedState, type FeedState } from "./state.js";
-import type { AgentIngestSpec } from "../ingestTypes.js";
+import { AGENT_INGEST_KIND } from "../ingestTypes.js";
 import type { RefreshResult } from "./refreshResult.js";
 
 export type { AgentWorkerResult, AgentWorkerRunner } from "./host.js";
@@ -44,8 +44,8 @@ function result(slug: string, patch: Partial<RefreshResult>): RefreshResult {
 export async function refreshViaAgent(workspaceRoot: string, collection: LoadedCollection, opts?: { hidden?: boolean }): Promise<RefreshResult> {
   const hidden = opts?.hidden ?? true;
   const { slug } = collection;
-  const ingest = collection.schema.ingest as AgentIngestSpec | undefined;
-  if (!ingest || ingest.kind !== "agent") return result(slug, { errors: ["collection has no agent ingest config"] });
+  const { ingest } = collection.schema;
+  if (ingest?.kind !== AGENT_INGEST_KIND) return result(slug, { errors: ["collection has no agent ingest config"] });
   const workerRunner = workerRunnerOrNull();
   if (!workerRunner) return result(slug, { errors: ["agent ingest worker runner not configured"] });
 

--- a/packages/core/src/feeds/server/engine.ts
+++ b/packages/core/src/feeds/server/engine.ts
@@ -23,12 +23,11 @@ export type { RefreshResult } from "./refreshResult.js";
 const ONE_HOUR_MS = 3_600_000;
 const ONE_DAY_MS = 86_400_000;
 
-/** Feed schemas carry the rich `IngestSpec` (validated at discovery —
- *  `source === "feed"` requires `ingest`), but the canonical
- *  `CollectionSchema.ingest` only promises the minimal `CollectionIngest`.
- *  Narrow here so the engine can read the retrieval fields type-safely. */
+/** A feed's retrieval config, or undefined. `CollectionSchema.ingest` and the
+ *  engine's `IngestSpec` are both `IngestZ`'s inferred union, so this is a
+ *  rename, not a narrowing — the engine keeps its own vocabulary at the seam. */
 function feedIngest(schema: CollectionSchema): IngestSpec | undefined {
-  return schema.ingest as IngestSpec | undefined;
+  return schema.ingest;
 }
 
 /** A feed's store. `write`/`delete` are always present (discovery rejects

--- a/packages/core/src/feeds/server/pathResolver.ts
+++ b/packages/core/src/feeds/server/pathResolver.ts
@@ -12,6 +12,8 @@
 // Any miss (wrong type, out-of-range index, absent key) yields
 // `undefined` rather than throwing — declarative configs fail soft.
 
+import { isRecord, isUnknownArray } from "@mulmoclaude/common";
+
 interface KeyToken {
   kind: "key";
   key: string;
@@ -49,13 +51,12 @@ function tokenize(path: string): PathToken[] {
 function step(current: unknown, token: PathToken): unknown {
   if (current === null || current === undefined) return undefined;
   if (token.kind === "key") {
-    if (typeof current !== "object" || Array.isArray(current)) return undefined;
-    const record = current as Record<string, unknown>;
+    if (!isRecord(current)) return undefined;
     // A `__proto__` / `constructor` / `toString` key must miss (→ undefined),
     // not read an inherited Object.prototype member into a `naturalKey`.
-    return Object.hasOwn(record, token.key) ? record[token.key] : undefined;
+    return Object.hasOwn(current, token.key) ? current[token.key] : undefined;
   }
-  return Array.isArray(current) ? current[token.index] : undefined;
+  return isUnknownArray(current) ? current[token.index] : undefined;
 }
 
 /** Resolve a dot/bracket path against `root`, or `undefined` on any miss. */

--- a/packages/core/src/feeds/server/projectItem.ts
+++ b/packages/core/src/feeds/server/projectItem.ts
@@ -9,6 +9,7 @@
 // re-fetches upsert in place. The natural key comes from the mapped
 // primaryKey value, then `ingest.idFrom`, then a content hash.
 
+import { isRecord } from "@mulmoclaude/common";
 import { createHash } from "node:crypto";
 import { getByPath } from "./pathResolver.js";
 import type { CollectionItem, CollectionSchema } from "../../collection/index.js";
@@ -26,10 +27,9 @@ function asKeyString(value: unknown): string | null {
  *  shape — so a tag like `<guid isPermaLink="false">id</guid>` maps to
  *  its text without the caller needing to write `.#text`. */
 function unwrapTextNode(value: unknown): unknown {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    const obj = value as Record<string, unknown>;
-    if (typeof obj["#text"] === "string") return obj["#text"];
-    if (typeof obj["#cdata"] === "string") return obj["#cdata"];
+  if (isRecord(value)) {
+    if (typeof value["#text"] === "string") return value["#text"];
+    if (typeof value["#cdata"] === "string") return value["#cdata"];
   }
   return value;
 }

--- a/packages/core/src/feeds/server/state.ts
+++ b/packages/core/src/feeds/server/state.ts
@@ -47,9 +47,17 @@ export function defaultFeedState(slug: string): FeedState {
   return { slug, lastFetchedAt: null, cursor: {}, consecutiveFailures: 0 };
 }
 
+/** The stored cursor, keeping only the string entries its type promises. A
+ *  hand-edited state file can hold anything; a non-string entry is unreadable
+ *  to every retriever, so carrying it forward would only re-persist junk. */
+function readCursor(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
+}
+
 function normalizeState(slug: string, parsed: Record<string, unknown>): FeedState {
   const base = defaultFeedState(slug);
-  const cursor = parsed.cursor && typeof parsed.cursor === "object" ? (parsed.cursor as Record<string, string>) : base.cursor;
+  const cursor = parsed.cursor === undefined ? base.cursor : readCursor(parsed.cursor);
   return {
     slug,
     lastFetchedAt: typeof parsed.lastFetchedAt === "string" ? parsed.lastFetchedAt : base.lastFetchedAt,

--- a/packages/core/src/google/calendarStateLock.ts
+++ b/packages/core/src/google/calendarStateLock.ts
@@ -14,6 +14,7 @@
 // What it does NOT do: stop two hosts walking the same calendar at once. That
 // wastes API calls, but the records are upserts and the baseline is now safe,
 // so nothing is lost by it.
+import { hasStringProp } from "@mulmoclaude/common";
 import { open, readFile, stat, unlink } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { log } from "./host.js";
@@ -68,9 +69,7 @@ async function readLockRaw(lockPath: string): Promise<string | null> {
 function parseLock(raw: string): LockFile | null {
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const { holder } = parsed as Partial<LockFile>;
-    return typeof holder === "string" ? { holder } : null;
+    return hasStringProp(parsed, "holder") ? { holder: parsed.holder } : null;
   } catch {
     return null;
   }

--- a/packages/core/src/google/pushPlan.ts
+++ b/packages/core/src/google/pushPlan.ts
@@ -16,7 +16,7 @@ export const PUSHABLE_SOURCE_FIELDS = ["summary", "start", "end", "colorId", "de
 
 export type PushableSourceField = (typeof PUSHABLE_SOURCE_FIELDS)[number];
 
-const isPushableSource = (source: string): source is PushableSourceField => (PUSHABLE_SOURCE_FIELDS as readonly string[]).includes(source);
+const isPushableSource = (source: string): source is PushableSourceField => PUSHABLE_SOURCE_FIELDS.some((field) => field === source);
 
 /** The subset of a schema's `map` a push can act on: collection field → event field. */
 export function pushableMap(map: Record<string, string>): Record<string, PushableSourceField> {

--- a/packages/core/src/notifier/engine.ts
+++ b/packages/core/src/notifier/engine.ts
@@ -291,7 +291,7 @@ function buildHistoryEntry(entry: NotifierEntry, terminalType: "cleared" | "canc
 export async function publish<TPluginData = unknown>(input: PublishInput<TPluginData>): Promise<{ id: string }> {
   // Validate at the engine boundary so plugin-runtime callers and
   // HTTP callers hit the same wall.
-  const validationError = validatePublishInput(input as PublishInput);
+  const validationError = validatePublishInput(input);
   if (validationError) {
     throw new Error(`notifier.publish: ${validationError}`);
   }
@@ -308,8 +308,8 @@ export async function publish<TPluginData = unknown>(input: PublishInput<TPlugin
     createdAt: new Date().toISOString(),
   };
   await enqueue((state) => {
-    state.entries[entryId] = entry as NotifierEntry;
-    return { event: { type: "published", entry: entry as NotifierEntry } };
+    state.entries[entryId] = entry;
+    return { event: { type: "published", entry } };
   });
   return { id: entryId };
 }

--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -117,6 +117,9 @@ const writeError = (ref: DocumentReference, code: string, message: string) =>
 // Returns the method/params to run, or null if another handler already took it.
 const claimCommand = (firestore: Firestore, ref: DocumentReference): Promise<Claim | null> =>
   runTransaction(firestore, async (txn) => {
+    // Cast kept (#2692): `params` must satisfy `JsonObject`, and the only
+    // honest guard for that is a deep JSON walk whose rejection path would
+    // leave a malformed doc stuck in `queued` instead of erroring back.
     const data = (await txn.get(ref)).data() as Command | undefined;
     if (!data || data.status !== "queued") {
       return null;
@@ -232,6 +235,9 @@ const dispatchAddedCommands = (ctx: RunnerContext, snapshot: QuerySnapshot): voi
   snapshot
     .docChanges()
     .filter((change) => change.type === "added")
+    // Cast kept (#2692): this doc rides verbatim into the host's `onExpire`
+    // callback, so rebuilding it from checked fields would silently drop
+    // whatever else the remote wrote.
     .map((change) => ({ ref: change.doc.ref, command: change.doc.data() as Command }))
     .sort((left, right) => byCreatedAt(left.command, right.command))
     .forEach(({ ref, command }) => {

--- a/packages/core/src/remote-view/index.ts
+++ b/packages/core/src/remote-view/index.ts
@@ -20,6 +20,7 @@
 // (`{ items, total, offset, limit }`), or tighten limits a shipped view may
 // already rely on.
 
+import { isRecord } from "@mulmoclaude/common";
 import { projectRecordFields } from "../collection/core/project";
 
 /** Bump when the bootstrap/message contract changes shape; the bootstrap
@@ -293,8 +294,9 @@ export function normalizeMutate(data: { op?: unknown; id?: unknown; patch?: unkn
   if (!itemId) return null;
   if (data.op === "delete") return { op: "delete", id: itemId };
   if (data.op === "update") {
-    if (typeof data.patch !== "object" || data.patch === null || Array.isArray(data.patch)) return null;
-    return { op: "update", id: itemId, patch: data.patch as Record<string, unknown> };
+    const { patch } = data;
+    if (!isRecord(patch)) return null;
+    return { op: "update", id: itemId, patch };
   }
   return null;
 }
@@ -345,20 +347,8 @@ type RemoteViewReply = (message: Record<string, unknown>) => void;
  * was a remote-view request for this slug (callers ignore everything else).
  */
 export async function handleRemoteViewMessage(data: unknown, handlers: RemoteViewBridgeHandlers, reply: RemoteViewReply): Promise<boolean> {
-  if (typeof data !== "object" || data === null) return false;
-  const msg = data as {
-    type?: unknown;
-    slug?: unknown;
-    requestId?: unknown;
-    offset?: unknown;
-    limit?: unknown;
-    fields?: unknown;
-    op?: unknown;
-    id?: unknown;
-    patch?: unknown;
-    prompt?: unknown;
-    role?: unknown;
-  };
+  if (!isRecord(data)) return false;
+  const msg = data;
   if (msg.slug !== handlers.slug) return false;
   if (msg.type === REMOTE_VIEW_MESSAGES.startChat) {
     const prompt = typeof msg.prompt === "string" ? msg.prompt.trim() : "";

--- a/packages/core/src/whisper/sidecar-helpers.ts
+++ b/packages/core/src/whisper/sidecar-helpers.ts
@@ -2,6 +2,8 @@
 // so the argv/response/stderr logic can be unit-tested without spawning a
 // process or opening a socket.
 
+import { hasStringProp } from "@mulmoclaude/common";
+
 /** whisper-server CLI args to preload `modelPath` and bind to `host:port`. */
 export function buildServerArgs(modelPath: string, host: string, port: number): string[] {
   return ["--model", modelPath, "--host", host, "--port", String(port)];
@@ -15,9 +17,5 @@ export function appendStderrTail(previous: string, chunk: string, maxChars: numb
 /** Extract the transcript from a whisper-server `/inference` JSON response.
  *  Returns "" for any shape that lacks a string `text` field. */
 export function parseInferenceText(data: unknown): string {
-  if (typeof data === "object" && data !== null && "text" in data) {
-    const { text } = data as { text: unknown };
-    if (typeof text === "string") return text;
-  }
-  return "";
+  return hasStringProp(data, "text") ? data.text : "";
 }

--- a/packages/core/src/wiki/route.ts
+++ b/packages/core/src/wiki/route.ts
@@ -12,6 +12,7 @@
 // literals don't drift across the router definition, guards, views,
 // and tests.
 
+import { isRecord } from "@mulmoclaude/common";
 import { isSafeSlug } from "./slug.js";
 
 // URL segment used in `/wiki/:section/...`. Closed enum — the router
@@ -68,8 +69,8 @@ export function isSafeWikiSlug(value: unknown): value is string {
 // so the caller can decide what to do — the router guard redirects to
 // `/wiki`, the view watcher treats it as "render the index".
 export function readWikiRouteTarget(params: unknown): WikiTarget | null {
-  if (!params || typeof params !== "object") return null;
-  const { section, slug } = params as { section?: unknown; slug?: unknown };
+  if (!isRecord(params)) return null;
+  const { section, slug } = params;
 
   if (section === undefined || section === "") return { kind: "index" };
 

--- a/packages/core/test/collection/test_backlinks.ts
+++ b/packages/core/test/collection/test_backlinks.ts
@@ -58,6 +58,20 @@ test("dotted via is fail-soft: absent / non-array table field, or rows missing t
   assert.equal(viaMatches("characters.character", chapterEmpty, "hero"), false, "empty table");
 });
 
+test("a non-object table row matches nothing — never the row's own intrinsic members", () => {
+  // A `table` field stores row OBJECTS. Reading a column off a row that is a
+  // string / number / null used to reach through to the primitive's own
+  // members, so `via: "lines.length"` compared a string row's LENGTH against
+  // the record id and reported a backlink that does not exist. Rows are gated
+  // on being records now, so every non-object row is skipped instead.
+  assert.equal(viaMatches("lines.length", { lines: ["abc"] }, "3"), false, "a string row's `length` is not a ref value");
+  assert.equal(viaMatches("lines.ref", { lines: ["abc"] }, "abc"), false, "string row");
+  assert.equal(viaMatches("lines.ref", { lines: [42] }, "42"), false, "number row");
+  assert.equal(viaMatches("lines.ref", { lines: [null] }, "hero"), false, "null row");
+  // A malformed row alongside a good one must not hide the good one.
+  assert.equal(viaMatches("lines.ref", { lines: [null, "abc", { ref: "hero" }] }, "hero"), true, "valid row still matches");
+});
+
 test("an exact top-level key containing a dot keeps flat-match behavior (no nesting regression)", () => {
   // `schemaZ` allows field names with dots (`z.string()`), so a top-level ref
   // column literally named "client.id" must still match `item["client.id"]`

--- a/packages/core/test/collection/test_project.ts
+++ b/packages/core/test/collection/test_project.ts
@@ -1,0 +1,36 @@
+// `projectRecordFields` is the ONE projection behind the server store layer and
+// the remote-view page builder, so "what does a projected record still carry?"
+// is a contract both sides depend on. These pin the boundaries the
+// entries-rebuild → prune-a-copy rewrite had to preserve: the record's own type,
+// the caller's input, and the rule that nothing outside `fields` survives.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { projectRecordFields } from "../../src/collection/core/project.ts";
+
+const records = [{ id: "a", title: "T", note: "drop-me", n: 1 }, { id: "b" }, { id: "c", title: null, nested: { x: [1, 2] } }];
+
+test("no `fields` passes the records through untouched (same array identity)", () => {
+  assert.equal(projectRecordFields(records, undefined, "id"), records);
+});
+
+test("keeps only the requested fields plus the primary key", () => {
+  assert.deepEqual(projectRecordFields(records, ["title"], "id"), [{ id: "a", title: "T" }, { id: "b" }, { id: "c", title: null }]);
+  assert.deepEqual(projectRecordFields(records, [], "id"), [{ id: "a" }, { id: "b" }, { id: "c" }]);
+  assert.deepEqual(projectRecordFields(records, ["nope"], "id"), [{ id: "a" }, { id: "b" }, { id: "c" }]);
+});
+
+test("does not mutate the records it was given", () => {
+  projectRecordFields(records, ["title"], "id");
+  assert.deepEqual(records[0], { id: "a", title: "T", note: "drop-me", n: 1 });
+});
+
+test("a symbol-keyed property is dropped — a symbol can never be a requested field", () => {
+  // Pruning a shallow copy is what keeps the record's type, but the spread also
+  // copies enumerable SYMBOL keys, which `Object.keys` would not have seen.
+  // Leaving one would hand the caller data it did not select (CodeRabbit, #2730).
+  const marker = Symbol("marker");
+  const [projected] = projectRecordFields([{ id: "a", title: "T", [marker]: "leaked" }], ["title"], "id");
+  assert.deepEqual(Object.getOwnPropertySymbols(projected), [], "no symbol survives the projection");
+  assert.deepEqual(projected, { id: "a", title: "T" });
+});

--- a/packages/core/test/wiki/test_route.ts
+++ b/packages/core/test/wiki/test_route.ts
@@ -89,6 +89,11 @@ describe("readWikiRouteTarget", () => {
     assert.equal(readWikiRouteTarget(null), null);
     assert.equal(readWikiRouteTarget(undefined), null);
     assert.equal(readWikiRouteTarget("pages"), null);
+    // An array is `typeof "object"`, so it used to slip through the non-object
+    // gate and — having no `section` — resolve as the index route. Route params
+    // are a plain object; anything else is the "invalid state" null path.
+    assert.equal(readWikiRouteTarget([]), null, "array params are not route params");
+    assert.equal(readWikiRouteTarget(["pages", "onboarding"]), null, "a positional array is still not route params");
   });
 });
 

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -211,7 +211,7 @@ function mirrorSkillDelete(workspaceRoot2, slug) {
   return { dest };
 }
 
-// packages/core/dist/dist-HC-r8qQi.js
+// packages/core/dist/dist-D8zokgGo.js
 function isRecord2(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary

`packages/core` の `as` 型アサーション **40 → 6**（うち 4 件は未マージ PR #2727 が所有するファイルなので対象外、実質 **36 → 2**）。
残った 2 件は `remote-host/server/hostRunner.ts` の Firestore ドキュメント読み出しで、理由を 1 行コメントで明示して意図的に残した。
`packages/core` の **public export は一切変更していない**（npm 公開パッケージのため version も据え置き）。
`server/build/dispatcher.mjs` は core の dist チャンク名が変わるため 1 行だけ再生成が必要になり、同梱している。

## Items to Confirm / Review

**壊れた/部分的なペイロードが今どうなるか（サイト別）**

| 箇所 | 変更前 | 変更後 |
|---|---|---|
| `collection/core/backlinks.ts` `viaMatches` | `table` 行が非オブジェクト（文字列など）でも `row[refColumn]` を読んでいた | `isRecord` を通らない行はマッチしない。**唯一の実挙動差**（下記「検証」の差分①） |
| `collection/core/project.ts` `projectRecordFields` | `Object.fromEntries` で再構築 → `as T` | 浅いコピーから不要キーを `Reflect.deleteProperty` で削る。返却型が本当に `T` になる。入力は非破壊（検証済み） |
| `collection/core/recordZ.ts` `strictTableProblem` | `row as Record<string, unknown>` | `isRecord(row)` で判定。ガード条件は元の `!row \|\| typeof !== "object" \|\| Array.isArray` と完全一致 |
| `collection/core/schemaZ.ts` prototype-key 前処理 | 生入力を 3 箇所で構造アサーション | `isRecord` / `isUnknownArray` + ローカルヘルパ。`fields` が配列・文字列・`actions` が非配列・`null` 要素…といった壊れた入力での **zod issue 出力が完全一致**することを確認済み |
| `collection/server/io.ts` `parseRecordJson` | `parsed as CollectionItem` | `isRecord(parsed) ? parsed : null`。壊れたレコードは従来どおり `null`（呼び出し側の "missing" 扱い）で、スキップ範囲は不変 |
| `collection/server/validate.ts` | `parsed as CollectionItem` | `isRecord` 判定。JSON オブジェクトでないファイルは従来どおり `"not a JSON object — skipped"` |
| `collection/server/manageTool.ts` `optionalStringArray` / `parseDeleteIds` | `value as string[]` | `isStringArray`（共有ガード）+ 空文字チェックは元のまま（`fields` は `length > 0`、`ids` は `trim().length > 0` で**別条件のまま維持**） |
| `collection/server/manageTool.ts` `parsePutItems` | `items as CollectionItem[]` / `mode as PutItemsArgs["mode"]` | `isRecordArray`（`isUnknownArray + every(isRecord)`）と `PUT_MODES.find()`。不正 `mode` のエラーメッセージは同一文字列 |
| `collection/server/skillAssets.ts` i18n | `block as Record<string, unknown>` | `isRecord`。locale ブロック内の非文字列値を落とす挙動は従来どおり |
| `feeds/server/state.ts` `normalizeState` | `parsed.cursor as Record<string, string>` | **要確認**: cursor は `Record<string, string>` を宣言しているのに、非文字列値がそのまま通っていた。今は文字列エントリだけを残す。cursor を読むコードは core に無く（retriever が書いて次回書き戻すだけ）、宣言型に違反するエントリのみが落ちる。cursor キー自体は保持される |
| `google/calendarStateLock.ts` | `parsed as Partial<LockFile>` | `hasStringProp(parsed, "holder")` で確認済みフィールドから再構築 |
| `notifier/engine.ts` (3 箇所) | `input as PublishInput` / `entry as NotifierEntry` | **キャストは元々 no-op だった**。`PublishInput<T>` / `NotifierEntry<T>` は `pluginData?: T` が唯一のジェネリック位置なので `unknown` インスタンスへそのまま代入可能。削除のみで typecheck 通過 |
| `feeds/server/engine.ts` `feedIngest` / `agentIngest.ts` | `schema.ingest as IngestSpec` | **キャストは元々 no-op だった**。`CollectionSchema.ingest` も feeds の `IngestSpec` も同じ `IngestZ` の推論結果。コメントが「最小の `CollectionIngest` しか約束しない」と主張していたが実装と乖離していたので直した |
| `wiki/route.ts` `readWikiRouteTarget` | `params as { section?, slug? }` | `isRecord(params)`。**実挙動差**: 配列を渡すと従来 `{kind:"index"}`、今は `null`（下記 差分②） |
| `remote-view/index.ts` | `data.patch as Record<string, unknown>` / `msg = data as {...}` | `isRecord`。iframe からの不正メッセージの応答は全経路で同一（検証済み） |
| `whisper/sidecar-helpers.ts` | `data as { text: unknown }` | `hasStringProp(data, "text")` |

**意図的に残したキャスト（2 件、どちらも `remote-host/server/hostRunner.ts`）**

- L123 `claimCommand`: `(await txn.get(ref)).data() as Command | undefined`
  `Claim.params` は `JsonObject`（= 再帰的な JSON 型）を満たす必要があり、正直なガードは深い JSON ウォークになる。そのガードが弾いた場合、壊れたドキュメントは `queued` のまま取り残され、**今なら書き戻されるエラー応答（`unknown_method`）がモバイル側に届かなくなる**。失敗経路を悪化させるので見送り。
- L241 `dispatchAddedCommands`: `change.doc.data() as Command`
  この doc はホスト側の `onExpire(command, uid)` コールバックへ**そのまま**渡る（`server/remoteHost/onExpire.ts` が `command.params.attachments` を読む）。検証済みフィールドから組み直すと、リモートが書いた他のフィールドを黙って落とすことになる。

いずれも「型を綺麗にするために永続データ / 障害通知を悪化させない」という判断です。ここは人間のレビューを希望します。

## 実装方針

- 新しい述語を書くより **`@mulmoclaude/common` の既存ガードを使う**方針（`isRecord` / `isUnknownArray` / `isStringArray` / `hasStringProp`）。`docs/shared-utils.md` は「`isRecord` の実装が 12 個ある」と警告しているので 13 個目は作らない。
- 型述語（`value is T`）も**チェックしていない事は主張しない**。新規に書いたのは `isRecordArray`（`isUnknownArray` + 全要素 `isRecord` を実際に確認）のみ。
- `manageTool` の `mode` は `PUT_MODES.find()` で照合して `PutMode | null` を返す。述語を書かずに済み、既定値 `"upsert"` の適用位置も元のまま。
- `calendarGrid.daySlice` は `hasStart` / `hasEnd` という boolean 経由だったので narrowing が効かずキャストしていた。`const { startMin, endMin } = span` に分解して `!== null` を使用箇所で直接効かせた。
- `projectRecordFields` は「エントリから再構築」をやめ「浅いコピーから削る」に変更。これで宣言どおり `T` を返す（再構築だと `Record<string, unknown>` にしかならない）。
- `schemaZ` の prototype キー走査は 20 行を超えるので `ownEntries` / `nameDefiningSubRecord` / `prototypeActionParamPath` に分割。`ownEntries` は**配列も index キーで列挙**して元の `Object.entries` の挙動を保存している。
- 新規に追加した共有ヘルパは無し（すべてファイルローカル）なので `docs/shared-utils.md` の更新は不要。
- 対象外ファイル（PR #2727 が所有）: `collection/server/csvQuery.ts` / `collection/server/csvStore.ts` / `plugin-vue/sanitizeMarkdownHtml.ts` / `remote-host/index.ts`。

## 検証

すべて `origin/main` から切った専用 worktree で実施（`node_modules` はワークスペース参照が worktree 内を指すことを `require.resolve` で確認済み）。

```
npx prettier --write <touched files>          # 全ファイル unchanged
npx eslint packages/core/src                  # 0 errors / 21 warnings
                                              #   → consistent-type-assertions は 6 件だけ
                                              #     (対象外 4 + 意図的に残した 2)
cd packages/core && yarn typecheck            # 0 errors
cd packages/core && yarn test                 # 710 pass / 0 fail
yarn typecheck        (repo root, 全 workspace) # 0 errors
npx tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts
                                              # tests 8900 / pass 8893 / fail 0 / skip 7
```

### リスクの高い経路の外部 ground truth 差分

`projectRecordFields` / `daySlice` / `viaMatches` / `CollectionSchemaZ`（prototype 前処理）/ `normalizeMutate` / `handleRemoteViewMessage` / `readWikiRouteTarget` / `parseInferenceText` を、**正常入力・壊れた入力・欠落入力**の 60 ケースで実行して JSON 化するスクリプトを書き、`git checkout origin/main -- packages/core/src` で本体だけを切り替えて **同一スクリプトを両リビジョンで実行**し diff を取りました（スクリプトは削除済み）。

差分は 2 行のみ:

```diff
   "via/row-string-length",       // viaMatches("lines.length", { lines: ["abc"] }, "3")
-  true
+  false
```
① `table` 行が文字列 `"abc"` で、`via` が `lines.length` のとき、旧実装は文字列の `.length`（= 3）を ref 値として比較していた。`isRecord` ガードでマッチしなくなる。`table` フィールドは「行オブジェクトの配列」を格納する契約なので、これは修正側。

```diff
   "wiki/array",
-  { "kind": "index" }
+  null
```
② `readWikiRouteTarget([])`。`typeof [] === "object"` なので配列が「セクション未指定」として index 判定されていた。`isRecord` は配列を弾くので `null`（= 呼び出し側の「不正な状態」経路）になる。既存テストの `"rejects non-object input"` の意図どおりで、そもそも vue-router の `route.params` は必ずプレーンオブジェクト。

他の 58 ケース（zod issue の文字列まで含む）は**バイト単位で一致**。とくに `schema/fields-array` / `schema/fields-string` / `schema/actions-not-array` / `schema/action-null` / `schema/top-array` が一致したことで、`schemaZ` の書き換えが壊れた入力に対しても同じ判定をしていることを確認しています。

### ビルド成果物

`docs/build-orchestration.md` の手順どおり、**まず未変更の `origin/main` をこの worktree でビルドして、コミット済み `server/build/dispatcher.mjs` がバイト一致で再生産されること**を確認（`git diff --exit-code` clean）してから、変更込みで再ビルドしました。

差分は 1 行のみ:

```diff
-// packages/core/dist/dist-HC-r8qQi.js
+// packages/core/dist/dist-D8zokgGo.js
```

core の dist チャンクのハッシュが変わったことによるソース注記の更新で、バンドルされたコード本体に差分はありません。CI の `git diff --exit-code` ゲートを通すため同梱しています。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Reduce unsafe type assertions in packages/core by replacing them with shared runtime guards while preserving public API behavior and documented runtime semantics.

Enhancements:
- Replace many `as` casts with existing `@mulmoclaude/common` predicates (isRecord, isUnknownArray, isStringArray, hasStringProp) across core, server, feeds, wiki, remote-view, and whisper utilities to harden input validation.
- Refine projection and calendar helpers so they respect declared types (e.g., projectRecordFields preserves record types, daySlice narrows time span fields correctly) without relying on assertions.
- Adjust feed state and path resolution logic to drop invalid cursor entries and safely traverse nested config structures.
- Tighten prototype-key detection in CollectionSchemaZ using helper functions that handle broken inputs while keeping zod error outputs stable.
- Use explicit helper functions for collection write modes and record arrays in manageTool to validate incoming payloads more robustly.
- Clarify ingest typing in feeds engine and agent ingest by aligning usage with the validated schema kind constants instead of type assertions.
- Slightly refine push plan and registry import writer helpers for safer primitive checks and error handling around filesystem operations.
- Add comments in hostRunner to justify the remaining Firestore Command casts as intentional trade-offs for error reporting and data fidelity.

Build:
- Regenerate dispatcher.mjs to reflect the new core dist chunk hash while keeping bundled runtime code identical.

Tests:
- Keep behavior parity across critical flows (schema preprocessing, backlinks, remote-view messaging, wiki routing, inference parsing, etc.) with targeted ground-truth comparisons and existing test suites, accepting only two small, intentional behavior fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and handling of records, arrays, schemas, feed data, cursors, routes, and configuration inputs.
  * Strengthened protection against unsafe schema keys such as `__proto__`, `constructor`, and `prototype`.
  * Ensured persisted feed cursors accept only valid string values.
  * Improved handling of malformed rows and route inputs.
  * Standardized validation of calendar, import, notification, and content-processing data.

* **Refactor**
  * Consolidated validation and supported-mode checks for more consistent behavior.
  * Improved type safety and reliability without changing expected runtime behavior.

* **Tests**
  * Added regression coverage for malformed data, field projection, and route validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->