### PR TITLE
fix: make src/plugins/spreadsheet noUncheckedIndexedAccess-clean (247 → 0)

### DIFF
--- a/src/plugins/spreadsheet/engine/calculator.ts
+++ b/src/plugins/spreadsheet/engine/calculator.ts
@@ -5,9 +5,8 @@
  */
 
 import { formatCellForDisplay } from "./cellFormatting";
-import { columnToIndex } from "./parser";
 import { evaluateFormula as evaluateFormulaFn } from "./evaluator";
-import { expandRangeOrCell } from "./formulaRefs";
+import { expandRangeOrCell, parseSingleCellRef } from "./formulaRefs";
 import { parseDate, getDefaultDateFormat } from "./date-parser";
 import type { SheetData, CellValue, CalculatedSheet, CalculationError, FormulaInfo, SpreadsheetCell, CalculateOptions } from "./types";
 import { isObj } from "../../../utils/types";
@@ -20,6 +19,12 @@ import { isSpreadsheetErrorValue, spreadsheetError } from "./spreadsheet-errors"
 // whether it points at the sheet currently being calculated (which decides
 // whether recursive formula evaluation is allowed for the cell it lands on).
 type ResolvedSheetRef = { sheetData: (SpreadsheetCell | CellValue)[][]; ref: string; isCurrentSheet: boolean };
