### PR TITLE
fix: drop the last 6 `<template>` type assertions (#2692)

### DIFF
--- a/e2e/tests/accounting-reports-row-click.spec.ts
+++ b/e2e/tests/accounting-reports-row-click.spec.ts
@@ -13,6 +13,9 @@
 //   3. Balance Sheet's Period dropdown ("This month / Last month /
 //      Last quarter / Last year") snaps the `<input type=month>` to
 //      the chosen shortcut.
+//   4. The shared DateRangePicker (P&L / Ledger / Journal) — its
+//      shortcut <select> and its from/to <input type=date>s each
+//      write the range the report reads.
 
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
@@ -157,6 +160,54 @@ test.describe("Balance Sheet — row click and period shortcuts", () => {
     expect(lastYear).toMatch(/^\d{4}-12$/);
     // Last year must be strictly older than this month.
     expect(lastYear < thisMonth).toBe(true);
+  });
+});
+
+test.describe("Date range picker — shortcut and manual from/to", () => {
+  // Every assertion here reads the SHORTCUT select or the from/to inputs,
+  // all three of which are `:value`-bound to the parent's range. A handler
+  // that never emitted would leave the control showing whatever the user
+  // just typed or picked, so only a value that CHANGED (or fell back to the
+  // blank "custom" sentinel) proves the event reached the parent.
+  test("the shortcut dropdown and the from/to inputs each drive the shared range", async ({ page }) => {
+    const SEED_BOOK_ID = "book-daterange";
+    await setupSession(page, {
+      books: [{ id: SEED_BOOK_ID, name: "Range Book", withEmptyOpening: true }],
+      envelope: { bookId: SEED_BOOK_ID, initialTab: "profitLoss" },
+    });
+
+    await page.goto(`/chat/${SESSION_ID}`);
+    await expect(page.getByTestId("accounting-profit-loss")).toBeVisible();
+
+    const shortcut = page.getByTestId("accounting-daterange-shortcut");
+    const fromInput = page.getByTestId("accounting-daterange-from");
+    const toInput = page.getByTestId("accounting-daterange-to");
+
+    // P&L opens on the current fiscal year, so the picker starts on a preset.
+    await expect(shortcut).toHaveValue("currentYear");
+    const currentYearFrom = await fromInput.inputValue();
+    expect(currentYearFrom).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    // Shortcut → range: from/to only move if the select's handler emitted.
+    await shortcut.selectOption("previousYear");
+    await expect(shortcut).toHaveValue("previousYear");
+    await expect(fromInput).not.toHaveValue(currentYearFrom);
+
+    // Manual `from` → range. The 2019 dates can't collide with a preset
+    // computed from the system clock, so the select must land on the blank
+    // "custom" sentinel.
+    await fromInput.fill("2019-06-01");
+    await expect(shortcut).toHaveValue("");
+    await expect(fromInput).toHaveValue("2019-06-01");
+
+    // Back to a preset, then the same round trip through `to` — the two
+    // inputs have separate handlers, so one working proves nothing about
+    // the other.
+    await shortcut.selectOption("previousYear");
+    await expect(shortcut).toHaveValue("previousYear");
+    await toInput.fill("2019-06-30");
+    await expect(shortcut).toHaveValue("");
+    await expect(toInput).toHaveValue("2019-06-30");
   });
 });
 

