### PR TITLE
fix: drop `as` casts in the remote-host, collection-query and i18n paths (#2692)

### DIFF
--- a/batch/i18n-dump.ts
+++ b/batch/i18n-dump.ts
@@ -19,21 +19,12 @@ const locales = { en: enMessages, ja: jaMessages };
 
 // vue-i18n supports a "message function" form — e.g.
 // `argsPlaceholder: () => "…"`. JSON.stringify skips those keys
-// (functions → undefined). Replace them with a placeholder literal
-// so the eslint plugin still sees the key exists. The runtime
-// dictionary keeps the function; only the lint cache loses it.
-function serializableDictionary(input: unknown): unknown {
-  if (typeof input === "function") return "[message-function]";
-  if (Array.isArray(input)) return input.map(serializableDictionary);
-  if (input !== null && typeof input === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
-      out[key] = serializableDictionary(value);
-    }
-    return out;
-  }
-  return input;
-}
+// (functions → undefined). Substituting a placeholder literal in the
+// replacer keeps the key visible to the eslint plugin; the runtime
+// dictionary keeps the function, only the lint cache loses it.
+const MESSAGE_FUNCTION_PLACEHOLDER = "[message-function]";
+
+const replaceMessageFunctions = (_key: string, value: unknown): unknown => (typeof value === "function" ? MESSAGE_FUNCTION_PLACEHOLDER : value);
 
 const thisFile = url.fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(thisFile), "..");
