### PR TITLE
fix: remove the 8 `as` assertions in scripts/ (#2692)

### DIFF
--- a/scripts/codegen-plugin-barrels.ts
+++ b/scripts/codegen-plugin-barrels.ts
@@ -34,8 +34,6 @@ import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "n
 import { fileURLToPath, pathToFileURL } from "node:url";
 import path from "node:path";
 
-import type { PluginMeta } from "../src/plugins/meta-types.js";
-
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
 const PLUGINS_DIR = path.join(REPO_ROOT, "src", "plugins");
@@ -100,20 +98,45 @@ function camelize(parts: readonly string[]): string {
   return parts.map((part, index) => (index === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1))).join("");
 }
 
-/** Load a META by dynamic-importing the meta file under tsx and
- *  reading the runtime object. Replaces the brittle regex-based
- *  string extraction (Codex iter 1 #1143): single quotes, varied
- *  indentation, computed values, or multi-line declarations would
- *  all silently miss `apiNamespace` / `mcpDispatch` and omit the
+/** The two META fields this codegen reads. Kept separate from
+ *  `PluginMeta` on purpose: a dynamically-imported module has been
+ *  checked by nothing at the point it is read, so the codegen
+ *  rebuilds exactly the fields it uses instead of claiming the
+ *  whole declared shape. */
+interface MetaDispatch {
+  apiNamespace: string | null;
+  mcpDispatch: string | null;
+}
+
+/** Own enumerable properties of an unknown value, as `unknown`-typed
+ *  entries — for a module namespace object those are its exports.
+ *  Non-objects yield no entries, so callers narrow by lookup rather
+ *  than by asserting a shape. */
+function ownFields(value: unknown): ReadonlyMap<string, unknown> {
+  if (typeof value !== "object" || value === null) return new Map();
+  return new Map(Object.entries(value));
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+/** Load a META's dispatch fields by dynamic-importing the meta file
+ *  under tsx and reading the runtime object. Replaces the brittle
+ *  regex-based string extraction (Codex iter 1 #1143): single quotes,
+ *  varied indentation, computed values, or multi-line declarations
+ *  would all silently miss `apiNamespace` / `mcpDispatch` and omit the
  *  server binding — the exact wiring footgun this codegen exists
  *  to eliminate. Reading the live object closes that gap because
  *  TypeScript itself is the parser. */
-async function loadMeta(absoluteMetaPath: string): Promise<PluginMeta> {
-  const mod = (await import(pathToFileURL(absoluteMetaPath).href)) as { META?: unknown };
-  if (!mod.META || typeof mod.META !== "object") {
+async function loadMetaDispatch(absoluteMetaPath: string): Promise<MetaDispatch> {
+  const mod: unknown = await import(pathToFileURL(absoluteMetaPath).href);
+  const meta = ownFields(mod).get("META");
+  if (typeof meta !== "object" || meta === null) {
     throw new Error(`Meta file ${absoluteMetaPath} does not export a top-level \`META\` object`);
   }
-  return mod.META as PluginMeta;
+  const fields = ownFields(meta);
+  return { apiNamespace: stringOrNull(fields.get("apiNamespace")), mcpDispatch: stringOrNull(fields.get("mcpDispatch")) };
 }
 
 async function findMetas(pluginDir: string): Promise<MetaEntry[]> {
@@ -122,7 +145,7 @@ async function findMetas(pluginDir: string): Promise<MetaEntry[]> {
   const metaFiles = files.filter((file) => file === "meta.ts" || (file.endsWith("Meta.ts") && file !== "Meta.ts"));
   const entries: MetaEntry[] = [];
   for (const file of metaFiles) {
-    const meta = await loadMeta(path.join(dir, file));
+    const dispatch = await loadMetaDispatch(path.join(dir, file));
     const role = file === "meta.ts" ? "" : file.replace(/Meta\.ts$/, "");
     const importName = role === "" ? `${pluginDir}Meta` : camelize([pluginDir, role, "meta"]);
     entries.push({
@@ -130,8 +153,8 @@ async function findMetas(pluginDir: string): Promise<MetaEntry[]> {
       file: `${pluginDir}/${file}`,
       importName,
       importPath: `../${pluginDir}/${file.replace(/\.ts$/, "")}`,
-      apiNamespace: meta.apiNamespace ?? null,
-      mcpDispatch: meta.mcpDispatch ?? null,
+      apiNamespace: dispatch.apiNamespace,
+      mcpDispatch: dispatch.mcpDispatch,
     });
   }
   return entries;

--- a/scripts/verify-phase-c.mts
+++ b/scripts/verify-phase-c.mts
@@ -4,9 +4,100 @@
 // resolves "vue" to the host's runtime, and runtimeRegistry contains
 // the expected entries.
 
-import { chromium } from "@playwright/test";
+import { chromium, type Page } from "@playwright/test";
+import { hasStringProp, isRecord, isUnknownArray } from "@mulmoclaude/common";
 
 const URL = "http://localhost:5173/";
+const RUNTIME_LIST_PATH = "/api/plugins/runtime/list";
+const AUTH_META_SELECTOR = 'meta[name="mulmoclaude-auth"]';
+
+/** The `/api/plugins/runtime/list` fields this script uses. The endpoint is
+ *  the thing under test, so its payload is rebuilt field by field rather than
+ *  declared — a shape change has to surface as a named failure here, not as a
+ *  TypeError three steps later. */
+interface RuntimePluginRow {
+  toolName: string;
+  assetBase: string;
+}
+
+interface PluginAssetStatus {
+  toolName: string;
+  viewModuleStatus: number;
+  cssStatus: number;
+}
+
+function toRuntimePluginRows(payload: unknown): RuntimePluginRow[] {
+  const plugins = isRecord(payload) ? payload.plugins : undefined;
+  if (!isUnknownArray(plugins)) {
+    throw new Error(`${RUNTIME_LIST_PATH} did not return a \`plugins\` array: ${JSON.stringify(payload)}`);
+  }
+  return plugins.map((entry) => {
+    if (!hasStringProp(entry, "toolName") || !hasStringProp(entry, "assetBase")) {
+      throw new Error(`${RUNTIME_LIST_PATH} entry lacks string \`toolName\`/\`assetBase\`: ${JSON.stringify(entry)}`);
+    }
+    return { toolName: entry.toolName, assetBase: entry.assetBase };
+  });
+}
+
+/** The server hands the page its bearer token through a meta tag. Read once
+ *  and passed into the later steps as an argument — `page.evaluate` runs in
+ *  the browser, so nothing in this module's scope is reachable from inside. */
+function readAuthToken(page: Page): Promise<string> {
+  return page.evaluate((selector) => document.querySelector(selector)?.getAttribute("content") ?? "", AUTH_META_SELECTOR);
+}
+
+/** Raw payload, or null when the endpoint answered non-2xx. */
+function fetchRuntimeList(page: Page, token: string): Promise<unknown> {
+  return page.evaluate(
+    async (args): Promise<unknown> => {
+      const resp = await fetch(args.path, { headers: { Authorization: `Bearer ${args.token}` } });
+      if (!resp.ok) return null;
+      return resp.json();
+    },
+    { path: RUNTIME_LIST_PATH, token },
+  );
+}
+
+function fetchPluginAssets(page: Page, rows: RuntimePluginRow[]): Promise<PluginAssetStatus[]> {
+  return page.evaluate(async (pluginRows) => {
+    const results: PluginAssetStatus[] = [];
+    for (const row of pluginRows) {
+      const viewResp = await fetch(`${row.assetBase}/dist/vue.js`);
+      const cssResp = await fetch(`${row.assetBase}/dist/style.css`);
+      results.push({
+        toolName: row.toolName,
+        viewModuleStatus: viewResp.status,
+        cssStatus: cssResp.status,
+      });
+    }
+    return results;
+  }, rows);
+}
+
+/** Inspect imported modules — verify the bare "vue" specifier was
+ *  resolved. The plugin's vue.js exports `plugin` with viewComponent. */
+function inspectRuntimeImport(page: Page, first: RuntimePluginRow | null) {
+  return page.evaluate(async (row) => {
+    try {
+      if (!row) return { error: "no plugins" };
+      // Dynamic import via the same path the runtime loader used
+      const mod = await import(/* @vite-ignore */ `${row.assetBase}/dist/vue.js`);
+      const plugin = mod.plugin ?? mod.default?.plugin;
+      const hostVue = await import("vue");
+      const pluginVue = await import("vue"); // same URL via importmap → same module instance
+      return {
+        toolName: row.toolName,
+        hasPlugin: Boolean(plugin),
+        hasViewComponent: Boolean(plugin?.viewComponent),
+        hasPreviewComponent: Boolean(plugin?.previewComponent),
+        sameVueIdentity: hostVue === pluginVue,
+        hostVueVersion: hostVue.version,
+      };
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : String(err) };
+    }
+  }, first);
+}
 
 async function main(): Promise<void> {
   const browser = await chromium.launch({ headless: true });
@@ -23,71 +114,22 @@ async function main(): Promise<void> {
   console.log(`status: ${resp?.status()}`);
   await page.waitForTimeout(2000);
 
-  // Read window-level state — the runtimeLoader's runtimeRegistry is
-  // a module-private Map, but we can inspect via the registered tool
-  // names through getAllPluginNames if it's exported on the global
-  // for debugging. Falls back to reading network requests.
-  const runtimeNames = await page.evaluate(async () => {
-    const url = "/api/plugins/runtime/list";
-    const meta = document.querySelector('meta[name="mulmoclaude-auth"]') as HTMLMetaElement | null;
-    const token = meta?.content ?? "";
-    const r = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
-    if (!r.ok) return null;
-    const body = (await r.json()) as { plugins: { toolName: string }[] };
-    return body.plugins.map((p) => p.toolName);
-  });
+  const token = await readAuthToken(page);
+  const listPayload = await fetchRuntimeList(page, token);
+  const runtimeRows = listPayload === null ? null : toRuntimePluginRows(listPayload);
+  const runtimeNames = runtimeRows === null ? null : runtimeRows.map((row) => row.toolName);
 
-  console.log(`\n=== /api/plugins/runtime/list returns: ${runtimeNames === null ? "FAILED" : runtimeNames.join(", ")} ===`);
+  console.log(`\n=== ${RUNTIME_LIST_PATH} returns: ${runtimeNames === null ? "FAILED" : runtimeNames.join(", ")} ===`);
 
   // Check that each runtime plugin's vue.js was actually fetched.
-  const pluginNetworkHits = await page.evaluate(async () => {
-    const meta = document.querySelector('meta[name="mulmoclaude-auth"]') as HTMLMetaElement | null;
-    const token = meta?.content ?? "";
-    const r = await fetch("/api/plugins/runtime/list", { headers: { Authorization: `Bearer ${token}` } });
-    const body = (await r.json()) as { plugins: { assetBase: string; toolName: string }[] };
-    const results: { toolName: string; viewModuleStatus: number; cssStatus: number }[] = [];
-    for (const p of body.plugins) {
-      const viewResp = await fetch(`${p.assetBase}/dist/vue.js`);
-      const cssResp = await fetch(`${p.assetBase}/dist/style.css`);
-      results.push({
-        toolName: p.toolName,
-        viewModuleStatus: viewResp.status,
-        cssStatus: cssResp.status,
-      });
-    }
-    return results;
-  });
+  const pluginNetworkHits = await fetchPluginAssets(page, runtimeRows ?? []);
   console.log(`\n=== plugin asset fetches ===`);
-  for (const r of pluginNetworkHits) {
-    console.log(`  ${r.toolName}: vue.js=${r.viewModuleStatus} style.css=${r.cssStatus}`);
+  for (const hit of pluginNetworkHits) {
+    console.log(`  ${hit.toolName}: vue.js=${hit.viewModuleStatus} style.css=${hit.cssStatus}`);
   }
 
-  // Inspect imported modules — verify the bare "vue" specifier was
-  // resolved. The plugin's vue.js exports `plugin` with viewComponent.
-  const vueResolution = await page.evaluate(async () => {
-    try {
-      const meta = document.querySelector('meta[name="mulmoclaude-auth"]') as HTMLMetaElement | null;
-      const token = meta?.content ?? "";
-      const list = await fetch("/api/plugins/runtime/list", { headers: { Authorization: `Bearer ${token}` } }).then((r) => r.json());
-      const [first] = list.plugins;
-      if (!first) return { error: "no plugins" };
-      // Dynamic import via the same path the runtime loader used
-      const mod = await import(/* @vite-ignore */ `${first.assetBase}/dist/vue.js`);
-      const plugin = mod.plugin ?? mod.default?.plugin;
-      const hostVue = await import("vue");
-      const pluginVue = await import("vue"); // same URL via importmap → same module instance
-      return {
-        toolName: first.toolName,
-        hasPlugin: Boolean(plugin),
-        hasViewComponent: Boolean(plugin?.viewComponent),
-        hasPreviewComponent: Boolean(plugin?.previewComponent),
-        sameVueIdentity: hostVue === pluginVue,
-        hostVueVersion: hostVue.version,
-      };
-    } catch (err) {
-      return { error: (err as Error).message };
-    }
-  });
+  const firstRow: RuntimePluginRow | null = runtimeRows !== null && runtimeRows.length > 0 ? runtimeRows[0] : null;
+  const vueResolution = await inspectRuntimeImport(page, firstRow);
   console.log(`\n=== runtime import + Vue identity check ===`);
   console.log(JSON.stringify(vueResolution, null, 2));
 
@@ -95,7 +137,7 @@ async function main(): Promise<void> {
   for (const line of consoleLines.slice(-30)) console.log(line);
   if (errors.length > 0) {
     console.log(`\n=== errors ===`);
-    for (const e of errors) console.log(e);
+    for (const err of errors) console.log(err);
   }
 
   await browser.close();
@@ -103,7 +145,7 @@ async function main(): Promise<void> {
   const ok =
     runtimeNames !== null &&
     runtimeNames.length >= 1 &&
-    pluginNetworkHits.every((r) => r.viewModuleStatus === 200 && r.cssStatus === 200) &&
+    pluginNetworkHits.every((hit) => hit.viewModuleStatus === 200 && hit.cssStatus === 200) &&
     "sameVueIdentity" in vueResolution &&
     vueResolution.sameVueIdentity === true &&
     vueResolution.hasPlugin === true;


### PR DESCRIPTION
## Summary

Removes all 8 `@typescript-eslint/consistent-type-assertions` findings in `scripts/` — the last `as` casts in the build/verification script layer. No `eslint-disable`, no `@ts-ignore`, no new type predicate written by hand.

| File | Was | Now |
|---|---|---|
| `scripts/codegen-plugin-barrels.ts` (2) | `await import(...) as { META?: unknown }`, `mod.META as PluginMeta` | reads the imported namespace's own fields as `unknown`, rebuilds the two fields the codegen uses (`apiNamespace`, `mcpDispatch`) behind `typeof === "string"` |
| `scripts/verify-phase-c.mts` (6) | `querySelector(...) as HTMLMetaElement \| null` ×3, `await r.json() as {plugins: …}` ×2, `(err as Error).message` | `getAttribute("content")` (no element cast, read once and passed in), one Node-side parse of the list payload using the shared `@mulmoclaude/common` guards, `err instanceof Error ? … : String(err)` |

**Rebuild, not assert.** `loadMeta` used to promise a whole `PluginMeta` from a module nothing had checked; only two of its fields were ever read. It is now `loadMetaDispatch`, returning exactly `{ apiNamespace, mcpDispatch }` reconstructed from proven strings. Same for the runtime-plugin list: `toRuntimePluginRows` returns `{ toolName, assetBase }` built from `hasStringProp` checks, so nothing downstream trusts a shape the endpoint never guaranteed.

The only guards used are the existing shared ones (`isRecord`, `isUnknownArray`, `hasStringProp` from `@mulmoclaude/common`) — no new helper, so no `docs/shared-utils.md` entry is needed. `ownFields()` in the codegen is deliberately local: `scripts/plugins:codegen` runs in `prebuild` **before** `build:packages`, so it must not import a workspace package whose `dist/` may not exist yet (verified: `packages/common/dist` is absent on a cold worktree and the codegen still runs).

## Items to Confirm / Review

1. **`verify-phase-c.mts` now fetches `/api/plugins/runtime/list` once instead of three times.** Each of the three browser steps used to re-fetch it (and re-query the auth meta tag). The fixture server log confirms 3 requests before → 1 after. Behaviour is otherwise identical on the happy path (byte-identical stdout, exit 0 — see below).
2. **Failure-path behaviour change, exit code preserved.** When the list endpoint answers non-2xx, the old script printed `FAILED` and then died with `TypeError: body.plugins is not iterable` from step 2. It now prints `FAILED`, an empty asset list, `{"error": "no plugins"}`, and `[phase-c] FAILED`. **Both exit 1.** No `throw` was invented where a fallback existed — the `!res.ok → null` fallback and the `{ error: "no plugins" }` fallback are both preserved verbatim. For a *malformed* 200 body the old code also ended in exit 1 (via a 404 on `undefined/dist/vue.js`); the new code throws a named error naming the bad entry, again exit 1. Please sanity-check that a louder, earlier failure is what you want from a verification script.
3. **Deleted a stale comment** in `verify-phase-c.mts` ("…we can inspect via the registered tool names through `getAllPluginNames` if it's exported on the global for debugging. Falls back to reading network requests.") — it described an approach the code never took.
4. **Not touched, but noticed:** `sameVueIdentity: hostVue === pluginVue` compares two `await import("vue")` results in the same realm, so it is always `true` regardless of the importmap. Left exactly as-is (out of scope for this issue), but the check is vacuous.
5. `scripts/**` is in no `tsconfig` `include`, so `yarn typecheck` never sees these two files. Both were typechecked by hand — see below.

## Verification

```
yarn build:packages   ✅
yarn format           ✅ (no files changed)
yarn lint             ✅ 0 errors, 68 warnings (all in other files/other agents' scopes;
                         both target files now report zero)
yarn typecheck        ✅ exit 0
yarn build            ✅ exit 0
yarn test             ✅ exit 0
yarn plugins:codegen:check  ✅ no drift — src/plugins/_generated/*.ts byte-identical
```

`scripts/` is outside every tsconfig, so both files were additionally typechecked directly, and the pre-change versions were run through the same command as a baseline (both clean):

```
npx tsc --noEmit --ignoreConfig --strict --module esnext --moduleResolution bundler \
  --target es2022 --lib es2022,dom --skipLibCheck --types node scripts/verify-phase-c.mts
npx tsc ... scripts/codegen-plugin-barrels.ts
→ exit 0 (before and after)
```

### `codegen-plugin-barrels.ts` — external ground truth

`yarn plugins:codegen:check` compares regenerated output against the committed `src/plugins/_generated/{metas,registrations,server-bindings}.ts` over all 16 real METAs, including the multi-meta `scheduler` case and the `server-bindings` barrel whose entire content depends on `apiNamespace` + `mcpDispatch` being read correctly. **No drift**, so the rebuilt field reads are provably equivalent to the old cast.

The throw for a bad META was exercised against a fixture (`export const META = 42;`) in an isolated copy of the script:

```
Error: Meta file …/src/plugins/bad/meta.ts does not export a top-level `META` object
    at loadMetaDispatch (…:136:11)
```

— same message and same failure point as before the change.

### `verify-phase-c.mts` — A/B against a live server

`verify-phase-c.mts` can only be judged against a running server, so the pre-change and post-change scripts were both run against the *same* stand-in dev server (auth meta tag, importmap for `vue`, `/api/plugins/runtime/list`, one plugin's `dist/vue.js` + `dist/style.css`).

**Happy path — stdout byte-identical, both exit 0:**

```
navigating to http://localhost:45991/
status: 200

=== /api/plugins/runtime/list returns: manageBookmarks ===

=== plugin asset fetches ===
  manageBookmarks: vue.js=200 style.css=200

=== runtime import + Vue identity check ===
{
  "toolName": "manageBookmarks",
  "hasPlugin": true,
  "hasViewComponent": true,
  "hasPreviewComponent": true,
  "sameVueIdentity": true,
  "hostVueVersion": "3.5.0-fixture"
}

=== console (last 30) ===

[phase-c] SUCCESS
```

The fixture also logged `auth="Bearer TESTTOKEN"` on every list request, which is the external proof that the `getAttribute("content")` token read replaces the `HTMLMetaElement` cast correctly — and it logged **3 requests for the old script vs 1 for the new one**, confirming item 1 above.

**List endpoint returns 500 — before (exit 1):**

```
=== /api/plugins/runtime/list returns: FAILED ===
page.evaluate: TypeError: body.plugins is not iterable
```

**after (exit 1):**

```
=== /api/plugins/runtime/list returns: FAILED ===

=== plugin asset fetches ===

=== runtime import + Vue identity check ===
{
  "error": "no plugins"
}

=== console (last 30) ===
[error] Failed to load resource: the server responded with a status of 500 (Internal Server Error)

[phase-c] FAILED
```

**Malformed 200 body (`{"plugins":[{"toolName":42}]}`) — before (exit 1):**

```
=== /api/plugins/runtime/list returns: 42 ===
  42: vue.js=404 style.css=404
{ "error": "Failed to resolve module specifier 'undefined/dist/vue.js'" }
[phase-c] FAILED
```

**after (exit 1):**

```
Error: /api/plugins/runtime/list entry lacks string `toolName`/`assetBase`: {"toolName":42}
    at toRuntimePluginRows (…)
```

### Environment notes (not part of the diff)

Two failures on the first `yarn test` in this worktree were environmental, not caused by this change: `test/agent/test_mcp_smoke.ts` hardcodes `<repo-root>/node_modules/.bin/tsx`, which a git worktree without its own `node_modules` does not have. After making that path resolvable the whole suite is green (exit 0). Likewise `yarn build` regenerated `server/build/dispatcher.mjs` with `../../../packages/...` esbuild path comments (worktree module resolution reaching the parent checkout); that artifact was reverted and is **not** in this PR.

No bug was uncovered by removing these casts — every cast was over-claiming a shape rather than hiding a wrong one.

Refs #2692 (partial scope: `scripts/` only).

work in mulmoclaude3

## Summary by Sourcery

Tighten type safety in build and verification scripts by reconstructing data from validated runtime values instead of asserting types, and streamline the runtime plugin verification flow.

New Features:
- Introduce structured parsing of the runtime plugins list into typed rows used across asset fetch and import checks.

Bug Fixes:
- Ensure malformed or unexpected `/api/plugins/runtime/list` payloads surface as explicit verification failures rather than deferred TypeErrors.
- Preserve and clarify failure-path behaviour in the runtime verification script while keeping exit codes consistent.

Enhancements:
- Refactor the runtime verification script to read the auth token once, reuse a single list payload across checks, and reduce redundant network requests.
- Strengthen runtime list handling by validating payload structure with shared guards and centralizing plugin asset checks.
- Simplify dynamic META handling in the plugin barrels codegen to read only the dispatch-related fields from module exports without relying on global plugin meta types.

Tests:
- Keep existing verification behaviour intact on the happy path, confirmed via A/B runs against a live fixture server and plugins codegen output comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of plugin metadata and runtime plugin lists.
  * Added safer handling for malformed responses, invalid metadata, and unexpected runtime errors.
  * Reduced redundant runtime list requests during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->