--- a/e2e/tests/collection-toolbar-field-selects.spec.ts
+++ b/e2e/tests/collection-toolbar-field-selects.spec.ts
@@ -1,0 +1,103 @@
+// E2E for the two field choosers in the collection toolbar: which date
+// field anchors the calendar grid, and which enum field groups the kanban
+// board. Both `<select>`s render ONLY when the schema carries more than one
+// field of that type — a single date / enum field needs no chooser — and no
+// other spec feeds a two-of-each schema, so neither control had coverage.
+//
+// Each assertion reads the GRID (which day cell holds the chip / which
+// columns exist), never the select's own value. A `<select>` keeps showing
+// whatever the user picked even when its change handler drops the event on
+// the floor, so its value proves nothing; only the re-anchored calendar and
+// the re-grouped board prove the emit reached the parent.
+//
+// Records sit in the *current* month so they land on the calendar's
+// default-visible grid without mocking the clock.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const today = new Date();
+const monthPrefix = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}`;
+const DUE_DAY = `${monthPrefix}-15`;
+const STARTED_DAY = `${monthPrefix}-05`;
+
+const TASKS = {
+  collection: {
+    slug: "toolbar-fields",
+    title: "Toolbar Fields",
+    icon: "checklist",
+    source: "user",
+    schema: {
+      title: "Toolbar Fields",
+      icon: "checklist",
+      dataPath: "data/toolbar-fields/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+        // Two date fields → the calendar anchor chooser appears.
+        due: { type: "date", label: "Due" },
+        startedOn: { type: "date", label: "Started" },
+        // Two enum fields → the kanban group chooser appears. Their values
+        // are disjoint so a column testid names the grouping field.
+        status: { type: "enum", label: "Status", values: ["todo", "doing", "done"] },
+        priority: { type: "enum", label: "Priority", values: ["low", "high"] },
+      },
+      displayField: "name",
+      calendarField: "due",
+    },
+  },
+  items: [{ id: "a", name: "Task A", due: DUE_DAY, startedOn: STARTED_DAY, status: "doing", priority: "high" }],
+};
+
+async function setup(page: Page): Promise<void> {
+  await mockAllApis(page);
+  await page.route(
+    (url) => url.pathname === "/api/collections/toolbar-fields",
+    (route) => route.fulfill({ json: TASKS }),
+  );
+}
+
+test.describe("collection toolbar field choosers", () => {
+  test.beforeEach(async ({ page }) => {
+    await setup(page);
+  });
+
+  test("the calendar anchor chooser re-anchors the grid to the picked date field", async ({ page }) => {
+    await page.goto("/collections/toolbar-fields");
+    await page.getByTestId("collection-view-toggle-calendar").click();
+    await expect(page.getByTestId("collection-calendar")).toBeVisible();
+
+    const anchor = page.getByTestId("collection-calendar-field");
+    await expect(anchor).toBeVisible();
+    await expect(anchor).toHaveValue("due");
+
+    // Anchored on `due`: the chip sits in the 15th's cell, not the 5th's.
+    await expect(page.getByTestId(`collection-calendar-day-${DUE_DAY}`).getByTestId("collection-calendar-chip-a")).toBeVisible();
+    await expect(page.getByTestId(`collection-calendar-day-${STARTED_DAY}`).getByTestId("collection-calendar-chip-a")).toHaveCount(0);
+
+    // Re-anchor on `startedOn`: the chip moves to the 5th.
+    await anchor.selectOption("startedOn");
+    await expect(page.getByTestId(`collection-calendar-day-${STARTED_DAY}`).getByTestId("collection-calendar-chip-a")).toBeVisible();
+    await expect(page.getByTestId(`collection-calendar-day-${DUE_DAY}`).getByTestId("collection-calendar-chip-a")).toHaveCount(0);
+  });
+
+  test("the kanban group chooser re-groups the board by the picked enum field", async ({ page }) => {
+    await page.goto("/collections/toolbar-fields");
+    await page.getByTestId("collection-view-toggle-kanban").click();
+    await expect(page.getByTestId("collection-kanban")).toBeVisible();
+
+    const group = page.getByTestId("collection-kanban-field");
+    await expect(group).toBeVisible();
+    await expect(group).toHaveValue("status");
+
+    // Grouped by `status`: columns are the status values.
+    await expect(page.getByTestId("collection-kanban-column-doing")).toBeVisible();
+    await expect(page.getByTestId("collection-kanban-column-high")).toHaveCount(0);
+
+    // Re-group by `priority`: the columns become the priority values.
+    await group.selectOption("priority");
+    await expect(page.getByTestId("collection-kanban-column-high")).toBeVisible();
+    await expect(page.getByTestId("collection-kanban-column-doing")).toHaveCount(0);
+  });
+});

--- a/packages/plugins/accounting-plugin/src/vue/components/BalanceSheet.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/BalanceSheet.vue
@@ -7,7 +7,7 @@
           :value="selectedShortcut"
           class="h-8 px-2 rounded border border-gray-300 text-sm bg-white"
           data-testid="accounting-bs-shortcut"
-          @change="onShortcutChange(($event.target as HTMLSelectElement).value)"
+          @change="onShortcutChange"
         >
           <option value="" hidden></option>
           <option value="thisMonth">{{ t("pluginAccounting.balanceSheet.thisMonth") }}</option>
@@ -161,7 +161,10 @@ const selectedShortcut = computed<SelectedShortcut>(() => {
   return "";
 });
 
-function onShortcutChange(raw: string): void {
+function onShortcutChange(event: Event): void {
+  const { target } = event;
+  if (!(target instanceof HTMLSelectElement)) return;
+  const raw = target.value;
   const now = new Date();
   if (raw === "thisMonth") period.value = localMonthString(now);
   else if (raw === "lastMonth") period.value = previousMonthString(now);

--- a/packages/plugins/accounting-plugin/src/vue/components/DateRangePicker.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/DateRangePicker.vue
@@ -10,7 +10,7 @@
         :value="selectedShortcut"
         class="h-8 px-2 rounded border border-gray-300 text-sm bg-white"
         data-testid="accounting-daterange-shortcut"
-        @change="onShortcutChange(($event.target as HTMLSelectElement).value)"
+        @change="onShortcutChange"
       >
         <!-- Sentinel for the "custom" state. Hidden from the menu
              but bound when the current range doesn't match any
@@ -32,7 +32,7 @@
         type="date"
         class="h-8 px-2 rounded border border-gray-300 text-sm"
         data-testid="accounting-daterange-from"
-        @input="onFromChange(($event.target as HTMLInputElement).value)"
+        @input="onFromChange"
       />
     </label>
     <label class="text-xs text-gray-500 flex flex-col gap-1">
@@ -42,7 +42,7 @@
         type="date"
         class="h-8 px-2 rounded border border-gray-300 text-sm"
         data-testid="accounting-daterange-to"
-        @input="onToChange(($event.target as HTMLInputElement).value)"
+        @input="onToChange"
       />
     </label>
   </div>
@@ -125,7 +125,10 @@ const selectedShortcut = computed<SelectedShortcut>(() => {
   return "";
 });
 
-function onShortcutChange(raw: string): void {
+function onShortcutChange(event: Event): void {
+  const { target } = event;
+  if (!(target instanceof HTMLSelectElement)) return;
+  const raw = target.value;
   const today = new Date();
   if (raw === "currentQuarter") emit("update:modelValue", currentQuarterRange(props.fiscalYearEnd, today));
   else if (raw === "previousQuarter") emit("update:modelValue", previousQuarterRange(props.fiscalYearEnd, today));
@@ -137,11 +140,15 @@ function onShortcutChange(raw: string): void {
   } else if (raw === "all") emit("update:modelValue", UNBOUNDED_RANGE);
 }
 
-function onFromChange(value: string): void {
-  emit("update:modelValue", { from: value, to: props.modelValue.to });
+function onFromChange(event: Event): void {
+  const { target } = event;
+  if (!(target instanceof HTMLInputElement)) return;
+  emit("update:modelValue", { from: target.value, to: props.modelValue.to });
 }
 
-function onToChange(value: string): void {
-  emit("update:modelValue", { from: props.modelValue.from, to: value });
+function onToChange(event: Event): void {
+  const { target } = event;
+  if (!(target instanceof HTMLInputElement)) return;
+  emit("update:modelValue", { from: props.modelValue.from, to: target.value });
 }
 </script>

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionToolbar.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionToolbar.vue
@@ -195,7 +195,7 @@
         class="h-8 px-2 rounded border border-slate-200 bg-white text-xs font-semibold text-slate-600 focus:outline-none focus:border-indigo-500 cursor-pointer"
         :aria-label="t('collectionsView.calendarFieldLabel')"
         data-testid="collection-calendar-field"
-        @change="emit('update:anchorField', ($event.target as HTMLSelectElement).value)"
+        @change="onAnchorFieldChange"
       >
         <option v-for="key in dateFields" :key="key" :value="key">{{ collection?.schema.fields[key]?.label ?? key }}</option>
       </select>
@@ -206,7 +206,7 @@
         class="h-8 px-2 rounded border border-slate-200 bg-white text-xs font-semibold text-slate-600 focus:outline-none focus:border-indigo-500 cursor-pointer"
         :aria-label="t('collectionsView.kanbanFieldLabel')"
         data-testid="collection-kanban-field"
-        @change="emit('update:groupField', ($event.target as HTMLSelectElement).value)"
+        @change="onGroupFieldChange"
       >
         <option v-for="key in enumFields" :key="key" :value="key">{{ collection?.schema.fields[key]?.label ?? key }}</option>
       </select>
@@ -312,6 +312,16 @@ function flagChipTitle(chip: FlagChip): string {
   if (mode === "hide") return t("collectionsView.flagFilterHide", { label: chip.label });
   if (mode === "only") return t("collectionsView.flagFilterOnly", { label: chip.label });
   return t("collectionsView.flagFilterAll", { label: chip.label });
+}
+
+function onAnchorFieldChange(event: Event): void {
+  const { target } = event;
+  if (target instanceof HTMLSelectElement) emit("update:anchorField", target.value);
+}
+
+function onGroupFieldChange(event: Event): void {
+  const { target } = event;
+  if (target instanceof HTMLSelectElement) emit("update:groupField", target.value);
 }
 
 /** "+" click: open the target chooser, or skip the one-item menu and seed


### PR DESCRIPTION
## Summary

Removes the **6 remaining `<template>`-block type assertions** — the entire remainder of what `vue/no-restricted-syntax` still reported. They were all in two plugin packages:

| File | Casts | Controls |
|---|---|---|
| `packages/plugins/accounting-plugin/src/vue/components/DateRangePicker.vue` | 3 | shortcut `<select>`, from/to `<input type=date>` |
| `packages/plugins/collection-plugin/src/vue/components/CollectionToolbar.vue` | 2 | calendar-anchor `<select>`, kanban-group `<select>` |
| `packages/plugins/accounting-plugin/src/vue/components/BalanceSheet.vue` | 1 | period shortcut `<select>` |

Each `($event.target as HTMLSelectElement).value` becomes a named handler taking `Event` and narrowing with `instanceof` — the narrowing is **replaced by a real check**, not relocated into the script. This matches what `BookSwitcher.vue` and `CollectionCell.vue` already do in these same two directories, so no new helper or shared util was introduced.

Measured before/after (`yarn lint`, after `yarn build:packages`):

```
before:  76 problems (0 errors, 76 warnings) — 6 × vue/no-restricted-syntax
after:   70 problems (0 errors, 70 warnings) — 0 × vue/no-restricted-syntax
```

The 6 findings in scope were *exactly* the 6 remaining template casts; nothing outside these three files was touched.

## Items to Confirm / Review

1. **Narrowing failure is a no-op, matching the cast's real path.** The `instanceof` can only fail for a target the listener is not bound to (a `<select>`'s only children are `<option>`s, which do not fire `change`). On the path that actually runs, behaviour is identical. No `throw` was invented where the caller expected a fallback.
2. **The tests read the PARENT's state, never the control's own value.** This is the part worth a careful look. A `<select>` / `<input>` with `:value` bound keeps displaying whatever the user just picked even when its handler drops the event on the floor — so `toHaveValue(...)` on the control itself would pass against a completely broken handler. Assertions therefore go through observables that only move if the emit reached the parent: the picker's blank `""` "custom" sentinel (computed from the parent's range), the calendar chip's day cell, and the kanban column set.
3. **New fixture in `collection-toolbar-field-selects.spec.ts`.** Both toolbar selects render only when the schema has **more than one** date / enum field. Nothing in the suite fed such a schema, so both controls had zero coverage. The new fixture is the first two-date / two-enum collection — please sanity-check the schema shape against real collection schemas.
4. **`DateRangePicker.onShortcutChange` grew 3 lines** (narrow + read `.value`) rather than being refactored into a pure `rangeForShortcut()`. That refactor was deliberately skipped to keep the diff reviewable; say the word if you'd prefer it split.
5. **No visual/manual UI inspection was done.** Verification is the automated e2e runs below, driven in a real Chromium — not a human looking at the screen.

## Verification

Full chain, all green:

```
yarn build:packages && yarn format && yarn lint && yarn typecheck && yarn build && yarn test
→ lint: 70 problems (0 errors), 0 template casts
→ typecheck exit=0   build exit=0   test exit=0
```

e2e (always with `--config e2e/playwright.config.ts`):

```
accounting-reports-row-click + collection-toolbar-field-selects
  + accounting-journal-detail-panel .......... 12 passed
