### PR TITLE
fix(tsconfig): enable noUncheckedIndexedAccess for the src and node projects (#2736)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "useUnknownInCatchVariables": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,8 +23,8 @@ function resolveWorkspacePath(): string {
   try {
     const envPath = path.join(process.cwd(), '.env')
     const content = fs.readFileSync(envPath, 'utf-8')
-    const match = content.match(/^MULMOCLAUDE_WORKSPACE_PATH=(.+)$/m)
-    if (match) return match[1].trim()
+    const assigned = content.match(/^MULMOCLAUDE_WORKSPACE_PATH=(.+)$/m)?.[1]
+    if (assigned !== undefined) return assigned.trim()
   } catch {
     /* .env not present, fall through to default */
   }


### PR DESCRIPTION
## Summary

`src` と `node` の2プロジェクトで `noUncheckedIndexedAccess` を有効化します。#2753（spreadsheet 以外の `src/`、68件）と #2755（spreadsheet エンジン、247件）が入って `src/` が0になったので、フラグでその状態を固定します。

6プロジェクト全部が0になるのを待たず**プロジェクト単位でラチェット**します。`test/`（765件）を潰している間、既に終わった領域が自由に後戻りできる状態を残さないためです。

`tsconfig.node.json` に1件だけ残っていた `vite.config.ts` も直しました。

## Items to Confirm / Review

**1. フラグが実際に効くことを実証済み（推測していません）。** typecheck が緑でも、フラグが効いていない場合と見分けがつきません。一時的な probe で後戻りが捕まることを確認してから削除しました:

```
src/__nuia_probe.ts(1,48): error TS2532: Object is possibly 'undefined'.
```

**2. `vite.config.ts` は既存の失敗パスを保存しています。** 元は正規表現のキャプチャを `match[1]` で読んでいました:

```diff
-    const match = content.match(/^MULMOCLAUDE_WORKSPACE_PATH=(.+)$/m)
-    if (match) return match[1].trim()
+    const assigned = content.match(/^MULMOCLAUDE_WORKSPACE_PATH=(.+)$/m)?.[1]
+    if (assigned !== undefined) return assigned.trim()
```

マッチしない `.env` は従来どおり既定のワークスペースパスにフォールスルーします。ここで throw に変えると挙動が変わるので、そうしていません。このファイルは format glob（`{src,server,test,…}/**`）の外にあるため、周囲のセミコロン無しスタイルに合わせています。

**3. 残るプロジェクトはまだ未適用です:** `test` 765 / `packages` 87 / `server` 39 / `e2e` 31。それぞれ0になった時点で有効化します（`server` と `packages` は #2756、`test` と `e2e` は別PRで進行中）。

**測定に関する注意** — 後続で数える人向け:
- `--pretty false` が必須です。付けないと ANSI エスケープが `error TS` を分断し、`grep -c` が **0 を返します**（壊れた測定が成功に見える）
- `src` と `test` は **`vue-tsc`** で測る必要があります。plain `tsc` は `.vue` 内の指摘を見ません。`packages/**` も同様で、両方のパスが要ります

## 検証

`main` @ `e938dd2b6` から分岐。

```
yarn build:packages  0
yarn format          0
yarn lint            0  → 0 errors
yarn typecheck       0
yarn build           0
yarn test            0  → 11085 tests / fail 0
```

refs #2736

work in mulmoclaude3

## Summary by Sourcery

Enable stricter TypeScript indexed access checks for core projects and adjust workspace path resolution to be more type-safe while preserving existing behavior.

Bug Fixes:
- Ensure workspace path resolution from .env handles missing regex captures safely without changing fallback behavior.

Enhancements:
- Enable noUncheckedIndexedAccess in the main src TypeScript configuration and the node configuration to ratchet stricter type safety for those projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of workspace paths configured through environment variables.
  * Added safer checks for missing configuration values to prevent unexpected behavior.

* **Refactor**
  * Strengthened TypeScript checks for indexed access, improving reliability during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->