### PR TITLE
refactor: remove `as` type assertions across server/ (42 -> 3)

### DIFF
--- a/server/agent/activeTools.ts
+++ b/server/agent/activeTools.ts
@@ -31,6 +31,7 @@ import type { ToolDefinition } from "gui-chat-protocol";
 import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { PLUGIN_DEFS, TOOL_ENDPOINTS } from "./plugin-names.js";
 import { getRuntimePlugins } from "../plugins/runtime-registry.js";
+import { hasStringProp } from "../utils/types.js";
 
 /** The MCP server id the parent registers via `--mcp-config` (see
  *  `buildMulmoclaudeServer` in `config.ts`). The Claude Agent SDK
@@ -70,12 +71,7 @@ export interface ActiveToolDescriptor {
 
 const FULL_PREFIX = `mcp__${MCP_SERVER_ID}__`;
 const fullNameFor = (toolName: string): string => `${FULL_PREFIX}${toolName}`;
-const promptFor = (def: ToolDefinition): string | undefined => {
-  if ("prompt" in def && typeof (def as { prompt?: unknown }).prompt === "string") {
-    return (def as { prompt: string }).prompt;
-  }
-  return undefined;
-};
+const promptFor = (def: ToolDefinition): string | undefined => (hasStringProp(def, "prompt") ? def.prompt : undefined);
 
 export function getActiveToolDescriptors(role: Role): ActiveToolDescriptor[] {
   const allowed = new Set<string>(role.availablePlugins);

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -180,7 +180,7 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
 
   let buffer = "";
   for await (const chunk of proc.stdout) {
-    buffer += (chunk as Buffer).toString();
+    buffer += String(chunk);
     const lines = buffer.split("\n");
     buffer = lines.pop() ?? "";
 

--- a/server/agent/backend/fake-echo.ts
+++ b/server/agent/backend/fake-echo.ts
@@ -29,6 +29,7 @@ import path from "node:path";
 import { getCurrentToken } from "../../api/auth/token.js";
 import { errorMessage } from "../../utils/errors.js";
 import { makeUuid } from "../../utils/id.js";
+import { isRecord } from "../../utils/types.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { EVENT_TYPES } from "../../../src/types/events.js";
 import { WORKSPACE_DIRS } from "../../workspace/paths.js";
@@ -242,7 +243,8 @@ async function dispatchToPlugin(call: FakeToolCall, port: number, chatSessionId:
       const errBody = await response.text();
       return JSON.stringify({ error: `plugin ${call.toolName} returned ${response.status}: ${errBody.slice(0, 200)}` });
     }
-    const envelope = ((await response.json()) ?? {}) as PluginEnvelope;
+    const parsed: unknown = await response.json();
+    const envelope: PluginEnvelope = isRecord(parsed) ? parsed : {};
     if (envelope.data !== undefined) {
       // Query key is `session`, not `chatSessionId` — matches the
       // `getSessionQuery(req)` reader and what the MCP bridge's

--- a/server/agent/mcp-tools/handlePermission.ts
+++ b/server/agent/mcp-tools/handlePermission.ts
@@ -62,11 +62,6 @@ function buildDenyGenericMessage(toolName: string): string {
   );
 }
 
-interface PermissionInput {
-  tool_name?: unknown;
-  input?: unknown;
-}
-
 function buildDenyResponse(message: string): string {
   return JSON.stringify({ behavior: "deny", message });
 }
@@ -97,8 +92,7 @@ export const handlePermission: McpTool = {
   // directly through the `--permission-prompt-tool` flag.
 
   async handler(args: Record<string, unknown>, __ctx?: McpToolContext): Promise<string> {
-    const raw = args as PermissionInput;
-    const toolName = typeof raw.tool_name === "string" ? raw.tool_name : "";
+    const toolName = typeof args.tool_name === "string" ? args.tool_name : "";
 
     if (toolName === ASK_USER_QUESTION_TOOL_NAME) {
       log.info("mcp/handlePermission", "deny AskUserQuestion — instruct LLM to use presentForm");

--- a/server/api/auth/viewToken.ts
+++ b/server/api/auth/viewToken.ts
@@ -58,7 +58,7 @@ function signPayload(payloadB64: string, key: string): string {
  *  the least-privilege default `["read"]`; undefined requested ⇒ grant the
  *  full declared set. The result is `declared ∩ requested`. */
 export function clampCapabilities(declared: ViewCapability[] | undefined, requested: ViewCapability[] | undefined): ViewCapability[] {
-  const declaredCaps = declared && declared.length > 0 ? declared : (["read"] as ViewCapability[]);
+  const declaredCaps: ViewCapability[] = declared && declared.length > 0 ? declared : ["read"];
   const requestedCaps = requested && requested.length > 0 ? requested : declaredCaps;
   return declaredCaps.filter((cap) => requestedCaps.includes(cap));
 }

