### PR TITLE
refactor: drain `as` casts from packages/bridges, markdown-utils and packages/plugins (50 -> 2) (#2692)

### DIFF
--- a/packages/bridges/discord/src/index.ts
+++ b/packages/bridges/discord/src/index.ts
@@ -42,9 +42,8 @@ mulmo.onPush((pushEvent) => {
 async function onPushEvent(pushEvent: { chatId: string; message: string }): Promise<void> {
   try {
     const channel = discord.channels.cache.get(pushEvent.chatId) ?? (await discord.channels.fetch(pushEvent.chatId).catch(() => null));
-    if (channel?.isTextBased() && "send" in channel) {
-      const sendable = channel as { send: (messageText: string) => Promise<unknown> };
-      await sendChunkedToSendable(sendable, pushEvent.message);
+    if (channel?.isTextBased() && channel.isSendable()) {
+      await sendChunkedToSendable(channel, pushEvent.message);
     } else {
       console.warn(`[discord] push: channel ${pushEvent.chatId} not found or not text-based`);
     }
@@ -88,8 +87,8 @@ async function sendChunked(msg: Message, text: string): Promise<void> {
     const chunk = text.slice(i, i + MAX_DISCORD_LENGTH);
     if (i === 0) {
       await msg.reply(chunk);
-    } else if ("send" in msg.channel) {
-      await (msg.channel as { send: (messageText: string) => Promise<unknown> }).send(chunk);
+    } else if (msg.channel.isSendable()) {
+      await msg.channel.send(chunk);
     }
   }
 }

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -105,8 +105,8 @@ const app = createWebhookApp();
 const webhookRateLimit = createWebhookRateLimit();
 
 app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
-  const signature = req.headers["x-line-signature"] as string;
-  const bodyStr = req.body as string;
+  const signature = typeof req.headers["x-line-signature"] === "string" ? req.headers["x-line-signature"] : "";
+  const bodyStr = typeof req.body === "string" ? req.body : "";
 
   if (!signature || !verifyHmacSignature(bodyStr, signature, channelSecret)) {
     res.status(401).send("Invalid signature");

--- a/packages/bridges/line/src/parse.ts
+++ b/packages/bridges/line/src/parse.ts
@@ -52,14 +52,40 @@ export function extractIncomingLineMessage(event: LineEvent): IncomingLineMessag
   return null;
 }
 
-/** Best-effort JSON parse for the webhook body — null on malformed input. */
+const isOptionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
+
+function isLineEventSource(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  if ("userId" in value && !isOptionalString(value.userId)) return false;
+  return !("type" in value) || isOptionalString(value.type);
+}
+
+function isLineMessage(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("type" in value) || typeof value.type !== "string") return false;
+  if ("text" in value && !isOptionalString(value.text)) return false;
+  return !("id" in value) || isOptionalString(value.id);
+}
+
+/** True only when every field `LineEvent` declares is present in the shape it
+ *  declares. Extra platform fields we don't model are left untouched. */
+function isLineEvent(value: unknown): value is LineEvent {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("type" in value) || typeof value.type !== "string") return false;
+  if ("replyToken" in value && !isOptionalString(value.replyToken)) return false;
+  if ("source" in value && value.source !== undefined && !isLineEventSource(value.source)) return false;
+  return !("message" in value) || value.message === undefined || isLineMessage(value.message);
+}
+
+/** Best-effort JSON parse for the webhook body — null on malformed input.
+ *  Events that don't match `LineEvent` are dropped rather than handed on as if
+ *  they did: a `null` element used to throw inside the delivery loop. */
 export function parseLineWebhookBody(raw: string): LineWebhookBody | null {
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object" || !Array.isArray((parsed as { events?: unknown }).events)) {
-      return null;
-    }
-    return parsed as LineWebhookBody;
+    if (typeof parsed !== "object" || parsed === null || !("events" in parsed)) return null;
+    const { events } = parsed;
+    return Array.isArray(events) ? { events: events.filter(isLineEvent) } : null;
   } catch {
     return null;
   }

--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -12,7 +12,7 @@
 
 import "dotenv/config";
 import WebSocket from "ws";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, asJsonRecord } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "mattermost";
@@ -48,7 +48,7 @@ async function apiGet(path: string): Promise<Record<string, unknown>> {
     signal: AbortSignal.timeout(15_000),
   });
   if (!res.ok) throw new Error(`GET ${path}: ${res.status}`);