collection-calendar + view-dashboard-removed + flag-filter
  + add-view-menu + view-config .............. 31 passed
```

### Every one of the 6 handlers was proved to be exercised

Rather than trusting that the new tests cover the changed code, each handler's `instanceof` was broken to the wrong element type, the plugin rebuilt, and the matching assertion watched to fail — then restored:

| Handler | Failed assertion when broken |
|---|---|
| `BalanceSheet.onShortcutChange` | `Expected: not "2026-08"` (period never moved) |
| `DateRangePicker.onShortcutChange` | `expect(locator).not.toHaveValue()` (from never moved) |
| `DateRangePicker.onFromChange` | `toHaveValue("")` — select stuck on `previousYear` |
| `DateRangePicker.onToChange` | `toHaveValue("")` — select stuck on `previousYear` |
| `CollectionToolbar.onAnchorFieldChange` | calendar test — chip never re-anchored |
| `CollectionToolbar.onGroupFieldChange` | kanban test — columns never re-grouped |

**Trap this caught, worth knowing:** the e2e dev server serves each plugin's built `dist`, not its `src`. The first "fail-before" attempt **passed with deliberately broken code** because the plugin had not been rebuilt. Any e2e judgement about a `packages/plugins/*` source edit is meaningless without `yarn workspace <pkg> run build` first.

## User Prompt

> Work issue #2692: eliminate `as` type assertions. Scope: `DateRangePicker.vue` (3), `CollectionToolbar.vue` (2), `BalanceSheet.vue` (1). Also in scope: the 6 remaining `<template>`-block casts flagged by `vue/no-restricted-syntax` — if any live outside those three files, leave them and just list them. The usual shape is `($event.target as HTMLInputElement).value`; the fix is a typed handler in `<script setup>` that takes `Event` and narrows with `instanceof HTMLInputElement`, called from the template — NOT a cast moved into the script. Never use `as` / `@ts-ignore` / `eslint-disable` to silence. These are UI components — if behaviour changes, add a test and show fail-before/pass-after output; state plainly whether anything was visually verified.

The 6 template casts turned out to be exactly the 6 findings in the three named files, so nothing had to be left behind or listed.

Refs #2692 (partial scope — the script-side `@typescript-eslint/consistent-type-assertions` drain continues; 27 remain).

work in mulmoclaude3

## Summary by Sourcery

Remove remaining template-level DOM type assertions from accounting and collection Vue plugins and verify event handling via new e2e coverage.

Bug Fixes:
- Ensure date range picker shortcut and from/to inputs correctly emit range updates without relying on template type assertions.
- Ensure collection toolbar calendar anchor and kanban group selects correctly emit field updates using runtime-checked event handlers.

Enhancements:
- Replace inline template type assertions with event handlers that narrow DOM event targets at runtime for date range and balance sheet shortcuts and collection toolbar field selectors.

Tests:
- Add Playwright e2e coverage for the shared accounting date range picker shortcut and from/to inputs.
- Add Playwright e2e coverage for collection toolbar calendar anchor and kanban group field selectors, including a new multi-field collection fixture.