### PR TITLE
fix(lint): make the `as` ban reach Vue templates, and clear src/ (#2692)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -447,6 +447,21 @@ export default [
       "vue/no-useless-v-bind": "error",
       "vue/prefer-true-attribute-shorthand": "error",
       "vue/no-empty-component-block": "error",
+      // The `as`-cast ban reaches `<script>` only: typescript-eslint's rules
+      // never visit the TEMPLATE body, which `vue-eslint-parser` exposes as a
+      // separate AST. `@change="…($event.target as HTMLInputElement).value"`
+      // was therefore invisible to `consistent-type-assertions` — 18 of them
+      // across host and plugin components (#2692). `vue/no-restricted-syntax`
+      // is the one rule that does walk that AST, so the same ban is spelled
+      // here as a selector. `warn` matches the script-side severity; both
+      // graduate together.
+      "vue/no-restricted-syntax": [
+        "warn",
+        {
+          selector: "TSAsExpression",
+          message: "Do not use any type assertions — narrow in <script> and pass the result to the template.",
+        },
+      ],
     },
   },
   // Plugin import restrictions — codify the loose-coupling pattern

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -68,7 +68,7 @@
           :placeholder="placeholder"
           rows="2"
           class="flex-1 bg-white border border-gray-300 rounded px-3 py-2 text-sm text-gray-900 placeholder-gray-400 resize-none"
-          @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+          @input="onInput"
           @compositionstart="imeEnter.onCompositionStart"
           @compositionend="imeEnter.onCompositionEnd"
           @keydown="onKeydown"