-  return res.json() as Promise<Record<string, unknown>>;
+  return asJsonRecord(await res.json());
 }
 
 async function postMessage(channelId: string, text: string): Promise<void> {

--- a/packages/bridges/nostr/src/index.ts
+++ b/packages/bridges/nostr/src/index.ts
@@ -219,7 +219,7 @@ async function loadCursor(): Promise<void> {
     const raw = await readFile(cursorFile, "utf-8");
     const parsed: unknown = JSON.parse(raw);
     if (typeof parsed === "object" && parsed !== null && "lastSeenAt" in parsed) {
-      const value = (parsed as { lastSeenAt: unknown }).lastSeenAt;
+      const { lastSeenAt: value } = parsed;
       if (typeof value === "number" && Number.isFinite(value) && value > 0) {
         cursorState.lastSeenAt = Math.floor(value);
       }

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -40,25 +40,20 @@ if (!botToken || !appToken) {
 const allowedChannels = parseCsvSet(process.env.SLACK_ALLOWED_CHANNELS);
 const allowAll = allowedChannels.size === 0;
 
-const granularity = (() => {
+// The explicit `T` return annotation is what lets TS see `process.exit`'s
+// `never` and accept the catch branch as non-returning.
+function parseEnvOrExit<T>(parse: () => T): T {
   try {
-    return parseGranularity(process.env.SLACK_SESSION_GRANULARITY);
+    return parse();
   } catch (err) {
     console.error(`[slack] ${err instanceof Error ? err.message : String(err)}`);
-    process.exit(1);
-    return undefined as never;
   }
-})();
+  return process.exit(1);
+}
 
-const ackEmoji = (() => {
-  try {
-    return parseAckReaction(process.env.SLACK_ACK_REACTION);
-  } catch (err) {
-    console.error(`[slack] ${err instanceof Error ? err.message : String(err)}`);
-    process.exit(1);
-    return undefined as never;
-  }
-})();
+const granularity = parseEnvOrExit(() => parseGranularity(process.env.SLACK_SESSION_GRANULARITY));
+
+const ackEmoji = parseEnvOrExit(() => parseAckReaction(process.env.SLACK_ACK_REACTION));
 
 const web = new WebClient(botToken);
 const socketMode = new SocketModeClient({ appToken });

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -90,7 +90,7 @@ async function sendViber(receiverId: string, text: string): Promise<void> {
     }
     // Viber returns {status: 0} on success; log non-zero as warnings
     const body: unknown = await res.json().catch(() => null);
-    if (body && typeof body === "object" && "status" in body && (body as { status: number }).status !== 0) {
+    if (body && typeof body === "object" && "status" in body && body.status !== 0) {
       console.warn(`[viber] send non-zero status: ${JSON.stringify(body)}`);
     }
   }

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -99,8 +99,8 @@ registerMetaWebhookVerification(app, { rateLimit: webhookRateLimit, verifyToken,
 
 // Webhook events (POST) — signature-verified + rate-limited
 app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
-  const signature = req.headers["x-hub-signature-256"] as string;
-  const rawBody = req.body as string;
+  const signature = typeof req.headers["x-hub-signature-256"] === "string" ? req.headers["x-hub-signature-256"] : "";
+  const rawBody = typeof req.body === "string" ? req.body : "";
 
   if (!signature || !verifyMetaHmacSignature(rawBody, signature, appSecret)) {
     console.warn("[whatsapp] webhook signature verification failed");

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -18,7 +18,7 @@ import type { Request, Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, registerMetaWebhookVerification, verifyMetaHmacSignature } from "@mulmobridge/webhook-runtime";
 import { parseCsvSet } from "@mulmoclaude/common";
-import { extractWhatsAppMessages } from "@mulmoclaude/common/meta-webhook";
+import { extractWhatsAppMessages, type WhatsAppTextMessage } from "@mulmoclaude/common/meta-webhook";
 
 const TRANSPORT_ID = "whatsapp";
 const PORT = Number(process.env.WHATSAPP_BRIDGE_PORT) || 3003;
@@ -97,6 +97,48 @@ const webhookRateLimit = createWebhookRateLimit();
 // `narrowChallenge` `js/reflected-xss` whitelist + a `text/plain` response.
 registerMetaWebhookVerification(app, { rateLimit: webhookRateLimit, verifyToken, label: "whatsapp" });
 
+async function processOneMessage(msg: WhatsAppTextMessage): Promise<void> {
+  if (!allowAll && !allowedNumbers.has(msg.from)) {
+    console.log(`[whatsapp] denied from=${msg.from}`);
+    return;
+  }
+
+  console.log(`[whatsapp] message from=${msg.from} len=${msg.text.body.length}`);
+
+  try {
+    const ack = await mulmo.send(msg.from, msg.text.body);
+    if (ack.ok) {
+      await sendWhatsAppMessage(msg.from, ack.reply ?? "");
+    } else {
+      const status = ack.status ? ` (${ack.status})` : "";
+      await sendWhatsAppMessage(msg.from, `Error${status}: ${ack.error ?? "unknown"}`);
+    }
+  } catch (err) {
+    console.error(`[whatsapp] message handling failed: ${err}`);
+  }
+}
+
+/** `undefined` is an unambiguous parse-failure sentinel — JSON has no
+ *  `undefined` literal, so a valid body can never produce it. */
+function parseWebhookJson(rawBody: string): unknown {
+  try {
+    return JSON.parse(rawBody);
+  } catch {
+    return undefined;
+  }
+}
+
+async function handleWebhookBody(rawBody: string): Promise<void> {
+  const parsed = parseWebhookJson(rawBody);
+  if (parsed === undefined) {
+    console.error("[whatsapp] malformed JSON in webhook body");
+    return;
+  }
+  for (const msg of extractWhatsAppMessages(parsed)) {
+    await processOneMessage(msg);
+  }
+}
+
 // Webhook events (POST) — signature-verified + rate-limited
 app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
   const signature = typeof req.headers["x-hub-signature-256"] === "string" ? req.headers["x-hub-signature-256"] : "";
@@ -109,35 +151,7 @@ app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
   }
 
   res.status(200).send("OK");
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawBody);
-  } catch {
-    console.error("[whatsapp] malformed JSON in webhook body");
-    return;
-  }
-
-  for (const msg of extractWhatsAppMessages(parsed)) {
-    if (!allowAll && !allowedNumbers.has(msg.from)) {
-      console.log(`[whatsapp] denied from=${msg.from}`);
-      continue;
-    }
-
-    console.log(`[whatsapp] message from=${msg.from} len=${msg.text.body.length}`);
-
-    try {
-      const ack = await mulmo.send(msg.from, msg.text.body);
-      if (ack.ok) {
-        await sendWhatsAppMessage(msg.from, ack.reply ?? "");
-      } else {
-        const status = ack.status ? ` (${ack.status})` : "";
-        await sendWhatsAppMessage(msg.from, `Error${status}: ${ack.error ?? "unknown"}`);
-      }
-    } catch (err) {
-      console.error(`[whatsapp] message handling failed: ${err}`);
-    }
-  }
+  await handleWebhookBody(rawBody);
 });
 
 app.listen(PORT, () => {

--- a/packages/markdown-utils/src/image/htmlSrcAttrs.ts
+++ b/packages/markdown-utils/src/image/htmlSrcAttrs.ts
@@ -208,22 +208,33 @@ export function transformResolvableUrlsInHtml(html: string, transform: (url: str
   });
 }
 
+interface AttrCaptures {
+  full: string;
+  leading: string;
+  name: string;
+  eqWithSpaces: string | undefined;
+  doubleQuoted: string | undefined;
+  singleQuoted: string | undefined;
+  bare: string | undefined;
+}
+
+// Named view of `ATTR_ITER_RE`'s capture list (group 4, the full quoted
+// value, is captured for clarity and skipped here). Groups that never
+// participate come back `undefined`; the three the regex always fills fall
+// back to `""` so a non-string can only ever blank the attribute, never
+// reach the rewriter as if it were text.
+function readAttrCaptures(captures: unknown[]): AttrCaptures {
+  const [full, leading, name, eqWithSpaces, , doubleQuoted, singleQuoted, bare] = captures.map((value) => (typeof value === "string" ? value : undefined));
+  return { full: full ?? "", leading: leading ?? "", name: name ?? "", eqWithSpaces, doubleQuoted, singleQuoted, bare };
+}
+
 function replaceAttrIfResolvable(
   captures: unknown[],
   resolvableAttrs: readonly string[],
   srcsetAttrs: readonly string[],
   transform: (url: string) => string | null,
 ): string {
-  const [full, leading, name, eqWithSpaces, , doubleQuoted, singleQuoted, bare] = captures as [
-    string,
-    string,
-    string,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-    string | undefined,
-  ];
+  const { full, leading, name, eqWithSpaces, doubleQuoted, singleQuoted, bare } = readAttrCaptures(captures);
   if (!eqWithSpaces) return full;
   const lowerName = name.toLowerCase();
   const isSrcset = srcsetAttrs.includes(lowerName);

--- a/packages/markdown-utils/src/image/rewriteMarkdownImageRefs.ts
+++ b/packages/markdown-utils/src/image/rewriteMarkdownImageRefs.ts
@@ -1,5 +1,5 @@
 import { marked } from "marked";
-import type { Token, Tokens } from "marked";
+import type { Token } from "marked";
 import { resolveImageSrc } from "./resolve";
 import { transformResolvableUrlsInHtml } from "./htmlSrcAttrs";
 
@@ -87,7 +87,10 @@ function extractBracketedAlt(raw: string): string | null {
   return null;
 }
 
-function rewriteImageToken(token: Tokens.Image, basePath: string): string | null {
+// Declares the four fields it reads rather than the whole `Tokens.Image`:
+// `type === "image"` leaves marked's open `Tokens.Generic` member in the
+// union, and every read below already tolerates a missing value.
+function rewriteImageToken(token: { href?: string; raw: string; text?: string; title?: string | null }, basePath: string): string | null {
   const href = (token.href ?? "").trim();
   if (href === "" || shouldSkip(href)) return null;
   const resolved = resolveWorkspacePath(basePath, href);
@@ -144,15 +147,24 @@ function isSkippable(token: Token): boolean {
   return token.type === "code" || token.type === "codespan";
 }
 
+// `Tokens.Generic` — the open member of marked's `Token` union — requires
+// only a string `type` and a string `raw`, so proving those two is enough
+// to call a value a `Token`.
+function isToken(value: unknown): value is Token {
+  if (typeof value !== "object" || value === null) return false;
+  return "type" in value && typeof value.type === "string" && "raw" in value && typeof value.raw === "string";
+}
+
+function toTokenArray(value: unknown): Token[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const candidates: unknown[] = value;
+  return candidates.every(isToken) ? candidates : null;
+}
+
 function getContainerChildren(token: Token): Token[] | null {
-  const container = token as { tokens?: Token[]; items?: Token[] };
-  if (Array.isArray(container.tokens) && container.tokens.length > 0) {
-    return container.tokens;
-  }
-  if (Array.isArray(container.items) && container.items.length > 0) {
-    return container.items;
-  }
-  return null;
+  const tokens: unknown = "tokens" in token ? token.tokens : undefined;
+  const items: unknown = "items" in token ? token.items : undefined;
+  return toTokenArray(tokens) ?? toTokenArray(items);
 }
 
 // Render a container's children back into the output, preserving any
@@ -161,7 +173,7 @@ function getContainerChildren(token: Token): Token[] | null {
 // Returns true if the container was rendered via its children, false
 // if the caller should fall back to emitting the parent's raw.
 function renderContainerChildren(raw: string, children: Token[], basePath: string, out: string[]): boolean {
-  const joined = children.map((token) => (token as { raw?: string }).raw ?? "").join("");
+  const joined = children.map((token) => token.raw).join("");
   if (joined === "") return false;
   const idx = raw.indexOf(joined);
   if (idx < 0) return false;
@@ -187,7 +199,7 @@ function renderToken(token: Token, basePath: string, out: string[]): void {
     return;
   }
   if (token.type === "image") {
-    const replacement = rewriteImageToken(token as Tokens.Image, basePath);
+    const replacement = rewriteImageToken(token, basePath);
     out.push(replacement ?? token.raw);
     return;
   }
@@ -195,13 +207,11 @@ function renderToken(token: Token, basePath: string, out: string[]): void {
     // Block / inline HTML — rewrite raw <img> tags inside before
     // emitting. Markdown image syntax (![alt](url)) is handled by the
     // image-token branch above; this branch covers the HTML-fallback
-    // path (#1011 Stage A). Fall back to verbatim raw if `raw` is
-    // unexpectedly missing — defensive against future marked changes.
-    const raw = (token as { raw?: string }).raw ?? "";
-    out.push(rewriteImgSrcAttrsInHtml(raw, basePath));
+    // path (#1011 Stage A).
+    out.push(rewriteImgSrcAttrsInHtml(token.raw, basePath));
     return;
   }
-  const raw = (token as { raw?: string }).raw ?? "";
+  const { raw } = token;
   const children = getContainerChildren(token);
   if (children && renderContainerChildren(raw, children, basePath, out)) {
     return;

--- a/packages/markdown-utils/src/markdown/frontmatter.ts
+++ b/packages/markdown-utils/src/markdown/frontmatter.ts
@@ -11,6 +11,7 @@
 // approximation in the legacy `src/utils/format/frontmatter.ts`.
 
 import { FAILSAFE_SCHEMA, dump as yamlDump, load as yamlLoad } from "js-yaml";
+import { isRecord } from "@mulmoclaude/common";
 
 export interface ParsedMarkdown {
   /** Parsed YAML object. Empty `{}` when the document has no
@@ -136,8 +137,8 @@ function safeYamlLoad(text: string): Record<string, unknown> | null {
     // (e.g. `"hello"` parses to the string `"hello"`). Only accept
     // plain objects — anything else is a malformed header.
     if (loaded === null || loaded === undefined) return {};
-    if (typeof loaded !== "object" || Array.isArray(loaded)) return null;
-    return loaded as Record<string, unknown>;
+    if (!isRecord(loaded)) return null;
+    return loaded;
   } catch {
     return null;
   }

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -181,13 +181,10 @@ function coerceFiscalYearEndInput(raw: unknown): FiscalYearEnd | undefined {
   return month;
 }
 
-/** Boundary checks shared by updateBook (name / country only —
- *  fiscalYearEnd is coerced + validated separately via
- *  `coerceFiscalYearEndInput`). Throws on the first failure so the
- *  surrounding function stays under the cognitive-complexity threshold;
- *  each rule is also unit-testable independently via the service entry
- *  point. */
-/** Throws on malformed input, and hands back the country to persist:
+/** Boundary checks for updateBook (name / country only — fiscalYearEnd is
+ *  coerced + validated separately via `coerceFiscalYearEndInput`). Throws on
+ *  the first failure so the surrounding function stays under the
+ *  cognitive-complexity threshold, and hands back the country to persist:
  *  `undefined` = the field was omitted, `""` = explicit clear. */
 function parseUpdateBookInput(input: { name?: string; country?: string }): SupportedCountryCode | "" | undefined {
   if (input.name !== undefined && (typeof input.name !== "string" || input.name.trim() === "")) {

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -187,16 +187,21 @@ function coerceFiscalYearEndInput(raw: unknown): FiscalYearEnd | undefined {
  *  surrounding function stays under the cognitive-complexity threshold;
  *  each rule is also unit-testable independently via the service entry
  *  point. */
-function validateUpdateBookInput(input: { name?: string; country?: string }): void {
+/** Throws on malformed input, and hands back the country to persist:
+ *  `undefined` = the field was omitted, `""` = explicit clear. */
+function parseUpdateBookInput(input: { name?: string; country?: string }): SupportedCountryCode | "" | undefined {
   if (input.name !== undefined && (typeof input.name !== "string" || input.name.trim() === "")) {
     throw new AccountingError(400, "name must be a non-empty string when supplied");
   }
+  const { country } = input;
   // Empty string is the explicit "clear the field" sentinel from the
   // settings UI; anything else has to land in the curated list, same
   // contract as createBook.
-  if (input.country !== undefined && input.country !== "" && !isSupportedCountryCode(input.country)) {
-    throw unsupportedCountryError(input.country);
+  if (country === undefined || country === "") return country;
+  if (!isSupportedCountryCode(country)) {
+    throw unsupportedCountryError(country);
   }
+  return country;
 }
 
 export async function createBook(
@@ -210,8 +215,9 @@ export async function createBook(
   // the UI dropdown, the role prompt's per-jurisdiction guidance, and
   // the on-disk JSON in sync. A typo from the LLM or an untrusted
   // client is rejected here rather than silently persisted.
-  if (input.country !== undefined && !isSupportedCountryCode(input.country)) {
-    throw unsupportedCountryError(input.country);
+  const { country } = input;
+  if (country !== undefined && !isSupportedCountryCode(country)) {
+    throw unsupportedCountryError(country);
   }
   const fiscalYearEnd = coerceFiscalYearEndInput(input.fiscalYearEnd) ?? DEFAULT_FISCAL_YEAR_END;
   const config = await loadOrInitConfig(workspaceRoot);
@@ -237,8 +243,7 @@ export async function createBook(
     id: bookId,
     name: input.name,
     currency: input.currency ?? DEFAULT_CURRENCY,
-    // Narrowed by the isSupportedCountryCode check above.
-    ...(input.country ? { country: input.country as SupportedCountryCode } : {}),
+    ...(country ? { country } : {}),
     fiscalYearEnd,
     createdAt: new Date().toISOString(),
   };
@@ -259,7 +264,7 @@ export async function updateBook(
   if (!target) {
     throw new AccountingError(404, `book ${JSON.stringify(input.bookId)} not found`);
   }
-  validateUpdateBookInput(input);
+  const country = parseUpdateBookInput(input);
   // Coerce + validate up front so a malformed value 400s before any
   // write (undefined = the field was omitted → leave it untouched).
   const fiscalYearEnd = coerceFiscalYearEndInput(input.fiscalYearEnd);
@@ -271,12 +276,12 @@ export async function updateBook(
   const next: BookSummary = {
     ...target,
     ...(input.name !== undefined ? { name: input.name } : {}),
-    ...(input.country !== undefined && input.country !== "" ? { country: input.country as SupportedCountryCode } : {}),
+    ...(country ? { country } : {}),
     ...(fiscalYearEnd !== undefined ? { fiscalYearEnd } : {}),
   };
   // Strip an explicitly-cleared country so the JSON file stays clean
   // (matches the createBook policy of omitting the field when unset).
-  if (input.country === "") delete next.country;
+  if (country === "") delete next.country;
   const nextConfig: AccountingConfig = {
     books: config.books.map((book) => (book.id === input.bookId ? next : book)),
   };
@@ -647,17 +652,19 @@ function ensureValidYmd(label: string, value: unknown): string {
 }
 
 function ensureMetric(value: unknown): TimeSeriesMetric {
-  if (typeof value !== "string" || !(TIME_SERIES_METRICS as readonly string[]).includes(value)) {
+  const metric = TIME_SERIES_METRICS.find((candidate) => candidate === value);
+  if (metric === undefined) {
     throw new AccountingError(400, `getTimeSeries: metric must be one of ${TIME_SERIES_METRICS.join(", ")}`);
   }
-  return value as TimeSeriesMetric;
+  return metric;
 }
 
 function ensureGranularity(value: unknown): TimeSeriesGranularity {
-  if (typeof value !== "string" || !(TIME_SERIES_GRANULARITIES as readonly string[]).includes(value)) {
+  const granularity = TIME_SERIES_GRANULARITIES.find((candidate) => candidate === value);
+  if (granularity === undefined) {
     throw new AccountingError(400, `getTimeSeries: granularity must be one of ${TIME_SERIES_GRANULARITIES.join(", ")}`);
   }
-  return value as TimeSeriesGranularity;
+  return granularity;
 }
 
 function resolveAccountCode(metric: TimeSeriesMetric, raw: unknown): string | undefined {

--- a/packages/plugins/accounting-plugin/src/shared/countries.ts
+++ b/packages/plugins/accounting-plugin/src/shared/countries.ts
@@ -96,7 +96,7 @@ export function localizedCountryName(code: string, locale: string): string {
  *  LLM input arrives as raw `string` (form submit, JSON-RPC body),
  *  so the service layer narrows here before persisting. */
 export function isSupportedCountryCode(value: unknown): value is SupportedCountryCode {
-  return typeof value === "string" && (SUPPORTED_COUNTRY_CODES as readonly string[]).includes(value);
+  return SUPPORTED_COUNTRY_CODES.some((code) => code === value);
 }
 
 /** Country-gated UI features. Each key is a feature name; the value

--- a/packages/plugins/accounting-plugin/src/vue/View.vue
+++ b/packages/plugins/accounting-plugin/src/vue/View.vue
@@ -183,7 +183,7 @@ const TABS: readonly TabDef[] = [
 ];
 
 function isTabKey(value: string | undefined): value is TabKey {
-  return typeof value === "string" && (TAB_KEYS as readonly string[]).includes(value);
+  return TAB_KEYS.some((key) => key === value);
 }
 
 const initialPayload = computed<AccountingAppPayload>(() => props.selectedResult?.data ?? props.selectedResult?.jsonData ?? {});

--- a/packages/plugins/accounting-plugin/src/vue/components/NewBookForm.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/NewBookForm.vue
@@ -68,6 +68,7 @@ import {
   SUPPORTED_CURRENCY_CODES,
   localizedCurrencyName,
   SUPPORTED_COUNTRY_CODES,
+  isSupportedCountryCode,
   localizedCountryName,
   type SupportedCountryCode,
   DEFAULT_FISCAL_YEAR_END,
@@ -81,8 +82,8 @@ const { t, locale } = useAccountingI18n();
 function regionFromLocaleTag(tag: string): SupportedCountryCode | "" {
   try {
     const { region } = new Intl.Locale(tag).maximize();
-    if (region && (SUPPORTED_COUNTRY_CODES as readonly string[]).includes(region)) {
-      return region as SupportedCountryCode;
+    if (isSupportedCountryCode(region)) {
+      return region;
     }
   } catch {
     /* fall through */

--- a/packages/plugins/accounting-plugin/src/vue/components/OpeningBalancesForm.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/OpeningBalancesForm.vue
@@ -180,12 +180,13 @@ function toApiLines(): JournalLine[] {
   for (const account of bsAccounts.value) {
     const row = rows.value[account.code];
     if (!row) continue;
-    const debitOk = isPositiveAmount(row.debit);
-    const creditOk = isPositiveAmount(row.credit);
+    const { debit, credit } = row;
+    const debitOk = isPositiveAmount(debit);
+    const creditOk = isPositiveAmount(credit);
     if (!debitOk && !creditOk) continue;
     const line: JournalLine = { accountCode: account.code };
-    if (debitOk) line.debit = row.debit as number;
-    if (creditOk) line.credit = row.credit as number;
+    if (debitOk) line.debit = debit;
+    if (creditOk) line.credit = credit;
     out.push(line);
   }
   return out;

--- a/packages/plugins/accounting-plugin/src/vue/components/accountNumbering.ts
+++ b/packages/plugins/accounting-plugin/src/vue/components/accountNumbering.ts
@@ -33,6 +33,7 @@
 // imports between Vue components.
 
 import type { Account, AccountType } from "../api";
+import { ACCOUNT_TYPES } from "../../shared";
 
 export const ACCOUNT_TYPE_PREFIX: Record<AccountType, number> = {
   asset: 1,
@@ -65,10 +66,7 @@ export function isValidAccountCode(code: string): boolean {
 export function typeForCode(code: string): AccountType | null {
   if (!isValidAccountCode(code)) return null;
   const leading = Number.parseInt(code[0], 10);
-  for (const [type, prefix] of Object.entries(ACCOUNT_TYPE_PREFIX) as [AccountType, number][]) {
-    if (prefix === leading) return type;
-  }
-  return null;
+  return ACCOUNT_TYPES.find((type) => ACCOUNT_TYPE_PREFIX[type] === leading) ?? null;
 }
 
 export function codeMatchesType(code: string, type: AccountType): boolean {

--- a/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
+++ b/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
@@ -18,8 +18,20 @@
 // own `./shared` so publisher and subscriber stay in lockstep.
 
 import { ref, watch, onUnmounted, type Ref } from "vue";
-import { bookChannel, ACCOUNTING_BOOKS_CHANNEL, type BookChannelPayload } from "../shared";
+import { bookChannel, ACCOUNTING_BOOKS_CHANNEL, BOOK_EVENT_KINDS, type BookChannelPayload } from "../shared";
 import { hostSubscribe } from "./hostContext";
+
+const BOOK_EVENT_KIND_VALUES = Object.values(BOOK_EVENT_KINDS);
+
+/** The host hands subscribers an `unknown`, so rebuild the payload from
+ *  the fields we can prove rather than trusting the publisher's type. */
+function toBookChannelPayload(data: unknown): BookChannelPayload | null {
+  if (typeof data !== "object" || data === null || !("kind" in data)) return null;
+  const kind = BOOK_EVENT_KIND_VALUES.find((candidate) => candidate === data.kind);
+  if (kind === undefined) return null;
+  const period = "period" in data && typeof data.period === "string" ? data.period : undefined;
+  return period === undefined ? { kind } : { kind, period };
+}
 
 export interface UseAccountingChannelReturn {
   /** Bumps on every per-book event for the current bookId. Resets to
@@ -37,9 +49,9 @@ export function useAccountingChannel(bookId: Ref<string | null>, onPayload?: (pa
     version.value = 0;
     if (!nextBookId) return;
     unsubscribe = hostSubscribe(bookChannel(nextBookId), (data) => {
-      const event = data as BookChannelPayload;
       version.value += 1;
-      onPayload?.(event);
+      const event = toBookChannelPayload(data);
+      if (event) onPayload?.(event);
     });
   }
 

--- a/packages/plugins/collection-plugin/src/vue/chat/Preview.vue
+++ b/packages/plugins/collection-plugin/src/vue/chat/Preview.vue
@@ -16,6 +16,7 @@ import { computed } from "vue";
 import { useCollectionI18n } from "../lang";
 import type { ToolResult } from "gui-chat-protocol";
 import type { PresentCollectionData } from "@mulmoclaude/core/collection";
+import { toPresentCollectionData } from "./presentCollectionData";
 
 const { t } = useCollectionI18n();
 
@@ -23,7 +24,7 @@ const props = defineProps<{
   result: ToolResult;
 }>();
 
-const data = computed<PresentCollectionData | null>(() => (props.result?.data ?? props.result?.jsonData ?? null) as PresentCollectionData | null);
+const data = computed<PresentCollectionData | null>(() => toPresentCollectionData(props.result?.data ?? props.result?.jsonData));
 
 const collectionSlug = computed<string>(() => data.value?.collectionSlug ?? "");
 const itemId = computed<string | undefined>(() => data.value?.itemId);

--- a/packages/plugins/collection-plugin/src/vue/chat/View.vue
+++ b/packages/plugins/collection-plugin/src/vue/chat/View.vue
@@ -19,6 +19,7 @@ import { computed } from "vue";
 import type { ToolResult } from "gui-chat-protocol";
 import CollectionView from "../components/CollectionView.vue";
 import type { PresentCollectionData } from "@mulmoclaude/core/collection";
+import { toPresentCollectionData } from "./presentCollectionData";
 
 /** Card-local UI state persisted in the tool result's `viewState` so it
  *  survives a re-render — same pattern as presentForm. `selected` is the
@@ -46,13 +47,23 @@ const emit = defineEmits<{
   updateResult: [result: ToolResult];
 }>();
 
-const data = computed<PresentCollectionData | null>(
-  () => (props.selectedResult?.data ?? props.selectedResult?.jsonData ?? null) as PresentCollectionData | null,
-);
+const data = computed<PresentCollectionData | null>(() => toPresentCollectionData(props.selectedResult?.data ?? props.selectedResult?.jsonData));
 
 const slug = computed<string | undefined>(() => data.value?.collectionSlug);
 
-const viewState = computed<PresentCollectionViewState | null>(() => (props.selectedResult?.viewState as PresentCollectionViewState | undefined) ?? null);
+/** Keep a field only when the stored value still matches what the interface
+ *  declares, so `"selected" in state` keeps meaning "the user navigated". */
+function toViewState(value: unknown): PresentCollectionViewState | null {
+  if (typeof value !== "object" || value === null) return null;
+  const state: PresentCollectionViewState = {};
+  if ("selected" in value && (typeof value.selected === "string" || value.selected === null)) state.selected = value.selected;
+  if ("view" in value && (value.view === "table" || value.view === "calendar" || value.view === "kanban")) state.view = value.view;
+  if ("anchorField" in value && typeof value.anchorField === "string") state.anchorField = value.anchorField;
+  if ("groupField" in value && typeof value.groupField === "string") state.groupField = value.groupField;
+  return state;
+}
+
+const viewState = computed<PresentCollectionViewState | null>(() => toViewState(props.selectedResult?.viewState));
 
 /** Open record: the card-local `viewState.selected` once the user has
  *  navigated within the card (including an explicit close → null), else

--- a/packages/plugins/collection-plugin/src/vue/chat/presentCollectionData.ts
+++ b/packages/plugins/collection-plugin/src/vue/chat/presentCollectionData.ts
@@ -1,0 +1,12 @@
+// The host hands a tool result's `data` / `jsonData` through untyped, so the
+// two chat surfaces read the render payload back out field by field instead of
+// trusting whatever produced the result.
+
+import type { PresentCollectionData } from "@mulmoclaude/core/collection";
+
+export function toPresentCollectionData(value: unknown): PresentCollectionData | null {
+  if (typeof value !== "object" || value === null) return null;
+  if (!("collectionSlug" in value) || typeof value.collectionSlug !== "string") return null;
+  const itemId = "itemId" in value && typeof value.itemId === "string" ? value.itemId : undefined;
+  return { collectionSlug: value.collectionSlug, itemId };
+}

--- a/packages/plugins/collection-plugin/src/vue/collectionViewMode.ts
+++ b/packages/plugins/collection-plugin/src/vue/collectionViewMode.ts
@@ -64,13 +64,19 @@ const SORT_STORAGE_KEY = "collection_sorts";
 
 const BUILT_IN_MODES: readonly BuiltInViewMode[] = ["table", "calendar", "kanban"];
 
+/** `Object.entries` of a value already narrowed to a non-array object, with the
+ *  values kept `unknown` so each store re-validates before storing. */
+function readEntries(source: object): [string, unknown][] {
+  return Object.entries(source);
+}
+
 /** A persisted mode is valid if it's a known built-in OR any `custom:<id>`
  *  key (the id is validated against the live schema at render time, so an
  *  unknown custom id simply collapses to the table there). Takes `unknown`
  *  and type-guards `string` first: a corrupted localStorage entry could hold a
  *  number/object, and calling `.startsWith` on that would throw. */
 function isValidViewMode(value: unknown): value is CollectionViewMode {
-  return typeof value === "string" && (BUILT_IN_MODES.includes(value as BuiltInViewMode) || value.startsWith("custom:"));
+  return typeof value === "string" && (BUILT_IN_MODES.some((mode) => mode === value) || value.startsWith("custom:"));
 }
 
 type ViewModeMap = Record<string, CollectionViewMode>;
@@ -82,7 +88,14 @@ function readAll(): ViewModeMap {
     const parsed: unknown = JSON.parse(raw);
     // Plain object only — an array would pass `typeof === "object"` and then
     // let writeCollectionViewMode write string keys onto it.
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as ViewModeMap) : {};
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    // Same policy as the sort / flag-filter stores below: drop entries whose
+    // stored value no longer validates rather than handing them back.
+    const out: ViewModeMap = {};
+    for (const [slug, value] of readEntries(parsed)) {
+      if (isValidViewMode(value)) out[slug] = value;
+    }
+    return out;
   } catch {
     return {};
   }
@@ -110,8 +123,8 @@ type SortMap = Record<string, SortState>;
 
 function isSortState(value: unknown): value is SortState {
   if (!value || typeof value !== "object") return false;
-  const rec = value as Record<string, unknown>;
-  return typeof rec.field === "string" && (rec.direction === "asc" || rec.direction === "desc");
+  if (!("field" in value) || typeof value.field !== "string") return false;
+  return "direction" in value && (value.direction === "asc" || value.direction === "desc");
 }
 
 function readAllSorts(): SortMap {
@@ -124,7 +137,7 @@ function readAllSorts(): SortMap {
     // whose field was renamed away leaves a stale value) so callers only ever
     // see a well-formed SortState.
     const out: SortMap = {};
-    for (const [slug, value] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [slug, value] of readEntries(parsed)) {
       if (isSortState(value)) out[slug] = value;
     }
     return out;
@@ -172,7 +185,7 @@ function readAllFlagFilters(): Record<string, FlagFilterState> {
     const parsed: unknown = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
     const out: Record<string, FlagFilterState> = {};
-    for (const [slug, value] of Object.entries(parsed as Record<string, unknown>)) {
+    for (const [slug, value] of readEntries(parsed)) {
       if (isFlagFilterState(value)) out[slug] = value;
     }
     return out;

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
@@ -187,10 +187,12 @@ function handleStartChat(body: { prompt?: unknown; role?: unknown }): void {
 
 function onWindowMessage(event: MessageEvent): void {
   if (event.source !== iframeEl.value?.contentWindow) return;
-  const msg = event.data as { type?: string; slug?: string; id?: unknown; mode?: unknown; prompt?: unknown; role?: unknown };
-  if (!msg || msg.slug !== props.slug) return;
-  if (msg.type === "mc-open-item") handleOpenItem(msg);
-  else if (msg.type === "mc-start-chat") handleStartChat(msg);
+  const msg: unknown = event.data;
+  if (typeof msg !== "object" || msg === null) return;
+  if (!("slug" in msg) || msg.slug !== props.slug) return;
+  const type = "type" in msg ? msg.type : undefined;
+  if (type === "mc-open-item") handleOpenItem({ id: "id" in msg ? msg.id : undefined, mode: "mode" in msg ? msg.mode : undefined });
+  else if (type === "mc-start-chat") handleStartChat({ prompt: "prompt" in msg ? msg.prompt : undefined, role: "role" in msg ? msg.role : undefined });
 }
 
 onMounted(() => window.addEventListener("message", onWindowMessage));

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionOntologyGraphView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionOntologyGraphView.vue
@@ -80,9 +80,39 @@ const edgeTooltip = (data: { source: string; target: string; field: string; kind
   return `${escapeHtml(data.source)} —${escapeHtml(data.field)}→ ${escapeHtml(data.target)}<br><span style="color:#64748b">${escapeHtml(data.kind)}${escapeHtml(reverse)}</span>`;
 };
 
+// echarts hands the formatter an untyped callback param, so read the item back
+// out field by field. `nodeItem` / `edgeItem` above are the only producers;
+// anything else degrades to empty labels instead of rendering `undefined`.
+const asString = (value: unknown): string => (typeof value === "string" ? value : "");
+
+const toTooltipNode = (data: unknown): { id: string; name: string; missing: boolean; recordCount: number | null } => {
+  if (typeof data !== "object" || data === null) return { id: "", name: "", missing: false, recordCount: null };
+  return {
+    id: asString("id" in data ? data.id : undefined),
+    name: asString("name" in data ? data.name : undefined),
+    missing: "missing" in data && data.missing === true,
+    recordCount: "recordCount" in data && typeof data.recordCount === "number" ? data.recordCount : null,
+  };
+};
+
+const toTooltipEdge = (data: unknown): { source: string; target: string; field: string; kind: string; reverseFields: string[] } => {
+  if (typeof data !== "object" || data === null) return { source: "", target: "", field: "", kind: "", reverseFields: [] };
+  const rawReverse: unknown = "reverseFields" in data ? data.reverseFields : undefined;
+  const reverse: unknown[] = Array.isArray(rawReverse) ? rawReverse : [];
+  return {
+    source: asString("source" in data ? data.source : undefined),
+    target: asString("target" in data ? data.target : undefined),
+    field: asString("field" in data ? data.field : undefined),
+    kind: asString("kind" in data ? data.kind : undefined),
+    reverseFields: reverse.filter((item): item is string => typeof item === "string"),
+  };
+};
+
 const tooltipFormatter = (params: unknown): string => {
-  const { dataType, data } = params as { dataType: string; data: never };
-  return dataType === "edge" ? edgeTooltip(data) : nodeTooltip(data);
+  if (typeof params !== "object" || params === null) return "";
+  const data: unknown = "data" in params ? params.data : undefined;
+  const isEdge = "dataType" in params && params.dataType === "edge";
+  return isEdge ? edgeTooltip(toTooltipEdge(data)) : nodeTooltip(toTooltipNode(data));
 };
 
 const buildOption = (value: OntologyGraph): echarts.EChartsCoreOption => ({
@@ -112,8 +142,11 @@ const render = (): void => {
     instance = echarts.init(element);
     instance.on("click", (params) => {
       if (params.dataType !== "node") return;
-      const data = params.data as { id?: unknown; missing?: unknown } | null | undefined;
-      if (typeof data?.id === "string" && data.missing !== true) emit("open", data.id);
+      const clicked: unknown = params.data;
+      if (typeof clicked !== "object" || clicked === null) return;
+      const nodeId = "id" in clicked ? clicked.id : undefined;
+      const missing = "missing" in clicked ? clicked.missing : undefined;
+      if (typeof nodeId === "string" && missing !== true) emit("open", nodeId);
     });
   }
   instance.setOption(buildOption(graph.value), true);

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
@@ -40,7 +40,6 @@ import type { CollectionCustomView } from "@mulmoclaude/core/collection";
 import {
   handleRemoteViewMessage,
   REMOTE_VIEW_MAX_BYTES,
-  type RemoteViewItem,
   type RemoteViewMutateRequest,
   type RemoteViewMutateResult,
   type RemoteViewPage,
@@ -144,7 +143,7 @@ async function onMutate(request: RemoteViewMutateRequest): Promise<RemoteViewMut
   if (!binding.mutateRemoteView) throw new Error("mutateRemoteView is not wired on this host");
   const resp = await binding.mutateRemoteView(props.slug, props.view.id, request);
   if (!resp.ok) throw new Error(resp.error);
-  return resp.data.op === "update" ? { item: resp.data.item as RemoteViewItem } : { id: resp.data.id };
+  return resp.data.op === "update" ? { item: resp.data.item } : { id: resp.data.id };
 }
 
 function onWindowMessage(event: MessageEvent): void {

--- a/packages/plugins/x-plugin/src/client.ts
+++ b/packages/plugins/x-plugin/src/client.ts
@@ -1,4 +1,4 @@
-import { errorMessage, toUtcIsoDate } from "@mulmoclaude/common";
+import { errorMessage, isRecord, isUnknownArray, toUtcIsoDate } from "@mulmoclaude/common";
 import { fetchWithTimeout, ONE_SECOND_MS, safeResponseText } from "./internal";
 
 const X_API_BASE = "https://api.twitter.com/2";
@@ -50,6 +50,94 @@ export function xBearerToken(): string | undefined {
   return process.env.X_BEARER_TOKEN;
 }
 
+const readString = (source: Record<string, unknown>, key: string): string | undefined => {
+  const value = source[key];
+  return typeof value === "string" ? value : undefined;
+};
+
+const readNumber = (source: Record<string, unknown>, key: string): number | undefined => {
+  const value = source[key];
+  return typeof value === "number" ? value : undefined;
+};
+
+function toXUser(value: unknown): XUser | null {
+  if (!isRecord(value)) return null;
+  const userId = readString(value, "id");
+  const name = readString(value, "name");
+  const username = readString(value, "username");
+  if (userId === undefined || name === undefined || username === undefined) return null;
+  return { id: userId, name, username };
+}
+
+function toNoteTweet(value: unknown): XTweet["note_tweet"] {
+  if (!isRecord(value)) return undefined;
+  const text = readString(value, "text");
+  return text === undefined ? undefined : { text };
+}
+
+function toArticle(value: unknown): XTweet["article"] {
+  if (!isRecord(value)) return undefined;
+  return { title: readString(value, "title"), plain_text: readString(value, "plain_text") };
+}
+
+function toPublicMetrics(value: unknown): XTweet["public_metrics"] {
+  if (!isRecord(value)) return undefined;
+  const like_count = readNumber(value, "like_count");
+  const retweet_count = readNumber(value, "retweet_count");
+  const reply_count = readNumber(value, "reply_count");
+  if (like_count === undefined || retweet_count === undefined || reply_count === undefined) return undefined;
+  return { like_count, retweet_count, reply_count };
+}
+
+function toXTweet(value: unknown): XTweet | null {
+  if (!isRecord(value)) return null;
+  const tweetId = readString(value, "id");
+  const text = readString(value, "text");
+  if (tweetId === undefined || text === undefined) return null;
+  return {
+    id: tweetId,
+    text,
+    author_id: readString(value, "author_id"),
+    created_at: readString(value, "created_at"),
+    note_tweet: toNoteTweet(value.note_tweet),
+    article: toArticle(value.article),
+    public_metrics: toPublicMetrics(value.public_metrics),
+  };
+}
+
+function toXErrors(value: unknown): { detail: string }[] | undefined {
+  if (!isUnknownArray(value)) return undefined;
+  return value.flatMap((item) => {
+    const detail = isRecord(item) ? readString(item, "detail") : undefined;
+    return detail === undefined ? [] : [{ detail }];
+  });
+}
+
+function toXIncludes(value: unknown): XApiResponse["includes"] {
+  if (!isRecord(value) || !isUnknownArray(value.users)) return undefined;
+  return { users: value.users.flatMap((user) => toXUser(user) ?? []) };
+}
+
+function toXMeta(value: unknown): XApiResponse["meta"] {
+  if (!isRecord(value)) return undefined;
+  const result_count = readNumber(value, "result_count");
+  return result_count === undefined ? undefined : { result_count };
+}
+
+/** Rebuild the response from the fields we can prove. Every member of
+ *  `XApiResponse` is optional, so an unrecognised body degrades to `{}`
+ *  and the tools report "not found" / "no results" instead of formatting
+ *  a half-shaped tweet. */
+export function parseXApiResponse(json: unknown): XApiResponse {
+  if (!isRecord(json)) return {};
+  return {
+    data: isUnknownArray(json.data) ? json.data.flatMap((item) => toXTweet(item) ?? []) : (toXTweet(json.data) ?? undefined),
+    includes: toXIncludes(json.includes),
+    errors: toXErrors(json.errors),
+    meta: toXMeta(json.meta),
+  };
+}
+
 export async function fetchX(path: string): Promise<XApiResponse> {
   const token = xBearerToken();
   if (!token) throw new Error("X_BEARER_TOKEN is not configured in .env");
@@ -71,7 +159,7 @@ export async function fetchX(path: string): Promise<XApiResponse> {
     throw new Error(`X API error ${response.status}: ${body}`);
   }
 
-  return response.json() as Promise<XApiResponse>;
+  return parseXApiResponse(await response.json());
 }
 
 // `text` caps at 280 chars; long-form Posts and Articles carry their real body

--- a/packages/plugins/x-plugin/src/index.ts
+++ b/packages/plugins/x-plugin/src/index.ts
@@ -7,7 +7,7 @@
 // `X_BEARER_TOKEN` env var. All formatting/fetch logic lives here.
 
 import { errorMessage } from "@mulmoclaude/common";
-import { EXPANSIONS, extractTweetId, fetchX, formatTweet, TWEET_FIELDS, USER_FIELDS, type XApiResponse, type XTweet, type XUser } from "./client";
+import { EXPANSIONS, extractTweetId, fetchX, formatTweet, TWEET_FIELDS, USER_FIELDS, type XApiResponse, type XUser } from "./client";
 
 /** A tweet URL or bare id from model-emitted args: a string as given, a finite
  *  integer rendered as its digits, and nothing else. Objects/arrays have no id
@@ -73,7 +73,9 @@ export const readXPost: XTool = {
 
     if (data.errors?.length) return `X API error: ${data.errors.map((err) => err.detail).join("; ")}`;
 
-    const tweet = data.data as XTweet | undefined;
+    // `/tweets/{id}` answers with a single object; an array here means the
+    // response wasn't the one this endpoint documents.
+    const tweet = Array.isArray(data.data) ? undefined : data.data;
     if (!tweet) return "Tweet not found.";
 
     const author = data.includes?.users?.find((user) => user.id === tweet.author_id);


### PR DESCRIPTION
## Summary

`packages/bridges` / `packages/markdown-utils` / `packages/plugins` の `as` 型アサーションを **50 箇所 → 2 箇所** に削減した（48 箇所削除）。`eslint-disable` / `@ts-ignore` / `any` は一切追加していない。
残した 2 箇所は、`markdown-utils/src/markdown/mermaidRender.ts`（未マージの #2727 が所有しているため意図的に触っていない）と、`accounting-plugin/src/server/io.ts:100`（既存コメントが理由を説明済み）。
`packages/plugins/bookmarks-plugin` と `packages/plugins/todo-plugin` は eslint の `ignores` 対象のため対象外。`src/` / `server/` / `packages/core` には一切触れていない。

| パッケージ | 削除 / 全体 | 残 |
|---|---|---|
| packages/bridges | 13 / 13 | 0 |
| packages/markdown-utils | 7 / 8 | 1（#2727 所有ファイル） |
| accounting-plugin | 14 / 15 | 1（意図的） |
| collection-plugin | 12 / 12 | 0 |
| x-plugin | 2 / 2 | 0 |

公開 API（`exports` 経由で外に出る型・関数のシグネチャ）は変更していない。バージョンも上げていない。

## Items to Confirm / Review

**1. webhook 署名パスの accept/reject 境界（`line` / `whatsapp`）**

`req.headers[...] as string` / `req.body as string` を、messenger / line-works / viber / twilio-sms / webhook が既に使っている `typeof === "string" ? … : ""` に揃えただけ。**以前 accept されていたものが reject されるようになった箇所は無い**：

- 署名ヘッダが文字列でない（配列・欠落）→ 旧: `""`/配列が `verifyHmacSignature` に渡り TypeError か長さ不一致で `false`。新: `""` → `!signature` で 401。**どちらも通らない。**
- body が文字列でない（`express.text({type:"application/json"})` が効かない Content-Type）→ 旧: `crypto.update(object)` が throw。新: `""` で HMAC 不一致 → 401。**どちらも通らない。**
- 正しい署名 + 正しい body は両者とも 200。`verifyHmacSignature` / `verifyMetaHmacSignature` 自体は未変更。

**2. `line` の webhook body 検証（挙動が変わる／バグ修正を含む）**

`parseLineWebhookBody` が `LineWebhookBody` 全体をアサートしていたのをやめ、`LineEvent` が宣言する全フィールド（`type` / `replyToken` / `source.userId` / `source.type` / `message.{type,text,id}`）を実際に検証したイベントだけを返すようにした。フィルタなので**元のオブジェクトはそのまま**返り、モデルしていない LINE 側の追加フィールドは保持される。

- **見つけたバグ**: `{"events":[null]}` は旧実装だと配信ループ内の `extractIncomingLineMessage(null)` → `event.type` で TypeError。`res.send("OK")` の後の async ハンドラ内なので unhandled rejection になる。今は該当イベントを落とすだけ。到達には正しい channel secret が必要なので remote exploit ではない。
- `null` 要素以外は、旧実装でも `extractIncomingLineMessage` が `null` を返していたため利用側の結果は同じ。

**3. `x-plugin` の X API レスポンス解析（挙動が変わる）**

`response.json() as Promise<XApiResponse>` をやめ、`parseXApiResponse` が証明できたフィールドから再構築する。`XApiResponse` は全メンバー optional なので、認識できない body は `{}` に落ちて "Tweet not found." / "No recent posts found" になる。旧実装で 5 箇所クラッシュしていた入力がある（下の検証セクションに実測 diff）。`getTweet`（`readXPost`）は `data` が配列なら "not found" 扱いにした（`/tweets/{id}` は単一オブジェクトを返す仕様）。

**4. `@mulmoclaude/common` 依存が無いパッケージ**

- `packages/bridges/line` — `isRecord` が使えないため、`parse.ts` の guard はドメイン固有の `isLineEvent` / `isLineMessage` として書き、`in` narrowing で実装した。新しい `isRecord` コピーは作っていない。
- `packages/plugins/collection-plugin` — 同上（`@mulmoclaude/core` にのみ依存）。`collectionViewMode.ts` / chat views / components すべて `in` narrowing と const タプルへの `some`/`find` で処理した。

どちらも依存追加は**していない**（スコープ外と判断）。もし `@mulmoclaude/common` を足す方針なら、これらの guard は `isRecord` ベースに単純化できる。

**5. 挙動が変わり得る小さな箇所**

- `collectionViewMode.readAll()` — 値が検証を通らない slug エントリを落とすようになった。同ファイルの `readAllSorts` / `readAllFlagFilters` が既に採っている方針に合わせた。結果として `writeCollectionViewMode` は壊れたエントリを localStorage に書き戻さなくなる。
- `chat/View.vue` の `toViewState` — `"selected" in state`（= ユーザーが操作した）の意味を保つため、宣言どおりの値のときだけフィールドを残す。非オブジェクトの `viewState` は旧実装だと `"selected" in "str"` で TypeError だった。
- `useAccountingChannel` — `version` は従来どおり**全イベントで**インクリメントする。`onPayload` だけが検証済みペイロードで呼ばれる（現状 `onPayload` を渡す呼び出し元は無い）。
- `CollectionOntologyGraphView` の `data: never` は tooltip 引数のチェックを完全に無効化していた。node/edge を 1 フィールドずつ読み直したので、壊れた payload は `undefined` を描画せず空文字になる。
- `mattermost` `apiGet` — `asJsonRecord`（`@mulmobridge/client`）に変更。オブジェクト以外のレスポンスは `{}` になるが、唯一の呼び出し元 `/users/me` は既に `typeof … === "string" ? … : ""` で防御済み。

## 実装方針

- **アサートせず再構築する**。`some` / `find` を const タプルに掛けて、証明済みの要素そのものを返す（`ensureMetric` / `isSupportedCountryCode` / `isTabKey` / `isValidViewMode`）。widen した `includes` の後に `as` を置く形は全廃した。
- **型述語は実際に検証した分しか主張しない**。`isLineEvent` は `LineEvent` が宣言する全フィールドを、`isToken` は marked の `Tokens.Generic` が要求する `type: string` + `raw: string` を検証している。
- **既存の失敗パスに合わせる**。新しい throw は追加していない。`null` を返していた所は `null`、スキップしていた所はスキップ、`{}` にフォールバックしていた所は `{}`。
- **既にあるヘルパーを使う**（`docs/shared-utils.md`）。`isRecord` / `isUnknownArray`（`@mulmoclaude/common`）、`asJsonRecord`（`@mulmobridge/client`）、`isSupportedCountryCode`（accounting の shared）。`isRecord` の 13 個目のコピーは作っていない。
- **呼び先を直して呼び出し側をまとめて消す**:
  - `discord` — `channel.isSendable()`（discord.js 自身の `'send' in this`）で 2 箇所。
  - `rewriteMarkdownImageRefs` — `Token.raw` は union の全メンバーが宣言しているので `{ raw?: string }` アサートは元から不要（3 箇所）。`rewriteImageToken` は読む 4 フィールドだけを宣言する形に変えた（`type === "image"` では `Tokens.Generic` が union に残るので `Tokens.Image` は保証されない）。
  - `slack` — `parseEnvOrExit` が `process.exit(1)` を直接 return するので `undefined as never` のプレースホルダが不要になり 2 箇所消えた。
- **DRY**: `whatsapp` は messenger と同じ `handleWebhookBody` / `processOneMessage` 分割に揃えた（`typeof` 判定 2 つを足した結果 `sonarjs/cognitive-complexity` が 16 になったため）。`chat/Preview.vue` と `chat/View.vue` は `toPresentCollectionData` を共有する。

## 検証

すべて `/Users/isamu/ss/llm/mc3-wt-pkgs`（本 PR 専用の worktree）で実行。`node_modules` は共有ストアへの symlink とワークスペースパッケージ（`@mulmoclaude/*` / `@mulmobridge/*`）を**この worktree 内**へ向けた実ディレクトリで構成し、`require.resolve("@mulmoclaude/markdown-utils")` が worktree 内を指すことを確認済み。

### 残存アサーションの再スキャン

```bash
npx eslint packages/plugins packages/bridges packages/markdown-utils --format json
```

```
packages/markdown-utils/src/markdown/mermaidRender.ts:97   (#2727 所有 / 未変更)
packages/plugins/accounting-plugin/src/server/io.ts:100    (意図的に残置)
REMAINING consistent-type-assertions: 2
ESLINT ERRORS (severity 2): 0
```

### パッケージ単位

```bash
npx prettier --write <触った全ファイル>     # 全て unchanged
npx eslint <触った全ファイル>               # 0 errors / 新規 warning 0
```

| パッケージ | typecheck | test |
|---|---|---|
| bridges/discord, mattermost, nostr, viber, whatsapp | ✅ | テスト無し |
| bridges/line | ✅ | 18 pass / 0 fail |
| bridges/slack | ✅ | 57 pass / 0 fail |
| markdown-utils | ✅ | 6 pass（本体テストは root 側） |
| accounting-plugin | ✅ (vue-tsc) | 302 pass / 0 fail |
| collection-plugin | ✅ (vue-tsc) | in-package テスト無し（`vite build` 通過を確認） |
| x-plugin | ✅ | 11 pass / 0 fail |

markdown-utils 関連の root テスト（`test/utils/image/test_rewriteMarkdownImageRefs.ts`, `test_htmlSrcAttrs.ts`, `test/utils/markdown/test_frontmatter.ts`, `test/server/utils/markdown/test_frontmatter.ts`, `test/workspace/wiki-pages/test_io.ts`）: **207 pass / 0 fail**。

### リポジトリ全体

```bash
yarn typecheck        # exit 0
npx tsx --test ./test/*/test_*.ts ./test/*/*/test_*.ts ./test/*/*/*/test_*.ts
# tests 8900 / pass 8893 / fail 0 / skipped 7
```

### 生成物（`server/build/dispatcher.mjs`）

CI が `git diff --exit-code` でゲートしているため、`docs/build-orchestration.md` の手順どおり 2 段階で確認した。

1. `git checkout origin/main -- packages/` → `yarn build:packages && yarn build:hooks` → `git diff --exit-code server/build/dispatcher.mjs` が **通る**（= この worktree のツールチェーンがコミット済み生成物を再現できる）。
2. 自分のブランチに戻して同じコマンド → **diff 無し**。

つまり `dispatcher.mjs` の更新は不要。core の該当チャンクが `markdown-utils` の `image/*` / `markdown/frontmatter.ts` をバンドルしていないため（`grep -rln "readAttrCaptures" packages/core/dist/` は空）。`packages/markdown-utils/dist/image/htmlSrcAttrs.js` に `readAttrCaptures` が出ることでビルドが自分のソースを拾っていることも確認済み。

### x-plugin: 外部 ground truth による旧/新の突き合わせ

`fetch` をスタブして**実際のツールハンドラ**（`readXPost` / `searchX`）を 21 種の payload（正常 / 不正 / 敵対的）で実行し、`git checkout origin/main -- packages/plugins/x-plugin/src` で revert した版と出力を diff した（スクリプトは scratch に置き、実行後に削除）。

**正常な payload はすべて byte 一致**（`valid-single` / `valid-note-tweet` / `valid-article` / `valid-search` / `api-errors` / `empty-object` / `array-body` / `string-body` / `prototype-pollution`）。差分は不正入力のみで、すべて「壊れて出力する」→「素直に落とす」方向：

| payload | 旧 | 新 |
|---|---|---|
| `null` body | **THREW** `Cannot read properties of null (reading 'errors')` | "Tweet not found." / "No recent posts found" |
| `errors` が配列でない | **THREW** `data.errors.map is not a function` | "Tweet not found." / "No recent posts found" |
| `includes.users` が配列でない | **THREW** `users?.find is not a function` | 本文のみ描画 |
| 検索結果に `null` 混入 | **THREW** `Cannot read properties of null (reading 'author_id')` | 有効な 1 件のみ描画 |
| `data` が文字列 / `text` 欠落 / `id` が数値 | 空文字や欠損混じりの描画 | "Tweet not found." |
| `public_metrics` の型違い | `Likes: 3 \| Retweets: null \| Replies: 1` | metrics 行を出さない |
| `note_tweet.text` が数値 | 本文に `42` を描画 | 本来の `text` を描画 |
| `errors[].detail` が数値 | `X API error: 5; real` | `X API error: real` |
| `users[]` に `username` 欠落 | `@undefined (A)` と `https://x.com/undefined/status/13` | 著者情報を出さない |

### E2E（`.vue` を触ったため）

**注意**: `e2e/playwright.config.ts` は `port: 45173` + `reuseExistingServer: true` なので、**他の worktree が同じポートで dev server を上げていると、その別ツリーに対してテストが走る**。実際 1 回目は `lsof` で 45173 の owner が別 worktree（`mc3-wt-src`）だったため結果が無効だった（364 passed / 396 passed と件数すら不一致）。同一 config をポート 45273・`reuseExistingServer: false` にしただけの一時 config を作り直して実行し、`lsof -nP -iTCP:45273` の cwd がこの worktree であることを確認してから計測した（一時 config は削除済み・コミットしていない）。

| 対象 | 結果 |
|---|---|
| 本ブランチ | **446 passed / 4 failed** (4.5m) |
| `packages/` を origin/main に戻して再ビルド | **446 passed / 4 failed** (4.0m) |

失敗した 4 件は両側で同一であり、本 PR とは無関係（`origin/main` 側の `test-results/` にも同じ 4 件が出る）:

```
chat-flow.spec.ts:264 › creating a new session › new-session button creates a fresh session
chat-flow.spec.ts:281 › creating a new session › new-session from a session with content preserves it in Back history
right-sidebar-toggle.spec.ts:14 › clicking the header button shows/hides the sidebar
right-sidebar-toggle.spec.ts:32 › toggle state persists to localStorage
```

`chat-flow` 側の直接原因は `new-session-btn` のクリックが `session-history-toggle-off` ボタンの subtree に intercept されること。**main 既存の問題なのでこの PR では触っていない**（複数 worktree を同時に走らせている環境要因の可能性も残る）。

### line: `{"events":[null, …]}` の再現

```
$ npx tsx run.ts   # origin/main 版と本ブランチ版の parse.ts を同時 import して同じ body を流す
origin/main: THREW TypeError: Cannot read properties of null (reading 'type')
this branch: 1 event(s), delivered [{"kind":"text","userId":"u1","text":"hi"}]
```

旧実装では `null` 要素で throw するだけでなく、**その後ろにある正常なテキストイベントも配信されない**。

refs #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Reduce unsafe TypeScript type assertions across bridges, markdown-utils, and plugins by rebuilding data from validated shapes and aligning behavior with existing failure paths.

New Features:
- Add structured parsing and validation for X API responses so tools operate on well-formed tweet/user data and treat unrecognised payloads as "not found" or "no results".
- Introduce helpers to safely interpret collection tool results and view state in chat/preview surfaces, ensuring only validated collection data and view settings are persisted and rendered.

Bug Fixes:
- Harden LINE webhook body parsing to drop invalid events (e.g. null entries) instead of crashing the delivery loop, allowing valid events in the same batch to be processed.
- Make WhatsApp webhook handling resilient to malformed JSON and non-string headers/body values while preserving existing accept/reject signature boundaries.
- Prevent crashes and undefined output in X plugin tooling when the API returns malformed or adversarial payloads, degrading to empty results or simple error messages instead.
- Ensure collection ontology graph tooltips and click handlers degrade to empty labels on malformed payloads instead of rendering undefined or throwing.
- Avoid TypeErrors in collection view mode and chat view state when localStorage or tool result state is corrupted, by re-validating stored values and dropping invalid entries.

Enhancements:
- Replace `as`-based narrowing with explicit runtime validation in multiple bridges (Discord, Slack, Mattermost, Viber, LINE, Nostr) and plugins to better align runtime behavior with declared types.
- Refine accounting plugin input validation for book creation/update, time series metrics, granularity, opening balances, and account numbering to use curated value lists and structured parsing.
- Tighten markdown-utils image rewriting and frontmatter YAML loading by validating token/attribute shapes and using shared `isRecord` helpers, ensuring only well-formed tokens and attributes are transformed.
- Unify collection plugin localStorage handling for view modes, sorts, and flag filters by re-validating entries and sharing helper utilities, keeping persisted state consistent with current schemas.
- Use shared helpers (e.g., `parseEnvOrExit`, `asJsonRecord`, `isSupportedCountryCode`) and new small utilities to DRY up validation and error handling across packages.

Tests:
- Rely on existing unit, integration, and e2e coverage for bridges, markdown-utils, accounting, collection, and X plugin to validate the new parsing and validation logic without changing public APIs or versions.