--- a/server/api/routes/agent.ts
+++ b/server/api/routes/agent.ts
@@ -1134,7 +1134,7 @@ function runPostTurnSideEffects(chatSessionId: string, requestStartedAt: number)
 // Read claudeSessionId from meta (primary) or jsonl (legacy fallback).
 async function readClaudeSessionIdFromSession(chatSessionId: string): Promise<string | undefined> {
   const meta = await readSessionMeta(chatSessionId);
-  if (meta?.claudeSessionId) return meta.claudeSessionId as string;
+  if (meta?.claudeSessionId) return meta.claudeSessionId;
   // Legacy scan: search jsonl lines backwards for a claudeSessionId event
   const jsonl = await readSessionJsonl(chatSessionId);
   if (!jsonl) return undefined;

--- a/server/api/routes/collectionAgentActions.ts
+++ b/server/api/routes/collectionAgentActions.ts
@@ -107,13 +107,14 @@ async function onWorkerComplete(
 ): Promise<void> {
   clearRunning(collection.slug, key);
   const bellKey = `${collection.slug}\n${key}`;
+  const existingBell = failureBells.get(bellKey);
   try {
-    if (didError && !failureBells.has(bellKey)) {
+    if (didError && existingBell === undefined) {
       const body = `“${action.label}” on “${collection.schema.title}” (${collection.slug}) failed. Open the collection to retry.`;
       failureBells.set(bellKey, await deps.notifyFailure("Collection action failed", body, collection.slug));
     }
-    if (!didError && failureBells.has(bellKey)) {
-      await deps.clearNotification(failureBells.get(bellKey) as string);
+    if (!didError && existingBell !== undefined) {
+      await deps.clearNotification(existingBell);
       failureBells.delete(bellKey);
     }
   } catch (err) {

--- a/server/api/routes/collectionParams.ts
+++ b/server/api/routes/collectionParams.ts
@@ -9,6 +9,7 @@
 
 import type { CollectionItem } from "../../workspace/collections/index.js";
 import type { ViewCapability } from "../auth/viewToken.js";
+import { isRecord } from "../../utils/types.js";
 
 /** Parse a `read`/`write` capability list from a request body value.
  *  Anything else in the list is dropped rather than rejected — the result is
@@ -48,6 +49,5 @@ export function stringParam(value: unknown): string {
  *  otherwise pass a bare `typeof === "object"` check and be written as a
  *  record with numeric keys. */
 export function extractRecord(body: unknown): CollectionItem | null {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
-  return body as CollectionItem;
+  return isRecord(body) ? body : null;
 }

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -29,7 +29,13 @@ import { loadReferenceDirs, saveReferenceDirs, validateReferenceDirs, type Refer
 
 // ── Scheduler overrides (#493) ──────────────────────────────────
 
-import { loadSchedulerOverrides, saveSchedulerOverrides, UTC_HH_MM_RE, type ScheduleOverrides } from "../../utils/files/scheduler-overrides-io.js";
+import {
+  keepValidOverrides,
+  loadSchedulerOverrides,
+  saveSchedulerOverrides,
+  UTC_HH_MM_RE,
+  type ScheduleOverrides,
+} from "../../utils/files/scheduler-overrides-io.js";
 import { applyScheduleOverride } from "../../events/scheduler-adapter.js";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { ONE_SECOND_MS } from "../../utils/time.js";
@@ -291,7 +297,7 @@ router.put(
       badRequest(res, "overrides must be an object");
       return;
     }
-    const overrides = raw as ScheduleOverrides;
+    const overrides = keepValidOverrides(raw);
     saveSchedulerOverrides(overrides);
 
     // Apply to running task-manager immediately

--- a/server/api/routes/files.ts
+++ b/server/api/routes/files.ts
@@ -65,7 +65,7 @@ export type Spawner = typeof spawn;
 
 function spawnDetachedOsCommand(command: string, args: readonly string[], label: string, spawner: Spawner): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    const child = spawner(command, args as string[], { detached: true, stdio: "ignore" });
+    const child = spawner(command, args, { detached: true, stdio: "ignore" });
     let settled = false;
     child.once("error", (err) => {
       if (settled) return;

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -12,6 +12,7 @@ import { mulmoScriptOps } from "../../plugins/mulmoscript-server.js";
 import { errorMessage } from "../../utils/errors.js";
 import { badRequest, notFound } from "../../utils/httpError.js";
 import { getOptionalStringQuery, getSessionQuery } from "../../utils/request.js";
+import { requestBodyRecord } from "../../utils/requestBody.js";
 import { API_ROUTES } from "../../../src/config/apiRoutes.js";
 import { bindRoute } from "../../utils/router.js";
 import { GENERATION_KINDS } from "../../../src/types/events.js";
@@ -142,7 +143,7 @@ bindRoute(router, API_ROUTES.mulmoScript.save, async (req: Request<object, objec
 // package execute they call: guard the wire path, run the execute, map a
 // failure onto the pre-extraction status, else 200. Share the shell.
 async function runGuardedUpdate(req: Request<object, object, unknown>, res: Response, execute: typeof executeUpdateBeat): Promise<void> {
-  const guard = mulmoScriptOps.guardStoryWirePath((req.body as { filePath?: unknown } | undefined)?.filePath);
+  const guard = mulmoScriptOps.guardStoryWirePath(requestBodyRecord(req.body).filePath);
   if (guard) {
     sendOpFailure(res, guard);
     return;

--- a/server/api/routes/scheduler.ts
+++ b/server/api/routes/scheduler.ts
@@ -20,7 +20,10 @@ export interface ScheduledItem {
   id: string;
   title: string;
   createdAt: number;
-  props: Record<string, string | number | boolean | null>;
+  /** `unknown` values, not scalars: `sanitizeProps` only ever inspects
+   *  `endDate`, so any other JSON the LLM sends survives verbatim. Every
+   *  reader re-checks the value's type before using it. */
+  props: Record<string, unknown>;
 }
 
 function loadItems(): ScheduledItem[] {

--- a/server/api/routes/schedulerHandlers.ts
+++ b/server/api/routes/schedulerHandlers.ts
@@ -11,6 +11,7 @@
 
 import type { ScheduledItem } from "./scheduler.js";
 import { makeId } from "../../utils/id.js";
+import { isRecord } from "../../utils/types.js";
 
 export interface SchedulerActionInput {
   title?: string;
@@ -44,14 +45,11 @@ export type SchedulerActionResult =
 // surfaces those as a "broken range" chip so the user/LLM gets
 // visible feedback instead of having the bad data silently erased.
 export function sanitizeProps(props: unknown): ScheduledItem["props"] {
-  if (typeof props !== "object" || props === null || Array.isArray(props)) {
-    return {};
-  }
-  const record = props as ScheduledItem["props"];
-  if (!("endDate" in record)) return record;
-  if (typeof record.endDate === "string") return record;
-  if (record.endDate === null) return record;
-  const next = { ...record };
+  if (!isRecord(props)) return {};
+  if (!("endDate" in props)) return props;
+  if (typeof props.endDate === "string") return props;
+  if (props.endDate === null) return props;
+  const next = { ...props };
   Reflect.deleteProperty(next, "endDate");
   return next;
 }
@@ -160,12 +158,11 @@ export function handleUpdate(items: ScheduledItem[], input: SchedulerActionInput
 // safe default (newly minted id, empty title, current timestamp)
 // rather than failing the whole replace.
 export function sanitizeItem(raw: unknown): ScheduledItem | null {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  const obj = raw as Partial<ScheduledItem>;
-  const itemId = typeof obj.id === "string" && obj.id.length > 0 ? obj.id : makeId("sched");
-  const title = typeof obj.title === "string" ? obj.title : "";
-  const createdAt = typeof obj.createdAt === "number" && Number.isFinite(obj.createdAt) ? obj.createdAt : Date.now();
-  return { id: itemId, title, createdAt, props: sanitizeProps(obj.props) };
+  if (!isRecord(raw)) return null;
+  const itemId = typeof raw.id === "string" && raw.id.length > 0 ? raw.id : makeId("sched");
+  const title = typeof raw.title === "string" ? raw.title : "";
+  const createdAt = typeof raw.createdAt === "number" && Number.isFinite(raw.createdAt) ? raw.createdAt : Date.now();
+  return { id: itemId, title, createdAt, props: sanitizeProps(raw.props) };
 }
 
 export function handleReplace(_items: ScheduledItem[], input: SchedulerActionInput): SchedulerActionResult {

--- a/server/events/collection-change.ts
+++ b/server/events/collection-change.ts
@@ -37,7 +37,9 @@ type SetPublisher = (publish: ((payload: CollectionChangePayload) => void) | nul
 /** The package's publisher setter, or null when the installed package predates
  *  it (see the module header on why this is feature-detected, not imported). */
 function resolveSetPublisher(): SetPublisher | null {
-  const candidate = (collectionPlugin as { setCollectionChangePublisher?: SetPublisher }).setCollectionChangePublisher;
+  // Typed from the workspace source, which always has the export; the runtime
+  // check is what covers an older installed package (see the module header).
+  const candidate = collectionPlugin.setCollectionChangePublisher;
   return typeof candidate === "function" ? candidate : null;
 }
 

--- a/server/plugins/builtin-dispatch.ts
+++ b/server/plugins/builtin-dispatch.ts
@@ -11,6 +11,8 @@
 // via gui-chat-protocol's `ToolContext.app`, which the generic runtime
 // path (scoped files/fetch only) doesn't carry.
 
+import { isObj, isRecord } from "../utils/types.js";
+
 export type BuiltinDispatchHandler = (args: Record<string, unknown>) => Promise<unknown>;
 
 const registry = new Map<string, BuiltinDispatchHandler>();
@@ -28,8 +30,8 @@ const registry = new Map<string, BuiltinDispatchHandler>();
  *  belt-and-braces for a direct caller — a test, or another host wiring the
  *  registry up itself. */
 export function describeKind(payload: unknown): string {
-  if (payload === null || typeof payload !== "object") return JSON.stringify(payload) ?? String(payload);
-  return JSON.stringify((payload as { kind?: unknown }).kind) ?? "undefined";
+  if (!isObj(payload)) return JSON.stringify(payload) ?? String(payload);
+  return JSON.stringify(isRecord(payload) ? payload.kind : undefined) ?? "undefined";
 }
 
 /** Register a built-in plugin's dispatch handler under its scope name.

--- a/server/remoteHost/handlers/collectionPage.ts
+++ b/server/remoteHost/handlers/collectionPage.ts
@@ -8,6 +8,7 @@
 // serve identical page semantics — re-exported here for the handlers.
 import { clampLimit, clampOffset, readIdParam } from "@mulmoclaude/core/remote-view";
 import { deriveAll, type DerivableFieldSpec, type DerivableRecord } from "@mulmoclaude/core/collection";
+import { isRecord } from "../../utils/types.js";
 import type { JsonObject } from "../commandChannel.js";
 
 export { clampLimit, clampOffset, readIdParam };
@@ -18,7 +19,7 @@ export { clampLimit, clampOffset, readIdParam };
  *  channel, so formulas that dereference `ref` fields stay absent; the desktop
  *  phone-frame preview derives with the same empty cache (parity). */
 export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec> }, items: unknown[]): DerivableRecord[] =>
-  items.map((item) => deriveAll({ fields: schema.fields ?? {} }, item as DerivableRecord, {}));
+  items.map((item) => deriveAll({ fields: schema.fields ?? {} }, isRecord(item) ? item : {}, {}));
 
 /** Build the paginated result.
  *

--- a/server/system/appVersion.ts
+++ b/server/system/appVersion.ts
@@ -13,16 +13,14 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { errorMessage } from "../utils/errors.js";
+import { hasStringProp } from "../utils/types.js";
 import { log } from "./logger/index.js";
 
 function readAppVersion(): string {
   const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
   try {
     const parsed: unknown = JSON.parse(readFileSync(pkgPath, "utf8"));
-    if (typeof parsed === "object" && parsed !== null && "version" in parsed) {
-      const { version } = parsed as { version: unknown };
-      if (typeof version === "string" && version.length > 0) return version;
-    }
+    if (hasStringProp(parsed, "version") && parsed.version.length > 0) return parsed.version;
     log.warn("appVersion", "package.json has no usable version field", { pkgPath });
   } catch (err) {
     log.warn("appVersion", "failed to read package.json", { pkgPath, error: errorMessage(err) });

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -186,15 +186,15 @@ function isPhotoExifSettings(value: unknown): value is { autoCapture: boolean } 
 }
 
 function isEffortLevel(value: unknown): value is EffortLevel {
-  return typeof value === "string" && (EFFORT_LEVELS as readonly string[]).includes(value);
+  return EFFORT_LEVELS.some((level) => level === value);
 }
 
 function isChatIndexMode(value: unknown): value is ChatIndexMode {
-  return typeof value === "string" && (CHAT_INDEX_MODES as readonly string[]).includes(value);
+  return CHAT_INDEX_MODES.some((mode) => mode === value);
 }
 
 function isJournalMode(value: unknown): value is JournalMode {
-  return typeof value === "string" && (JOURNAL_MODES as readonly string[]).includes(value);
+  return JOURNAL_MODES.some((mode) => mode === value);
 }
 
 function isVoiceInputSettings(value: unknown): value is { enabled: boolean; model?: string } {

--- a/server/system/macosNotify.ts
+++ b/server/system/macosNotify.ts
@@ -132,7 +132,7 @@ if (autoDisabledForTests && !env.disableMacosReminderNotifications && process.pl
 }
 
 export function pushToMacosReminder(title: string, body?: string): Promise<void> {
-  const platform: Platform = process.platform;
+  const { platform } = process;
   // Off darwin the sink is a no-op, so don't pay for the synchronous
   // settings read just to reach the same answer.
   if (platform !== "darwin") return Promise.resolve();

--- a/server/system/macosNotify.ts
+++ b/server/system/macosNotify.ts
@@ -132,7 +132,7 @@ if (autoDisabledForTests && !env.disableMacosReminderNotifications && process.pl
 }
 
 export function pushToMacosReminder(title: string, body?: string): Promise<void> {
-  const platform = process.platform as Platform;
+  const platform: Platform = process.platform;
   // Off darwin the sink is a no-op, so don't pay for the synchronous
   // settings read just to reach the same answer.
   if (platform !== "darwin") return Promise.resolve();

--- a/server/utils/exif.ts
+++ b/server/utils/exif.ts
@@ -123,13 +123,13 @@ const PARSE_OPTIONS = {
  *  for photos with a zeroed-out GPS block (sometimes seen on Android
  *  exports where the user opted out mid-stream); treating 0/0 as
  *  "no fix" avoids a useless pin in the middle of the Atlantic. */
-function isValidCoord(lat: unknown, lng: unknown): lat is number {
-  if (typeof lat !== "number" || typeof lng !== "number") return false;
-  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return false;
-  if (lat < VALID_LAT_MIN || lat > VALID_LAT_MAX) return false;
-  if (lng < VALID_LNG_MIN || lng > VALID_LNG_MAX) return false;
-  if (lat === 0 && lng === 0) return false;
-  return true;
+function validCoordPair(lat: unknown, lng: unknown): { lat: number; lng: number } | null {
+  if (typeof lat !== "number" || typeof lng !== "number") return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  if (lat < VALID_LAT_MIN || lat > VALID_LAT_MAX) return null;
+  if (lng < VALID_LNG_MIN || lng > VALID_LNG_MAX) return null;
+  if (lat === 0 && lng === 0) return null;
+  return { lat, lng };
 }
 
 function pickString(raw: Record<string, unknown>, key: string): string | undefined {
@@ -191,9 +191,10 @@ function pickFiniteNumber(value: unknown, opts?: { min?: number; max?: number })
  *  → decimal), the rest are 1:1 tag renames. */
 function pickGps(record: Record<string, unknown>): Pick<PhotoExif, "lat" | "lng" | "altitude" | "hPositioningError" | "heading" | "speed"> {
   const out: Pick<PhotoExif, "lat" | "lng" | "altitude" | "hPositioningError" | "heading" | "speed"> = {};
-  if (isValidCoord(record.latitude, record.longitude)) {
-    out.lat = record.latitude as number;
-    out.lng = record.longitude as number;
+  const coord = validCoordPair(record.latitude, record.longitude);
+  if (coord) {
+    out.lat = coord.lat;
+    out.lng = coord.lng;
   }
   const altitude = pickFiniteNumber(record.GPSAltitude);
   if (altitude !== undefined) out.altitude = altitude;

--- a/server/utils/files/by-path.ts
+++ b/server/utils/files/by-path.ts
@@ -27,5 +27,5 @@ export async function existsAsFile(value: string, extensions: readonly string[])
 
 /** `FileOps` over caller-supplied paths — the host's `files.byPath` capability. */
 export function makeByPathFileOps(extensions: readonly string[]): FileOps {
-  return createByPathFileOps({ rootFor, extensions }) as FileOps;
+  return createByPathFileOps({ rootFor, extensions });
 }

--- a/server/utils/files/csp-io.ts
+++ b/server/utils/files/csp-io.ts
@@ -8,7 +8,7 @@
 import path from "node:path";
 import { WORKSPACE_FILES, workspacePath } from "../../workspace/paths.js";
 import { readTextSafeSync } from "./safe.js";
-import { sanitizeCspExtra, type CspExtraHosts, type CspDirective } from "../../../src/utils/html/previewCsp.js";
+import { sanitizeCspExtra, type CspExtraHosts } from "../../../src/utils/html/previewCsp.js";
 import { log } from "../../system/logger/index.js";
 
 function cspFilePath(workspaceRoot?: string): string {
@@ -31,9 +31,9 @@ export function readCspExtraSync(workspaceRoot?: string): CspExtraHosts {
 // custom view's scoped token/data (#1989).
 export function warnIfCspExtended(workspaceRoot?: string): void {
   const extra = readCspExtraSync(workspaceRoot);
-  const directives = Object.keys(extra) as CspDirective[];
+  const directives = Object.entries(extra);
   if (directives.length === 0) return;
-  const summary = directives.map((directive) => `${directive}=[${(extra[directive] ?? []).join(", ")}]`).join(" ");
+  const summary = directives.map(([directive, hosts]) => `${directive}=[${(hosts ?? []).join(", ")}]`).join(" ");
   log.warn("csp", `config/csp.json extends the sandbox CSP; every added host is a supply-chain / exfiltration surface: ${summary}`);
   const connectHosts = extra["connect-src"] ?? [];
   if (connectHosts.length > 0) {

--- a/server/utils/files/scheduler-overrides-io.ts
+++ b/server/utils/files/scheduler-overrides-io.ts
@@ -29,13 +29,10 @@ function overridesPath(root?: string): string {
   return path.join(root ?? workspacePath, WORKSPACE_FILES.schedulerOverrides);
 }
 
-// Filters out invalid entries with a warning.
-export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
-  const raw = loadJsonFile<unknown>(overridesPath(root), {});
-  if (!isRecord(raw)) {
-    log.warn("scheduler-overrides", "overrides.json is not an object");
-    return {};
-  }
+/** Keep only the entries that parse as an override, warning about the rest.
+ *  Shared by the disk read and the PUT route so both accept exactly the same
+ *  shapes — a value that survives here is the only thing ever stored. */
+export function keepValidOverrides(raw: Record<string, unknown>): ScheduleOverrides {
   const result: ScheduleOverrides = {};
   for (const [key, value] of Object.entries(raw)) {
     if (isScheduleOverride(value)) {
@@ -45,6 +42,16 @@ export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
     }
   }
   return result;
+}
+
+// Filters out invalid entries with a warning.
+export function loadSchedulerOverrides(root?: string): ScheduleOverrides {
+  const raw = loadJsonFile<unknown>(overridesPath(root), {});
+  if (!isRecord(raw)) {
+    log.warn("scheduler-overrides", "overrides.json is not an object");
+    return {};
+  }
+  return keepValidOverrides(raw);
 }
 
 export function saveSchedulerOverrides(overrides: ScheduleOverrides, root?: string): void {

--- a/server/utils/files/shortcuts-io.ts
+++ b/server/utils/files/shortcuts-io.ts
@@ -9,8 +9,6 @@ import { readTextSafe } from "./safe.js";
 import { isRecord } from "../types.js";
 import { SHORTCUT_KINDS, sameShortcut, type Shortcut, type ShortcutsFile } from "../../../src/types/shortcuts.js";
 
-const KINDS = new Set<string>(SHORTCUT_KINDS);
-
 function shortcutsFilePath(workspaceRoot?: string): string {
   return path.join(workspaceRoot ?? workspacePath, WORKSPACE_FILES.shortcuts);
 }
@@ -24,11 +22,14 @@ export function normalizeShortcuts(input: unknown): Shortcut[] {
   const out: Shortcut[] = [];
   for (const raw of input) {
     if (!isRecord(raw)) continue;
-    const { kind, slug, title, icon } = raw;
-    if (typeof kind !== "string" || !KINDS.has(kind)) continue;
+    const { slug, title, icon } = raw;
+    // `find` over the literal list narrows to `ShortcutKind` by construction —
+    // a membership predicate would only assert it.
+    const kind = SHORTCUT_KINDS.find((candidate) => candidate === raw.kind);
+    if (kind === undefined) continue;
     if (typeof slug !== "string" || slug.length === 0) continue;
     const entry: Shortcut = {
-      kind: kind as Shortcut["kind"],
+      kind,
       slug,
       title: typeof title === "string" ? title : slug,
       icon: typeof icon === "string" && icon.length > 0 ? icon : "bookmark",

--- a/server/workspace/collections/remoteView.ts
+++ b/server/workspace/collections/remoteView.ts
@@ -200,8 +200,7 @@ async function updateViaView(
   // (same as the page builder) so a record with large text/markdown fields can't
   // push the mutate result over the command-document cap — over budget, the field
   // stays a path (placeholder), never a doc-write failure.
-  const [enriched] = await deps.enrichItems(collection, [result.item]);
-  const item = enriched as RemoteViewItem;
+  const [item] = await deps.enrichItems(collection, [result.item]);
   // Enrichment can inflate the base item (an `embed` attaches a whole target
   // record, a computed field a large payload). If the base JSON already exceeds
   // the doc budget, no thumbnail-skipping can save it — the write DID persist,
@@ -213,7 +212,7 @@ async function updateViaView(
   if (imageFields.length > 0) {
     await inlineImages([item], imageFields, clampImageMaxEdge(view.imageMaxEdge), deps.resolveThumbnail, REMOTE_VIEW_ITEMS_MAX_BYTES - baseBytes);
   }
-  return { kind: "ok", op: "update", item: item as CollectionItem };
+  return { kind: "ok", op: "update", item };
 }
 
 export const mutateRemoteView = createMutateRemoteView({ storeFor, enrichItems, resolveThumbnail });
@@ -294,7 +293,7 @@ export const createRemoteViewItems =
     // resolve), toggles projected, embeds resolved. The phone gets plain resolved
     // scalars — no network, no dataUrl — so mobile numbers match desktop exactly.
     const items = await deps.listRecords(collection);
-    const derived = (await deps.enrichItems(collection, items)) as RemoteViewItem[];
+    const derived = await deps.enrichItems(collection, items);
     const page = pageFromItems(derived, request, collection.schema.primaryKey);
     // Resolving an `embed` column attaches a whole target record per row, so the
     // base (path-only) page JSON can itself blow the doc budget before a single

--- a/server/workspace/hooks/provision.ts
+++ b/server/workspace/hooks/provision.ts
@@ -29,6 +29,7 @@ import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { workspacePath as defaultWorkspacePath } from "../workspace.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
+import { isRecord, isUnknownArray } from "../../utils/types.js";
 
 // The esbuild bundle is the source of truth for the dispatcher
 // script written into <workspace>/.claude/hooks/. Source TS is
@@ -83,17 +84,15 @@ interface HookCommandEntry {
 
 interface HookMatcher {
   matcher?: string;
-  hooks?: HookCommandEntry[];
+  /** `unknown`, not `HookCommandEntry[]`: this comes from the user's own
+   *  settings.json, so every level is re-checked where it is read. */
+  hooks?: unknown;
   [key: string]: unknown;
 }
 
-interface SettingsShape {
-  hooks?: {
-    PostToolUse?: HookMatcher[];
-    [key: string]: HookMatcher[] | undefined;
-  };
-  [key: string]: unknown;
-}
+/** The user's `.claude/settings.json`, as parsed. Nothing below the top level
+ *  is modelled — see `HookMatcher.hooks`. */
+type SettingsShape = Record<string, unknown>;
 
 export interface ProvisionOptions {
   workspaceRoot?: string;
@@ -143,13 +142,18 @@ async function mergeDispatcherIntoSettings(settingsPath: string): Promise<boolea
 function safeParse(raw: string): SettingsShape {
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as SettingsShape;
-    }
+    if (isRecord(parsed)) return parsed;
   } catch {
     // Corrupted settings get rebuilt with our entry only.
   }
   return {};
+}
+
+/** The `PostToolUse` entries we can reason about. A non-object entry could
+ *  never have carried one of our markers, and the empty-`hooks` filter below
+ *  dropped it anyway, so it is discarded here instead of one step later. */
+function matcherEntries(value: unknown): HookMatcher[] {
+  return isUnknownArray(value) ? value.filter(isRecord) : [];
 }
 
 // Pure helper exported for unit testing. Strip every MulmoClaude-
@@ -172,30 +176,27 @@ function safeParse(raw: string): SettingsShape {
 // must survive. The previous entry-level filter dropped the whole
 // object, silently deleting the user's hook.
 export function upsertDispatcherEntry(settings: SettingsShape): SettingsShape {
-  const hooks = settings.hooks ?? {};
-  const rawPostToolUse = hooks.PostToolUse;
-  const postToolUse = Array.isArray(rawPostToolUse) ? rawPostToolUse : [];
+  const hooks = isRecord(settings.hooks) ? settings.hooks : {};
 
-  const cleaned = postToolUse
+  const cleaned = matcherEntries(hooks.PostToolUse)
     .map(stripOwnedDescriptors)
     // Drop any entry whose `hooks` array is empty after stripping
     // — those were 100% ours and only existed to host our hook.
     // Keeping an empty `hooks` array would be a Claude Code
     // schema-violation noise file.
-    .filter((entry) => Array.isArray(entry.hooks) && entry.hooks.length > 0);
+    .filter((entry) => isUnknownArray(entry.hooks) && entry.hooks.length > 0);
 
+  const ownedDescriptor: HookCommandEntry = {
+    type: "command",
+    command: HOOK_COMMAND,
+    [OWNER_MARKER]: true,
+  };
   const desiredEntry: HookMatcher = {
     // Bash matcher is required so the skill-bridge delete branch
     // gets a chance to run. Write|Edit covers wiki-snapshot,
     // config-refresh, and skill-bridge write paths.
     matcher: "Write|Edit|Bash",
-    hooks: [
-      {
-        type: "command",
-        command: HOOK_COMMAND,
-        [OWNER_MARKER]: true,
-      },
-    ],
+    hooks: [ownedDescriptor],
   };
 
   return {
@@ -213,13 +214,14 @@ export function upsertDispatcherEntry(settings: SettingsShape): SettingsShape {
 // without a `hooks` array pass through unchanged — defensive
 // against future schema fields we don't yet model.
 function stripOwnedDescriptors(entry: HookMatcher): HookMatcher {
-  if (!Array.isArray(entry.hooks)) return entry;
+  if (!isUnknownArray(entry.hooks)) return entry;
   const nextHooks = entry.hooks.filter((hook) => !isOwnedDescriptor(hook));
   if (nextHooks.length === entry.hooks.length) return entry;
   return { ...entry, hooks: nextHooks };
 }
 
-function isOwnedDescriptor(hook: HookCommandEntry): boolean {
+function isOwnedDescriptor(hook: unknown): boolean {
+  if (!isRecord(hook)) return false;
   if (hook[OWNER_MARKER] === true) return true;
   return LEGACY_MARKERS.some((marker) => hook[marker] === true);
 }

--- a/server/workspace/memory/llm-classifier.ts
+++ b/server/workspace/memory/llm-classifier.ts
@@ -91,7 +91,7 @@ export function parseClassifierVerdict(raw: string): MemoryClassification | null
     return null;
   }
   if (!isRecord(parsed)) return null;
-  const { type, description } = parsed as { type?: unknown; description?: unknown };
+  const { type, description } = parsed;
   if (!isMemoryType(type)) return null;
   const desc = typeof description === "string" ? description.trim() : "";
   // The description is optional from the spec's perspective —
@@ -100,7 +100,7 @@ export function parseClassifierVerdict(raw: string): MemoryClassification | null
   // Cap matches the prompt's `<=100 chars>` declaration so persisted
   // entries never exceed the schema the classifier was told to follow
   // (#1061 review).
-  return desc.length > 0 ? { type: type as MemoryType, description: oneLine(desc).slice(0, 100) } : { type: type as MemoryType };
+  return desc.length > 0 ? { type, description: oneLine(desc).slice(0, 100) } : { type };
 }
 
 function oneLine(text: string): string {

--- a/server/workspace/memory/llm-classifier.ts
+++ b/server/workspace/memory/llm-classifier.ts
@@ -15,7 +15,7 @@
 // is one-time and small — keep the request shape simple.
 
 import type { MemoryClassification, MemoryCandidate, MemoryClassifier } from "./migrate.js";
-import { isMemoryType, type MemoryType } from "./types.js";
+import { isMemoryType } from "./types.js";
 import { extractFirstObject, stripFenceAndWhitespace } from "./llm-json.js";
 
 import { ClaudeCliNotFoundError, type Summarize } from "../journal/archivist-cli.js";

--- a/server/workspace/memory/types.ts
+++ b/server/workspace/memory/types.ts
@@ -28,7 +28,7 @@ export interface MemoryEntry {
 }
 
 export function isMemoryType(value: unknown): value is MemoryType {
-  return typeof value === "string" && (MEMORY_TYPES as readonly string[]).includes(value);
+  return MEMORY_TYPES.some((memoryType) => memoryType === value);
 }
 
 // Bound the alphanumeric portion of a slug. Long bullets in the

--- a/server/workspace/paths.ts
+++ b/server/workspace/paths.ts
@@ -265,6 +265,10 @@ const WORKSPACE_DIRS_AGGREGATE = defineHostAggregate(BUILT_IN_PLUGIN_METAS, {
 export const WORKSPACE_DIRS_HOST_COLLISIONS: readonly HostPluginCollision[] = WORKSPACE_DIRS_AGGREGATE.hostCollisions;
 export const WORKSPACE_DIRS_INTRA_COLLISIONS: readonly IntraPluginCollision[] = WORKSPACE_DIRS_AGGREGATE.intraCollisions;
 
+// Cast kept (#2692): `defineHostAggregate` returns `Record<string, V>` by
+// design and documents that the caller owns the literal-preserving cast —
+// removing it means making that helper (in `src/plugins/metas.ts`, shared with
+// `apiRoutes.ts`) generic over the merged key set.
 export const WORKSPACE_DIRS = WORKSPACE_DIRS_AGGREGATE.merged as unknown as typeof HOST_WORKSPACE_DIRS & PluginWorkspaceDirsMap<BuiltInPluginMetas>;
 export { WORKSPACE_FILES };
 
@@ -279,15 +283,19 @@ export { WORKSPACE_FILES };
 // required (CodeRabbit #1125 review: previously plugins adding
 // `workspaceDirs` keys still needed a manual `WORKSPACE_PATHS`
 // patch-up to be reachable in absolute form).
-const WORKSPACE_DIR_PATHS = Object.fromEntries(Object.entries(WORKSPACE_DIRS).map(([key, relativePath]) => [key, path.join(workspacePath, relativePath)])) as {
-  readonly [K in keyof typeof WORKSPACE_DIRS]: string;
-};
+// Seeded from the source map so the result carries exactly its keys —
+// `Object.fromEntries` would widen them to a bare string index.
+function toAbsolutePaths<T extends Record<string, string>>(relativePaths: T, root: string): { readonly [K in keyof T]: string } {
+  const absolute: { -readonly [K in keyof T]: string } = { ...relativePaths };
+  for (const key in absolute) {
+    absolute[key] = path.join(root, relativePaths[key]);
+  }
+  return absolute;
+}
 
-const WORKSPACE_FILE_PATHS = Object.fromEntries(
-  Object.entries(WORKSPACE_FILES).map(([key, relativePath]) => [key, path.join(workspacePath, relativePath)]),
-) as {
-  readonly [K in keyof typeof WORKSPACE_FILES]: string;
-};
+const WORKSPACE_DIR_PATHS = toAbsolutePaths(WORKSPACE_DIRS, workspacePath);
+
+const WORKSPACE_FILE_PATHS = toAbsolutePaths(WORKSPACE_FILES, workspacePath);
 
 export const WORKSPACE_PATHS = {
   ...WORKSPACE_DIR_PATHS,

--- a/server/workspace/skills/catalog.ts
+++ b/server/workspace/skills/catalog.ts
@@ -49,7 +49,7 @@ export type CatalogSource = "preset" | "external";
 export const CATALOG_SOURCES: readonly CatalogSource[] = ["preset", "external"] as const;
 
 export function isCatalogSource(value: unknown): value is CatalogSource {
-  return typeof value === "string" && (CATALOG_SOURCES as readonly string[]).includes(value);
+  return CATALOG_SOURCES.some((source) => source === value);
 }
 
 export interface CatalogEntry {
@@ -87,7 +87,7 @@ function catalogDirForSource(source: "preset", workspaceRoot: string): string {
     return path.join(workspaceRoot, WORKSPACE_DIRS.skillsCatalogPreset);
   }
   const exhaustive: never = source;
-  throw new Error(`unknown catalog source: ${exhaustive as string}`);
+  throw new Error(`unknown catalog source: ${String(exhaustive)}`);
 }
 
 function activeDir(workspaceRoot: string): string {

--- a/server/workspace/wiki-pages/snapshot.ts
+++ b/server/workspace/wiki-pages/snapshot.ts
@@ -137,7 +137,7 @@ const SNAPSHOT_KEYS = ["_snapshot_ts", "_snapshot_editor", "_snapshot_session", 
 export function stripSnapshotMeta(meta: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(meta)) {
-    if ((SNAPSHOT_KEYS as readonly string[]).includes(key)) continue;
+    if (SNAPSHOT_KEYS.some((snapshotKey) => snapshotKey === key)) continue;
     out[key] = value;
   }
   return out;

--- a/test/workspace/hooks/test_provision.ts
+++ b/test/workspace/hooks/test_provision.ts
@@ -16,6 +16,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { OWNER_MARKER, provisionDispatcherHook, upsertDispatcherEntry } from "../../../server/workspace/hooks/provision.js";
+import { isRecord, isUnknownArray } from "../../../server/utils/types.js";
 
 interface HookEntry {
   matcher?: string;
@@ -206,25 +207,34 @@ describe("provisionDispatcherHook — descriptor-level stripping", () => {
   });
 });
 
+/** The provisioner models the settings tree as `Record<string, unknown>` (it is
+ *  the user's own file), so the assertions narrow the branch they read. */
+function postToolUseEntries(settings: Record<string, unknown>): unknown[] {
+  const { hooks } = settings;
+  const entries = isRecord(hooks) ? hooks.PostToolUse : undefined;
+  if (!isUnknownArray(entries)) assert.fail("settings.hooks.PostToolUse is not an array");
+  return entries;
+}
+
 describe("upsertDispatcherEntry — pure helper", () => {
   it("dedupes our own marker on repeated calls", () => {
     const first = upsertDispatcherEntry({});
     const second = upsertDispatcherEntry(first);
     // Both passes produce settings with exactly one dispatcher
     // entry — the helper recognises its own marker.
-    assert.equal((second.hooks?.PostToolUse as HookEntry[]).length, 1);
+    assert.equal(postToolUseEntries(second).length, 1);
   });
 
   it("normalises a malformed PostToolUse field without throwing", () => {
-    // Cast through `unknown` because the provisioner's `SettingsShape`
-    // is strictly typed but we want to feed in a corrupted on-disk
-    // shape (string instead of array) — exactly the scenario this
-    // test is meant to cover.
-    const settings = { hooks: { PostToolUse: "not-an-array" } } as unknown as Parameters<typeof upsertDispatcherEntry>[0];
-    const next = upsertDispatcherEntry(settings);
-    const entries = next.hooks?.PostToolUse as HookEntry[];
-    assert.ok(Array.isArray(entries));
+    // A corrupted on-disk shape (string instead of array) — exactly the
+    // scenario this test is meant to cover.
+    const next = upsertDispatcherEntry({ hooks: { PostToolUse: "not-an-array" } });
+    const entries = postToolUseEntries(next);
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].hooks?.[0]?.[OWNER_MARKER], true);
+    const [entry] = entries;
+    if (!isRecord(entry) || !isUnknownArray(entry.hooks)) assert.fail("dispatcher entry carries no hooks array");
+    const [descriptor] = entry.hooks;
+    if (!isRecord(descriptor)) assert.fail("dispatcher descriptor is not an object");
+    assert.equal(descriptor[OWNER_MARKER], true);
   });
 });


### PR DESCRIPTION
## Summary

`server/` 配下に残っていた `as` 型アサーションを一掃しました（**42 → 3**、うち 39 箇所を削除）。
共有ガード（`isRecord` / `isObj` / `isUnknownArray` / `hasStringProp` / `requestBodyRecord`）による本物の絞り込み、検証済みフィールドからの値の再構築、あるいは「キャストが隠していた嘘の型宣言そのものを直す」ことで対応しています。
`#2727` が保有する 3 ファイル（`getRemoteViewItems.ts` / `mutateRemoteView.ts` / `utils/router.ts`）はスコープ外です。
残した 3 箇所はいずれも理由を 1 行コメントで明記しました（下記）。

## Items to Confirm / Review

レビューで特に見ていただきたい点です。

### 1. `ScheduledItem.props` の型を `Record<string, unknown>` に修正（型のみの変更）

`sanitizeProps` は `endDate` しか検査しておらず、それ以外の値は素通しでした。つまり `Record<string, string | number | boolean | null>` という宣言は**実行時の事実と食い違う嘘**で、`as` がそれを隠していました。実行時挙動は変わりません（下記の検証で確認済み）。
`src/plugins/scheduler/index.ts` 側のクライアント用 `ScheduledItem` は別定義なので影響ありません。

### 2. `PUT /api/config/scheduler-overrides` — ディスクに書く内容だけが変わります

これまでは受け取った record を**そのまま**保存し、読み出し時（`loadSchedulerOverrides`）に不正エントリを捨てていました。本 PR では保存前に同じフィルタ（`keepValidOverrides`、`loadSchedulerOverrides` と共用）を通します。

- **クライアントに返るレスポンスは完全に同一**（レスポンスは元々 `loadSchedulerOverrides()` の結果）。
- **スケジューラに適用される内容も同一**。
- 変わるのは `config/scheduler/overrides.json` の中身で、これまで書き込まれていた「読み出し時に必ず捨てられる無効エントリ」が保存されなくなります。
- 副作用として、無効エントリ受信時に PUT 時点でも warn ログが出ます。

### 3. `provision.ts`（ユーザーの `.claude/settings.json` を書き換える経路）

`SettingsShape` / `HookMatcher.hooks` はトップレベル以下をモデル化しない型に変えました（読み手は元々すべて `Array.isArray` で再確認していたので、宣言の方が嘘でした）。
これに伴い、**壊れた settings.json に対する挙動が改善**されます（改悪ではありませんが挙動差分なのでご確認ください）。

| 入力 | before | after |
| --- | --- | --- |
| `hooks: { PostToolUse: [null] }` | `TypeError` で provisioning 全体が失敗 | `null` を落として正常終了 |
| `hooks: { PostToolUse: [{ hooks: [null, {...}] }] }` | `TypeError` で失敗 | 正常終了、ユーザーの descriptor は保持 |
| `hooks: "weird"`（文字列） | 文字列が spread されて `{"0":"w","1":"e",…}` というゴミキーが書き込まれる | 無視して `{}` 扱い |

正常な settings.json に対する出力はバイト単位で同一です。

### 4. 残したキャスト（3 箇所）

- `server/workspace/paths.ts:272` — `defineHostAggregate` が設計上 `Record<string, V>` を返し、「リテラル保持のキャストは呼び出し側の責務」と自身の JSDoc に書いています。外すには `src/plugins/metas.ts`（`apiRoutes.ts` と共用）をキー集合についてジェネリックにする必要があり、本 PR のスコープ外。`#2692` を含む 1 行コメントを追加しました。
- `server/utils/files/json.ts:24` — 既存の「Cast kept (#2692)」コメントのまま据え置き。
- `server/remoteHost/handlers/collectionPage.ts:35` — 既存コメントのとおり、`schema.spawn.set` に JSON 型を与えない限り外せません。

### 5. 挙動が変わらないことを確認した細かい判断

- `describeKind`: 配列 payload は before/after とも `"undefined"` を返すよう `isObj` + `isRecord` の 2 段で書き分けました（`isRecord` 一本にすると配列で `"[]"` になり挙動が変わります）。
- `collectionAgentActions`: `failureBells.has()` + `get()!` を `get()` 1 回に集約。`Map<string, string>` なので等価です。
- `normalizeShortcuts`: `Set.has` + キャストを `SHORTCUT_KINDS.find()` に置換。`find` は構築上 `ShortcutKind` に絞れるので述語（`value is T`）を書かずに済みます。
- `exif.ts`: `isValidCoord(lat, lng): lat is number` は lng を絞れず結局キャストが必要でした。`validCoordPair()` が検証済みの `{ lat, lng }` を返す形に変更（述語より「検証済みの値を組み立て直す」方針）。

## 実装方針

1. **共有ガードを使う** — `server/utils/types.ts`（`@mulmoclaude/common` の re-export）の `isRecord` / `isObj` / `isUnknownArray` / `hasStringProp`、`server/utils/requestBody.ts` の `requestBodyRecord`。新しいヘルパは基本的に追加していません。
2. **冗長なキャストは単純に削除** — `agent.ts` の `meta.claudeSessionId as string`（宣言済み `string`）、`macosNotify.ts` の `process.platform as Platform`（同一 union）、`remoteView.ts` の 3 箇所（`RemoteViewItem` と `CollectionItem` はどちらも `Record<string, unknown>`）、`llm-classifier.ts`（`isMemoryType` で既に絞れている）、`by-path.ts`（`ByPathFileOps` は `FileOps` と構造的に同一）、`files.ts`（`spawn` は `readonly string[]` を受け取れる）。
3. **リテラル配列のメンバシップ判定** — `(X as readonly string[]).includes(v)` を `X.some((entry) => entry === v)` に統一（5 箇所）。`readonly` 配列は共変なのでキャスト不要になります。
4. **キャストが型の嘘を隠していた箇所は型を直す** — 上記 Items 1 / 3。
5. **`Object.fromEntries` のキー幅寄せ** — `paths.ts` の `WORKSPACE_DIR_PATHS` / `WORKSPACE_FILE_PATHS` は、元マップを spread して seed する `toAbsolutePaths<T>()` に置換し、キー集合を型として保ったままキャストを削除しました。
6. **新規に追加した共有ヘルパは 1 つだけ** — `keepValidOverrides`（`scheduler-overrides-io.ts`）。既存の `loadSchedulerOverrides` 内のフィルタを切り出したもので、読み出し／PUT の両方が同じ規則を使うようにする DRY 化です。

## 検証

すべて worktree `/Users/isamu/ss/llm/mc3-wt-server`（`origin/main` = `a5209fa4b` から分岐）で実行。

```bash
npx prettier --write <touched files>        # 全ファイル整形済み
npx eslint <touched files>                  # 0 errors
yarn lint                                   # ✖ 217 problems (0 errors, 217 warnings)
                                            #   → server/ に残る consistent-type-assertions は
                                            #     上記「残したキャスト」3 箇所のみ
yarn typecheck                              # vue / server / test / e2e / e2e-live / packages すべて green
npx tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts
                                            # tests 8900 / pass 8893 / fail 0 / skipped 7
```

`server/` の `consistent-type-assertions` 実測値（同じ eslint スキャンでの行単位カウント）:

| | before | after |
| --- | --- | --- |
| in-scope | 42 | 3 |
| `#2727` 保有（スキップ） | 3 | 3 |

### 外部 ground truth との差分（リスクの高い箇所）

永続化・リクエストボディ・認証・レスポンス形状に触れる関数を、**同一のプローブスクリプトで本ブランチと `origin/main` の両方**（`git checkout origin/main -- server test` で切替）に対して実行し、JSON 出力を diff しました。

対象: `sanitizeProps` / `sanitizeItem` / `handleReplace` / `handleUpdate` / `upsertDispatcherEntry` / `normalizeShortcuts` / `clampCapabilities` / `extractRecord` / `parseCapabilities` / `describeKind` / `stripSnapshotMeta` / `isMemoryType` / `isCatalogSource` / `parseClassifierVerdict` / `openArgv` / `revealArgv` / `WORKSPACE_DIRS` / `WORKSPACE_PATHS` / `readCspExtraSync` / `readPhotoExif` / scheduler-overrides の保存→読み戻し。

**差分が出たのは 2 グループだけで、いずれも意図した変更**です。

1. `upsertDispatcherEntry` の壊れ入力 3 ケース（上記 Items 3 の表そのまま）:

```diff
-    "THREW: Cannot read properties of null (reading 'hooks')",
-    "THREW: Cannot read properties of null (reading 'mulmoclaudeDispatcher')"
+    { "hooks": { "PostToolUse": [ { "matcher": "Write|Edit|Bash", … } ] } },
+    { "hooks": { "PostToolUse": [ { "matcher": "Write", "hooks": [ null, {"type":"command","command":"u.sh"} ] }, … ] } }
```

```diff
       "hooks": {
-        "0": "w",
-        "1": "e",
-        "2": "i",
-        "3": "r",
-        "4": "d",
         "PostToolUse": [
```

2. scheduler-overrides の PUT — **`response`（クライアントに返る値）は全ケースで完全一致**、差分は `onDisk` のみ:

```diff
     "onDisk": {
       "taskA": { "intervalMs": 5000, "extra": 1 }
-      ,"taskB": {}
     },
     "response": { "taskA": { "intervalMs": 5000, "extra": 1 } }   ← 変化なし
```

```diff
     "onDisk": {
       "taskB": { "time": "07:30" }
-      ,"taskC": { "time": "99:99" }
-      ,"taskD": 7
     },
     "response": { "taskB": { "time": "07:30" } }                  ← 変化なし
```

`sanitizeProps` / `sanitizeItem` / `handleReplace` / `handleUpdate` / `normalizeShortcuts`（`__proto__` / `constructor` を kind に持つケース含む）/ `clampCapabilities` / `describeKind`（配列・関数・プリミティブ含む）/ `WORKSPACE_PATHS` 全キー / EXIF の GPS 7 ケースは**バイト単位で同一**でした。プローブスクリプトは検証後に削除しています。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Reduce unsafe type assertions in server code by tightening runtime validation and aligning TypeScript types with actual data shapes.

Bug Fixes:
- Make scheduler overrides persistence drop invalid entries at write time while keeping client responses and scheduler behavior unchanged.
- Harden `.claude/settings.json` provisioning so malformed hook trees no longer throw or corrupt settings, instead discarding invalid structures while preserving user descriptors.
- Ensure plugin envelopes, collection records, and remote view items are only processed when they are actual records, avoiding crashes from malformed inputs.
- Fix potential type and runtime issues in shortcut normalization, MCP permission handling, app version reading, view capability clamping, and spawned commands by removing unnecessary casts.

Enhancements:
- Model user settings and scheduler props as generic records with runtime guards instead of relying on `as` casts.
- Reuse shared type guards (`isRecord`, `isObj`, `isUnknownArray`, `hasStringProp`, `requestBodyRecord`) across server routes, plugins, and agents to validate untyped inputs.
- Preserve literal key sets for workspace path maps via a `toAbsolutePaths` helper instead of casting `Object.fromEntries` results.
- Improve EXIF GPS parsing by returning validated coordinate pairs rather than casting validated numbers.
- Simplify and harden collection, shortcut, plugin, and classifier helpers by replacing membership casts and structural casts with safer checks.
- Clarify ownership checks and error messages in collection change publishing, catalog source handling, CSP warnings, and memory type detection.

Tests:
- Update provisioner tests to exercise malformed settings inputs without relying on type assertions and to assert on structurally validated results.