+
+// Where a cell sits in the grid CURRENTLY being calculated, carrying the row it
+// belongs to so a formula's result is written back without re-indexing. Only a
+// same-sheet cell has one: a cross-sheet read is resolved by that sheet's own
+// calculateSheet pass, so it has no position here to recurse from.
+type CellPosition = { cells: any[]; row: number; col: number };
 
 /**
  * Normalize malformed data structures
@@ -157,17 +162,17 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
   // Evaluate one formula cell, guarding circular references, caching the result,
   // and turning a thrown failure into a typed errors[] entry plus the Excel
   // error value in the cell — never a swallowed bare string/number (#2359).
-  const resolveFormulaCell = (formulaText: string, row: number, col: number): CellValue => {
+  const resolveFormulaCell = (formulaText: string, { cells, row, col }: CellPosition): CellValue => {
     const cellKey = `${row},${col}`;
     if (calculating.has(cellKey)) {
       errors.push({ cell: { row, col }, formula: formulaText, error: "Circular reference detected", type: "circular" });
       return 0;
     }
-    if (evaluated.has(cellKey)) return calculated[row][col];
+    if (evaluated.has(cellKey)) return cells[col];
     calculating.add(cellKey);
     try {
       const result = evaluateFormula(formulaText.substring(1)); // drop leading "="
-      calculated[row][col] = result;
+      cells[col] = result;
       return result;
     } catch (error) {
       const { type, display } = classifyThrownError(error);
@@ -175,7 +180,7 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
       // The error VALUE, not its text: a cell that reads this one must see a
       // real error, and the display pass renders it back to `#DIV/0!`.
       const errorValue = spreadsheetError(display);
-      calculated[row][col] = errorValue;
+      cells[col] = errorValue;
       return errorValue;
     } finally {
       calculating.delete(cellKey);
@@ -184,7 +189,7 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
   };
 
   // Helper to extract raw value from cell with recursive formula evaluation
-  const getRawValue = (cell: any, row?: number, col?: number): CellValue => {
+  const getRawValue = (cell: any, position?: CellPosition): CellValue => {
     // Handle null/undefined cells - treat as 0
     if (cell === null || cell === undefined) return 0;
 
@@ -228,10 +233,7 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
       if (typeof value === "string" && value.startsWith("=")) {
         // Only evaluatable when we know the cell's position (for recursion +
         // circular tracking); otherwise treat as 0.
-        if (row !== undefined && col !== undefined) {
-          return resolveFormulaCell(value, row, col);
-        }
-        return 0; // No position info, can't evaluate
+        return position ? resolveFormulaCell(value, position) : 0;
       }
       // Try to parse as number, but preserve original type on failure
       if (typeof value === "number") return value;
@@ -258,8 +260,12 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
     const sheetMatch = fullRef.match(/^(?:'([^']+)'|([^!]+))!(.+)$/);
     if (!sheetMatch) return { sheetData: calculated, ref: fullRef, isCurrentSheet: true };
 
-    const targetSheetName = sheetMatch[1] || sheetMatch[2]; // Quoted or unquoted sheet name
-    const innerRef = sheetMatch[3]; // Reference part after the sheet name
+    // Exactly one of the two name branches participates; the reference part
+    // always does. A shortfall would mean the pattern and this read disagree, so
+    // it lands on the caller's "sheet not found" path rather than a guess.
+    const [, quotedName, plainName, innerRef] = sheetMatch;
+    const targetSheetName = quotedName ?? plainName;
+    if (targetSheetName === undefined || innerRef === undefined) return null;
 
     // Check cache first to prevent infinite loops
     const cached = sheetsCache.get(targetSheetName);
@@ -285,21 +291,16 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
     if (!resolved) throw invalidRefError(ref); // Sheet not found → #REF!
     const { sheetData, ref: cellRef, isCurrentSheet } = resolved;
 
-    // Remove $ symbols for absolute references
-    const cleanRef = cellRef.replace(/\$/g, "");
-    const match = cleanRef.match(/^([A-Z]+)(\d+)$/);
-    if (!match) return 0;
+    // `$` symbols and the A1 shape are parsed by the shared single-cell reader.
+    const coord = parseSingleCellRef(cellRef);
+    if (!coord) return 0;
 
-    const col = columnToIndex(match[1]); // A=0, B=1, ..., Z=25, AA=26, etc.
-    const row = parseInt(match[2]) - 1; // 1-indexed to 0-indexed
+    const { row, col } = coord;
+    const gridRow = row >= 0 ? sheetData[row] : undefined;
+    if (!gridRow || col < 0 || col >= gridRow.length) return 0;
 
-    if (row < 0 || row >= sheetData.length || col < 0 || col >= sheetData[row].length) {
-      return 0;
-    }
-
-    const cell = sheetData[row][col];
-    // Pass row/col only if this is the current sheet (for recursive evaluation)
-    return getRawValue(cell, isCurrentSheet ? row : undefined, isCurrentSheet ? col : undefined);
+    // Pass the position only if this is the current sheet (for recursive evaluation)
+    return getRawValue(gridRow[col], isCurrentSheet ? { cells: gridRow, row, col } : undefined);
   };
 
   const collectRangeValues = (range: string, options: { numericOnly: boolean }): CellValue[] => {
@@ -312,10 +313,11 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
 
     const values: CellValue[] = [];
     for (const { row, col } of coords) {
-      if (row >= 0 && row < sheetData.length && col >= 0 && col < sheetData[row].length) {
-        const cell = sheetData[row][col];
-        // Pass row/col only if current sheet (for recursive evaluation)
-        const rawValue = getRawValue(cell, isCurrentSheet ? row : undefined, isCurrentSheet ? col : undefined);
+      const gridRow = row >= 0 ? sheetData[row] : undefined;
+      if (gridRow && col >= 0 && col < gridRow.length) {
+        const cell = gridRow[col];
+        // Pass the position only if current sheet (for recursive evaluation)
+        const rawValue = getRawValue(cell, isCurrentSheet ? { cells: gridRow, row, col } : undefined);
 
         if (options.numericOnly) {
           // A blank cell is not a value. Dropping it from the NUMERIC list keeps
@@ -352,62 +354,58 @@ export function calculateSheet(sheet: SheetData, allSheets?: SheetData[], option
     });
   };
 
-  // Process all cells and calculate formulas
-  for (let rowIdx = 0; rowIdx < data.length; rowIdx++) {
-    for (let colIdx = 0; colIdx < data[rowIdx].length; colIdx++) {
-      const originalCell = data[rowIdx][colIdx];
-      const calculatedCell = calculated[rowIdx][colIdx];
+  // Compute one cell into its calculated row. A cell not in {v, f} format is
+  // left as-is (it is already a plain value).
+  const calculateCell = (originalCell: SpreadsheetCell, position: CellPosition): void => {
+    if (!isObj(originalCell) || !("v" in originalCell)) return;
+    const value = originalCell.v;
 
-      // Skip if cell was already calculated recursively
-      if (typeof calculatedCell === "number" && isObj(originalCell) && "f" in originalCell) {
-        // Cell was already evaluated - keep it as number for now
-        // Formatting will be applied at the end
-        continue;
-      }
-
-      // Handle cell format {v, f}
-      if (isObj(originalCell) && "v" in originalCell) {
-        const value = originalCell.v;
-
-        // Check if value is a formula (string starting with "=")
-        if (typeof value === "string" && value.startsWith("=")) {
-          // Track formula info
-          formulas.push({
-            cell: { row: rowIdx, col: colIdx },
-            formula: value,
-            dependencies: [], // TODO: Extract dependencies from formula
-            result: 0, // Will be updated below
-          });
-
-          // Route through the protected path so a thrown failure is classified
-          // into errors[] instead of escaping this loop, and a cell already
-          // resolved via another formula's recursion is read from cache (#2359).
-          const result = resolveFormulaCell(value, rowIdx, colIdx);
-
-          // Update formula result
-          formulas[formulas.length - 1].result = result;
-
-          // Store result as-is (formatting will be applied at the end)
-          calculated[rowIdx][colIdx] = result;
-        } else {
-          // Regular value cell (not a formula)
-          // Convert to plain value (important for range evaluation)
-          calculated[rowIdx][colIdx] = value;
-        }
-      }
-      // If cell is not in {v, f} format, leave it as-is (already a plain value)
+    // A plain value is copied through, so range evaluation reads it.
+    if (typeof value !== "string" || !value.startsWith("=")) {
+      position.cells[position.col] = value;
+      return;
     }
-  }
+
+    const info: FormulaInfo = {
+      cell: { row: position.row, col: position.col },
+      formula: value,
+      dependencies: [], // TODO: Extract dependencies from formula
+      result: 0, // Will be updated below
+    };
+    formulas.push(info);
+    // Route through the protected path so a thrown failure is classified into
+    // errors[] instead of escaping this walk, and a cell already resolved via
+    // another formula's recursion is read from cache (#2359).
+    info.result = resolveFormulaCell(value, position);
+    // Store result as-is (formatting will be applied at the end)
+    position.cells[position.col] = info.result;
+  };
+
+  // Walk every cell of the grid. `calculated` is built as a row-for-row copy of
+  // `data` and never resized, so a missing row cannot happen; skipping one keeps
+  // the walk total rather than asserting the invariant at each cell.
+  const forEachCell = (visit: (originalCell: SpreadsheetCell, position: CellPosition) => void): void => {
+    data.forEach((dataRow, row) => {
+      const cells = calculated[row];
+      if (!cells) return;
+      dataRow.forEach((originalCell, col) => visit(originalCell, { cells, row, col }));
+    });
+  };
+
+  // Process all cells and calculate formulas. A cell already evaluated through
+  // another formula's recursion keeps its number; formatting comes at the end.
+  forEachCell((originalCell, position) => {
+    const alreadyCalculated = typeof position.cells[position.col] === "number" && isObj(originalCell) && "f" in originalCell;
+    if (!alreadyCalculated) calculateCell(originalCell, position);
+  });
 
   // Final display-formatting pass: turn raw serials into presentation strings.
   // Skipped when this sheet is computed only to resolve a cross-sheet reference,
   // so the referencing cell reads the underlying value, not a display string.
   if (!skipFormatting) {
-    for (let rowIdx = 0; rowIdx < data.length; rowIdx++) {
-      for (let colIdx = 0; colIdx < data[rowIdx].length; colIdx++) {
-        calculated[rowIdx][colIdx] = formatCellForDisplay(data[rowIdx][colIdx], calculated[rowIdx][colIdx], preferDDMMYYYY);
-      }
-    }
+    forEachCell((originalCell, { cells, col }) => {
+      cells[col] = formatCellForDisplay(originalCell, cells[col], preferDDMMYYYY);
+    });
   }
 
   return {

--- a/src/plugins/spreadsheet/engine/date-parser.ts
+++ b/src/plugins/spreadsheet/engine/date-parser.ts
@@ -52,6 +52,27 @@ export function serialFromParts(year: number, month: number, day: number): numbe
 }
 
 /**
+ * The three capture groups of a date pattern, as a tuple the caller can
+ * destructure. `null` when the text does not match — or when a group did not
+ * participate, which every pattern here makes impossible, so it lands on the
+ * same "not a date" answer rather than reading an absent group as text.
+ */
+function matchDateParts(text: string, pattern: RegExp): [string, string, string] | null {
+  const [, first, second, third] = text.match(pattern) ?? [];
+  if (first === undefined || second === undefined || third === undefined) return null;
+  return [first, second, third];
+}
+
+const SLASH_DATE_PATTERN = /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/;
+const MAX_MONTH = 12;
+
+/** Whether `A/B/YYYY` reads day-first. A number no month can hold decides on its
+ *  own; an ambiguous pair follows the reading preference. Shared with
+ *  `getDefaultDateFormat` so a slash date renders in the order it was READ. */
+const readsDayFirst = (first: number, second: number, preferDDMMYYYY: boolean): boolean =>
+  first > MAX_MONTH || (second <= MAX_MONTH && first <= MAX_MONTH && preferDDMMYYYY);
+
+/**
  * Parse a month name to month number (1-12)
  */
 function parseMonthName(monthStr: string): number | null {
@@ -88,79 +109,61 @@ export function parseDate(dateStr: string, preferDDMMYYYY: boolean = false): num
   const trimmed = dateStr.trim();
 
   // Try YYYY-MM-DD or YYYY/MM/DD (ISO format)
-  const isoMatch = trimmed.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
-  if (isoMatch) {
-    const year = parseInt(isoMatch[1]);
-    const month = parseInt(isoMatch[2]);
-    const day = parseInt(isoMatch[3]);
-
-    return serialFromParts(year, month, day);
+  const isoParts = matchDateParts(trimmed, /^(\d{4})[-/](\d{1,2})[-/](\d{1,2})$/);
+  if (isoParts) {
+    const [year, month, day] = isoParts;
+    return serialFromParts(parseInt(year), parseInt(month), parseInt(day));
   }
 
   // Try DD-MMM-YYYY or D-MMM-YYYY
-  const dmmyMatch = trimmed.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2,4})$/);
-  if (dmmyMatch) {
-    const day = parseInt(dmmyMatch[1]);
-    const monthName = dmmyMatch[2];
-    let year = parseInt(dmmyMatch[3]);
-
-    // Handle 2-digit years
-    if (year < 100) {
-      year = year < 30 ? 2000 + year : 1900 + year;
-    }
-
-    const month = parseMonthName(monthName);
-    if (month === null) return null;
-    return serialFromParts(year, month, day);
+  const dmmyParts = matchDateParts(trimmed, /^(\d{1,2})-([A-Za-z]{3})-(\d{2,4})$/);
+  if (dmmyParts) {
+    const [day, monthName, year] = dmmyParts;
+    return serialFromNamedMonth(expandTwoDigitYear(parseInt(year)), monthName, parseInt(day));
   }
 
   // Try MMM D, YYYY or MMMM D, YYYY
-  const mmmMatch = trimmed.match(/^([A-Za-z]{3,9})\s+(\d{1,2}),?\s+(\d{4})$/);
-  if (mmmMatch) {
-    const monthName = mmmMatch[1];
-    const day = parseInt(mmmMatch[2]);
-    const year = parseInt(mmmMatch[3]);
-
-    const month = parseMonthName(monthName);
-    if (month === null) return null;
-    return serialFromParts(year, month, day);
+  const mmmParts = matchDateParts(trimmed, /^([A-Za-z]{3,9})\s+(\d{1,2}),?\s+(\d{4})$/);
+  if (mmmParts) {
+    const [monthName, day, year] = mmmParts;
+    return serialFromNamedMonth(parseInt(year), monthName, parseInt(day));
   }
 
   // Try D MMM YYYY
-  const dMmmMatch = trimmed.match(/^(\d{1,2})\s+([A-Za-z]{3,9})\s+(\d{4})$/);
-  if (dMmmMatch) {
-    const day = parseInt(dMmmMatch[1]);
-    const monthName = dMmmMatch[2];
-    const year = parseInt(dMmmMatch[3]);
-
-    const month = parseMonthName(monthName);
-    if (month === null) return null;
-    return serialFromParts(year, month, day);
+  const dMmmParts = matchDateParts(trimmed, /^(\d{1,2})\s+([A-Za-z]{3,9})\s+(\d{4})$/);
+  if (dMmmParts) {
+    const [day, monthName, year] = dMmmParts;
+    return serialFromNamedMonth(parseInt(year), monthName, parseInt(day));
   }
 
   // Try MM/DD/YYYY or DD/MM/YYYY
-  const slashMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/);
-  if (slashMatch) {
-    const first = parseInt(slashMatch[1]);
-    const second = parseInt(slashMatch[2]);
-    let year = parseInt(slashMatch[3]);
-
-    // Handle 2-digit years
-    if (year < 100) {
-      year = year < 30 ? 2000 + year : 1900 + year;
-    }
-
-    // Determine if it's MM/DD/YYYY or DD/MM/YYYY
-    // If first > 12, it must be DD/MM; if second > 12, it must be MM/DD
-    // Otherwise use preference (default to MM/DD for US format)
-    const isDayFirst = first > 12 || (second <= 12 && first <= 12 && preferDDMMYYYY);
-    const month = isDayFirst ? second : first;
-    const day = isDayFirst ? first : second;
-
-    return serialFromParts(year, month, day);
+  const slashParts = matchDateParts(trimmed, SLASH_DATE_PATTERN);
+  if (slashParts) {
+    const [first, second, year] = slashParts;
+    // If first > 12, it must be DD/MM; if second > 12, it must be MM/DD.
+    // Otherwise use preference (default to MM/DD for US format).
+    const dayFirst = readsDayFirst(parseInt(first), parseInt(second), preferDDMMYYYY);
+    const month = dayFirst ? parseInt(second) : parseInt(first);
+    const day = dayFirst ? parseInt(first) : parseInt(second);
+    return serialFromParts(expandTwoDigitYear(parseInt(year)), month, day);
   }
 
   return null;
+}
+
+/** A two-digit year reads as this century up to 29, the previous one after. */
+const TWO_DIGIT_YEAR_LIMIT = 100;
+const CENTURY_PIVOT = 30;
+
+function expandTwoDigitYear(year: number): number {
+  if (year >= TWO_DIGIT_YEAR_LIMIT) return year;
+  return year < CENTURY_PIVOT ? 2000 + year : 1900 + year;
+}
+
+function serialFromNamedMonth(year: number, monthName: string, day: number): number | null {
+  const month = parseMonthName(monthName);
+  if (month === null) return null;
+  return serialFromParts(year, month, day);
 }
 
 /**
@@ -220,12 +223,10 @@ export function getDefaultDateFormat(originalStr: string, preferDDMMYYYY: boolea
   // user's own input with its two halves swapped. `parseDate` takes the first
   // number as the day whenever it cannot be a month, whatever the preference
   // says, so that case is decided here the same way.
-  const slashMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/\d{2,4}$/);
-  if (slashMatch) {
-    const first = parseInt(slashMatch[1]);
-    const second = parseInt(slashMatch[2]);
-    const isDayFirst = first > 12 || (second <= 12 && first <= 12 && preferDDMMYYYY);
-    return isDayFirst ? "DD/MM/YYYY" : "MM/DD/YYYY";
+  const slashParts = matchDateParts(trimmed, SLASH_DATE_PATTERN);
+  if (slashParts) {
+    const [first, second] = slashParts;
+    return readsDayFirst(parseInt(first), parseInt(second), preferDDMMYYYY) ? "DD/MM/YYYY" : "MM/DD/YYYY";
   }
 
   // Anything unrecognised keeps the reading order's default.

--- a/src/plugins/spreadsheet/engine/date-utils.ts
+++ b/src/plugins/spreadsheet/engine/date-utils.ts
@@ -41,16 +41,33 @@ export const serialToDate = (serial: number): Date => {
   return date;
 };
 
+/** A name list that always has a first entry, so a formatter can fall back to it
+ *  when a date is unreadable and its month/weekday index comes out NaN. */
+export type NameList = readonly [string, ...string[]];
+
 /**
  * Month names for formatting
  */
-export const MONTH_NAMES_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+export const MONTH_NAMES_SHORT: NameList = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-export const MONTH_NAMES_FULL = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+export const MONTH_NAMES_FULL: NameList = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
 
 /**
  * Day names for formatting
  */
-export const DAY_NAMES_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+export const DAY_NAMES_SHORT: NameList = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-export const DAY_NAMES_FULL = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+export const DAY_NAMES_FULL: NameList = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];

--- a/src/plugins/spreadsheet/engine/evaluator.ts
+++ b/src/plugins/spreadsheet/engine/evaluator.ts
@@ -4,7 +4,7 @@
  * Evaluates spreadsheet formulas including functions, cell references, and arithmetic
  */
 
-import { functionRegistry } from "./registry";
+import { functionRegistry, tooFewArgumentsError } from "./registry";
 import type { CellValue } from "./types";
 import { parseDate } from "./date-parser";
 import { caretToPow, replaceConcatOperator, rewriteComparisonEq, isSafeArithmetic, isSafeComparison } from "./translateFormula";
@@ -124,8 +124,13 @@ function matchUnquotedRef(expr: string, start: number): string | null {
  *  constant, not a reference, and substituting it would turn `="A1"&"!"` into
  *  A1's value. A `'` opens either a `'Sheet'!A1` reference or a string literal —
  *  only the former is a reference; the latter is skipped like a `"` literal. */
-export function findCellRefs(expr: string): { ref: string; start: number }[] {
-  const cellRefs: { ref: string; start: number }[] = [];
+export interface CellRefSpan {
+  ref: string;
+  start: number;
+}
+
+export function findCellRefs(expr: string): CellRefSpan[] {
+  const cellRefs: CellRefSpan[] = [];
   let i = 0;
   while (i < expr.length) {
     const char = expr[i];
@@ -152,6 +157,15 @@ export function findCellRefs(expr: string): { ref: string; start: number }[] {
     i++;
   }
   return cellRefs;
+}
+
+/** Replace every reference span in `expr` with the text `render` gives for it,
+ *  walking BACK TO FRONT so the spans ahead of each edit stay valid. A global
+ *  string replace rewrote every occurrence of the shorter reference first, so
+ *  `=A1+A10` had its `A10` broken into `<A1's value>0` and produced a plausible
+ *  wrong number (#2357). */
+export function substituteCellRefs(expr: string, cellRefs: CellRefSpan[], render: (ref: string) => string): string {
+  return [...cellRefs].reverse().reduce((text, { ref, start }) => text.slice(0, start) + render(ref) + text.slice(start + ref.length), expr);
 }
 
 /**
@@ -267,10 +281,8 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
 
   // Check if it's a SIMPLE function call (not a complex expression)
   // We need to ensure the formula is JUST a function, not "FUNC(...) + something"
-  const funcMatch = formula.match(/^([A-Z]+)\((.*)\)$/i);
-  if (funcMatch) {
-    const [, funcName, argsStr] = funcMatch;
-
+  const [, funcName, argsStr] = formula.match(/^([A-Z]+)\((.*)\)$/i) ?? [];
+  if (funcName !== undefined && argsStr !== undefined) {
     // Check that the closing paren is actually the end of the function
     // by counting parentheses in argsStr
     let parenDepth = 0;
@@ -296,7 +308,7 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
 
       // Validate argument count
       if (func.minArgs !== undefined && args.length < func.minArgs) {
-        throw new Error(`${normalizedFuncName} requires at least ${func.minArgs} argument${func.minArgs !== 1 ? "s" : ""}`);
+        throw tooFewArgumentsError(normalizedFuncName, func.minArgs);
       }
       if (func.maxArgs !== undefined && args.length > func.maxArgs) {
         throw new Error(`${normalizedFuncName} accepts at most ${func.maxArgs} argument${func.maxArgs !== 1 ? "s" : ""}`);
@@ -304,6 +316,7 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
 
       // Execute function with context
       return func.handler(args, {
+        functionName: normalizedFuncName,
         getCellValue: context.getCellValue,
         getRangeValues: context.getRangeValues,
         getRangeValuesRaw: context.getRangeValuesRaw,
@@ -333,8 +346,8 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
 
   while (searchIndex < expr.length && iterations < maxIterations) {
     iterations++;
-    const funcNameMatch = expr.substring(searchIndex).match(/^([A-Z]+)\(/i);
-    if (!funcNameMatch) {
+    const [, funcName] = expr.substring(searchIndex).match(/^([A-Z]+)\(/i) ?? [];
+    if (funcName === undefined) {
       // No more functions found, move to next character
       searchIndex++;
       if (searchIndex >= expr.length) break;
@@ -342,7 +355,6 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
     }
 
     const funcStartIndex = searchIndex;
-    const funcName = funcNameMatch[1];
     const argsStartIndex = searchIndex + funcName.length + 1;
 
     // Find matching closing parenthesis
@@ -402,21 +414,16 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
   // holding `say "hi"` would come back `say \"hi\"`. Surrounding whitespace
   // (`= A1`, `=A1 `) is part of "nothing but one reference", so compare the
   // span against the trimmed expression rather than the raw one.
-  if (cellRefs.length === 1) {
-    const { ref, start } = cellRefs[0];
-    const before = expr.slice(0, start);
-    const after = expr.slice(start + ref.length);
+  const soleRef = cellRefs.length === 1 ? cellRefs[0] : undefined;
+  if (soleRef) {
+    const before = expr.slice(0, soleRef.start);
+    const after = expr.slice(soleRef.start + soleRef.ref.length);
     if (before.trim() === "" && after.trim() === "") {
-      return context.getCellValue(ref);
+      return context.getCellValue(soleRef.ref);
     }
   }
 
-  // Substitute by POSITION, back to front. A global string replace rewrote
-  // every occurrence of the shorter reference first, so `=A1+A10` had its
-  // `A10` broken into `<A1's value>0` and produced a plausible wrong number
-  // (#2357). Walking backwards keeps the earlier spans valid as we go.
-  for (let index = cellRefs.length - 1; index >= 0; index--) {
-    const { ref, start } = cellRefs[index];
+  expr = substituteCellRefs(expr, cellRefs, (ref) => {
     const value = context.getCellValue(ref);
     // A referenced cell holding an error poisons the whole expression:
     // rendering it would produce `"#DIV/0!"+1` garbage, so propagate the error
@@ -425,8 +432,8 @@ export function evaluateFormula(formula: string, context: EvaluatorContext): Cel
     // as an error, and arithmetic over it is never meaningful.
     const referencedErrorCode = errorCodeOf(value);
     if (referencedErrorCode !== null) throw propagatedError(referencedErrorCode);
-    expr = expr.slice(0, start) + renderOperand(value) + expr.slice(start + ref.length);
-  }
+    return renderOperand(value);
+  });
 
   // Parse date strings in arithmetic expressions (e.g., "06/01/2025" → serial number)
   // This allows formulas like =B3-"06/01/2025" to work correctly

--- a/src/plugins/spreadsheet/engine/financial-math.ts
+++ b/src/plugins/spreadsheet/engine/financial-math.ts
@@ -86,17 +86,23 @@ export function computeNpv(rate: number, cashflows: number[]): number {
   return cashflows.reduce((npv, value, index) => npv + value / Math.pow(1 + rate, index + 1), 0);
 }
 
+/** The present value of `values` (element 0 at period 0) discounted at `rate`,
+ *  together with its derivative — the pair one Newton-Raphson step needs. */
+function discountedSeries(values: number[], rate: number): { npv: number; dnpv: number } {
+  return values.reduce(
+    (totals, value, period) => {
+      const factor = Math.pow(1 + rate, period);
+      return { npv: totals.npv + value / factor, dnpv: totals.dnpv - (period * value) / (factor * (1 + rate)) };
+    },
+    { npv: 0, dnpv: 0 },
+  );
+}
+
 /** Internal rate of return of `values` (element 0 at period 0), via Newton-Raphson. */
 export function computeIrr(values: number[], guess: number): number | SpreadsheetError {
   let rate = guess;
   for (let i = 0; i < NEWTON_MAX_ITERATIONS; i++) {
-    let npv = 0;
-    let dnpv = 0;
-    for (let j = 0; j < values.length; j++) {
-      const factor = Math.pow(1 + rate, j);
-      npv += values[j] / factor;
-      dnpv -= (j * values[j]) / (factor * (1 + rate));
-    }
+    const { npv, dnpv } = discountedSeries(values, rate);
     if (Math.abs(npv) < NEWTON_TOLERANCE) return rate;
     // A flat derivative leaves nowhere to step: the series has no root here.
     if (Math.abs(dnpv) < NEWTON_TOLERANCE) return NUM_ERROR;

--- a/src/plugins/spreadsheet/engine/formatter.ts
+++ b/src/plugins/spreadsheet/engine/formatter.ts
@@ -94,9 +94,9 @@ export const groupThousands = (digits: string): string =>
 /** Group the integer part of a formatted number ("1234567.89" → "1,234,567.89"),
  *  leaving any fractional part after the decimal point untouched. */
 export const addThousandSeparators = (formatted: string): string => {
-  const parts = formatted.split(".");
-  parts[0] = groupThousands(parts[0]);
-  return parts.join(".");
+  const [whole, ...fraction] = formatted.split(".");
+  if (whole === undefined) return formatted;
+  return [groupThousands(whole), ...fraction].join(".");
 };
 
 /**

--- a/src/plugins/spreadsheet/engine/formulaRefs.ts
+++ b/src/plugins/spreadsheet/engine/formulaRefs.ts
@@ -35,22 +35,39 @@ export function stripFormulaPrefix(formula: string): string {
   return formula.startsWith("=") ? formula.slice(1) : formula;
 }
 
+const A1_REGEX = /^([A-Z]+)(\d+)$/;
+
+// One `A1` token as its column index (0-based) and its row NUMBER as written
+// (1-based). The single place a column letter + row digit pair is read, so the
+// range and single-cell parsers below cannot drift apart.
+function parseA1Token(token: string): { col: number; rowNumber: number } | null {
+  const [, column, row] = token.match(A1_REGEX) ?? [];
+  if (column === undefined || row === undefined) return null;
+  return { col: columnToIndex(column), rowNumber: parseInt(row, 10) };
+}
+
+// The two endpoints of an `A1:B3` range, or null for anything that is not
+// exactly two `A1` tokens joined by one colon.
+function parseRangeEndpoints(body: string): { start: { col: number; rowNumber: number }; end: { col: number; rowNumber: number } } | null {
+  const [startToken, endToken, ...extra] = body.split(":");
+  if (startToken === undefined || endToken === undefined || extra.length > 0) return null;
+  const start = parseA1Token(startToken);
+  const end = parseA1Token(endToken);
+  return start && end ? { start, end } : null;
+}
+
 // Expand a single range token (`A1:B3`, `$A$1:$C$5`) into every
 // coordinate the range covers. Returns an empty array for malformed
 // input so callers never have to handle exceptions; the worst case
 // is "we silently ignored a weird-looking substring," which matches
 // the original inline behaviour.
 export function expandRange(rangeStr: string): CellCoord[] {
-  const cleanRange = rangeStr.replace(/\$/g, "");
-  const match = cleanRange.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-  if (!match) return [];
-  const startCol = columnToIndex(match[1]);
-  const startRow = parseInt(match[2], 10) - 1;
-  const endCol = columnToIndex(match[3]);
-  const endRow = parseInt(match[4], 10) - 1;
+  const endpoints = parseRangeEndpoints(rangeStr.replace(/\$/g, ""));
+  if (!endpoints) return [];
+  const { start, end } = endpoints;
   const cells: CellCoord[] = [];
-  for (let row = startRow; row <= endRow; row++) {
-    for (let col = startCol; col <= endCol; col++) {
+  for (let row = start.rowNumber - 1; row <= end.rowNumber - 1; row++) {
+    for (let col = start.col; col <= end.col; col++) {
       cells.push({ row, col });
     }
   }
@@ -78,13 +95,8 @@ export function expandRangeOrCell(ref: string): CellCoord[] | null {
 // caller's loop flat (the engine-layer `parseCellRef` throws, which
 // is fine for the evaluator but wrong for a best-effort scanner).
 export function parseSingleCellRef(refStr: string): CellCoord | null {
-  const cleanRef = refStr.replace(/\$/g, "");
-  const match = cleanRef.match(/^([A-Z]+)(\d+)$/);
-  if (!match) return null;
-  return {
-    col: columnToIndex(match[1]),
-    row: parseInt(match[2], 10) - 1,
-  };
+  const parsed = parseA1Token(refStr.replace(/\$/g, ""));
+  return parsed ? { col: parsed.col, row: parsed.rowNumber - 1 } : null;
 }
 
 // Numeric bounds of a `A2:C10` range, with any `Sheet1!` / `'My Sheet'!`
@@ -109,15 +121,10 @@ export function parseRangeBounds(range: string): RangeBounds | null {
   const bang = range.lastIndexOf("!");
   const sheetPrefix = bang >= 0 ? range.slice(0, bang + 1) : "";
   const body = bang >= 0 ? range.slice(bang + 1) : range;
-  const match = body.match(/^([A-Z]+)(\d+):([A-Z]+)(\d+)$/);
-  if (!match) return null;
-  return {
-    sheetPrefix,
-    startCol: columnToIndex(match[1]),
-    startRow: parseInt(match[2], 10),
-    endCol: columnToIndex(match[3]),
-    endRow: parseInt(match[4], 10),
-  };
+  const endpoints = parseRangeEndpoints(body);
+  if (!endpoints) return null;
+  const { start, end } = endpoints;
+  return { sheetPrefix, startCol: start.col, startRow: start.rowNumber, endCol: end.col, endRow: end.rowNumber };
 }
 
 // Excel's `0` row/column index selects the entire row/column. This scalar engine

--- a/src/plugins/spreadsheet/engine/functions/date.ts
+++ b/src/plugins/spreadsheet/engine/functions/date.ts
@@ -4,7 +4,7 @@
  * January 1, 1900 is serial number 1.
  */
 
-import { functionRegistry, toNumber, toString, type FunctionHandler } from "../registry";
+import { functionRegistry, requiredArg, toNumber, toString, type FunctionHandler } from "../registry";
 import { computeDatedif } from "../datedif";
 import { dateToSerial, serialToDate } from "../date-utils";
 
@@ -25,9 +25,9 @@ const todayHandler: FunctionHandler = () => {
 };
 
 const dateHandler: FunctionHandler = (args, context) => {
-  const year = toNumber(context.evaluateFormula(args[0]));
-  const month = toNumber(context.evaluateFormula(args[1]));
-  const day = toNumber(context.evaluateFormula(args[2]));
+  const year = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const month = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const day = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
 
   // JS Date constructor handles overflow (e.g. month 13 becomes Jan of next year)
   // Month is 0-indexed in JS, 1-indexed in Excel
@@ -36,9 +36,9 @@ const dateHandler: FunctionHandler = (args, context) => {
 };
 
 const timeHandler: FunctionHandler = (args, context) => {
-  const hour = toNumber(context.evaluateFormula(args[0]));
-  const minute = toNumber(context.evaluateFormula(args[1]));
-  const second = toNumber(context.evaluateFormula(args[2]));
+  const hour = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const minute = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const second = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
 
   // Time is a fraction of a day
   // 1 hour = 1/24
@@ -53,25 +53,25 @@ const timeHandler: FunctionHandler = (args, context) => {
 };
 
 const yearHandler: FunctionHandler = (args, context) => {
-  const serial = toNumber(context.evaluateFormula(args[0]));
+  const serial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   const date = serialToDate(serial);
   return date.getUTCFullYear();
 };
 
 const monthHandler: FunctionHandler = (args, context) => {
-  const serial = toNumber(context.evaluateFormula(args[0]));
+  const serial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   const date = serialToDate(serial);
   return date.getUTCMonth() + 1; // 1-indexed
 };
 
 const dayHandler: FunctionHandler = (args, context) => {
-  const serial = toNumber(context.evaluateFormula(args[0]));
+  const serial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   const date = serialToDate(serial);
   return date.getUTCDate();
 };
 
 const hourHandler: FunctionHandler = (args, context) => {
-  const serial = toNumber(context.evaluateFormula(args[0]));
+  const serial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   // Get fractional part
   const timePart = serial - Math.floor(serial);
   const totalSeconds = Math.round(timePart * 86400);
@@ -79,23 +79,23 @@ const hourHandler: FunctionHandler = (args, context) => {
 };
 
 const minuteHandler: FunctionHandler = (args, context) => {
-  const serial = toNumber(context.evaluateFormula(args[0]));
+  const serial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   const timePart = serial - Math.floor(serial);
   const totalSeconds = Math.round(timePart * 86400);
   return Math.floor((totalSeconds % 3600) / 60);
 };
 
 const secondHandler: FunctionHandler = (args, context) => {
-  const serial = toNumber(context.evaluateFormula(args[0]));
+  const serial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   const timePart = serial - Math.floor(serial);
   const totalSeconds = Math.round(timePart * 86400);
   return totalSeconds % 60;
 };
 
 const datedifHandler: FunctionHandler = (args, context) => {
-  const startSerial = toNumber(context.evaluateFormula(args[0]));
-  const endSerial = toNumber(context.evaluateFormula(args[1]));
-  const unit = toString(context.evaluateFormula(args[2]));
+  const startSerial = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const endSerial = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const unit = toString(context.evaluateFormula(requiredArg(context, args, 2)));
 
   return computeDatedif(startSerial, endSerial, unit);
 };

--- a/src/plugins/spreadsheet/engine/functions/financial.ts
+++ b/src/plugins/spreadsheet/engine/functions/financial.ts
@@ -2,7 +2,7 @@
  * Financial Functions
  */
 
-import { functionRegistry, toNumber, type FunctionContext, type FunctionHandler } from "../registry";
+import { functionRegistry, requiredArg, toNumber, type FunctionContext, type FunctionHandler } from "../registry";
 import { computeFv, computePmt, computeIpmt, computePpmt, computePv, computeNper, computeRate, computeNpv, computeIrr } from "../financial-math";
 
 /**
@@ -16,11 +16,11 @@ import { computeFv, computePmt, computeIpmt, computePpmt, computePv, computeNper
  * - type: 0 = end of period, 1 = beginning of period (optional, default 0)
  */
 const fvHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
-  const nper = toNumber(context.evaluateFormula(args[1]));
-  const pmt = toNumber(context.evaluateFormula(args[2]));
-  const pv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
-  const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
+  const rate = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const nper = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const pmt = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const pv = args.length >= 4 ? toNumber(context.evaluateFormula(requiredArg(context, args, 3))) : 0;
+  const type = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
 
   return computeFv(rate, nper, pmt, pv, type);
 };
@@ -31,11 +31,11 @@ const fvHandler: FunctionHandler = (args, context) => {
  * PV(rate, nper, pmt, [fv], [type])
  */
 const pvHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
-  const nper = toNumber(context.evaluateFormula(args[1]));
-  const pmt = toNumber(context.evaluateFormula(args[2]));
-  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
-  const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
+  const rate = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const nper = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const pmt = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(requiredArg(context, args, 3))) : 0;
+  const type = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
 
   return computePv(rate, nper, pmt, fv, type);
 };
@@ -46,11 +46,11 @@ const pvHandler: FunctionHandler = (args, context) => {
  * PMT(rate, nper, pv, [fv], [type])
  */
 const pmtHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
-  const nper = toNumber(context.evaluateFormula(args[1]));
-  const pv = toNumber(context.evaluateFormula(args[2]));
-  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
-  const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
+  const rate = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const nper = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const pv = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(requiredArg(context, args, 3))) : 0;
+  const type = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
 
   return computePmt(rate, nper, pv, fv, type);
 };
@@ -61,11 +61,11 @@ const pmtHandler: FunctionHandler = (args, context) => {
  * NPER(rate, pmt, pv, [fv], [type])
  */
 const nperHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
-  const pmt = toNumber(context.evaluateFormula(args[1]));
-  const pv = toNumber(context.evaluateFormula(args[2]));
-  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
-  const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
+  const rate = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const pmt = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const pv = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(requiredArg(context, args, 3))) : 0;
+  const type = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
 
   return computeNper(rate, pmt, pv, fv, type);
 };
@@ -77,12 +77,12 @@ const nperHandler: FunctionHandler = (args, context) => {
  * Uses Newton-Raphson method for iteration
  */
 const rateHandler: FunctionHandler = (args, context) => {
-  const nper = toNumber(context.evaluateFormula(args[0]));
-  const pmt = toNumber(context.evaluateFormula(args[1]));
-  const pv = toNumber(context.evaluateFormula(args[2]));
-  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(args[3])) : 0;
-  const type = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
-  const guess = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0.1;
+  const nper = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const pmt = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const pv = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const fv = args.length >= 4 ? toNumber(context.evaluateFormula(requiredArg(context, args, 3))) : 0;
+  const type = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
+  const guess = args.length >= 6 ? toNumber(context.evaluateFormula(requiredArg(context, args, 5))) : 0.1;
 
   return computeRate(nper, pmt, pv, fv, type, guess);
 };
@@ -95,12 +95,12 @@ type PeriodicComponent = (rate: number, per: number, nper: number, pv: number, f
 const makePeriodicComponentHandler =
   (compute: PeriodicComponent): FunctionHandler =>
   (args, context) => {
-    const rate = toNumber(context.evaluateFormula(args[0]));
-    const per = toNumber(context.evaluateFormula(args[1]));
-    const nper = toNumber(context.evaluateFormula(args[2]));
-    const pv = toNumber(context.evaluateFormula(args[3]));
-    const fv = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
-    const type = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 0;
+    const rate = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+    const per = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+    const nper = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+    const pv = toNumber(context.evaluateFormula(requiredArg(context, args, 3)));
+    const fv = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
+    const type = args.length >= 6 ? toNumber(context.evaluateFormula(requiredArg(context, args, 5))) : 0;
 
     return compute(rate, per, nper, pv, fv, type);
   };
@@ -132,7 +132,7 @@ const collectCashFlows = (valueArgs: string[], context: FunctionContext): number
   valueArgs.flatMap((arg) => (arg.includes(":") ? context.getRangeValues(arg) : [context.evaluateFormula(arg)]).map(toNumber));
 
 const npvHandler: FunctionHandler = (args, context) => {
-  const rate = toNumber(context.evaluateFormula(args[0]));
+  const rate = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return computeNpv(rate, collectCashFlows(args.slice(1), context));
 };
 
@@ -143,8 +143,8 @@ const npvHandler: FunctionHandler = (args, context) => {
  * Uses Newton-Raphson method for iteration
  */
 const irrHandler: FunctionHandler = (args, context) => {
-  const values = context.getRangeValues(args[0]).map(toNumber);
-  const guess = args.length === 2 ? toNumber(context.evaluateFormula(args[1])) : 0.1;
+  const values = context.getRangeValues(requiredArg(context, args, 0)).map(toNumber);
+  const guess = args.length === 2 ? toNumber(context.evaluateFormula(requiredArg(context, args, 1))) : 0.1;
 
   if (values.length === 0) {
     throw new Error("IRR requires at least one value");

--- a/src/plugins/spreadsheet/engine/functions/logical.ts
+++ b/src/plugins/spreadsheet/engine/functions/logical.ts
@@ -3,16 +3,16 @@
  */
 
 import { evaluateConditionValues, readOperand, renderConditionOperand } from "../condition";
-import { findCellRefs } from "../evaluator";
-import { functionRegistry, type FunctionHandler } from "../registry";
+import { findCellRefs, substituteCellRefs } from "../evaluator";
+import { functionRegistry, requiredArg, type FunctionHandler } from "../registry";
 import { isErrorResult, isSpreadsheetErrorValue, NA_ERROR } from "../spreadsheet-errors";
 import { coerceToBoolean } from "../coerce-boolean";
 import type { CellValue } from "../types";
 
 const ifHandler: FunctionHandler = (args, context) => {
-  const condition = args[0];
-  const trueValue = args[1];
-  const falseValue = args[2];
+  const condition = requiredArg(context, args, 0);
+  const trueValue = requiredArg(context, args, 1);
+  const falseValue = requiredArg(context, args, 2);
 
   // Evaluate condition - use evaluateFormula to handle nested functions like MONTH()
   const conditionValue = context.evaluateFormula(condition);
@@ -53,12 +53,12 @@ const orHandler: FunctionHandler = (args, context) => {
 };
 
 const notHandler: FunctionHandler = (args, context) => {
-  return !coerceToBoolean(context.evaluateFormula(args[0]));
+  return !coerceToBoolean(context.evaluateFormula(requiredArg(context, args, 0)));
 };
 
 const iferrorHandler: FunctionHandler = (args, context) => {
   try {
-    const result = context.evaluateFormula(args[0]);
+    const result = context.evaluateFormula(requiredArg(context, args, 0));
     // Catches NaN/∞ and the formula error VALUES functions return (a math domain
     // miss like SQRT(-1) → #NUM!), so IFERROR(SQRT(-1), 0) is 0. Text that
     // merely spells an error is not an error value, so it passes through
@@ -66,20 +66,20 @@ const iferrorHandler: FunctionHandler = (args, context) => {
     // (IFERROR(CONCAT("#N","UM!"), 42)) — the computed case is why errors carry
     // provenance at all (#2451).
     if (isErrorResult(result)) {
-      return context.evaluateFormula(args[1]);
+      return context.evaluateFormula(requiredArg(context, args, 1));
     }
     return result;
   } catch {
     // If evaluation throws an error, return the fallback value
-    return context.evaluateFormula(args[1]);
+    return context.evaluateFormula(requiredArg(context, args, 1));
   }
 };
 
 const ifnaHandler: FunctionHandler = (args, context) => {
-  const result = context.evaluateFormula(args[0]);
+  const result = context.evaluateFormula(requiredArg(context, args, 0));
   const isNotAvailable = isSpreadsheetErrorValue(result) && result.code === NA_ERROR.code;
   if (result === null || result === undefined || isNotAvailable) {
-    return context.evaluateFormula(args[1]);
+    return context.evaluateFormula(requiredArg(context, args, 1));
   }
   return result;
 };
@@ -91,8 +91,8 @@ const ifsHandler: FunctionHandler = (args, context) => {
 
   // Iterate through condition-value pairs
   for (let i = 0; i < args.length; i += 2) {
-    const condition = args[i];
-    const value = args[i + 1];
+    const condition = requiredArg(context, args, i);
+    const value = requiredArg(context, args, i + 1);
 
     // Substitute references by POSITION (back to front), skipping any that sit
     // inside a quoted string literal: `IFS(A1="B2", …)` must compare A1 to the
@@ -100,13 +100,7 @@ const ifsHandler: FunctionHandler = (args, context) => {
     // skips literals and matches absolute / sheet-qualified refs, so this also
     // avoids the earlier regex double-escaping. renderConditionOperand quotes a
     // text cell so its own operators are not re-parsed as comparisons.
-    let condExpr = condition;
-    const cellRefs = findCellRefs(condition);
-    for (let index = cellRefs.length - 1; index >= 0; index--) {
-      const { ref, start } = cellRefs[index];
-      const rendered = renderConditionOperand(context.getCellValue(ref));
-      condExpr = condExpr.slice(0, start) + rendered + condExpr.slice(start + ref.length);
-    }
+    const condExpr = substituteCellRefs(condition, findCellRefs(condition), (ref) => renderConditionOperand(context.getCellValue(ref)));
 
     // Parsed, not executed. This used to call `eval` on `condExpr`, which is
     // the substituted text — so a cell containing `globalThis.x = 1` ran as

--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -2,7 +2,7 @@
  * Lookup and Reference Functions
  */
 
-import { functionRegistry, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
+import { functionRegistry, requiredArg, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
 import { indexToColumn } from "../parser";
 import { parseRangeBounds, resolveIndexTarget, resolveTableOffset } from "../formulaRefs";
 import { isApproximateMatch } from "./lookup-math";
@@ -19,6 +19,20 @@ const columnValues = (context: FunctionContext, sheetPrefix: string, colStr: str
 const rowValues = (context: FunctionContext, sheetPrefix: string, row: number, startCol: number, endCol: number): CellValue[] =>
   inclusiveRange(startCol, endCol).map((c) => context.getCellValue(`${sheetPrefix}${indexToColumn(c)}${row}`));
 
+/** The index of the LAST value that satisfies `matches`, or -1. Array.findIndex
+ *  only walks forward, and XLOOKUP's `searchMode: -1` searches from the end. */
+const findLastMatchIndex = (values: CellValue[], matches: (value: CellValue) => boolean): number =>
+  values.reduce<number>((found, value, index) => (matches(value) ? index : found), -1);
+
+/** The index of the last value in a SORTED list before `keepGoing` stops
+ *  holding, or -1 when the very first value already fails. The list is assumed
+ *  sorted (as Excel's approximate match requires), so the first failure ends the
+ *  run. */
+const lastIndexWhile = (values: CellValue[], keepGoing: (value: CellValue) => boolean): number => {
+  const stop = values.findIndex((value) => !keepGoing(value));
+  return (stop === -1 ? values.length : stop) - 1;
+};
+
 // Helper to find match index
 const findMatchIndex = (
   lookupValue: CellValue,
@@ -33,73 +47,31 @@ const findMatchIndex = (
 
   // Exact match
   if (matchType === 0) {
-    // Handle wildcards for strings if it's an exact match request
-    if (typeof lookupValue === "string" && (lookupValue.includes("*") || lookupValue.includes("?"))) {
-      const criteriaFn = parseCriteria(lookupValue);
-
-      if (searchMode === 1) {
-        return lookupArray.findIndex((item) => criteriaFn(item));
-      } else {
-        for (let i = lookupArray.length - 1; i >= 0; i--) {
-          if (criteriaFn(lookupArray[i])) return i;
-        }
-        return -1;
-      }
-    }
-
-    if (searchMode === 1) {
-      return lookupArray.findIndex((item) => item == lookupValue); // Loose equality for "10" == 10
-    } else {
-      for (let i = lookupArray.length - 1; i >= 0; i--) {
-        if (lookupArray[i] == lookupValue) return i;
-      }
-      return -1;
-    }
+    // Handle wildcards for strings if it's an exact match request.
+    // Loose equality otherwise, for "10" == 10.
+    const usesWildcards = typeof lookupValue === "string" && (lookupValue.includes("*") || lookupValue.includes("?"));
+    const isMatch = usesWildcards ? parseCriteria(lookupValue) : (item: CellValue) => item == lookupValue;
+    return searchMode === 1 ? lookupArray.findIndex(isMatch) : findLastMatchIndex(lookupArray, isMatch);
   }
 
   // Approximate match (requires sorted array)
   // We'll assume the user knows what they are doing regarding sorting, as per Excel behavior
 
-  if (matchType === 1) {
-    // Less than or equal to
-    // Array must be sorted ascending
-    let bestIdx = -1;
-    for (let i = 0; i < lookupArray.length; i++) {
-      const item = lookupArray[i];
-      if (compare(item, lookupValue) <= 0) {
-        bestIdx = i;
-      } else {
-        // Since it's sorted ascending, once we exceed, we can stop
-        break;
-      }
-    }
-    return bestIdx;
-  }
+  // Less than or equal to, over an array sorted ascending: once we exceed, stop.
+  if (matchType === 1) return lastIndexWhile(lookupArray, (item) => compare(item, lookupValue) <= 0);
 
-  if (matchType === -1) {
-    // Greater than or equal to
-    // Array must be sorted descending
-    let bestIdx = -1;
-    for (let i = 0; i < lookupArray.length; i++) {
-      const item = lookupArray[i];
-      if (compare(item, lookupValue) >= 0) {
-        bestIdx = i;
-      } else {
-        break;
-      }
-    }
-    return bestIdx;
-  }
+  // Greater than or equal to, over an array sorted descending.
+  if (matchType === -1) return lastIndexWhile(lookupArray, (item) => compare(item, lookupValue) >= 0);
 
   return -1;
 };
 
 const vlookupHandler: FunctionHandler = (args, context) => {
-  const lookupValue = context.evaluateFormula(args[0]);
-  const bounds = parseRangeBounds(args[1]);
+  const lookupValue = context.evaluateFormula(requiredArg(context, args, 0));
+  const bounds = parseRangeBounds(requiredArg(context, args, 1));
   if (!bounds) throw new Error("Invalid table array range");
-  const colIndexNum = toNumber(context.evaluateFormula(args[2]));
-  const rangeLookup = args.length === 4 ? context.evaluateFormula(args[3]) : true;
+  const colIndexNum = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const rangeLookup = args.length === 4 ? context.evaluateFormula(requiredArg(context, args, 3)) : true;
   const matchType = isApproximateMatch(rangeLookup) ? 1 : 0;
 
   // Excel rejects a col_index_num past the table's width; reading on regardless
@@ -120,11 +92,11 @@ const vlookupHandler: FunctionHandler = (args, context) => {
 };
 
 const hlookupHandler: FunctionHandler = (args, context) => {
-  const lookupValue = context.evaluateFormula(args[0]);
-  const bounds = parseRangeBounds(args[1]);
+  const lookupValue = context.evaluateFormula(requiredArg(context, args, 0));
+  const bounds = parseRangeBounds(requiredArg(context, args, 1));
   if (!bounds) throw new Error("Invalid range format");
-  const rowIndexNum = toNumber(context.evaluateFormula(args[2]));
-  const rangeLookup = args.length === 4 ? context.evaluateFormula(args[3]) : true;
+  const rowIndexNum = toNumber(context.evaluateFormula(requiredArg(context, args, 2)));
+  const rangeLookup = args.length === 4 ? context.evaluateFormula(requiredArg(context, args, 3)) : true;
   const matchType = isApproximateMatch(rangeLookup) ? 1 : 0;
 
   const rowOffset = resolveTableOffset(rowIndexNum, bounds.endRow - bounds.startRow + 1);
@@ -140,9 +112,9 @@ const hlookupHandler: FunctionHandler = (args, context) => {
 };
 
 const matchHandler: FunctionHandler = (args, context) => {
-  const lookupValue = context.evaluateFormula(args[0]);
-  const lookupArrayRange = args[1];
-  const matchType = args.length === 3 ? toNumber(context.evaluateFormula(args[2])) : 1;
+  const lookupValue = context.evaluateFormula(requiredArg(context, args, 0));
+  const lookupArrayRange = requiredArg(context, args, 1);
+  const matchType = args.length === 3 ? toNumber(context.evaluateFormula(requiredArg(context, args, 2))) : 1;
 
   const lookupArray = context.getRangeValues(lookupArrayRange);
 
@@ -152,10 +124,10 @@ const matchHandler: FunctionHandler = (args, context) => {
 };
 
 const indexHandler: FunctionHandler = (args, context) => {
-  const bounds = parseRangeBounds(args[0]);
+  const bounds = parseRangeBounds(requiredArg(context, args, 0));
   if (!bounds) throw new Error("Invalid range format");
-  const rowNum = toNumber(context.evaluateFormula(args[1]));
-  const colNum = args.length >= 3 ? toNumber(context.evaluateFormula(args[2])) : 1; // Default to 1 if omitted (for 1D arrays)
+  const rowNum = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
+  const colNum = args.length >= 3 ? toNumber(context.evaluateFormula(requiredArg(context, args, 2))) : 1; // Default to 1 if omitted (for 1D arrays)
 
   const target = resolveIndexTarget(bounds, rowNum, colNum);
   if (!target) return REF_ERROR;
@@ -163,12 +135,12 @@ const indexHandler: FunctionHandler = (args, context) => {
 };
 
 const xlookupHandler: FunctionHandler = (args, context) => {
-  const lookupValue = context.evaluateFormula(args[0]);
-  const lookupArrayRange = args[1];
-  const returnArrayRange = args[2];
-  const ifNotFound = args.length >= 4 ? context.evaluateFormula(args[3]) : NA_ERROR;
-  const matchMode = args.length >= 5 ? toNumber(context.evaluateFormula(args[4])) : 0;
-  const searchMode = args.length >= 6 ? toNumber(context.evaluateFormula(args[5])) : 1;
+  const lookupValue = context.evaluateFormula(requiredArg(context, args, 0));
+  const lookupArrayRange = requiredArg(context, args, 1);
+  const returnArrayRange = requiredArg(context, args, 2);
+  const ifNotFound = args.length >= 4 ? context.evaluateFormula(requiredArg(context, args, 3)) : NA_ERROR;
+  const matchMode = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
+  const searchMode = args.length >= 6 ? toNumber(context.evaluateFormula(requiredArg(context, args, 5))) : 1;
 
   const lookupArray = context.getRangeValues(lookupArrayRange);
   const returnArray = context.getRangeValues(returnArrayRange);
@@ -220,11 +192,10 @@ const xlookupHandler: FunctionHandler = (args, context) => {
 
   if (matchIdx === -1) return ifNotFound;
 
-  if (matchIdx >= 0 && matchIdx < returnArray.length) {
-    return returnArray[matchIdx];
-  }
-
-  return NA_ERROR;
+  // A match past the end of the return range has nothing to return — the two
+  // ranges are independent arguments and need not be the same length.
+  const found = returnArray[matchIdx];
+  return found === undefined ? NA_ERROR : found;
 };
 
 // Register functions

--- a/src/plugins/spreadsheet/engine/functions/mathematical.ts
+++ b/src/plugins/spreadsheet/engine/functions/mathematical.ts
@@ -2,7 +2,7 @@
  * Mathematical Functions
  */
 
-import { functionRegistry, toNumber, type FunctionHandler } from "../registry";
+import { functionRegistry, requiredArg, toNumber, type FunctionHandler } from "../registry";
 import {
   roundTo,
   roundUpTo,
@@ -20,94 +20,94 @@ import { toScalarNumber } from "../numericCoercion";
 import { isSpreadsheetErrorValue } from "../spreadsheet-errors";
 
 const roundHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const digits = toNumber(context.evaluateFormula(args[1]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const digits = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return roundTo(number, digits);
 };
 
 const roundupHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const digits = toNumber(context.evaluateFormula(args[1]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const digits = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return roundUpTo(number, digits);
 };
 
 const rounddownHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const digits = toNumber(context.evaluateFormula(args[1]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const digits = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return roundDownTo(number, digits);
 };
 
 const floorHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const significance = toNumber(context.evaluateFormula(args[1]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const significance = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return floorToSignificance(number, significance);
 };
 
 const ceilingHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const significance = toNumber(context.evaluateFormula(args[1]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const significance = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return ceilingToSignificance(number, significance);
 };
 
 const absHandler: FunctionHandler = (args, context) => {
-  const number = toScalarNumber(context.evaluateFormula(args[0]));
+  const number = toScalarNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return isSpreadsheetErrorValue(number) ? number : Math.abs(number);
 };
 
 const powerHandler: FunctionHandler = (args, context) => {
-  const base = toNumber(context.evaluateFormula(args[0]));
-  const exponent = toNumber(context.evaluateFormula(args[1]));
+  const base = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const exponent = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return power(base, exponent);
 };
 
 const sqrtHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return safeSqrt(number);
 };
 
 const modHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const divisor = toNumber(context.evaluateFormula(args[1]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const divisor = toNumber(context.evaluateFormula(requiredArg(context, args, 1)));
   return modulo(number, divisor);
 };
 
 const intHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return Math.floor(number);
 };
 
 const truncHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const digits = args.length === 2 ? toNumber(context.evaluateFormula(args[1])) : 0;
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const digits = args.length === 2 ? toNumber(context.evaluateFormula(requiredArg(context, args, 1))) : 0;
   const multiplier = Math.pow(10, digits);
   return Math.trunc(number * multiplier) / multiplier;
 };
 
 const signHandler: FunctionHandler = (args, context) => {
-  const number = toScalarNumber(context.evaluateFormula(args[0]));
+  const number = toScalarNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return isSpreadsheetErrorValue(number) ? number : Math.sign(number);
 };
 
 const piHandler: FunctionHandler = () => Math.PI;
 
 const expHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return Math.exp(number);
 };
 
 const lnHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return safeLog(number);
 };
 
 const logHandler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
-  const base = args.length === 2 ? toNumber(context.evaluateFormula(args[1])) : 10;
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
+  const base = args.length === 2 ? toNumber(context.evaluateFormula(requiredArg(context, args, 1))) : 10;
   return logWithBase(number, base);
 };
 
 const log10Handler: FunctionHandler = (args, context) => {
-  const number = toNumber(context.evaluateFormula(args[0]));
+  const number = toNumber(context.evaluateFormula(requiredArg(context, args, 0)));
   return safeLog10(number);
 };
 

--- a/src/plugins/spreadsheet/engine/functions/statistical-math.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical-math.ts
@@ -29,9 +29,15 @@ export function computeAverage(values: number[]): number | SpreadsheetError {
  */
 export function computeMedian(values: number[]): number | SpreadsheetError {
   if (values.length === 0) return NUM_ERROR;
-  const sorted = [...values].sort((a, b) => a - b);
-  const middle = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle];
+  return arithmeticMean(middleValues([...values].sort((a, b) => a - b)));
+}
+
+/** The one or two values sitting in the middle of a sorted list — two when the
+ *  count is even, one when it is odd. Sliced rather than indexed, so the middle
+ *  of an empty list is simply nothing. */
+function middleValues(sorted: number[]): number[] {
+  const half = Math.floor(sorted.length / 2);
+  return sorted.slice(sorted.length % 2 === 0 ? half - 1 : half, half + 1);
 }
 
 /**

--- a/src/plugins/spreadsheet/engine/functions/statistical.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical.ts
@@ -2,7 +2,7 @@
  * Statistical Functions
  */
 
-import { functionRegistry, toNumber, parseCriteria, type FunctionContext, type FunctionHandler, type RangeGetter } from "../registry";
+import { functionRegistry, requiredArg, toNumber, parseCriteria, type FunctionContext, type FunctionHandler, type RangeGetter } from "../registry";
 import { computeAverage, computeMedian, computeMode, sampleStdev, sampleVariance } from "./statistical-math";
 import { DIV_ZERO_ERROR } from "../spreadsheet-errors";
 import { holdsNumber } from "../numericCoercion";
@@ -11,32 +11,19 @@ import type { CellValue } from "../types";
 // Excel accepts up to 255 arguments for its aggregate functions.
 const MAX_AGGREGATE_ARGS = 255;
 
-const isLetter = (char: string): boolean => /[A-Z]/i.test(char);
+// `A1`, `$A$1`, `AA100`: column letters then row digits, each half optionally
+// prefixed by `$`.
+const CELL_REFERENCE_PATTERN = /^\$?[A-Z]+\$?\d+$/i;
 
-const isCellReference = (segment: string): boolean => {
-  if (!segment) return false;
-  let index = 0;
-  if (segment[index] === "$") index++;
-  const colStart = index;
-  while (index < segment.length && isLetter(segment[index])) {
-    index++;
-  }
-  if (index === colStart) return false; // Require at least one column letter
-  if (segment[index] === "$") index++;
-  if (index >= segment.length) return false; // Require row digits
-  for (; index < segment.length; index++) {
-    const char = segment[index];
-    if (char < "0" || char > "9") {
-      return false;
-    }
-  }
-  return true;
-};
+const isCellReference = (segment: string): boolean => CELL_REFERENCE_PATTERN.test(segment);
+
+// Everything after the last `!` — the reference without its sheet name, or the
+// whole string when it carries none.
+const withoutSheetPrefix = (value: string): string => value.slice(value.lastIndexOf("!") + 1);
 
 const isRangeReference = (value: string): boolean => {
   if (!value) return false;
-  const rangePart = value.includes("!") ? value.split("!").slice(-1)[0] : value;
-  const [start, end] = rangePart.split(":");
+  const [start, end] = withoutSheetPrefix(value).split(":");
   if (!start || !end) return false;
   return isCellReference(start) && isCellReference(end);
 };
@@ -45,7 +32,7 @@ const isRangeReference = (value: string): boolean => {
 // evaluated as a scalar: the scalar path coerces a blank or text cell to 0, so
 // COUNT(A999) counted an empty cell as a value. The range path yields nothing
 // for a cell that holds nothing, which is what the count functions need.
-const isReference = (arg: string): boolean => isRangeReference(arg) || isCellReference(arg.includes("!") ? arg.split("!").slice(-1)[0] : arg);
+const isReference = (arg: string): boolean => isRangeReference(arg) || isCellReference(withoutSheetPrefix(arg));
 
 /** One value an argument contributed, tagged by where it came from. A range cell
  *  was already filtered by the range getter; a scalar is whatever the argument
@@ -126,51 +113,41 @@ const countaHandler: FunctionHandler = (args, context) => {
 };
 
 const countifHandler: FunctionHandler = (args, context) => {
-  const values = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
-  const criteria = args[1].trim();
-  const compareFn = parseCriteria(criteria);
-  return values.filter(compareFn).length;
+  const values = rawRangeReader(context)(requiredArg(context, args, 0));
+  return values.filter(parseCriteria(requiredArg(context, args, 1).trim())).length;
 };
 
+/** The criteria range, the matcher and the value range SUMIF and AVERAGEIF both
+ *  read. Both value ranges are RAW, not numeric-only: dropping blanks would
+ *  shift the value range out of alignment with the (raw) criteria range, so a
+ *  blank would pull a later row's number into an earlier match (#2358). */
+const readConditionalRanges = (args: string[], context: FunctionContext) => {
+  const criteriaRef = requiredArg(context, args, 0);
+  const readRaw = rawRangeReader(context);
+  const valueRef = args.length === 3 ? requiredArg(context, args, 2) : criteriaRef;
+  return {
+    criteriaRange: readRaw(criteriaRef),
+    valueRange: readRaw(valueRef),
+    matches: parseCriteria(requiredArg(context, args, 1).trim()),
+  };
+};
+
+/** Sum and count the values whose row in `criteriaRange` matches. The two
+ *  ranges stay row-aligned, so a matched row with no value contributes 0. */
+const aggregateMatchedRows = (criteriaRange: CellValue[], valueRange: CellValue[], matches: (value: CellValue) => boolean) =>
+  criteriaRange.reduce(
+    (totals, criteriaValue, index) => (matches(criteriaValue) ? { sum: totals.sum + toNumber(valueRange[index] ?? 0), count: totals.count + 1 } : totals),
+    { sum: 0, count: 0 },
+  );
+
 const sumifHandler: FunctionHandler = (args, context) => {
-  const criteriaRange = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
-  const criteria = args[1].trim();
-  // Raw, not numeric-only: dropping blanks here would shift the value range out
-  // of alignment with the (raw) criteria range, so a blank in sum_range would
-  // pull a later row's number into an earlier match (#2358 Codex review).
-  const sumRangeRef = args.length === 3 ? args[2] : args[0];
-  const sumRange = context.getRangeValuesRaw?.(sumRangeRef) ?? context.getRangeValues(sumRangeRef);
-
-  const compareFn = parseCriteria(criteria);
-
-  let sum = 0;
-  for (let i = 0; i < criteriaRange.length; i++) {
-    if (compareFn(criteriaRange[i])) {
-      sum += toNumber(sumRange[i] ?? 0);
-    }
-  }
-
-  return sum;
+  const { criteriaRange, valueRange, matches } = readConditionalRanges(args, context);
+  return aggregateMatchedRows(criteriaRange, valueRange, matches).sum;
 };
 
 const averageifHandler: FunctionHandler = (args, context) => {
-  const criteriaRange = context.getRangeValuesRaw?.(args[0]) ?? context.getRangeValues(args[0]);
-  const criteria = args[1].trim();
-  // Raw, to stay row-aligned with the criteria range (see SUMIF, #2358).
-  const avgRangeRef = args.length === 3 ? args[2] : args[0];
-  const avgRange = context.getRangeValuesRaw?.(avgRangeRef) ?? context.getRangeValues(avgRangeRef);
-
-  const compareFn = parseCriteria(criteria);
-
-  let sum = 0;
-  let count = 0;
-  for (let i = 0; i < criteriaRange.length; i++) {
-    if (compareFn(criteriaRange[i])) {
-      sum += toNumber(avgRange[i] ?? 0);
-      count++;
-    }
-  }
-
+  const { criteriaRange, valueRange, matches } = readConditionalRanges(args, context);
+  const { sum, count } = aggregateMatchedRows(criteriaRange, valueRange, matches);
   // Excel returns #DIV/0! when no cell matches (the average of nothing is
   // undefined), rather than a silent 0.
   return count > 0 ? sum / count : DIV_ZERO_ERROR;

--- a/src/plugins/spreadsheet/engine/functions/text.ts
+++ b/src/plugins/spreadsheet/engine/functions/text.ts
@@ -2,7 +2,7 @@
  * Text Functions
  */
 
-import { functionRegistry, toString, type FunctionHandler } from "../registry";
+import { functionRegistry, requiredArg, toString, type FunctionHandler } from "../registry";
 import { VALUE_ERROR, isSpreadsheetErrorValue, type SpreadsheetError } from "../spreadsheet-errors";
 import { formatWithPattern } from "../textFormat";
 
@@ -16,7 +16,10 @@ const isWordCharacter = (char: string): boolean => /[\p{L}\p{M}]/u.test(char);
 // boundaries include "'" and "-", which a space-only split misses.
 export const toProperCase = (text: string): string => {
   const chars = Array.from(text);
-  const cased = chars.map((char, index) => (index === 0 || !isWordCharacter(chars[index - 1]) ? char.toUpperCase() : char.toLowerCase()));
+  const cased = chars.map((char, index) => {
+    const previous = chars[index - 1];
+    return previous === undefined || !isWordCharacter(previous) ? char.toUpperCase() : char.toLowerCase();
+  });
   return cased.join("");
 };
 
@@ -71,15 +74,15 @@ const concatenateHandler: FunctionHandler = (args, context) => {
 const concatHandler: FunctionHandler = concatenateHandler; // Alias
 
 const leftHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
-  const numChars = args.length === 2 ? Number(context.evaluateFormula(args[1])) : 1;
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const numChars = args.length === 2 ? Number(context.evaluateFormula(requiredArg(context, args, 1))) : 1;
 
   return takeLeft(text, numChars);
 };
 
 const rightHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
-  const numChars = args.length === 2 ? Number(context.evaluateFormula(args[1])) : 1;
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const numChars = args.length === 2 ? Number(context.evaluateFormula(requiredArg(context, args, 1))) : 1;
 
   return takeRight(text, numChars);
 };
@@ -97,53 +100,53 @@ export const takeMid = (text: string, start: number, count: number): string | Sp
 };
 
 const midHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
-  const start = Number(context.evaluateFormula(args[1]));
-  const numChars = Number(context.evaluateFormula(args[2]));
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const start = Number(context.evaluateFormula(requiredArg(context, args, 1)));
+  const numChars = Number(context.evaluateFormula(requiredArg(context, args, 2)));
 
   return takeMid(text, start, numChars);
 };
 
 const lenHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
   return text.length;
 };
 
 const upperHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
   return text.toUpperCase();
 };
 
 const lowerHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
   return text.toLowerCase();
 };
 
 const properHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
   return toProperCase(text);
 };
 
 const trimHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
   // Trim leading/trailing spaces and replace multiple spaces with single space
   return text.trim().replace(/\s+/g, " ");
 };
 
 const substituteHandler: FunctionHandler = (args, context) => {
-  const text = toString(context.evaluateFormula(args[0]));
-  const oldText = toString(context.evaluateFormula(args[1]));
-  const newText = toString(context.evaluateFormula(args[2]));
-  const instance = args.length === 4 ? Number(context.evaluateFormula(args[3])) : undefined;
+  const text = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const oldText = toString(context.evaluateFormula(requiredArg(context, args, 1)));
+  const newText = toString(context.evaluateFormula(requiredArg(context, args, 2)));
+  const instance = args.length === 4 ? Number(context.evaluateFormula(requiredArg(context, args, 3))) : undefined;
 
   return substituteText(text, oldText, newText, instance);
 };
 
 const replaceHandler: FunctionHandler = (args, context) => {
-  const oldText = toString(context.evaluateFormula(args[0]));
-  const startPos = Number(context.evaluateFormula(args[1])) - 1; // 1-indexed to 0-indexed
-  const numChars = Number(context.evaluateFormula(args[2]));
-  const newText = toString(context.evaluateFormula(args[3]));
+  const oldText = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const startPos = Number(context.evaluateFormula(requiredArg(context, args, 1))) - 1; // 1-indexed to 0-indexed
+  const numChars = Number(context.evaluateFormula(requiredArg(context, args, 2)));
+  const newText = toString(context.evaluateFormula(requiredArg(context, args, 3)));
 
   return oldText.substring(0, startPos) + newText + oldText.substring(startPos + numChars);
 };
@@ -158,17 +161,17 @@ export const locateSubstring = (find: string, within: string, start: number, opt
 };
 
 const findHandler: FunctionHandler = (args, context) => {
-  const findText = toString(context.evaluateFormula(args[0]));
-  const withinText = toString(context.evaluateFormula(args[1]));
-  const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
+  const findText = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const withinText = toString(context.evaluateFormula(requiredArg(context, args, 1)));
+  const startPos = args.length === 3 ? Number(context.evaluateFormula(requiredArg(context, args, 2))) - 1 : 0;
 
   return locateSubstring(findText, withinText, startPos, { caseInsensitive: false });
 };
 
 const searchHandler: FunctionHandler = (args, context) => {
-  const findText = toString(context.evaluateFormula(args[0]));
-  const withinText = toString(context.evaluateFormula(args[1]));
-  const startPos = args.length === 3 ? Number(context.evaluateFormula(args[2])) - 1 : 0;
+  const findText = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const withinText = toString(context.evaluateFormula(requiredArg(context, args, 1)));
+  const startPos = args.length === 3 ? Number(context.evaluateFormula(requiredArg(context, args, 2))) - 1 : 0;
 
   return locateSubstring(findText, withinText, startPos, { caseInsensitive: true });
 };
@@ -178,8 +181,8 @@ const searchHandler: FunctionHandler = (args, context) => {
 const stripSurroundingQuotes = (text: string): string => text.replace(/^["']/, "").replace(/["']$/, "");
 
 const textHandler: FunctionHandler = (args, context) => {
-  const value = context.evaluateFormula(args[0]);
-  const format = stripSurroundingQuotes(toString(context.evaluateFormula(args[1])));
+  const value = context.evaluateFormula(requiredArg(context, args, 0));
+  const format = stripSurroundingQuotes(toString(context.evaluateFormula(requiredArg(context, args, 1))));
   if (typeof value !== "number") return toString(value);
   return formatWithPattern(value, format) ?? toString(value);
 };
@@ -215,12 +218,12 @@ export const parseValueText = (raw: string): number | SpreadsheetError => {
 };
 
 const valueHandler: FunctionHandler = (args, context) => {
-  return parseValueText(toString(context.evaluateFormula(args[0])));
+  return parseValueText(toString(context.evaluateFormula(requiredArg(context, args, 0))));
 };
 
 const exactHandler: FunctionHandler = (args, context) => {
-  const text1 = toString(context.evaluateFormula(args[0]));
-  const text2 = toString(context.evaluateFormula(args[1]));
+  const text1 = toString(context.evaluateFormula(requiredArg(context, args, 0)));
+  const text2 = toString(context.evaluateFormula(requiredArg(context, args, 1)));
 
   return text1 === text2;
 };

--- a/src/plugins/spreadsheet/engine/registry.ts
+++ b/src/plugins/spreadsheet/engine/registry.ts
@@ -13,11 +13,32 @@ export type RangeGetter = (range: string) => CellValue[];
 export type RawRangeGetter = (range: string) => CellValue[];
 
 export interface FunctionContext {
+  /** The registry name the formula invoked, so a handler can report a failure
+   *  the way the evaluator names it. */
+  functionName: string;
   getCellValue: CellGetter;
   getRangeValues: RangeGetter;
   getRangeValuesRaw?: RawRangeGetter | undefined;
   evaluateFormula: (formula: string) => CellValue;
 }
+
+/** The too-few-arguments error, raised by the evaluator from the registry's
+ *  `minArgs` before any handler runs — and by `requiredArg` for the argument a
+ *  handler actually reads, so both report one wording. */
+export const tooFewArgumentsError = (funcName: string, minArgs: number): Error =>
+  new Error(`${funcName} requires at least ${minArgs} argument${minArgs !== 1 ? "s" : ""}`);
+
+/** The argument at `index`, which the caller has already established is there —
+ *  the registry's `minArgs` for a mandatory argument, an `args.length` branch for
+ *  an optional one. An absent one means that guarantee is wrong, so it raises the
+ *  arity error the guarantee should have raised. Never a default value: a
+ *  substituted 0 or "" computes a plausible wrong answer, which is worse than
+ *  the error the formula deserves. */
+export const requiredArg = (context: FunctionContext, args: string[], index: number): string => {
+  const arg = args[index];
+  if (arg === undefined) throw tooFewArgumentsError(context.functionName, index + 1);
+  return arg;
+};
 
 export type FunctionHandler = (args: string[], context: FunctionContext) => CellValue;
 
@@ -88,6 +109,19 @@ const REGEXP_METACHARACTERS = /[.*+?^${}()|[\]\\]/;
 
 const escapeRegExpChar = (char: string): string => (REGEXP_METACHARACTERS.test(char) ? `\\${char}` : char);
 
+// One criteria token: `~x` (an escaped character) or any single character. The
+// escape branch needs a following character, so a TRAILING `~` falls through to
+// the single-character branch and stands for itself.
+const CRITERIA_TOKEN = /~([\s\S])|[\s\S]/g;
+
+const criteriaRegexSource = (pattern: string): string =>
+  pattern.replace(CRITERIA_TOKEN, (token, escaped: string | undefined) => {
+    if (escaped !== undefined) return escapeRegExpChar(escaped);
+    if (token === "*") return ".*";
+    if (token === "?") return ".";
+    return escapeRegExpChar(token);
+  });
+
 /**
  * Match text the way a spreadsheet criteria does: case-insensitively, with `*`
  * standing for any run of characters, `?` for exactly one, and `~` escaping the
@@ -95,21 +129,7 @@ const escapeRegExpChar = (char: string): string => (REGEXP_METACHARACTERS.test(c
  * "yes")` skipped a cell holding `Yes`, and `"A*"` was compared literally.
  */
 function textMatcher(pattern: string): (text: string) => boolean {
-  const source: string[] = [];
-  for (let index = 0; index < pattern.length; index++) {
-    const char = pattern[index];
-    if (char === "~" && index + 1 < pattern.length) {
-      source.push(escapeRegExpChar(pattern[index + 1]));
-      index++;
-    } else if (char === "*") {
-      source.push(".*");
-    } else if (char === "?") {
-      source.push(".");
-    } else {
-      source.push(escapeRegExpChar(char));
-    }
-  }
-  const regex = new RegExp(`^${source.join("")}$`, "iu");
+  const regex = new RegExp(`^${criteriaRegexSource(pattern)}$`, "iu");
   return (text) => regex.test(text);
 }
 
@@ -123,9 +143,8 @@ export function parseCriteria(criteria: string): (value: CellValue) => boolean {
 
   // Check for comparison operators
   // eslint-disable -- sonarjs/slow-regex
-  const opMatch = trimmedCriteria.match(/^([><=!]+)(.+)$/);
-  if (opMatch) {
-    const [, op, value] = opMatch;
+  const [, op, value] = trimmedCriteria.match(/^([><=!]+)(.+)$/) ?? [];
+  if (op !== undefined && value !== undefined) {
     const numValue = parseFloat(value);
 
     // `=` / `<>` compare like the bare criteria does — case-insensitive text

--- a/src/plugins/spreadsheet/engine/textFormat.ts
+++ b/src/plugins/spreadsheet/engine/textFormat.ts
@@ -54,7 +54,7 @@ export const parseNumberPattern = (pattern: string): NumberPattern | null => {
   if (hasUnsupportedLiteral(prefix) || hasUnsupportedLiteral(suffix)) return null;
 
   const [integerPart, decimalPart = "", ...extraParts] = core[0].split(".");
-  if (extraParts.length > 0) return null;
+  if (integerPart === undefined || extraParts.length > 0) return null;
 
   return {
     prefix,
@@ -75,7 +75,10 @@ const trimOptionalZeros = (decimals: string, minDecimals: number): string => {
 };
 
 const renderDigits = (absValue: number, pattern: NumberPattern): string => {
-  const [wholeDigits, decimalDigits = ""] = absValue.toFixed(pattern.maxDecimals).split(".");
+  const fixed = absValue.toFixed(pattern.maxDecimals);
+  const point = fixed.indexOf(".");
+  const wholeDigits = point === -1 ? fixed : fixed.slice(0, point);
+  const decimalDigits = point === -1 ? "" : fixed.slice(point + 1);
   const padded = wholeDigits.padStart(pattern.integerMinDigits, "0");
   const whole = pattern.useGrouping ? groupThousands(padded) : padded;
   const decimals = trimOptionalZeros(decimalDigits, pattern.minDecimals);

--- a/src/plugins/spreadsheet/engine/translateFormula.ts
+++ b/src/plugins/spreadsheet/engine/translateFormula.ts
@@ -29,16 +29,16 @@ function toggleQuote(openQuote: string, char: string): string {
  *  string literal untouched. A quote toggles the "inside a literal" state only
  *  when it is not backslash-escaped. */
 export function replaceConcatOperator(expr: string): string {
+  const chars = expr.split("");
   const out: string[] = [];
   let openQuote = "";
-  for (let index = 0; index < expr.length; index++) {
-    const char = expr[index];
-    const escaped = index > 0 && expr[index - 1] === "\\";
+  chars.forEach((char, index) => {
+    const escaped = index > 0 && chars[index - 1] === "\\";
     if (!escaped && (char === '"' || char === "'")) {
       openQuote = toggleQuote(openQuote, char);
     }
     out.push(char === "&" && openQuote === "" ? "+" : char);
-  }
+  });
   return out.join("");
 }
 

--- a/test/plugins/spreadsheet/engine/test_requiredArg.ts
+++ b/test/plugins/spreadsheet/engine/test_requiredArg.ts
@@ -1,0 +1,102 @@
+// #2736: adopting `noUncheckedIndexedAccess` turned every `args[N]` in a
+// function handler into `string | undefined`. `requiredArg` is the single reader
+// that resolves it — and the reason it can be a *reader* rather than a default
+// is that the evaluator validates the registry's `minArgs` before any handler
+// runs. These tests pin both halves of that contract.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { functionRegistry, requiredArg, tooFewArgumentsError, type FunctionContext } from "../../../../src/plugins/spreadsheet/engine/registry.ts";
+import "../../../../src/plugins/spreadsheet/engine/functions/index.ts";
+import { substituteCellRefs, findCellRefs } from "../../../../src/plugins/spreadsheet/engine/evaluator.ts";
+
+const stubContext = (functionName: string): FunctionContext => ({
+  functionName,
+  getCellValue: () => 1,
+  getRangeValues: () => [1, 2, 3],
+  getRangeValuesRaw: () => [1, 2, 3],
+  evaluateFormula: () => 1,
+});
+
+/** The wording the evaluator uses for an arity violation, which `requiredArg`
+ *  must reproduce rather than invent a second message for. */
+const TOO_FEW_MESSAGE = /^[A-Z]+ requires at least \d+ arguments?$/;
+
+describe("requiredArg", () => {
+  it("returns the argument at the index", () => {
+    assert.equal(requiredArg(stubContext("SUM"), ["A1", "B1"], 1), "B1");
+  });
+
+  it("throws the evaluator's own arity wording, naming the function and the count it needed", () => {
+    assert.throws(() => requiredArg(stubContext("ROUND"), ["A1"], 1), { message: "ROUND requires at least 2 arguments" });
+  });
+
+  it("uses the singular for a one-argument minimum, like the evaluator does", () => {
+    assert.equal(tooFewArgumentsError("UPPER", 1).message, "UPPER requires at least 1 argument");
+    assert.throws(() => requiredArg(stubContext("UPPER"), [], 0), { message: "UPPER requires at least 1 argument" });
+  });
+
+  it("never substitutes a default — an absent argument is an error, not a 0 or an empty string", () => {
+    assert.throws(() => requiredArg(stubContext("MID"), ["A1", "1"], 2), { message: TOO_FEW_MESSAGE });
+  });
+});
+
+describe("every registered function's minArgs covers what its handler reads", () => {
+  // The audit behind #2736's spreadsheet pass, kept as a permanent guard: a
+  // registration whose minArgs is LOWER than the highest index its handler reads
+  // unguarded is a crash path reachable from a user formula, because the
+  // evaluator's arity gate would let that call through. Calling each handler
+  // with exactly minArgs arguments makes `requiredArg` the detector.
+  functionRegistry.getAllFunctions().forEach((definition) => {
+    it(`${definition.name} reads no argument beyond its declared minimum`, () => {
+      const minArgs = definition.minArgs ?? 0;
+      const args = Array.from({ length: minArgs }, () => "A1");
+      try {
+        definition.handler(args, stubContext(definition.name));
+      } catch (error) {
+        // A handler may fail for unrelated reasons (a stub range is not a real
+        // table); only the arity wording means minArgs under-declares.
+        const message = error instanceof Error ? error.message : String(error);
+        assert.doesNotMatch(message, TOO_FEW_MESSAGE, `${definition.name} read past its declared minArgs=${minArgs}`);
+      }
+    });
+  });
+});
+
+describe("substituteCellRefs", () => {
+  // #2357: a global string replace rewrote every occurrence of the SHORTER
+  // reference first, so A10 became "<A1's value>0" and the cell showed a
+  // plausible wrong number. Substituting back to front is what prevents it.
+  it("substitutes back to front, so a longer reference is not broken by a shorter prefix", () => {
+    const expr = "A1+A10";
+    const result = substituteCellRefs(expr, findCellRefs(expr), (ref) => (ref === "A1" ? "5" : "7"));
+    assert.equal(result, "5+7");
+  });
+
+  it("leaves the caller's span list untouched", () => {
+    const spans = findCellRefs("A1+B2");
+    substituteCellRefs("A1+B2", spans, () => "0");
+    assert.deepEqual(
+      spans.map((span) => span.ref),
+      ["A1", "B2"],
+    );
+  });
+
+  it("returns the expression unchanged when there is nothing to substitute", () => {
+    assert.equal(
+      substituteCellRefs("1+2", [], () => "9"),
+      "1+2",
+    );
+  });
+
+  it("propagates a throw from the renderer, so an errored reference still poisons the expression", () => {
+    const expr = "A1+1";
+    assert.throws(
+      () =>
+        substituteCellRefs(expr, findCellRefs(expr), () => {
+          throw new Error("#DIV/0!");
+        }),
+      { message: "#DIV/0!" },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Drives `src/plugins/spreadsheet/**` from **247 → 0** findings under `--noUncheckedIndexedAccess`, the single largest cluster in the codebase. **The flag is NOT enabled** in any tsconfig — the rest of `src/` still has findings, and the flag can only go on once the whole project reaches zero.

Measured with (`--pretty false` is required; ANSI escapes otherwise split the string `error TS` and `grep -c` reports zero):

```bash
npx tsc -p tsconfig.json --noEmit --pretty false --noUncheckedIndexedAccess 2>&1 \
  | grep "error TS" | grep -c "src/plugins/spreadsheet"
# before: 247      after: 0
```

The dominant shape was `args[N]` handed to `context.evaluateFormula(...)` — 141 sites across the 7 function files. **One helper** resolves all of them; the remaining ~100 findings were fixed structurally rather than by annotation.

## Items to Confirm / Review

1. **`FunctionContext` gained a `functionName` field.** This is the one interface change. It exists so `requiredArg` can raise the *same* error the evaluator raises (`"ROUND requires at least 2 arguments"`) rather than inventing a second wording — #2397 deliberately consolidated on that one message. There is exactly one construction site (`evaluator.ts`), so the blast radius is small, but it is a shape change to a semi-public type. **Is threading the name worth it, versus a nameless message?**

2. **`calculator.ts` was restructured, not just annotated.** `resolveFormulaCell` / `getRawValue` now take a `CellPosition { cells, row, col }` instead of `(row, col)`, so a formula's result is written into a row already in hand rather than re-indexed through `calculated[row][col]`; the two grid walks share a `forEachCell`. Behaviour is pinned by the 976 existing spreadsheet tests, all green — but this is the riskiest file in the diff and deserves a human read.

3. **`getCellValue` now parses its ref through the shared `parseSingleCellRef`** instead of its own inline copy of `replace(/\$/g,"")` + `/^([A-Z]+)(\d+)$/`. I checked the two are equivalent character for character (including that neither upper-cases, so a lowercase `a1` still reads as 0). Worth a second pair of eyes.

4. **`requiredArg` is used inside `args.length >= N ?` branches too**, where the argument is *optional*. The read is still required at that point (the branch only runs when it is present), and using one mechanism everywhere was deliberate — but the name reads slightly oddly there. Flagging in case you would rather see a second `optionalArg` helper.

5. **Three pre-existing bugs found while auditing** — reported on #2736, NOT fixed here. They are wrong-answer bugs in `MATCH` / `XLOOKUP`, unrelated to indexed access, and each needs its own decision plus tests. One of them returns a silently wrong number rather than an error.

## The helper

```ts
export const tooFewArgumentsError = (funcName: string, minArgs: number): Error =>
  new Error(`${funcName} requires at least ${minArgs} argument${minArgs !== 1 ? "s" : ""}`);

export const requiredArg = (context: FunctionContext, args: string[], index: number): string => {
  const arg = args[index];
  if (arg === undefined) throw tooFewArgumentsError(context.functionName, index + 1);
  return arg;
};
```

Why a *reader* and not a default: `evaluator.ts` already enforces `minArgs` and throws **before** any handler runs, and all 81 registered functions declare `minArgs`. The runtime guarantee exists; the type system just cannot see it. So the absent case is unreachable — and if it ever is reached, it means a registration under-declares its minimum, which is a genuine bug. A `?? ""` / `?? 0` would convert that bug into a plausible wrong answer, which is precisely the failure `noUncheckedIndexedAccess` exists to expose. `tooFewArgumentsError` is now shared with the evaluator so both paths report one wording — the constraint #2397 established when it removed the handler-side arity guards.

No `as`, no `!`, no `@ts-ignore` / `@ts-expect-error` / `eslint-disable` anywhere in the diff. No new `let`.

## The three bug hunts

| Hunt | Result |
|---|---|
| A function whose `minArgs` is LOWER than the highest index it reads unguarded | **Clean — 81/81.** Verified statically (read every handler) *and* empirically: a `Proxy` over an args array of exactly `minArgs` entries, recording any read at index `>= minArgs`, run across every registered function. |
| `calculated[row][col]` in `calculator.ts` — is the row genuinely guaranteed? | **Guaranteed, proven.** `calculated = data.map(row => [...row])` and is never resized, so it mirrors `data` row for row and length for length. Every read is bounds-checked against the grid's own lengths first (`getCellValue`, `collectRangeValues`); the cached-value read is gated by an `evaluated` set that only ever holds keys that were in bounds when written; the top-level walks iterate the grid's own indices. Restructured to `CellPosition` so the invariant is stated once instead of at each of ten call sites. |
| Regex capture groups where a group may not participate | **One alternation found, already handled correctly.** `calculator.resolveSheetData`'s `/^(?:'([^']+)'\|([^!]+))!(.+)$/` — exactly one name branch participates, and the existing `sheetMatch[1] \|\| sheetMatch[2]` was already right (neither branch can match an empty string, so `\|\|` and `??` agree). Every other capture group in the plugin is mandatory. |

The `minArgs` audit is now a **permanent test** rather than a one-off: `test_requiredArg.ts` calls every registered function with exactly `minArgs` arguments and asserts no arity error escapes. Proven non-vacuous — lowering `DATE` / `TIME` / `DATEDIF` from `minArgs: 3` to `2` turns it red with `DATE read past its declared minArgs=2` (plus the other two), and restoring them turns it green.

## Structural fixes (the other ~100 findings)

Each removed real duplication rather than adding a guard:

- **`formulaRefs.ts`** — one `parseA1Token` behind `expandRange`, `parseSingleCellRef` and `parseRangeBounds`, which each carried their own copy of the `([A-Z]+)(\d+)` read (two of them the same 4-group range regex).
- **`date-parser.ts`** — `matchDateParts` returns a 3-tuple (destructuring a tuple is NUIA-safe); the day-first rule and the two-digit-year expansion are now shared with `getDefaultDateFormat`, which previously re-implemented the day-first rule under a comment saying it *must* match `parseDate`.
- **`evaluator.ts` / `functions/logical.ts`** — one `substituteCellRefs` for the back-to-front reference substitution that both files had (the #2357 fix, duplicated).
- **`functions/statistical.ts`** — SUMIF and AVERAGEIF shared everything but the final division; now `readConditionalRanges` + `aggregateMatchedRows`. `isCellReference`'s hand-rolled character scanner became the regex it was spelling out.
- **`functions/lookup.ts`** — the two reverse `for` loops became `findLastMatchIndex`; the two "scan until the ordering breaks" loops became `lastIndexWhile`.
- **`functions/statistical-math.ts`** — `computeMedian` slices the one-or-two middle values and averages them, instead of indexing `sorted[middle - 1]` / `sorted[middle]`.
- **`financial-math.ts`** — IRR's inner index loop became `discountedSeries`, returning the npv/derivative pair a Newton step needs.
- **`date-utils.ts`** — the four name lists are typed `readonly [string, ...string[]]`, so the existing `NAMES[month] ?? NAMES[0]` NaN fallback types without a cast.

## User Prompt

> Repo: receptron/mulmoclaude. Issue #2736: adopt `noUncheckedIndexedAccess`.
>
> Scope: `src/plugins/spreadsheet/**` only (741 findings, the single largest cluster). Do not touch files outside that directory.
>
> Measure with `npx tsc -p tsconfig.json --noEmit --pretty false --noUncheckedIndexedAccess 2>&1 | grep "error TS" | grep "src/plugins/spreadsheet"`. `--pretty false` is required — without it, ANSI escapes split the string `error TS` and `grep -c` reports ZERO.
>
> What I already established (verify, don't re-derive): the dominant shape is `args[0]` / `args[1]` handed to `context.evaluateFormula(...)`; under the flag `args[N]` is `string | undefined`. `evaluator.ts:298` ALREADY enforces `minArgs` and throws BEFORE calling a handler. All 81 registered functions declare `minArgs`. Optional args are already guarded with `args.length === N ? … : default`. So the runtime guarantee exists; the type system just cannot see it.
>
> The fix shape (design it, then apply consistently): introduce ONE helper that reads a required arg and, when absent, throws the SAME error the dispatcher already throws for an arity violation — so behaviour is unchanged and the failure path is matched rather than invented. Do NOT paper over it with `?? ""` / `?? 0`: a default silently produces a wrong answer, which is exactly the failure this flag exists to expose. Do NOT use `!` — `@typescript-eslint/no-non-null-assertion` is at `error`.
>
> Real bugs to hunt (this is the valuable part, not the type churn):
> 1. A function whose declared `minArgs` is LOWER than the highest index it reads unguarded. That is a genuine crash/`undefined` path reachable from a user formula. Check every function.
> 2. 2D indexing like `calculated[row][col]` in `engine/calculator.ts` — `calculated[row]` can be absent. Work out whether the row is genuinely guaranteed (and prove it) or whether a bad ref reaches it.
> 3. Regex capture groups (`match[3]`) — a group that does not participate is genuinely `undefined`. Check whether the surrounding code assumed otherwise.
>
> Post any real bug found as a comment on issue #2736 with a reproduction — a formula string that triggers it.
>
> Rules (CLAUDE.md, non-negotiable): no `as`, no `!`, no `@ts-ignore`/`@ts-expect-error`/`eslint-disable`. No `let`. Functions under 20 lines. No magic numbers. Honour `sonarjs/cognitive-complexity` (error at >15).
>
> Do NOT enable the flag in any tsconfig — `src/` also has findings outside this scope, handled by another agent, and the flag can only go on when the whole project reaches zero. Just drive these files to zero.
>
> Verify before pushing: `yarn build:packages && yarn format && yarn lint && yarn typecheck && yarn build && yarn test`, plus the scoped measurement showing spreadsheet at 0. The spreadsheet engine has substantial existing tests — they are the ground truth that behaviour did not change. If any behaviour is altered, show fail-before/pass-after.
>
> Branch `fix/2736-nuia-spreadsheet` off up-to-date `origin/main`. Commit prefix `fix:`. Do NOT merge.

## Verification

```
yarn build:packages   ok
yarn format           ok
yarn lint             0 errors, 51 warnings  (51 before AND after — no new warnings)
yarn typecheck        ok  (vue + server + test + e2e + e2e-live + packages)
yarn build            ok
yarn test             27 suites, 0 failures  (976 spreadsheet tests green)

scoped measurement    247 → 0
```

`server/build/dispatcher.mjs` was not committed — every file was staged individually.

refs #2736

work in mulmoclaude3

## Summary by Sourcery

Eliminate all noUncheckedIndexedAccess findings in the spreadsheet engine by tightening argument handling, centralizing A1/range parsing, and structurally refactoring key utilities and grid traversal without changing observable behavior.

Bug Fixes:
- Align function arity error messages between evaluator and handlers via a shared error helper to ensure consistent reporting.
- Prevent incorrect substitution of overlapping cell references in expressions by introducing a back-to-front substitution helper.
- Guard sheet and cell resolution against malformed matches and out-of-bounds indices to avoid undefined access and fall back cleanly.

Enhancements:
- Refactor calculator grid traversal to pass explicit cell positions, reducing duplicated index logic and clarifying recursion and formatting passes.
- Unify date parsing and formatting logic with shared regex helpers, day-first detection, and two-digit year expansion for consistent handling across APIs.
- Consolidate A1 and range parsing into shared helpers so single-cell and range readers use the same tokenization and bounds logic.
- Introduce reusable helpers for wildcard criteria regex construction and conditional range aggregation to simplify SUMIF/AVERAGEIF and text matching behavior.
- Streamline statistical and financial math helpers, including median computation and IRR series discounting, for clearer and more robust numeric operations.
- Tighten text, logical, and formatter utilities to handle edge cases (word boundaries, escaped concat, decimal splitting, thousand grouping) without unchecked indexed access.

Tests:
- Add a dedicated test suite for requiredArg and the minArgs contract, ensuring handlers never read arguments beyond their declared minimum and share evaluator arity wording.
- Add tests for reference substitution behavior to guarantee back-to-front replacement and error propagation in expression rewriting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spreadsheet formula evaluation, including cross-sheet references, ranges, circular references, and error handling.
  - Standardized missing-argument errors across date, financial, logical, lookup, mathematical, statistical, and text functions.
  - Fixed lookup behavior when a matched result falls outside the return range.
  - Improved date parsing, number formatting, criteria matching, and text rendering.

- **Enhancements**
  - Improved support for cell-reference substitution in complex formulas.
  - Increased consistency and reliability of financial calculations, conditional aggregations, and date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->