### PR TITLE
fix: stop `yarn format` rewriting the committed esbuild bundle

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,17 @@
+# esbuild output committed to git — `yarn build:hooks` regenerates it from
+# server/workspace/hooks/dispatcher.ts, and CI gates it with
+# `git diff --exit-code`. Formatting it makes `yarn format` and the build
+# fight over the same file, so the gate fails on a tree nobody edited.
+# `eslint.config.mjs` ignores it for the same reason.
+server/build/
+# The launcher's copy of the same bundle, written at publish time.
+packages/mulmoclaude/server/build/
+
+# Build output.
+dist/
+lib/
+packages/*/dist/
+packages/*/*/dist/
+
+# The i18n JSON cache `yarn dumpi18n` writes before every lint run.
+.i18n-cache/


### PR DESCRIPTION
## Summary

**#2740（私の PR）が入れた回帰です。** `yarn format` が**コミット済みの esbuild バンドルを書き換える**ようになっていました。

`scripts/` を対象に加える際、拡張子リストにも `mjs` を足しました。`server/build/dispatcher.mjs` は元から glob の `server/` 側に含まれていたので、**拡張子を足した瞬間に対象になった**という経路です。

このファイルは `yarn build:hooks` が生成し、CI が `git diff --exit-code` で新鮮さを検査します。format とビルドが同じファイルを取り合うことになり、**誰も編集していないツリーで gate が落ちます**。

## Items to Confirm / Review

1. **`eslint.config.mjs` は #955 から同じ理由で `server/build/**` を無視しています。** prettier 側に対応物が無かったのは、これまでどの prettier glob もこのファイルに届いていなかったからです。今回届いてしまったので `.prettierignore` を新設しました。
2. **`packages/mulmoclaude/server/build/` も除外しています** — publish 時にコピーされる同じバンドルです。
3. あわせて `dist/` / `lib/` / `packages/*/dist/` と、`yarn dumpi18n` が lint のたびに書く `.i18n-cache/` も対象外にしました。いずれも生成物です。

## 検証

**`.prettierignore` が実際に効いているのか**を、クリーンなツリーから両方向で確認しました。

```
.prettierignore なし  →  yarn format  →  M server/build/dispatcher.mjs
.prettierignore あり  →  yarn format  →  （変更なし）
```

```
yarn format --check -> exit 0
git status          -> クリーン（変更ファイルなし）
```

## 気づいた点

`#2740`（`scripts/` に lint が届いていない）と `#2741`（`tsconfig.node.json` の include が1ファイルだけ）に続いて、**「設定の対象範囲がコードと合っていない」問題の3件目**です。今回は逆方向 — 対象を広げた結果、**広げてはいけないものまで入った**という形でした。

生成物を扱う設定は eslint・prettier・CI の3箇所に散っているので、除外リストが揃っているかは今後も確認が要ります。

refs #2740

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude3

## Summary by Sourcery

Enhancements:
- Introduce a .prettierignore file to exclude generated server build outputs, package build artifacts, and i18n cache files from formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated formatting configuration to exclude generated bundles, build outputs, distribution files, and translation caches from automatic formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->