@@ -460,6 +460,11 @@ watch(
 watch(slashMenuOpen, (open) => {
   if (open) suggestionsExpanded.value = false;
 });
+
+function onInput(event: Event): void {
+  const { target } = event;
+  if (target instanceof HTMLTextAreaElement) emit("update:modelValue", target.value);
+}
 
 function onKeydown(event: KeyboardEvent): void {
   // Ctrl/Cmd+Enter inserts a newline instead of sending. Checked before the

--- a/src/components/FileTreePane.vue
+++ b/src/components/FileTreePane.vue
@@ -2,13 +2,7 @@
   <div class="w-72 flex-shrink-0 border-r border-gray-200 overflow-y-auto p-2 bg-gray-50">
     <div class="flex flex-wrap justify-end items-center gap-x-3 gap-y-1 pb-1 text-xs">
       <label class="flex items-center gap-1 text-gray-500 cursor-pointer select-none" :title="t('fileTreePane.showSystemFilesTitle')">
-        <input
-          type="checkbox"
-          class="h-3.5 w-3.5"
-          data-testid="file-tree-show-system-toggle"
-          :checked="showHiddenSystem"
-          @change="(e) => emit('update:showHiddenSystem', (e.target as HTMLInputElement).checked)"
-        />
+        <input type="checkbox" class="h-3.5 w-3.5" data-testid="file-tree-show-system-toggle" :checked="showHiddenSystem" @change="onShowHiddenSystemChange" />
         {{ t("fileTreePane.showSystemFiles") }}
       </label>
       <div class="flex items-center gap-2">
@@ -107,6 +101,11 @@ const emit = defineEmits<{
   createFile: [args: { folder: string; filename: string; resolve: (ok: boolean, error?: string) => void }];
   uploadFiles: [args: { folder: string; files: File[] }];
 }>();
+
+function onShowHiddenSystemChange(event: Event): void {
+  const { target } = event;
+  if (target instanceof HTMLInputElement) emit("update:showHiddenSystem", target.checked);
+}
 
 // Installed once for the whole tree: without it, a file released just
 // outside a folder row makes the browser navigate away from the app.

--- a/src/components/SettingsMcpTab.vue
+++ b/src/components/SettingsMcpTab.vue
@@ -201,12 +201,7 @@
             <span class="text-gray-500">{{ t("settingsMcpTab.urlLabel") }}</span>
             <code class="ml-1">{{ entry.spec.url }}</code>
           </div>
-          <i18n-t
-            v-if="dockerMode && wouldRewriteLocalhost((entry.spec as HttpSpec).url)"
-            keypath="settingsMcpTab.localhostRewrite"
-            tag="div"
-            class="text-amber-700"
-          >
+          <i18n-t v-if="dockerMode && wouldRewriteLocalhost(entry.spec.url)" keypath="settingsMcpTab.localhostRewrite" tag="div" class="text-amber-700">
             <template #localhost><code>localhost</code></template>
             <template #hostDockerInternal><code>host.docker.internal</code></template>
           </i18n-t>
@@ -215,8 +210,8 @@
           <div>
             <span class="text-gray-500">{{ t("settingsMcpTab.commandLabel") }}</span>
             <code class="ml-1">{{ entry.spec.command }}</code>
-            <code v-if="(entry.spec as StdioSpec).args?.length" class="ml-1">
-              {{ ((entry.spec as StdioSpec).args ?? []).join(" ") }}
+            <code v-if="entry.spec.args?.length" class="ml-1">
+              {{ (entry.spec.args ?? []).join(" ") }}
             </code>
           </div>
           <!-- Sandbox-incompatible warning (#1334) + host-exec opt-in
@@ -227,10 +222,8 @@
                it escapes the sandbox, hence the explicit
                acknowledgment checkbox rather than a silent default. -->
           <div v-if="dockerMode" class="space-y-1" :data-testid="'mcp-docker-warning-' + entry.id">
-            <div class="flex items-baseline gap-2" :class="(entry.spec as StdioSpec).hostExecInDocker ? 'text-red-700' : 'text-amber-700'">
-              <span>{{
-                (entry.spec as StdioSpec).hostExecInDocker ? t("settingsMcpTab.dockerStdioHostExecActive") : t("settingsMcpTab.dockerStdioUnsupported")
-              }}</span>
+            <div class="flex items-baseline gap-2" :class="entry.spec.hostExecInDocker ? 'text-red-700' : 'text-amber-700'">
+              <span>{{ entry.spec.hostExecInDocker ? t("settingsMcpTab.dockerStdioHostExecActive") : t("settingsMcpTab.dockerStdioUnsupported") }}</span>
               <a :href="MCP_SANDBOX_DOC_URL" target="_blank" rel="noopener noreferrer" class="underline whitespace-nowrap">
                 {{ t("settingsMcpTab.learnMore") }}
               </a>
@@ -239,7 +232,7 @@
               <input
                 type="checkbox"
                 class="mt-0.5 shrink-0"
-                :checked="(entry.spec as StdioSpec).hostExecInDocker === true"
+                :checked="entry.spec.hostExecInDocker === true"
                 :data-testid="'mcp-hostexec-' + entry.id"
                 @change="onToggleHostExec(idx, $event)"
               />

--- a/src/components/StackView.vue
+++ b/src/components/StackView.vue
@@ -46,7 +46,7 @@
       <div
         v-for="item in displayItems"
         :key="item.key"
-        :ref="(element) => setItemRefForMembers(item.members, element as HTMLElement | null)"
+        :ref="(element) => setItemRefForMembers(item.members, element)"
         class="bg-white rounded-lg border transition-colors"
         :class="item.members.some((m) => m.uuid === selectedResultUuid) ? 'border-blue-400 ring-2 ring-blue-200' : 'border-gray-200'"
       >
@@ -83,11 +83,7 @@
            / flex-1 via the .stack-natural scoped styles below. For
            plugins that embed iframes (e.g. presentHtml) we also size
            each iframe to its content after load. -->
-        <div
-          v-else-if="isStackNatural(item.head.toolName)"
-          :ref="(element) => setNaturalWrapperRef(item.head.uuid, element as HTMLElement | null)"
-          class="stack-natural"
-        >
+        <div v-else-if="isStackNatural(item.head.toolName)" :ref="(element) => setNaturalWrapperRef(item.head.uuid, element)" class="stack-natural">
           <component
             :is="getPlugin(item.head.toolName)?.viewComponent"
             v-if="getPlugin(item.head.toolName)?.viewComponent"
@@ -121,7 +117,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onUnmounted, type ComponentPublicInstance } from "vue";
 import { useI18n } from "vue-i18n";
 import { getPlugin } from "../tools";
 import { TOOL_NAMES, type ToolName } from "../config/toolNames";
@@ -253,7 +249,15 @@ function setItemRef(uuid: string, element: HTMLElement | null): void {
   else itemRefs.delete(uuid);
 }
 
-function setNaturalWrapperRef(uuid: string, element: HTMLElement | null): void {
+// What Vue hands a `:ref` callback: an element, a mounted component instance,
+// or null on unmount. Only the element case carries the DOM node these
+// setters store.
+type VueRefTarget = Element | ComponentPublicInstance | null;
+
+const asHtmlElement = (target: VueRefTarget): HTMLElement | null => (target instanceof HTMLElement ? target : null);
+
+function setNaturalWrapperRef(uuid: string, target: VueRefTarget): void {
+  const element = asHtmlElement(target);
   if (element) {
     naturalWrapperRefs.set(uuid, element);
     nextTick(() => sizeIframesIn(element));
@@ -279,7 +283,8 @@ const displayItems = computed(() => buildStackDisplayItems(props.toolResults, gr
 // Register the group card element under EVERY member uuid so the
 // scroll-spy and scroll-to-selection logic (which key on individual
 // result uuids) resolve any member to this one card.
-function setItemRefForMembers(members: ToolResultComplete[], element: HTMLElement | null): void {
+function setItemRefForMembers(members: ToolResultComplete[], target: VueRefTarget): void {
+  const element = asHtmlElement(target);
   for (const member of members) setItemRef(member.uuid, element);
 }
 


### PR DESCRIPTION
## Summary

**`as` 禁止は `<script>` にしか届いていませんでした。** `vue-eslint-parser` はテンプレート本体を別の AST として公開しており、typescript-eslint のルールはそこを一切走査しません。

```
@change="…($event.target as HTMLInputElement).value"
```

これが `consistent-type-assertions` から**完全に不可視**で、host + plugin あわせて **16箇所**が最初からゲートの外にありました。「ルールはあるのに機械が止めていない」という #2692 の問題そのものが、別の形で残っていたことになります。

`vue/no-restricted-syntax` はその AST を歩く唯一のルールなので、同じ禁止を `TSAsExpression` セレクタとして書きました（severity は script 側と揃えて `warn`）。

そのうえで `src/` の **10 → 0** を実施しています。

## Items to Confirm / Review

1. **`SettingsMcpTab.vue` の6件は全て陳腐化していました。** `v-if="entry.spec.type === 'stdio'"` の内側にあり、Vue のテンプレート narrowing が既に効いています（隣接する `entry.spec.command` は元からキャスト無し）。6件とも削除して vue-tsc は clean です。**削除しただけで、絞り込みロジックは変えていません。**
2. **`ChatInput` / `FileTreePane`** は narrowing を `<script>` の名前付きハンドラに移しました。DOM チェックは本来そこに置くべきものです。チェックが外れた場合は早期 return（従来はキャストで素通り）。
3. **`StackView`** の `:ref` は Vue から `Element | ComponentPublicInstance | null` を受け取ります。2つのセッタをその型で受け、`asHtmlElement` 1つで narrow するようにしました。
4. **plugins 側の6件（accounting / collection）は本 PR では触っていません** — 進行中のパッケージ sweep の担当範囲です。新ルールにより `warn` として可視化されます。
5. `chart-plugin` / `mulmoscript-plugin` のテンプレートにも各1件ありますが、これらは自己管理 eslint config 側で本 PR のルールが届きません。別途の判断が要ります。

## 実装方針

```js
// eslint.config.mjs — Vue SFC override
"vue/no-restricted-syntax": [
  "warn",
  { selector: "TSAsExpression", message: "Do not use any type assertions — narrow in <script> and pass the result to the template." },
],
```

| ファイル | 元 | 置換後 |
|---|---|---|
| `ChatInput.vue` | `($event.target as HTMLTextAreaElement).value` | `@input="onInput"` + script 内で `instanceof` |
| `FileTreePane.vue` | `(e.target as HTMLInputElement).checked` | `@change="onShowHiddenSystemChange"` + 同上 |
| `StackView.vue` ×2 | `element as HTMLElement \| null` | `VueRefTarget` を受けて `asHtmlElement` で narrow |
| `SettingsMcpTab.vue` ×6 | `(entry.spec as StdioSpec)` | **削除**（`v-if` が既に絞っている） |

## 検証

### 追加したルールが実際に検出するか

適用前は該当3ファイルで eslint が 2件しか報告しませんでした（テンプレート内の4件が不可視）。適用後は **16件を検出**します。

### ハンドラが実際に動くか（テンプレートは型が通っても実行時に壊れる）

`ChatInput` の narrowing をわざと失敗させると e2e が落ちます。

```
✖ chat-flow.spec.ts:147 › sending a chat message › streams the assistant's text event into the chat list
   1 failed / 8 passed
```

元に戻すと通ります。**「通るが壊れても通る」テストではない**ことの確認です。

```
npx playwright test --config e2e/playwright.config.ts  -> 449 passed / 1 failed
```

その1件は `stack-sticky-bottom-scroll`。単体では **2/2 pass**、かつ main でも同じく落ちる既知の flaky です。

```
yarn lint      -> exit 0
yarn typecheck -> exit 0
yarn build     -> exit 0
```

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Extend the existing ban on `as` type assertions to Vue templates and clean up related casts in core components.

New Features:
- Add a Vue `no-restricted-syntax` rule to flag TypeScript `as` assertions inside template ASTs.

Bug Fixes:
- Ensure event handlers in ChatInput and FileTreePane safely narrow DOM event targets without relying on template `as` casts.

Enhancements:
- Refine StackView ref handling by accepting Vue ref targets and centralizing HTMLElement narrowing logic.
- Simplify SettingsMcpTab template logic by removing redundant StdioSpec type assertions in already-narrowed branches.

Build:
- Update ESLint configuration so template `as` assertions are surfaced as warnings in Vue SFCs.