@@ -43,7 +34,7 @@ async function main(): Promise<void> {
   await mkdir(outDir, { recursive: true });
   await Promise.all(
     Object.entries(locales).map(([locale, dict]) =>
-      writeFile(path.join(outDir, `${locale}.json`), `${JSON.stringify(serializableDictionary(dict), null, 2)}\n`, "utf8"),
+      writeFile(path.join(outDir, `${locale}.json`), `${JSON.stringify(dict, replaceMessageFunctions, 2)}\n`, "utf8"),
     ),
   );
   console.log(`i18n JSON dumped to ${path.relative(repoRoot, outDir)}/`);

--- a/packages/core/src/collection/server/csvQuery.ts
+++ b/packages/core/src/collection/server/csvQuery.ts
@@ -54,7 +54,7 @@ function whereFragment(cond: CollectionQueryWhere): { sql: string; params: CsvQu
   const column = quoteIdent(cond.field);
   const asText = `CAST(${column} AS VARCHAR)`;
   if (cond.op === "in") {
-    const values = cond.value as (string | number | boolean)[];
+    const values = arrayValue(cond);
     const textual = values.every((value) => typeof value === "string");
     const lhs = textual ? asText : column;
     return { sql: `${lhs} IN (${values.map(() => "?").join(", ")})`, params: values };
@@ -66,6 +66,17 @@ function whereFragment(cond: CollectionQueryWhere): { sql: string; params: CsvQu
   const operator = { eq: "=", ne: "<>", gt: ">", gte: ">=", lt: "<", lte: "<=" }[cond.op];
   const lhs = typeof cond.value === "string" && (cond.op === "eq" || cond.op === "ne") ? asText : column;
   return { sql: `${lhs} ${operator} ?`, params: [scalarValue(cond)] };
+}
+
+/** Mirror of `scalarValue` for the one op that takes a set: a scalar under
+ *  `in` also means the query skipped `CollectionQueryZ`. Left unchecked it
+ *  failed as `values.every is not a function`, naming neither the field nor
+ *  the op. */
+function arrayValue(cond: CollectionQueryWhere): CsvQueryParam[] {
+  if (!Array.isArray(cond.value)) {
+    throw new Error(`where condition on '${cond.field}' uses op 'in', which requires an array value, not a scalar`);
+  }
+  return cond.value;
 }
 
 /** `CollectionQueryZ` refines "`in` ⇔ array value", so an array reaching a

--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -21,15 +21,17 @@ import {
   where,
 } from "firebase/firestore";
 
+import { isRecord } from "@mulmoclaude/common";
+
 import { errorMessage } from "../../collection/core/errorMessage.js";
 import {
   Channel,
   Command,
   CommandHandler,
   CommandHandlers,
-  JsonObject,
   buildHostPresence,
   byCreatedAt,
+  coerceJsonObject,
   commandsCollection,
   hostDoc,
   isExpired,
@@ -50,7 +52,6 @@ export const DEFAULT_HEARTBEAT_MS = 60_000;
 // either way, so even a doomed retry ends in an escalation rather than a spin.
 const TRANSIENT_LISTEN_ERROR_CODES = new Set(["aborted", "cancelled", "deadline-exceeded", "internal", "resource-exhausted", "unauthenticated", "unavailable"]);
 
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 const listenErrorCode = (error: unknown): string => (isRecord(error) && typeof error.code === "string" ? error.code : "");
 
 export const classifyListenerError = (error: unknown): "transient" | "fatal" =>
@@ -102,9 +103,11 @@ export interface HostRunnerOptions {
   expectedUndefined?: Record<string, readonly string[]>;
 }
 
-interface Claim {
+export interface Claim {
   method: string;
-  params: JsonObject;
+  // Still unproved JSON here: the doc is remote-written, so the walk that earns
+  // `JsonObject` runs at the handler boundary, outside the claim transaction.
+  params: Record<string, unknown>;
 }
 
 const noop = () => undefined;
@@ -113,19 +116,32 @@ const noop = () => undefined;
 const writeError = (ref: DocumentReference, code: string, message: string) =>
   updateDoc(ref, { status: "error", error: { code, message }, updatedAt: serverTimestamp() }).catch(noop);
 
+// What a queued command doc contributes to a claim, rebuilt from the two
+// members that were checked rather than asserted off a `DocumentData`.
+// `null` means "not ours to take" — the doc is gone or someone else moved it
+// out of `queued`.
+//
+// Anything else DEGRADES instead of bailing: a non-string method becomes "" so
+// the dispatch falls through to the unknown-method reply, and non-object params
+// become an empty set so the handler's own required-field check answers. Both
+// write an error back to the doc. Returning null for them instead would leave
+// the command claimed as `processing` with nothing ever written back — the one
+// outcome the remote cannot distinguish from a dead host.
+export const readClaim = (data: unknown): Claim | null => {
+  if (!isRecord(data) || data.status !== "queued") return null;
+  return { method: typeof data.method === "string" ? data.method : "", params: isRecord(data.params) ? data.params : {} };
+};
+
 // Atomically move a command queued -> processing so it is handled exactly once.
 // Returns the method/params to run, or null if another handler already took it.
 const claimCommand = (firestore: Firestore, ref: DocumentReference): Promise<Claim | null> =>
   runTransaction(firestore, async (txn) => {
-    // Cast kept (#2692): `params` must satisfy `JsonObject`, and the only
-    // honest guard for that is a deep JSON walk whose rejection path would
-    // leave a malformed doc stuck in `queued` instead of erroring back.
-    const data = (await txn.get(ref)).data() as Command | undefined;
-    if (!data || data.status !== "queued") {
+    const claim = readClaim((await txn.get(ref)).data());
+    if (!claim) {
       return null;
     }
     txn.update(ref, { status: "processing", updatedAt: serverTimestamp() });
-    return { method: data.method, params: data.params ?? {} };
+    return claim;
   });
 
 // Own-property lookup: a bare `handlers[method]` with a method name written by a
@@ -147,7 +163,10 @@ const reportStripped = (dropped: string[], claim: Claim, options: HostRunnerOpti
 
 const runHandler = async (ref: DocumentReference, claim: Claim, handler: CommandHandler, options: HostRunnerOptions): Promise<HostEvent> => {
   try {
-    const returned = await handler(claim.params);
+    // Inside the try on purpose: a params value JSON cannot carry throws
+    // naming its path, and that lands in the same `handler_error` reply the
+    // handler's own failures do, rather than stalling the command.
+    const returned = await handler(coerceJsonObject(claim.params));
     const dropped = undefinedPaths(returned);
     reportStripped(unexpectedPaths(dropped, options.expectedUndefined?.[claim.method]), claim, options);
     // The walk above already answered "is there anything to strip", so a clean
@@ -235,9 +254,14 @@ const dispatchAddedCommands = (ctx: RunnerContext, snapshot: QuerySnapshot): voi
   snapshot
     .docChanges()
     .filter((change) => change.type === "added")
-    // Cast kept (#2692): this doc rides verbatim into the host's `onExpire`
-    // callback, so rebuilding it from checked fields would silently drop
-    // whatever else the remote wrote.
+    // Cast kept (#2692). The runner itself reads only `createdAt`, `expiresAt`
+    // and `method` here, but the doc rides verbatim into the host's `onExpire`,
+    // whose published signature takes a whole `Command`. Rebuilding one would
+    // have to invent the members nothing on this path reads — `status`,
+    // `result`, `error`, `createdBy` — and hand a second host's cleanup
+    // callback values the document never carried, which is worse than the
+    // assertion. Removing it means narrowing `onExpire`'s parameter, a
+    // breaking change to a published contract MulmoTerminal also implements.
     .map((change) => ({ ref: change.doc.ref, command: change.doc.data() as Command }))
     .sort((left, right) => byCreatedAt(left.command, right.command))
     .forEach(({ ref, command }) => {

--- a/packages/core/test/remote-host/test_hostRunner.ts
+++ b/packages/core/test/remote-host/test_hostRunner.ts
@@ -16,6 +16,7 @@ import {
   LISTEN_RETRY_WINDOW_MS,
   backoffDelayMs,
   classifyListenerError,
+  readClaim,
   resolveCommandHandler,
   shouldGiveUpListening,
 } from "../../src/remote-host/server/hostRunner.js";
@@ -117,5 +118,41 @@ describe("shouldGiveUpListening", () => {
     // but the outage is not — that distinction is the whole point of the change.
     const lastAttemptAt = startedAt + LISTEN_RETRY_WINDOW_MS - 30_000;
     assert.equal(shouldGiveUpListening(startedAt, lastAttemptAt + 30_000), true);
+  });
+});
+
+// The claim used to be an `as Command` over whatever Firestore handed back
+// (#2692). These pin the two halves of replacing it: what is refused, and what
+// degrades to a reply the remote can actually see.
+describe("readClaim", () => {
+  it("takes a queued command and keeps its method and params", () => {
+    assert.deepEqual(readClaim({ status: "queued", method: "startChat", params: { text: "hi" } }), { method: "startChat", params: { text: "hi" } });
+  });
+
+  it("refuses a doc another host already moved out of queued", () => {
+    assert.equal(readClaim({ status: "processing", method: "startChat", params: {} }), null);
+  });
+
+  it("refuses a deleted doc (data() is undefined) and a non-object payload", () => {
+    assert.equal(readClaim(undefined), null);
+    assert.equal(readClaim("startChat"), null);
+    assert.equal(readClaim([{ status: "queued" }]), null);
+  });
+
+  it("degrades a missing/non-string method to '' so dispatch answers unknown_method", () => {
+    // Refusing here would leave the doc claimed as `processing` with no reply —
+    // indistinguishable from a dead host. resolveCommandHandler has no ""
+    // entry, so the runner writes unknown_method back instead.
+    assert.deepEqual(readClaim({ status: "queued", params: {} }), { method: "", params: {} });
+    assert.deepEqual(readClaim({ status: "queued", method: 42, params: {} }), { method: "", params: {} });
+    assert.equal(resolveCommandHandler(handlers, ""), undefined);
+  });
+
+  it("degrades absent or non-object params to {} so the handler's own check answers", () => {
+    // An array is not a params map: coercing one would present its indices as
+    // field names ({"0": …}), so it degrades like any other non-record.
+    assert.deepEqual(readClaim({ status: "queued", method: "startChat" }), { method: "startChat", params: {} });
+    assert.deepEqual(readClaim({ status: "queued", method: "startChat", params: "text" }), { method: "startChat", params: {} });
+    assert.deepEqual(readClaim({ status: "queued", method: "startChat", params: [1, 2] }), { method: "startChat", params: {} });
   });
 });

--- a/server/remoteHost/handlers/collectionPage.ts
+++ b/server/remoteHost/handlers/collectionPage.ts
@@ -9,7 +9,7 @@
 import { clampLimit, clampOffset, readIdParam } from "@mulmoclaude/core/remote-view";
 import { deriveAll, type DerivableFieldSpec, type DerivableRecord } from "@mulmoclaude/core/collection";
 import { isRecord } from "../../utils/types.js";
-import type { JsonObject } from "../commandChannel.js";
+import { coerceJsonObject, type JsonObject } from "../commandChannel.js";
 
 export { clampLimit, clampOffset, readIdParam };
 
@@ -23,19 +23,18 @@ export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec
 
 /** Build the paginated result.
  *
- *  `toJsonObject` cannot serve this one. `CollectionDetail` reaches
- *  `schema.spawn.set`, typed `Record<string, unknown>`, so the payload
- *  genuinely CANNOT be proven JSON by the type system — it is JSON at runtime
- *  because the schema loader only ever puts JSON there, a fact about the
- *  loader that these types do not record.
- *
- *  Removing this assertion means giving `spawn.set` a JSON-valued type at the
- *  schema layer, not adjusting anything here. */
+ *  Not `toJsonObject`: `CollectionDetail` reaches `schema.spawn.set`, typed
+ *  `Record<string, unknown>`, and the records are `unknown` too, so no mapped
+ *  type can PROVE the payload is JSON. `coerceJsonObject` establishes it by
+ *  walking the value — the same choice the sibling remote-view handlers make.
+ *  A value the channel cannot carry throws naming its path, which `runHandler`
+ *  turns into the command doc's `handler_error`, instead of reaching Firestore
+ *  as a silently mangled write. */
 export const pageResult = (detail: unknown, items: unknown[], offset: number, limit: number): JsonObject =>
-  ({
+  coerceJsonObject({
     collection: detail,
     items: items.slice(offset, offset + limit),
     total: items.length,
     offset,
     limit,
-  }) as JsonObject;
+  });

--- a/src/tools/runtimeLoader.ts
+++ b/src/tools/runtimeLoader.ts
@@ -142,7 +142,14 @@ export async function loadOne(listing: RuntimePluginListing): Promise<void> {
 
   let mod: PluginVueModule;
   try {
-    // Kept (#2692): "is this a Vue component" isn't decidable at runtime.
+    // Cast kept (#2692). The blocker is `ToolDefinition.parameters`: a
+    // recursive JSON-Schema shape (`JsonSchemaProperty` nests `items`,
+    // `properties`, `oneOf`), so proving it means shipping a JSON-Schema
+    // validator to the browser for a field nothing on this path reads — the
+    // fallback entry above states as much, and LLM dispatch goes through the
+    // MCP server, not this entry. Dropping the field instead would silently
+    // tighten what a third-party bundle must export. `plugin` and the two
+    // components ARE checkable, and the code below already null-checks them.
     mod = (await import(/* @vite-ignore */ moduleUrl)) as PluginVueModule;
   } catch (err) {
     // Asset is reachable but the import threw — parse error,

--- a/test/remoteHost/test_dataHandlers.ts
+++ b/test/remoteHost/test_dataHandlers.ts
@@ -69,6 +69,25 @@ describe("createGetCollection", () => {
     assert.equal(neg.offset, 0);
     assert.equal(neg.limit, 50); // DEFAULT_LIMIT
   });
+
+  // The page used to be asserted into JsonObject (#2692), so a record value the
+  // channel cannot carry reached Firestore as a mangled write. Walking it means
+  // the command doc gets an error naming the property instead.
+  it("names the property when a record holds something JSON cannot carry", async () => {
+    const handler = createGetCollection(collectionDeps([{ id: "r0", size: Number.NaN } as unknown as { id: string }]));
+    await assert.rejects(async () => {
+      await handler({ slug: "clients" });
+    }, /payload\.items\[0\]\.size is NaN, which JSON cannot represent/);
+  });
+
+  // A Date is the case JSON.stringify handles for free and a hand-walk would
+  // flatten to {}: it must serialise, not throw and not vanish.
+  it("keeps a Date in a record as its ISO string", async () => {
+    const seenAt = new Date("2026-01-02T03:04:05.000Z");
+    const handler = createGetCollection(collectionDeps([{ id: "r0", seenAt } as unknown as { id: string }]));
+    const result = (await handler({ slug: "clients" })) as { items: { seenAt: string }[] };
+    assert.equal(result.items[0].seenAt, seenAt.toISOString());
+  });
 });
 
 describe("createGetFeed", () => {

--- a/test/workspace/collections/test_dataSource.ts
+++ b/test/workspace/collections/test_dataSource.ts
@@ -347,6 +347,21 @@ describe("query DSL (v2)", () => {
     assert.ok(sql.includes("LIMIT 1000"), "default result clamp applies");
   });
 
+  // Both directions of the "`in` ⇔ array" refinement, reached by compiling a
+  // query that never went through CollectionQueryZ. The scalar-under-`in` half
+  // used to fail as `values.every is not a function` (#2692) because the value
+  // was cast to an array rather than checked.
+  it("compileCsvQuery names the offending field when an unvalidated query pairs the wrong op with its value", () => {
+    assert.throws(
+      () => compileCsvQuery({ groupBy: ["a"], where: [{ field: "status", op: "in", value: "open" }] }, "id"),
+      /where condition on 'status' uses op 'in', which requires an array value, not a scalar/,
+    );
+    assert.throws(
+      () => compileCsvQuery({ groupBy: ["a"], where: [{ field: "status", op: "eq", value: ["open", "shut"] }] }, "id"),
+      /where condition on 'status' uses op 'eq', which requires a scalar value, not an array/,
+    );
+  });
+
   it("aggregates over the WHOLE file — beyond the list row cap — with group-by / where / orderBy", async () => {
     writeSkill("students", CSV_SCHEMA);
     const rows = Array.from(


### PR DESCRIPTION
## Summary

Slice of #2692 covering the remote-host / file-I/O / plugin-loader plumbing: 11 `consistent-type-assertions` findings across 10 files. **4 removed, 7 deliberately kept** with the reason rewritten in place.

Three of the removals changed runtime behaviour, each for the better and each pinned by a new test with fail-before evidence below. One of them was a **real bug**: an unvalidated `in` query failed as `TypeError: values.every is not a function`, naming neither the field nor the op — the cast was hiding a missing check that its own sibling (`scalarValue`) already performed in the other direction.

| File | Was | Now |
|---|---|---|
| `packages/core/src/remote-host/server/hostRunner.ts` | `data() as Command \| undefined` | `readClaim()` rebuilds the claim from checked members; the JSON walk moved to the handler boundary |
| `packages/core/src/collection/server/csvQuery.ts` | `cond.value as (string\|number\|boolean)[]` | `arrayValue(cond)`, mirroring the existing `scalarValue` |
| `server/remoteHost/handlers/collectionPage.ts` | `({…}) as JsonObject` | `coerceJsonObject({…})`, matching the sibling remote-view handlers |
| `batch/i18n-dump.ts` | `input as Record<string, unknown>` | a `JSON.stringify` replacer — the hand-rolled walk is gone entirely |

Also drops a divergent local `isRecord` in `hostRunner.ts` (it accepted arrays, unlike the shared guard) in favour of `@mulmoclaude/common`'s. That difference is load-bearing here: an array `params` must NOT be treated as a record, or its indices would be presented to handlers as field names.

## Items to Confirm / Review

1. **`hostRunner` — the coercion moved, and that is the judgement call.** `claimCommand` now returns `params: Record<string, unknown>` (provable) and `runHandler` calls `coerceJsonObject` **inside its existing `try`**. Rationale: coercing inside the transaction would abort it on a throw, leaving the doc in `queued` with nothing written back — the one outcome the remote cannot distinguish from a dead host. Inside `runHandler` the throw lands in the same `handler_error` reply that a handler's own failures produce. Please sanity-check that reasoning.
2. **`readClaim` DEGRADES rather than refuses.** A non-string `method` becomes `""` (→ `unknown_method` written back, because `resolveCommandHandler` has no `""` entry) and non-object `params` becomes `{}` (→ the handler's own required-field check answers). Refusing either would leave the doc claimed as `processing` with no reply. This deliberately matches the pre-change failure path rather than inventing a `throw`.
3. **`pageResult` now throws on a value JSON cannot carry** (`NaN`, a function, a class instance) instead of letting it reach Firestore as a mangled write. Reachable in principle for a collection record holding a non-JSON value; a `Date` still serialises (via `toJSON`) rather than throwing — both pinned by tests. This is the behaviour `coerceJsonObject`'s own docstring promises and what the two sibling handlers already do.
4. **`Claim` is now exported** from `hostRunner.ts` (needed for `readClaim`'s declaration emit). It is a new public name on `@mulmoclaude/core`; flag if you'd rather it stayed internal.
5. **`packages/core` changed** — this PR does not bump or publish it. Worth folding into the next `chore(release)` for core.
6. **The i18n rewrite is behaviour-identical**, verified by diffing the generated cache rather than by reading the code (see below).

## Deliberately kept (7)

Each carries an in-code comment stating the blocker, so the next reader can judge whether it still holds.

| File | Why it stays |
|---|---|
| `packages/core/src/remote-host/index.ts:56` (`toJsonObject`) | As documented: widens a `Jsonify<T>` payload the compiler cannot express as `Record<string, JsonValue>` (interfaces get no index signature). Single, argued, already the one place the reasoning lives. |
| `packages/core/src/remote-host/server/hostRunner.ts:263` | The doc rides verbatim into the host's `onExpire`, whose **published** signature takes a whole `Command`. Rebuilding it would have to invent `status` / `result` / `error` / `createdBy` — nothing on this path reads them — and hand a second host's cleanup callback values the document never carried. That is worse than an assertion: a silent lie instead of an unproved claim. Removing it means narrowing `onExpire`'s parameter, a breaking change to a contract MulmoTerminal also implements. **Comment rewritten** — the old one claimed rebuilding would "drop whatever else the remote wrote", which understated the problem. |
| `src/tools/runtimeLoader.ts:153` | **Comment was factually wrong and is rewritten.** It claimed "is this a Vue component isn't decidable at runtime" — I checked, and Vue's `Component` accepts any object or function, so the components ARE provable. The real blocker is `ToolDefinition.parameters`: a recursive JSON-Schema shape (`JsonSchemaProperty` nests `items` / `properties` / `oneOf`), so proving it means shipping a JSON-Schema validator to the browser for a field nothing on this path reads — and dropping it instead would silently tighten what a third-party bundle must export. |
| `src/plugins/api.ts:102` | `E` is chosen by the caller (`pluginEndpoints<TodoEndpoints>("todos")`); nothing at the call site can check it. |
| `src/utils/plugin/runtime.ts:32` | Same family, plus an external contract: `gui-chat-protocol`'s `subscribe<T>(name, handler: (payload: T) => void)` is contravariant against the host's `(data: unknown) => void`. Fixing it properly means changing the published plugin runtime interface. |
| `server/utils/files/json.ts:24` | Caller-chosen `T` on `JSON.parse`. Verified the documented blocker still holds: of six call sites, four already pass `<unknown>` and validate themselves; only `loadSchedulerItems` / `loadUserTasks` propagate a concrete `T`, and both re-write the same file the same request read — so filtering unrecognised entries here would delete the user's data. Removing it needs per-entry validation at the scheduler/tasks layer first. |
| `packages/plugins/accounting-plugin/src/server/io.ts:100` | Caller-chosen `T`, and the persisted shapes are deliberately looser than their types: `BookSummary.fiscalYearEnd` is typed as a month number but legacy books hold `"Q1".."Q4"` on disk (`normalizeBookFiscalYearEnd` absorbs it on read). A predicate written against the type would reject those files and lock the user out of their books. |

## Bug found

`compileCsvQuery` with an unvalidated `in` condition. `CollectionQueryZ` refines "`in` ⇔ array value", and `scalarValue()` already threw a named error for the array-on-a-scalar-op direction — but the `in` direction was a bare cast, so a scalar there produced a stack-trace-only `TypeError` from deep inside the compiler.

Fail-before (`test/workspace/collections/test_dataSource.ts`):

```
✖ compileCsvQuery names the offending field when an unvalidated query pairs the wrong op with its value
  AssertionError: The input did not match the regular expression
  /where condition on 'status' uses op 'in', which requires an array value, not a scalar/.
  Input: 'TypeError: values.every is not a function'
```

Pass-after: `✔ compileCsvQuery names the offending field when an unvalidated query pairs the wrong op with its value`

## Behaviour-change evidence

**`pageResult` → `coerceJsonObject`** (`test/remoteHost/test_dataHandlers.ts`), fail-before:

```
✖ names the property when a record holds something JSON cannot carry
  AssertionError: Missing expected rejection.
✖ keeps a Date in a record as its ISO string
```

Pass-after:

```
✔ names the property when a record holds something JSON cannot carry
✔ keeps a Date in a record as its ISO string
```

**`readClaim`** (`packages/core/test/remote-host/test_hostRunner.ts`) — 5 new cases covering the happy path, both refusal cases (already-claimed doc, deleted/non-object payload), and both degradation cases. All pass; `readClaim` is a new export so there is no fail-before.

**`batch/i18n-dump.ts`** — verified against external ground truth rather than by re-reading the code: generated `.i18n-cache/` with the old implementation, then with the new one, and diffed.

```
$ diff -r <before>/i18n-cache .i18n-cache && echo "IDENTICAL"
IDENTICAL
```

## Verification

Run in a worktree with its own `yarn install`, so `@mulmoclaude/core` resolved to the edited source rather than the parent checkout's.

```
yarn build:packages   ✓
yarn format           ✓
yarn lint             ✓ 0 errors (72 pre-existing warnings; 23 are the remaining `as` findings repo-wide)
yarn typecheck        ✓
yarn build            ✓
yarn test             ✓ exit 0 — 8928 + 10 workspace suites, 0 fail
```

Scope check: `consistent-type-assertions` findings across the 10 files went **11 → 7**. `server/build/dispatcher.mjs` did not drift; only the 8 intended files are in the commit.

#2692

work in mulmoclaude3

## Summary by Sourcery

Remove unsafe type assertions in remote-host command handling, collection CSV query compilation, and i18n dump tooling, replacing them with validated JSON coercion and more robust value handling.

Bug Fixes:
- Ensure compileCsvQuery validates `in` conditions use array values and surfaces clear errors when op/value types mismatch.
- Prevent remote-host collection page results from writing non-JSON-safe values to Firestore by coercing payloads through JSON validation.

Enhancements:
- Refactor hostRunner claim acquisition to rebuild claims from checked fields and route JSON coercion to the handler boundary, aligning failure modes with handler errors.
- Replace a custom isRecord implementation with the shared guard from @mulmoclaude/common.
- Introduce a JSON-based coercion for collection page responses so non-JSON values throw with named paths while Dates serialize correctly.
- Simplify the i18n dump script by using a JSON.stringify replacer to substitute message functions with a placeholder string.
- Document the rationale for remaining type assertions across runtime loader, plugin APIs, JSON file utilities, and accounting plugin I/O, clarifying current constraints.

Tests:
- Add hostRunner readClaim tests covering happy path, refusal cases, and degraded fallback behaviour.
- Extend remote host data handler tests to cover non-JSON-safe values and Date serialization in collection page results.
- Add a workspace collection test ensuring compileCsvQuery reports clear errors when `in`/scalar op value types are mismatched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query validation with clearer errors when operators receive incompatible value types.
  * Added safer handling for malformed queued commands, including invalid methods and parameters.
  * Added runtime validation for collection responses, with property-specific errors for unsupported values.
  * Preserved correct ISO formatting for date values during serialization.
  * Improved localization export handling for message functions without affecting other values.

* **Tests**
  * Expanded coverage for query validation, command processing, collection data handling, and serialization edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->