### PR TITLE
fix(lint): ratchet no-unsafe-call / no-unsafe-return to error (#2736)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -594,17 +594,17 @@ export default [
     rules: {
       // (1) `any` that survives no-explicit-any.
       "@typescript-eslint/no-unsafe-assignment": "warn",
-      // Drained and ratcheted in #2736 (2026-08-02): both measured ZERO over
+      // Drained and ratcheted in #2736 (2026-08-02): all four measured ZERO over
       // `src server test e2e e2e-live packages` once their last finding was
       // fixed. Read those counts only after `yarn build:packages` — with
       // `packages/*/dist` missing, every `@mulmoclaude/*` import is an
-      // unresolved type and these two report ~2700 phantom findings. CI builds
+      // unresolved type and these report ~2700 phantom findings. CI builds
       // packages before both typecheck and lint, so the gate sees the real
       // numbers.
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
-      "@typescript-eslint/no-unsafe-call": "warn",
-      "@typescript-eslint/no-unsafe-return": "warn",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
       // Zero findings today — on to keep it that way.
       "@typescript-eslint/no-unsafe-enum-comparison": "warn",
       "@typescript-eslint/no-unsafe-declaration-merging": "warn",
@@ -640,9 +640,10 @@ export default [
       // return type. Each site carries a comment naming its upstream guard; the
       // rule stays a `warn` so a genuinely unguarded fold still surfaces.
       //
-      // Also left at `warn`: `no-unsafe-assignment` (19 findings), and
-      // `no-unsafe-call` / `no-unsafe-return`, which are at zero but were not
-      // part of this drain — promote them in their own PR.
+      // Still at `warn`: `no-unsafe-assignment`, the only one of the five with a
+      // backlog left (19 findings). `no-unsafe-call` / `no-unsafe-return` were
+      // the "promote them in their own PR" case named here and have since
+      // graduated alongside the other two.
       "sonarjs/deprecation": "error",
       "sonarjs/argument-type": "error",
       "sonarjs/no-selector-parameter": "error",


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-unsafe-call` と `no-unsafe-return` を `warn` → `error` に上げます。どちらも `src server test e2e e2e-live packages` 全体で **0件**。

これは新規提案ではなく、`eslint.config.mjs` 自身が名指ししていた後続作業です。#2743 で `no-unsafe-member-access` / `no-unsafe-argument` を昇格させた際、コメントに「この2つは0件だが今回のドレイン対象外 — 別PRで昇格させる」と書かれていました。その別PRです。

`no-unsafe-assignment` は **19件残っている**ので `warn` 据え置き。5つのうちバックログが残る唯一のルールです。

## Items to Confirm / Review

**1. 昇格が実際に効くことを実証済み（推測していません）。** 設定を変えても効いていないケースは、効いている場合と見分けがつきません。一時的な probe ファイルで違反を作り、`error` が出ることを確認してから削除しました:

```
4:3  error  Unsafe call of an `any` typed value     @typescript-eslint/no-unsafe-call
8:3  error  Unsafe return of a value of type `any`  @typescript-eslint/no-unsafe-return
✖ 4 problems (3 errors, 1 warning)   exit=1
```

**2. 0件という計測は `yarn build:packages` の後に読む必要があります。** `packages/*/dist` が欠けていると `@mulmoclaude/*` の import が未解決型になり、これら型認識ルールは大量の幻の指摘を出します（#2743 で dist を1つ外して実測: 2ファイルに19件）。CI は typecheck と lint の前にパッケージをビルドするので、gate は正しい数字を見ています。この事情は該当ルール直上のコメントに記載済みで、今回「both」→「all four」に更新しました。

**3. ローカルで `yarn lint` 単体を実行すると、dist が古い/無い場合にエラーになります。** これは `yarn typecheck` が以前から持っている性質と同じで、新しい種類のリスクではありません。

## 検証

`main` @ `32f3964dd` から分岐。

```
yarn build:packages  0
yarn format          0  (書き換えなし)
yarn lint            0  → 0 errors / 51 warnings
yarn typecheck       0
yarn build           0
yarn test            0  → 10996 tests / fail 0
```

refs #2736

work in mulmoclaude3

## Summary by Sourcery

Promote remaining TypeScript ESLint unsafe-operation rules to error-level and update config commentary to reflect the completed ratchet.

Build:
- Raise @typescript-eslint/no-unsafe-call and @typescript-eslint/no-unsafe-return from warn to error in the shared ESLint configuration.
- Clarify ESLint config comments around all four unsafe-* rules and document the remaining backlog on no-unsafe-assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Strengthened code quality checks by enforcing errors for unsafe calls and unsafe return values.
  * Updated linting documentation to reflect the current validation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->