### PR TITLE
fix: drive noUncheckedIndexedAccess to zero in test/{plugins,utils,composables,services,scripts}

### DIFF
--- a/test/composables/test_useChatScroll.ts
+++ b/test/composables/test_useChatScroll.ts
@@ -128,7 +128,9 @@ describe("useChatScroll — streaming auto-scroll", () => {
 
     // Sanity: the session accumulated the full message in place.
     assert.equal(session.toolResults.length, 1);
-    assert.equal(session.toolResults[0].message, "Hello world!");
+    const [accumulated] = session.toolResults;
+    assert.ok(accumulated);
+    assert.equal(accumulated.message, "Hello world!");
   });
 
   it("does not scroll when isRunning is the only change and no results", async () => {
@@ -220,7 +222,9 @@ describe("useChatScroll — sticky bottom (#2179)", () => {
 
     assert.equal(writes.length, writesWhenScrolledUp, "streaming must not scroll while the reader is scrolled up");
     // The stream itself still lands — only the viewport is left alone.
-    assert.equal(session.toolResults[0].message, "Hello world!");
+    const [accumulated] = session.toolResults;
+    assert.ok(accumulated);
+    assert.equal(accumulated.message, "Hello world!");
   });
 
   it("resumes following when the reader returns to the bottom", async () => {

--- a/test/composables/test_useDirChildrenCache.ts
+++ b/test/composables/test_useDirChildrenCache.ts
@@ -49,13 +49,16 @@ describe("useDirChildrenCache", () => {
 
     const stale = cache.loadDirChildren("a");
     const fresh = cache.reloadDirChildren("a");
+    const [staleCall, freshCall] = calls;
+    assert.ok(staleCall);
+    assert.ok(freshCall);
 
-    calls[0].resolve(jsonResponse(200, dirNode("a", [fileChild("stale")])));
+    staleCall.resolve(jsonResponse(200, dirNode("a", [fileChild("stale")])));
     await stale;
     assert.equal(cache.childrenByPath.value.get("a"), null);
     assert.equal(cache.treeError.value, null);
 
-    calls[1].resolve(jsonResponse(200, dirNode("a", [fileChild("fresh")])));
+    freshCall.resolve(jsonResponse(200, dirNode("a", [fileChild("fresh")])));
     await fresh;
     assert.deepEqual(cache.childrenByPath.value.get("a"), [fileChild("fresh")]);
   });
@@ -66,12 +69,15 @@ describe("useDirChildrenCache", () => {
 
     const stale = cache.loadDirChildren("dirA");
     const reload = cache.reloadRoot();
+    const [staleCall, reloadCall] = calls;
+    assert.ok(staleCall);
+    assert.ok(reloadCall);
 
-    calls[0].resolve(jsonResponse(200, dirNode("dirA", [fileChild("old")])));
+    staleCall.resolve(jsonResponse(200, dirNode("dirA", [fileChild("old")])));
     await stale;
     assert.equal(cache.childrenByPath.value.has("dirA"), false);
 
-    calls[1].resolve(jsonResponse(200, dirNode("", [fileChild("root")])));
+    reloadCall.resolve(jsonResponse(200, dirNode("", [fileChild("root")])));
     await reload;
     assert.deepEqual(cache.childrenByPath.value.get(""), [fileChild("root")]);
     assert.equal(cache.rootNode.value?.path, "");

--- a/test/composables/test_useFileContentLoader.ts
+++ b/test/composables/test_useFileContentLoader.ts
@@ -64,7 +64,9 @@ describe("useFileContentLoader", () => {
     assert.equal(loader.contentLoading.value, true);
     assert.equal(loader.content.value, null);
     assert.equal(loader.contentError.value, null);
-    calls[1].resolve(jsonResponse(200, textPayload("b.txt", "fresh")));
+    const [, freshCall] = calls;
+    assert.ok(freshCall);
+    freshCall.resolve(jsonResponse(200, textPayload("b.txt", "fresh")));
     await fresh;
     assert.deepEqual(loader.content.value, textPayload("b.txt", "fresh"));
     assert.equal(loader.contentLoading.value, false);

--- a/test/composables/test_useImageErrorRepair.ts
+++ b/test/composables/test_useImageErrorRepair.ts
@@ -191,7 +191,9 @@ function makeSource(opts: { srcset?: string | undefined; src?: string | undefine
     attrs,
     dataset: {},
     getAttribute(name) {
-      return Object.prototype.hasOwnProperty.call(attrs, name) ? attrs[name] : null;
+      if (!Object.prototype.hasOwnProperty.call(attrs, name)) return null;
+      const value = attrs[name];
+      return value === undefined ? null : value;
     },
     setAttribute(name, value) {
       attrs[name] = value;

--- a/test/composables/test_useOpenInOs.ts
+++ b/test/composables/test_useOpenInOs.ts
@@ -72,6 +72,7 @@ describe("useOpenInOs", () => {
     await open();
     assert.equal(fetchCalls.length, 1);
     const [call] = fetchCalls;
+    assert.ok(call);
     assert.match(call.url, /\/api\/files\/open\?path=docs%2Freport\.pptx$/);
     assert.equal(call.init?.method, "POST");
     const parsed = JSON.parse(call.init?.body ?? "{}") as { path?: string };
@@ -145,6 +146,7 @@ describe("useRevealInOs", () => {
     await reveal();
     assert.equal(fetchCalls.length, 1);
     const [call] = fetchCalls;
+    assert.ok(call);
     assert.match(call.url, /\/api\/files\/reveal\?path=docs%2Freport\.xlsx$/);
     assert.equal(call.init?.method, "POST");
     const parsed = JSON.parse(call.init?.body ?? "{}") as { path?: string };

--- a/test/composables/test_useSessionHistoryHelpers.ts
+++ b/test/composables/test_useSessionHistoryHelpers.ts
@@ -10,18 +10,25 @@ function session(sessionId: string, isBookmarked?: boolean): SessionSummary {
 describe("applyBookmarkFlag", () => {
   it("sets isBookmarked=true on the matching session", () => {
     const result = applyBookmarkFlag([session("a"), session("b")], "b", true);
-    assert.equal(result[1].isBookmarked, true);
+    const [, matched] = result;
+    assert.ok(matched);
+    assert.equal(matched.isBookmarked, true);
   });
 
   it("sets isBookmarked=false on the matching session", () => {
     const result = applyBookmarkFlag([session("a", true)], "a", false);
-    assert.equal(result[0].isBookmarked, false);
+    const [matched] = result;
+    assert.ok(matched);
+    assert.equal(matched.isBookmarked, false);
   });
 
   it("leaves non-matching sessions unchanged", () => {
     const result = applyBookmarkFlag([session("a", true), session("b", false)], "b", true);
-    assert.equal(result[0].isBookmarked, true);
-    assert.equal(result[1].isBookmarked, true);
+    const [untouched, matched] = result;
+    assert.ok(untouched);
+    assert.ok(matched);
+    assert.equal(untouched.isBookmarked, true);
+    assert.equal(matched.isBookmarked, true);
   });
 
   it("returns an all-unchanged copy when no id matches", () => {

--- a/test/composables/test_useSkillsList.ts
+++ b/test/composables/test_useSkillsList.ts
@@ -52,7 +52,9 @@ describe("useSkillsList — happy path", () => {
     const { skills, error, refresh } = useSkillsList();
     await refresh();
     assert.equal(skills.value.length, 2);
-    assert.equal(skills.value[0].name, "alpha");
+    const [firstSkill] = skills.value;
+    assert.ok(firstSkill);
+    assert.equal(firstSkill.name, "alpha");
     assert.equal(error.value, null);
   });
 });

--- a/test/composables/test_useTranslatedQueries.ts
+++ b/test/composables/test_useTranslatedQueries.ts
@@ -91,8 +91,10 @@ describe("useTranslatedQueries", () => {
     await settle();
     assert.deepEqual(queries.value, ["こんにちは", "世界"]);
     assert.equal(fetchCalls.length, 1);
-    assert.equal(fetchCalls[0].url, "/api/translation");
-    assert.deepEqual(fetchCalls[0].body, {
+    const [firstCall] = fetchCalls;
+    assert.ok(firstCall);
+    assert.equal(firstCall.url, "/api/translation");
+    assert.deepEqual(firstCall.body, {
       namespace: "role-queries",
       targetLanguage: "ja",
       sentences: ["Hello", "World"],

--- a/test/plugins/collection/test_collectionRenderers.ts
+++ b/test/plugins/collection/test_collectionRenderers.ts
@@ -32,6 +32,12 @@ const makeSchema = (fields: Record<string, FieldSpec>, primaryKey = "id"): Colle
   fields,
 });
 
+const specOf = (schema: CollectionSchema, key: string): FieldSpec => {
+  const spec = schema.fields[key];
+  assert.ok(spec, `schema has no field: ${key}`);
+  return spec;
+};
+
 const profileSchema = makeSchema({ id: field("text"), name: field("text"), fee: field("money", { currency: "USD" }) });
 const embedCache: EmbedCache = {
   profiles: {
@@ -104,24 +110,28 @@ describe("buildEmbedViews", () => {
   it("resolves a per-record idField embed to the row-specific target", () => {
     const schema = makeSchema({ billTo: field("embed", { to: "profiles", idField: "customerId", label: "Bill To" }) });
     const views = buildEmbedViews(schema, embedCache, { customerId: "you" }, "en-US");
-    assert.equal(views.billTo.found, true);
-    assert.equal(views.billTo.recordId, "you");
-    assert.equal(views.billTo.targetSlug, "profiles");
-    assert.equal(views.billTo.rows.find((row) => row.key === "name")?.display, "You LLC");
-    assert.ok(views.billTo.rows.find((row) => row.key === "fee")?.display.includes("200"));
+    const { billTo } = views;
+    assert.ok(billTo);
+    assert.equal(billTo.found, true);
+    assert.equal(billTo.recordId, "you");
+    assert.equal(billTo.targetSlug, "profiles");
+    assert.equal(billTo.rows.find((row) => row.key === "name")?.display, "You LLC");
+    assert.ok(billTo.rows.find((row) => row.key === "fee")?.display.includes("200"));
   });
 
   it("resolves a fixed-id embed and skips empty sub-fields", () => {
     const schema = makeSchema({ from: field("embed", { to: "profiles", id: "me" }) });
     const cacheWithBlank: EmbedCache = { profiles: { schema: profileSchema, items: [{ id: "me", name: "Me Inc", fee: "" }] } };
     const views = buildEmbedViews(schema, cacheWithBlank, null, "en-US");
-    assert.equal(views.from.found, true);
+    const { from } = views;
+    assert.ok(from);
+    assert.equal(from.found, true);
     assert.equal(
-      views.from.rows.some((row) => row.key === "fee"),
+      from.rows.some((row) => row.key === "fee"),
       false,
     );
     assert.equal(
-      views.from.rows.some((row) => row.key === "name"),
+      from.rows.some((row) => row.key === "name"),
       true,
     );
   });
@@ -129,9 +139,11 @@ describe("buildEmbedViews", () => {
   it("marks found=false when the idField points at a missing record", () => {
     const schema = makeSchema({ billTo: field("embed", { to: "profiles", idField: "customerId" }) });
     const views = buildEmbedViews(schema, embedCache, { customerId: "ghost" }, "en-US");
-    assert.equal(views.billTo.found, false);
-    assert.deepEqual(views.billTo.rows, []);
-    assert.equal(views.billTo.recordId, "ghost");
+    const { billTo } = views;
+    assert.ok(billTo);
+    assert.equal(billTo.found, false);
+    assert.deepEqual(billTo.rows, []);
+    assert.equal(billTo.recordId, "ghost");
   });
 
   it("returns an empty object when the schema is null (no collection loaded)", () => {
@@ -168,17 +180,17 @@ describe("evaluateDerived", () => {
     total: field("derived", { formula: "qty * price" }),
   });
   it("evaluates a derived formula against the item", () => {
-    assert.equal(evaluateDerived(schema.fields.total, "total", { qty: 3, price: 4 }, schema, {}), 12);
+    assert.equal(evaluateDerived(specOf(schema, "total"), "total", { qty: 3, price: 4 }, schema, {}), 12);
   });
   it("returns null for a field without a formula", () => {
     assert.equal(evaluateDerived(field("number"), "qty", { qty: 3 }, schema, {}), null);
   });
   it("returns null when the schema is null", () => {
-    assert.equal(evaluateDerived(schema.fields.total, "total", {}, null, {}), null);
+    assert.equal(evaluateDerived(specOf(schema, "total"), "total", {}, null, {}), null);
   });
   it("returns null when the computed result is non-numeric", () => {
     const stringSchema = makeSchema({ id: field("text"), note: field("text"), d: field("derived", { formula: "note" }) });
-    assert.equal(evaluateDerived(stringSchema.fields.d, "d", { note: "hello" }, stringSchema, {}), null);
+    assert.equal(evaluateDerived(specOf(stringSchema, "d"), "d", { note: "hello" }, stringSchema, {}), null);
   });
 });
 

--- a/test/plugins/collection/test_collectionRenderingHelpers.ts
+++ b/test/plugins/collection/test_collectionRenderingHelpers.ts
@@ -240,8 +240,10 @@ describe("buildRefRecordMap", () => {
     const detail = makeDetail(schema, [{ id: "a", qty: 2, price: 10 }]);
     const map = buildRefRecordMap(detail);
     assert.deepEqual(Object.keys(map), ["a"]);
-    assert.equal(map.a.total, 20);
-    assert.equal(map.a.qty, 2);
+    const recordA = map.a;
+    assert.ok(recordA);
+    assert.equal(recordA.total, 20);
+    assert.equal(recordA.qty, 2);
   });
   it("skips items without a valid string primary key", () => {
     const schema = makeSchema({ id: field("text") });

--- a/test/plugins/collection/test_linkedCollectionCaches.ts
+++ b/test/plugins/collection/test_linkedCollectionCaches.ts
@@ -82,7 +82,9 @@ describe("fetchLinkedCaches", () => {
     const snap = await fetchLinkedCaches(linkedTargets(refAndEmbedSchema), fetchDetail, () => "cur", "cur");
     assert.ok(snap);
     assert.deepEqual(snap.refCache.people, { a: "Alice", b: "Bob" });
-    assert.deepEqual(Object.keys(snap.refRecordCache.people).sort(), ["a", "b"]);
+    const peopleRecords = snap.refRecordCache.people;
+    assert.ok(peopleRecords);
+    assert.deepEqual(Object.keys(peopleRecords).sort(), ["a", "b"]);
     // profiles is embed-only, so it lands in embedCache but never refCache.
     assert.equal(snap.refCache.profiles, undefined);
     assert.equal(snap.embedCache.profiles?.items.length, 1);

--- a/test/plugins/collection/test_useCollectionRendering.ts
+++ b/test/plugins/collection/test_useCollectionRendering.ts
@@ -79,16 +79,20 @@ describe("useCollectionRendering (composition)", () => {
   it("evaluateDerivedAgainstItem reads the live refRecordCache mutated on the returned object", () => {
     const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
     render.refRecordCache.value = {}; // qty * price needs no ref records
-    assert.equal(render.evaluateDerivedAgainstItem(orderSchema.fields.total, "total", { qty: 3, price: 5 }), 15);
+    const totalSpec = orderSchema.fields.total;
+    assert.ok(totalSpec);
+    assert.equal(render.evaluateDerivedAgainstItem(totalSpec, "total", { qty: 3, price: 5 }), 15);
   });
 
   it("embedViewsFor resolves a per-record idField embed from the live embedCache", () => {
     const render = useCollectionRendering(ref<CollectionDetail | null>(orderDetail), ref("en-US"));
     render.embedCache.value = { profiles: { schema: profileSchema, items: [{ id: "you", name: "You LLC" }] } };
     const views = render.embedViewsFor({ customerId: "you" });
-    assert.equal(views.billTo.found, true);
-    assert.equal(views.billTo.recordId, "you");
-    assert.equal(views.billTo.rows.find((row) => row.key === "name")?.display, "You LLC");
+    const { billTo } = views;
+    assert.ok(billTo);
+    assert.equal(billTo.found, true);
+    assert.equal(billTo.recordId, "you");
+    assert.equal(billTo.rows.find((row) => row.key === "name")?.display, "You LLC");
   });
 
   it("resetLinkedCaches clears all three caches", () => {

--- a/test/plugins/manageSkills/test_categories.ts
+++ b/test/plugins/manageSkills/test_categories.ts
@@ -456,9 +456,10 @@ describe("manageSkills groupEntriesByRepo", () => {
   });
 
   it("sorts entries within a repo by slug", () => {
-    const groups = groupEntriesByRepo(entries, [repoA]);
+    const [group] = groupEntriesByRepo(entries, [repoA]);
+    assert.ok(group);
     assert.deepEqual(
-      groups[0].entries.map((entry) => entry.slug),
+      group.entries.map((entry) => entry.slug),
       ["a-one", "b-two"],
     );
   });
@@ -467,13 +468,16 @@ describe("manageSkills groupEntriesByRepo", () => {
     const emptyRepo = { repoId: "repo-empty", url: "https://github.com/acme/empty" };
     const groups = groupEntriesByRepo(entries, [emptyRepo]);
     assert.equal(groups.length, 1);
-    assert.deepEqual(groups[0].entries, []);
+    const [group] = groups;
+    assert.ok(group);
+    assert.deepEqual(group.entries, []);
   });
 
   it("drops entries whose repoId matches no repo", () => {
     const orphan = [{ slug: "orphan", repoId: "gone" }];
-    const groups = groupEntriesByRepo(orphan, [repoA]);
-    assert.deepEqual(groups[0].entries, []);
+    const [group] = groupEntriesByRepo(orphan, [repoA]);
+    assert.ok(group);
+    assert.deepEqual(group.entries, []);
   });
 
   it("returns no groups for an empty repo list", () => {

--- a/test/plugins/manageSkills/test_skillListEdits.ts
+++ b/test/plugins/manageSkills/test_skillListEdits.ts
@@ -8,16 +8,20 @@ const make = (name: string, description = ""): SkillSummary => ({ name, descript
 describe("updateSkillDescription", () => {
   it("replaces only the matching skill's description", () => {
     const input = [make("a", "old-a"), make("b", "old-b")];
-    const out = updateSkillDescription(input, "b", "new-b");
-    assert.equal(out[1].description, "new-b");
-    assert.equal(out[0].description, "old-a");
+    const [first, second] = updateSkillDescription(input, "b", "new-b");
+    assert.ok(first);
+    assert.ok(second);
+    assert.equal(second.description, "new-b");
+    assert.equal(first.description, "old-a");
   });
 
   it("does not mutate the input array or its objects", () => {
     const input = [make("a", "old-a")];
     const out = updateSkillDescription(input, "a", "new-a");
     assert.notEqual(out, input);
-    assert.equal(input[0].description, "old-a", "original object untouched");
+    const [original] = input;
+    assert.ok(original);
+    assert.equal(original.description, "old-a", "original object untouched");
   });
 
   it("returns an equivalent list when the name is absent", () => {
@@ -27,7 +31,9 @@ describe("updateSkillDescription", () => {
 
   it("is case-sensitive", () => {
     const input = [make("Foo", "orig")];
-    assert.equal(updateSkillDescription(input, "foo", "changed")[0].description, "orig");
+    const [unchanged] = updateSkillDescription(input, "foo", "changed");
+    assert.ok(unchanged);
+    assert.equal(unchanged.description, "orig");
   });
 
   it("handles an empty list", () => {

--- a/test/plugins/spotify/test_client.ts
+++ b/test/plugins/spotify/test_client.ts
@@ -12,10 +12,23 @@ interface FakeRuntimeOpts {
   responses: Response[];
 }
 
+interface CallRecord {
+  url: string;
+  method?: string | undefined;
+  headers?: Record<string, string> | undefined;
+  body?: string | undefined;
+}
+
+function callAt(calls: CallRecord[], index: number): CallRecord {
+  const call = calls[index];
+  assert.ok(call, `expected runtime.fetch call #${index}`);
+  return call;
+}
+
 /** Build a faux `PluginRuntime` covering only the surface
  *  `client.ts` touches (`fetch` + `files.config.write` + `log`). */
 function makeFakeRuntime(opts: FakeRuntimeOpts) {
-  const calls: { url: string; method?: string | undefined; headers?: Record<string, string> | undefined; body?: string | undefined }[] = [];
+  const calls: CallRecord[] = [];
   const written: SpotifyTokens[] = [];
   const queue = [...opts.responses];
   return {
@@ -97,8 +110,8 @@ describe("spotifyApi — happy path", () => {
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
     assert.deepEqual(result.data, { id: "user123" });
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me");
-    assert.equal(handle.calls[0].headers?.Authorization, "Bearer at-current");
+    assert.equal(callAt(handle.calls, 0).url, "https://api.spotify.com/v1/me");
+    assert.equal(callAt(handle.calls, 0).headers?.Authorization, "Bearer at-current");
   });
 
   it("returns null data on 204 No Content", async () => {
@@ -120,10 +133,12 @@ describe("spotifyApi — 401 → refresh → retry once", () => {
     const result = await spotifyApi(handle.runtime as any, "cid", validTokens, "GET", "/v1/me", {}, NOW);
     assert.equal(result.ok, true);
     assert.equal(handle.calls.length, 3);
-    assert.equal(handle.calls[1].url, "https://accounts.spotify.com/api/token");
-    assert.equal(handle.calls[2].headers?.Authorization, "Bearer at-new");
+    assert.equal(callAt(handle.calls, 1).url, "https://accounts.spotify.com/api/token");
+    assert.equal(callAt(handle.calls, 2).headers?.Authorization, "Bearer at-new");
     assert.equal(handle.written.length, 1);
-    assert.equal(handle.written[0].refreshToken, "rt-current"); // preserved (Spotify didn't return a new one)
+    const [persisted] = handle.written;
+    assert.ok(persisted);
+    assert.equal(persisted.refreshToken, "rt-current"); // preserved (Spotify didn't return a new one)
   });
 
   it("does NOT loop a second refresh when the retry also returns 401", async () => {
@@ -243,8 +258,8 @@ describe("spotifyApi — proactive refresh near expiry", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = await spotifyApi(handle.runtime as any, "cid", { ...validTokens, expiresAt: ALMOST_NOW }, "GET", "/v1/me", {}, NOW);
     assert.equal(result.ok, true);
-    assert.equal(handle.calls[0].url, "https://accounts.spotify.com/api/token");
-    assert.equal(handle.calls[1].url, "https://api.spotify.com/v1/me");
+    assert.equal(callAt(handle.calls, 0).url, "https://accounts.spotify.com/api/token");
+    assert.equal(callAt(handle.calls, 1).url, "https://api.spotify.com/v1/me");
   });
 });
 

--- a/test/plugins/spotify/test_listening.ts
+++ b/test/plugins/spotify/test_listening.ts
@@ -74,6 +74,18 @@ function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
+function callAt(calls: CallRecord[], index: number): CallRecord {
+  const call = calls[index];
+  assert.ok(call, `expected runtime.fetch call #${index}`);
+  return call;
+}
+
+function entryAt<T>(entries: T[], index: number): T {
+  const entry = entries[index];
+  assert.ok(entry, `expected a normalised entry at index ${index}`);
+  return entry;
+}
+
 describe("fetchLiked", () => {
   it("calls /v1/me/tracks with the requested limit and normalises the response", async () => {
     const handle = makeFakeRuntime([
@@ -88,9 +100,9 @@ describe("fetchLiked", () => {
     const result = await fetchLiked({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, 25);
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/tracks?limit=25");
+    assert.equal(callAt(handle.calls, 0).url, "https://api.spotify.com/v1/me/tracks?limit=25");
     assert.equal(result.data.length, 2);
-    assert.equal(result.data[0].name, "Track A");
+    assert.equal(entryAt(result.data, 0).name, "Track A");
   });
 
   it("forwards client errors instead of throwing", async () => {
@@ -119,9 +131,9 @@ describe("fetchPlaylists", () => {
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
     assert.equal(handle.calls.length, 1);
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/playlists?limit=50&offset=0");
+    assert.equal(callAt(handle.calls, 0).url, "https://api.spotify.com/v1/me/playlists?limit=50&offset=0");
     assert.equal(result.data.length, 2);
-    assert.equal(result.data[0].trackCount, 10);
+    assert.equal(entryAt(result.data, 0).trackCount, 10);
   });
 
   it("walks pages while Spotify returns a `next` URL", async () => {
@@ -140,8 +152,8 @@ describe("fetchPlaylists", () => {
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
     assert.equal(handle.calls.length, 2);
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/playlists?limit=50&offset=0");
-    assert.equal(handle.calls[1].url, "https://api.spotify.com/v1/me/playlists?limit=50&offset=50");
+    assert.equal(callAt(handle.calls, 0).url, "https://api.spotify.com/v1/me/playlists?limit=50&offset=0");
+    assert.equal(callAt(handle.calls, 1).url, "https://api.spotify.com/v1/me/playlists?limit=50&offset=50");
     assert.equal(result.data.length, 2);
     assert.deepEqual(
       result.data.map((entry) => entry.id),
@@ -156,7 +168,7 @@ describe("fetchPlaylistTracks", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = await fetchPlaylistTracks({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "p1?weird/id", 60);
     assert.equal(result.ok, true);
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/playlists/p1%3Fweird%2Fid/tracks?limit=60");
+    assert.equal(callAt(handle.calls, 0).url, "https://api.spotify.com/v1/playlists/p1%3Fweird%2Fid/tracks?limit=60");
   });
 });
 
@@ -171,8 +183,8 @@ describe("fetchRecent", () => {
     const result = await fetchRecent({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, 50);
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/recently-played?limit=50");
-    assert.equal(result.data[0].playedAt, "2026-05-05T10:00:00.000Z");
+    assert.equal(callAt(handle.calls, 0).url, "https://api.spotify.com/v1/me/player/recently-played?limit=50");
+    assert.equal(entryAt(result.data, 0).playedAt, "2026-05-05T10:00:00.000Z");
   });
 });
 

--- a/test/plugins/spotify/test_normalize.ts
+++ b/test/plugins/spotify/test_normalize.ts
@@ -15,6 +15,12 @@ import {
   normaliseTrackList,
 } from "../../../packages/plugins/spotify-plugin/src/normalize.js";
 
+function entryAt<T>(entries: T[], index: number): T {
+  const entry = entries[index];
+  assert.ok(entry, `expected a normalised entry at index ${index}`);
+  return entry;
+}
+
 describe("normaliseTrack", () => {
   it("collapses a full Spotify track to the View-friendly shape", () => {
     const result = normaliseTrack({
@@ -90,14 +96,14 @@ describe("normaliseTrackList", () => {
       "track",
     );
     assert.equal(result.length, 2);
-    assert.equal(result[0].id, "a");
-    assert.equal(result[1].name, "Liked B");
+    assert.equal(entryAt(result, 0).id, "a");
+    assert.equal(entryAt(result, 1).name, "Liked B");
   });
 
   it("walks `items[]` without a wrapper when trackPath is `self`", () => {
     const result = normaliseTrackList({ items: [{ id: "p", name: "Direct" }] }, "self");
     assert.equal(result.length, 1);
-    assert.equal(result[0].id, "p");
+    assert.equal(entryAt(result, 0).id, "p");
   });
 
   it("drops items that fail validation rather than crashing the list", () => {
@@ -108,7 +114,7 @@ describe("normaliseTrackList", () => {
       "track",
     );
     assert.equal(result.length, 1);
-    assert.equal(result[0].name, "Good");
+    assert.equal(entryAt(result, 0).name, "Good");
   });
 
   it("returns [] for non-record inputs", () => {
@@ -127,8 +133,8 @@ describe("normaliseRecentlyPlayed", () => {
       ],
     });
     assert.equal(result.length, 2);
-    assert.equal(result[0].playedAt, "2026-05-05T10:00:00.000Z");
-    assert.equal(result[1].track.name, "T2");
+    assert.equal(entryAt(result, 0).playedAt, "2026-05-05T10:00:00.000Z");
+    assert.equal(entryAt(result, 1).track.name, "T2");
   });
 
   it("drops entries whose track fails validation", () => {
@@ -139,12 +145,12 @@ describe("normaliseRecentlyPlayed", () => {
       ],
     });
     assert.equal(result.length, 1);
-    assert.equal(result[0].track.id, "a");
+    assert.equal(entryAt(result, 0).track.id, "a");
   });
 
   it("uses empty string when played_at is missing", () => {
     const result = normaliseRecentlyPlayed({ items: [{ track: { id: "a", name: "T" } }] });
-    assert.equal(result[0].playedAt, "");
+    assert.equal(entryAt(result, 0).playedAt, "");
   });
 });
 
@@ -282,7 +288,7 @@ describe("normalisePlaylistList", () => {
       items: [{ id: "ok", name: "Real" }, { id: "no-name" }, null],
     });
     assert.equal(result.length, 1);
-    assert.equal(result[0].id, "ok");
+    assert.equal(entryAt(result, 0).id, "ok");
   });
 });
 

--- a/test/plugins/spotify/test_playback.ts
+++ b/test/plugins/spotify/test_playback.ts
@@ -77,21 +77,27 @@ function noContent(): Response {
   return new Response(null, { status: 204 });
 }
 
+function onlyCall(calls: CallRecord[]): CallRecord {
+  const [call] = calls;
+  assert.ok(call, "expected runtime.fetch to have been called");
+  return call;
+}
+
 describe("playerPlay", () => {
   it("PUTs /v1/me/player/play with NO body for plain resume", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerPlay({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, {});
-    assert.equal(handle.calls[0].method, "PUT");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/play");
-    assert.equal(handle.calls[0].body, undefined);
+    assert.equal(onlyCall(handle.calls).method, "PUT");
+    assert.equal(onlyCall(handle.calls).url, "https://api.spotify.com/v1/me/player/play");
+    assert.equal(onlyCall(handle.calls).body, undefined);
   });
 
   it("includes context_uri in the body when provided", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerPlay({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, { contextUri: "spotify:playlist:abc" });
-    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { context_uri: "spotify:playlist:abc" });
+    assert.deepEqual(JSON.parse(onlyCall(handle.calls).body ?? "{}"), { context_uri: "spotify:playlist:abc" });
   });
 
   it("includes uris[] in the body for trackUris (mutually exclusive with contextUri)", async () => {
@@ -101,14 +107,14 @@ describe("playerPlay", () => {
       { runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW },
       { trackUris: ["spotify:track:a", "spotify:track:b"] },
     );
-    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { uris: ["spotify:track:a", "spotify:track:b"] });
+    assert.deepEqual(JSON.parse(onlyCall(handle.calls).body ?? "{}"), { uris: ["spotify:track:a", "spotify:track:b"] });
   });
 
   it("appends device_id query param when targeting a specific device", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerPlay({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, { deviceId: "dev1" });
-    assert.match(handle.calls[0].url, /\?device_id=dev1$/);
+    assert.match(onlyCall(handle.calls).url, /\?device_id=dev1$/);
   });
 });
 
@@ -117,24 +123,24 @@ describe("playerPause / next / previous", () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerPause({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
-    assert.equal(handle.calls[0].method, "PUT");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/pause");
+    assert.equal(onlyCall(handle.calls).method, "PUT");
+    assert.equal(onlyCall(handle.calls).url, "https://api.spotify.com/v1/me/player/pause");
   });
 
   it("next uses POST /v1/me/player/next", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerNext({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
-    assert.equal(handle.calls[0].method, "POST");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/next");
+    assert.equal(onlyCall(handle.calls).method, "POST");
+    assert.equal(onlyCall(handle.calls).url, "https://api.spotify.com/v1/me/player/next");
   });
 
   it("previous uses POST /v1/me/player/previous", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerPrevious({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
-    assert.equal(handle.calls[0].method, "POST");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player/previous");
+    assert.equal(onlyCall(handle.calls).method, "POST");
+    assert.equal(onlyCall(handle.calls).url, "https://api.spotify.com/v1/me/player/previous");
   });
 });
 
@@ -143,15 +149,15 @@ describe("playerSeek + playerSetVolume", () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerSeek({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, 30_000);
-    assert.match(handle.calls[0].url, /\/seek\?position_ms=30000/);
-    assert.equal(handle.calls[0].method, "PUT");
+    assert.match(onlyCall(handle.calls).url, /\/seek\?position_ms=30000/);
+    assert.equal(onlyCall(handle.calls).method, "PUT");
   });
 
   it("setVolume puts volume_percent in the URL query", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerSetVolume({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, 75);
-    assert.match(handle.calls[0].url, /\/volume\?volume_percent=75/);
+    assert.match(onlyCall(handle.calls).url, /\/volume\?volume_percent=75/);
   });
 });
 
@@ -160,16 +166,16 @@ describe("playerTransfer", () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerTransfer({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "device-x", undefined);
-    assert.equal(handle.calls[0].method, "PUT");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me/player");
-    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { device_ids: ["device-x"] });
+    assert.equal(onlyCall(handle.calls).method, "PUT");
+    assert.equal(onlyCall(handle.calls).url, "https://api.spotify.com/v1/me/player");
+    assert.deepEqual(JSON.parse(onlyCall(handle.calls).body ?? "{}"), { device_ids: ["device-x"] });
   });
 
   it("includes play: true when requested", async () => {
     const handle = makeFakeRuntime([noContent()]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await playerTransfer({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "device-x", true);
-    assert.deepEqual(JSON.parse(handle.calls[0].body ?? "{}"), { device_ids: ["device-x"], play: true });
+    assert.deepEqual(JSON.parse(onlyCall(handle.calls).body ?? "{}"), { device_ids: ["device-x"], play: true });
   });
 });
 
@@ -211,9 +217,12 @@ describe("playerGetDevices — normalisation", () => {
     const result = await playerGetDevices({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW });
     if (!result.ok) throw new Error("unreachable");
     assert.equal(result.data.length, 2);
-    assert.equal(result.data[0].id, null);
-    assert.equal(result.data[0].name, "Restricted Speaker");
-    assert.equal(result.data[1].id, null);
+    const [restricted, anonymous] = result.data;
+    assert.ok(restricted);
+    assert.ok(anonymous);
+    assert.equal(restricted.id, null);
+    assert.equal(restricted.name, "Restricted Speaker");
+    assert.equal(anonymous.id, null);
   });
 
   it("still drops devices with no `name` (a nameless device is not useful to surface)", async () => {

--- a/test/plugins/spotify/test_profile.ts
+++ b/test/plugins/spotify/test_profile.ts
@@ -84,7 +84,9 @@ describe("getProfile — fresh fetch + cache write", () => {
     if (!result.ok) throw new Error("unreachable");
     assert.equal(result.profile.product, "premium");
     assert.equal(result.profile.displayName, "Test User");
-    assert.equal(handle.calls[0].url, "https://api.spotify.com/v1/me");
+    const [profileCall] = handle.calls;
+    assert.ok(profileCall);
+    assert.equal(profileCall.url, "https://api.spotify.com/v1/me");
     // profile.json should be written.
     assert.ok(handle.store.has("profile.json"));
   });

--- a/test/plugins/spotify/test_search.ts
+++ b/test/plugins/spotify/test_search.ts
@@ -67,22 +67,28 @@ function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
 }
 
+function onlyCall(calls: CallRecord[]): CallRecord {
+  const [call] = calls;
+  assert.ok(call, "expected runtime.fetch to have been called");
+  return call;
+}
+
 describe("searchSpotify — URL construction", () => {
   it("includes all four types when `types` is undefined (default)", async () => {
     const handle = makeFakeRuntime([jsonResponse({})]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await searchSpotify({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "Bach", undefined, undefined);
-    assert.match(handle.calls[0].url, /type=track,artist,album,playlist/);
-    assert.match(handle.calls[0].url, /q=Bach/);
-    assert.match(handle.calls[0].url, /limit=10/);
+    assert.match(onlyCall(handle.calls).url, /type=track,artist,album,playlist/);
+    assert.match(onlyCall(handle.calls).url, /q=Bach/);
+    assert.match(onlyCall(handle.calls).url, /limit=10/);
   });
 
   it("respects an explicit `types` array", async () => {
     const handle = makeFakeRuntime([jsonResponse({})]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await searchSpotify({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "test", ["artist"], 5);
-    assert.match(handle.calls[0].url, /type=artist(?!,)/);
-    assert.match(handle.calls[0].url, /limit=5/);
+    assert.match(onlyCall(handle.calls).url, /type=artist(?!,)/);
+    assert.match(onlyCall(handle.calls).url, /limit=5/);
   });
 
   it("URL-encodes a query with spaces / special characters", async () => {
@@ -90,7 +96,7 @@ describe("searchSpotify — URL construction", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await searchSpotify({ runtime: handle.runtime as any, clientId: "cid", tokens: validTokens, now: NOW }, "Daft Punk & friends", undefined, undefined);
     // URLSearchParams encodes space as `+`
-    assert.match(handle.calls[0].url, /q=Daft\+Punk\+%26\+friends/);
+    assert.match(onlyCall(handle.calls).url, /q=Daft\+Punk\+%26\+friends/);
   });
 });
 
@@ -111,8 +117,12 @@ describe("searchSpotify — response normalisation", () => {
     );
     assert.equal(result.ok, true);
     if (!result.ok) throw new Error("unreachable");
-    assert.equal(result.data.tracks?.length, 1);
-    assert.equal(result.data.tracks?.[0].name, "Track One");
+    const { tracks } = result.data;
+    assert.ok(tracks);
+    assert.equal(tracks.length, 1);
+    const [firstTrack] = tracks;
+    assert.ok(firstTrack);
+    assert.equal(firstTrack.name, "Track One");
     // Artists key must be absent because the caller didn't request it.
     assert.equal("artists" in result.data, false);
   });

--- a/test/plugins/spreadsheet/engine/cellAccess.ts
+++ b/test/plugins/spreadsheet/engine/cellAccess.ts
@@ -1,0 +1,18 @@
+// Reading a cell out of a calculated grid. `0`, `""` and `false` are all
+// legitimate cell values, so absence has to be tested explicitly — a truthiness
+// check would reject a correct answer, and an assertion on `undefined` would let
+// a missing row pass unnoticed.
+
+import type { CellValue } from "../../../../src/plugins/spreadsheet/engine/types.ts";
+
+export const rowAt = (grid: CellValue[][], row: number): CellValue[] => {
+  const line = grid[row];
+  if (line === undefined) throw new Error(`calculated sheet has no row ${row}`);
+  return line;
+};
+
+export const cellAt = (grid: CellValue[][], row: number, col: number): CellValue => {
+  const cell = rowAt(grid, row)[col];
+  if (cell === undefined) throw new Error(`calculated sheet has no cell (${row}, ${col})`);
+  return cell;
+};

--- a/test/plugins/spreadsheet/engine/test_argCountValidation.ts
+++ b/test/plugins/spreadsheet/engine/test_argCountValidation.ts
@@ -13,13 +13,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData, type CellValue } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 /** Calculate `sheet` and report the value, error type, and recorded message for
  *  the cell at (row, col). */
 function cellResult(sheet: SheetData, row: number, col: number): { value: CellValue; type?: string | undefined; message?: string | undefined } {
   const result = new SpreadsheetEngine().calculate(sheet);
   const entry = result.errors.find((err) => err.cell.row === row && err.cell.col === col);
-  return { value: result.data[row][col], type: entry?.type, message: entry?.error };
+  return { value: cellAt(result.data, row, col), type: entry?.type, message: entry?.error };
 }
 
 /** A one-cell sheet holding `formula` at A1 (for formulas that need no other cells). */

--- a/test/plugins/spreadsheet/engine/test_calculateDateLocale.ts
+++ b/test/plugins/spreadsheet/engine/test_calculateDateLocale.ts
@@ -9,10 +9,12 @@ import assert from "node:assert/strict";
 // Imported through the barrel, not the class module: `engine/index.ts` is what
 // registers the built-in functions, so a direct import leaves DAY() unknown.
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt, rowAt } from "./cellAccess.ts";
 
 const sheetWith = (value: string): SheetData => ({ name: "S", data: [[{ v: value }]] });
 
-const renderedCell = (value: string, preferDDMMYYYY: boolean): unknown => new SpreadsheetEngine({ preferDDMMYYYY }).calculate(sheetWith(value)).data[0][0];
+const renderedCell = (value: string, preferDDMMYYYY: boolean): unknown =>
+  cellAt(new SpreadsheetEngine({ preferDDMMYYYY }).calculate(sheetWith(value)).data, 0, 0);
 
 describe("date order reaches the cell", () => {
   // The whole point: the same text means different days in different places,
@@ -29,8 +31,8 @@ describe("date order reaches the cell", () => {
     const dayFirst = new SpreadsheetEngine({ preferDDMMYYYY: true }).calculate(sheetWith("03/04/2025"));
     // Same displayed text, different underlying dates — which is exactly what a
     // user in each locale expects to see.
-    assert.equal(monthFirst.data[0][0], "03/04/2025");
-    assert.equal(dayFirst.data[0][0], "03/04/2025");
+    assert.equal(cellAt(monthFirst.data, 0, 0), "03/04/2025");
+    assert.equal(cellAt(dayFirst.data, 0, 0), "03/04/2025");
   });
 
   // Month-name formats are exercised in test_formatter.ts; this only needs the
@@ -64,7 +66,7 @@ describe("date order reaches the cell", () => {
 
 describe("date order reaches formulas", () => {
   const formulaResult = (cells: string[], preferDDMMYYYY: boolean): unknown =>
-    new SpreadsheetEngine({ preferDDMMYYYY }).calculate({ name: "S", data: [cells.map((cell) => ({ v: cell }))] }).data[0].at(-1);
+    rowAt(new SpreadsheetEngine({ preferDDMMYYYY }).calculate({ name: "S", data: [cells.map((cell) => ({ v: cell }))] }).data, 0).at(-1);
 
   // `DAY()` reads the serial, so it reports which number the parser took as the
   // day — the clearest observable difference between the two settings.

--- a/test/plugins/spreadsheet/engine/test_cellEmpty.ts
+++ b/test/plugins/spreadsheet/engine/test_cellEmpty.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { isEmptyCell } from "../../../../src/plugins/spreadsheet/engine/cellEmpty.ts";
 import type { SpreadsheetCell } from "../../../../src/plugins/spreadsheet/engine/types.ts";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 describe("isEmptyCell — empty", () => {
   it("treats an absent cell as empty", () => {
@@ -65,7 +66,7 @@ describe("blank cells are not values in an aggregate (#2358)", () => {
     name: "S",
     data: [[{ v: 10 }, { v: formula }], [{ v: 20 }], [{ v: 30 }], [{ v: "" }], [{ v: null } as unknown as SpreadsheetCell]],
   });
-  const run = (formula: string): unknown => new SpreadsheetEngine().calculate(withBlanks(formula)).data[0][1];
+  const run = (formula: string): unknown => cellAt(new SpreadsheetEngine().calculate(withBlanks(formula)).data, 0, 1);
 
   it("excludes blanks from AVERAGE's denominator", () => {
     assert.equal(run("=AVERAGE(A1:A5)"), 20, "not 15, which counts the two blanks as 0");
@@ -90,12 +91,12 @@ describe("blank cells are not values in an aggregate (#2358)", () => {
   // though a blank does not.
   it("still counts a stored zero", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 10 }, { v: "=COUNT(A1:A3)" }], [{ v: 0 }], [{ v: 20 }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], 3);
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), 3);
   });
 
   it("averages a stored zero in, but not a blank", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 6 }, { v: "=AVERAGE(A1:A3)" }], [{ v: 0 }], [{ v: "" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], 3, "(6 + 0) / 2, the blank excluded");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), 3, "(6 + 0) / 2, the blank excluded");
   });
 });
 
@@ -117,6 +118,6 @@ describe("blanks stay in the raw range so criteria and values stay aligned", () 
     // A1=10, A3=20, A4=30 are >5; their B values are 100, 300, 400 → 800.
     // If the blank A2 shifted the value range, B would misalign and the sum
     // would be wrong.
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][2], 800);
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 2), 800);
   });
 });

--- a/test/plugins/spreadsheet/engine/test_cellRefSubstitution.ts
+++ b/test/plugins/spreadsheet/engine/test_cellRefSubstitution.ts
@@ -5,13 +5,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, renderOperand, findCellRefs, endOfStringLiteral, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt, rowAt } from "./cellAccess.ts";
 
 /** A single column of values, with `formula` in the cell beside the first. */
 function columnSheet(values: (string | number)[], formula: string): SheetData {
   return { name: "S", data: values.map((value, index) => (index === 0 ? [{ v: value }, { v: formula }] : [{ v: value }])) };
 }
 
-const evaluate = (sheet: SheetData): unknown => new SpreadsheetEngine().calculate(sheet).data[0][1];
+const evaluate = (sheet: SheetData): unknown => cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1);
 
 describe("cell reference substitution — prefix collisions", () => {
   // A global string replace rewrote every occurrence of the shorter reference
@@ -35,7 +36,7 @@ describe("cell reference substitution — prefix collisions", () => {
   // the substring sense, and the old replace did not care about boundaries.
   it("does not let B1 rewrite AB1", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 0 }, { v: 2 }, { v: "=B1+AB1" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][2], 2, "AB1 is empty, so the sum is B1 alone");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 2), 2, "AB1 is empty, so the sum is B1 alone");
   });
 
   it("handles several colliding references in one formula", () => {
@@ -51,7 +52,7 @@ describe("a lone reference returns the cell value unchanged", () => {
   // review): `=A1` on `say "hi"` came back `say \"hi\"`.
   it("returns text with quotes and backslashes intact", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 'say "hi"' }, { v: "=A1" }, { v: "=$A$1" }]] };
-    const [row] = new SpreadsheetEngine().calculate(sheet).data;
+    const row = rowAt(new SpreadsheetEngine().calculate(sheet).data, 0);
     assert.equal(row[1], 'say "hi"');
     assert.equal(row[2], 'say "hi"', "absolute form too");
   });
@@ -62,30 +63,30 @@ describe("a lone reference returns the cell value unchanged", () => {
   it("takes the fast path despite surrounding whitespace", () => {
     for (const formula of ["= A1", "=A1 ", "=  A1  "]) {
       const sheet: SheetData = { name: "S", data: [[{ v: 'say "hi"' }, { v: formula }]] };
-      assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], 'say "hi"', `${formula} should return the value verbatim`);
+      assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), 'say "hi"', `${formula} should return the value verbatim`);
     }
   });
 
   it("still substitutes when whitespace surrounds a reference inside an expression", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 3 }, { v: "= A1 + 1" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], 4);
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), 4);
   });
 
   it("returns a backslash-bearing string intact", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: "C:\\path" }, { v: "=A1" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "C:\\path");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), "C:\\path");
   });
 
   it("returns a number, not its string form", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 42 }, { v: "=A1" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], 42);
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), 42);
   });
 
   // The fast path is only for a formula that is EXACTLY one reference; the
   // moment it is part of an expression the substitution path takes over.
   it("does not take the fast path when the reference is part of an expression", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 3 }, { v: "=A1+1" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], 4);
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), 4);
   });
 });
 

--- a/test/plugins/spreadsheet/engine/test_concatSafety.ts
+++ b/test/plugins/spreadsheet/engine/test_concatSafety.ts
@@ -8,6 +8,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { maskStringLiterals, isSafeConcatExpression, SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 describe("maskStringLiterals", () => {
   it("empties a double- or single-quoted literal, keeping the quotes", () => {
@@ -77,7 +78,7 @@ describe("isSafeConcatExpression", () => {
 
 describe("string concatenation through the engine (#2376)", () => {
   const concat = (cellValue: string): unknown =>
-    new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: cellValue }, { v: '=A1&"!"' }]] } satisfies SheetData).data[0][1];
+    cellAt(new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: cellValue }, { v: '=A1&"!"' }]] } satisfies SheetData).data, 0, 1);
 
   // The plain case that was already broken: a `!` in the appended string made
   // the whole concat fail the allowlist and return the raw formula text.
@@ -103,6 +104,6 @@ describe("string concatenation through the engine (#2376)", () => {
   // raw formula text instead of the joined value (Codex review).
   it("appends a literal to a boolean cell value", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: "=1=1" }, { v: '=A1&"!"' }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "true!");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), "true!");
   });
 });

--- a/test/plugins/spreadsheet/engine/test_conditionalAggregates.ts
+++ b/test/plugins/spreadsheet/engine/test_conditionalAggregates.ts
@@ -6,6 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 // A = criteria column, B = value column (with a blank at row 2), formula in C1.
 const sheet = (formula: string): SheetData => ({
@@ -17,7 +18,7 @@ const sheet = (formula: string): SheetData => ({
   ],
 });
 
-const evalFormula = (formula: string): unknown => new SpreadsheetEngine().calculate(sheet(formula)).data[0][2];
+const evalFormula = (formula: string): unknown => cellAt(new SpreadsheetEngine().calculate(sheet(formula)).data, 0, 2);
 
 describe("SUMIF / AVERAGEIF stay row-aligned when the value range has a blank", () => {
   // Rows 1 and 3 match (A > 0); their B values are 100 and 300. The blank B2
@@ -41,6 +42,6 @@ describe("SUMIF / AVERAGEIF stay row-aligned when the value range has a blank", 
         [{ v: 1 }, { v: 300 }],
       ],
     };
-    assert.equal(new SpreadsheetEngine().calculate(withBlankMatch).data[0][2], 300);
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(withBlankMatch).data, 0, 2), 300);
   });
 });

--- a/test/plugins/spreadsheet/engine/test_criteria.ts
+++ b/test/plugins/spreadsheet/engine/test_criteria.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { parseCriteria } from "../../../../src/plugins/spreadsheet/engine/registry.ts";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 describe("parseCriteria — text is matched case-insensitively", () => {
   it("matches regardless of case", () => {
@@ -76,7 +77,7 @@ describe("COUNTIF through the engine", () => {
     const rows = values.map((value) => [{ v: value }]);
     rows.push([{ v: `=COUNTIF(A1:A${values.length}, "${criteria}")` }]);
     const sheet: SheetData = { name: "S", data: rows };
-    return new SpreadsheetEngine().calculate(sheet).data[values.length][0];
+    return cellAt(new SpreadsheetEngine().calculate(sheet).data, values.length, 0);
   };
 
   it("counts a case-differing match", () => {

--- a/test/plugins/spreadsheet/engine/test_crossSheetReference.ts
+++ b/test/plugins/spreadsheet/engine/test_crossSheetReference.ts
@@ -8,10 +8,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { rowAt } from "./cellAccess.ts";
 
 const engine = new SpreadsheetEngine();
 
-const calcRow = (target: SheetData, all: SheetData[], row = 0) => engine.calculate(target, all).data[row];
+const calcRow = (target: SheetData, all: SheetData[], row = 0) => rowAt(engine.calculate(target, all).data, row);
 
 describe("cross-sheet date reference (#2332 regression)", () => {
   const data: SheetData = { name: "Data", data: [[{ v: "03/04/2025" }]] };

--- a/test/plugins/spreadsheet/engine/test_errorReporting.ts
+++ b/test/plugins/spreadsheet/engine/test_errorReporting.ts
@@ -7,6 +7,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData, type CalculatedSheet } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const calc = (sheet: SheetData, all?: SheetData[]): CalculatedSheet => new SpreadsheetEngine().calculate(sheet, all ?? [sheet]);
 
@@ -14,7 +15,7 @@ const calc = (sheet: SheetData, all?: SheetData[]): CalculatedSheet => new Sprea
 function cellAndError(sheet: SheetData, row: number, col: number, all?: SheetData[]) {
   const result = calc(sheet, all);
   const entry = result.errors.find((err) => err.cell.row === row && err.cell.col === col);
-  return { value: result.data[row][col], errorType: entry?.type };
+  return { value: cellAt(result.data, row, col), errorType: entry?.type };
 }
 
 describe("#2359 typed error reporting", () => {
@@ -65,7 +66,7 @@ describe("#2359 typed error reporting", () => {
   it("a failed formula never lands in the cell as a bare string", () => {
     const formulas = ["=1/0", "=UNKNOWNFN(A1)", '=IFS(A1>0, "yes", "orphan")'];
     for (const formula of formulas) {
-      const [[value]] = calc({ name: "S", data: [[{ v: formula }]] }).data;
+      const value = cellAt(calc({ name: "S", data: [[{ v: formula }]] }).data, 0, 0);
       assert.equal(typeof value === "string" && value.startsWith("#"), true, `${formula} → ${JSON.stringify(value)} should be an # error value`);
     }
   });
@@ -88,13 +89,13 @@ describe("#2359 success paths are preserved", () => {
   });
 
   it("valid SUM and arithmetic are unaffected", () => {
-    assert.equal(calc({ name: "S", data: [[{ v: 1 }, { v: "=SUM(A1:A3)" }], [{ v: 2 }], [{ v: 3 }]] }).data[0][1], 6);
-    assert.equal(calc({ name: "S", data: [[{ v: 2 }], [{ v: 3 }], [{ v: "=A1+A2" }]] }).data[2][0], 5);
+    assert.equal(cellAt(calc({ name: "S", data: [[{ v: 1 }, { v: "=SUM(A1:A3)" }], [{ v: 2 }], [{ v: 3 }]] }).data, 0, 1), 6);
+    assert.equal(cellAt(calc({ name: "S", data: [[{ v: 2 }], [{ v: 3 }], [{ v: "=A1+A2" }]] }).data, 2, 0), 5);
   });
 
   it("a valid cross-sheet reference still resolves", () => {
     const data: SheetData = { name: "Data", data: [[{ v: 100 }]] };
     const summary: SheetData = { name: "Summary", data: [[{ v: "=Data!A1*2" }]] };
-    assert.equal(calc(summary, [data, summary]).data[0][0], 200);
+    assert.equal(cellAt(calc(summary, [data, summary]).data, 0, 0), 200);
   });
 });

--- a/test/plugins/spreadsheet/engine/test_errorValue.ts
+++ b/test/plugins/spreadsheet/engine/test_errorValue.ts
@@ -22,6 +22,7 @@ import {
   spreadsheetError,
 } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 import type { CellValue } from "../../../../src/plugins/spreadsheet/engine/types.ts";
+import { cellAt } from "./cellAccess.ts";
 
 /** The raw computed value of a formula, before the display pass turns an error
  *  back into its code — this is where provenance is observable. */
@@ -33,7 +34,8 @@ const evaluateRaw: (formula: string) => CellValue = (formula) =>
   });
 
 /** What a single-formula sheet DISPLAYS, through the public engine API. */
-const displayed = (formula: string): CellValue => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
+const displayed = (formula: string): CellValue =>
+  cellAt(new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data, 0, 0);
 
 describe("the error value and its guard", () => {
   it("recognises an error value and rejects a string that spells the same code", () => {
@@ -122,7 +124,7 @@ describe("functions return an error VALUE, and the cell still shows its code", (
 
   it("propagates an error VALUE through a reference and shows the code", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: "=SQRT(-1)" }, { v: "=A1+1" }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "#NUM!");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), "#NUM!");
   });
 });
 
@@ -160,7 +162,7 @@ describe("IFERROR keys off provenance", () => {
 describe("IFNA keys off the error value's code", () => {
   it("substitutes the fallback for a real #N/A", () => {
     const sheet: SheetData = { name: "S", data: [[{ v: 1 }, { v: '=IFNA(MATCH(99, A1:A1, 0), "missing")' }]] };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "missing");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), "missing");
   });
 
   it("leaves a different error alone", () => {

--- a/test/plugins/spreadsheet/engine/test_financialPeriodicHandlers.ts
+++ b/test/plugins/spreadsheet/engine/test_financialPeriodicHandlers.ts
@@ -6,10 +6,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const evalA1 = (formula: string): unknown => {
   const sheet: SheetData = { name: "S", data: [[{ v: formula }]] };
-  return new SpreadsheetEngine().calculate(sheet).data[0][0];
+  return cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 0);
 };
 
 const closeTo = (actual: unknown, expected: number, eps = 0.01): boolean => typeof actual === "number" && Math.abs(actual - expected) <= eps;

--- a/test/plugins/spreadsheet/engine/test_formulaRefs.ts
+++ b/test/plugins/spreadsheet/engine/test_formulaRefs.ts
@@ -324,8 +324,10 @@ describe("extractCellReferences — boundary / precision", () => {
     // still produce a valid integer.
     const refs = extractCellReferences("=A1048576");
     assert.equal(refs.length, 1);
-    assert.equal(refs[0].row, 1048575);
-    assert.equal(refs[0].col, 0);
+    const [ref] = refs;
+    assert.ok(ref);
+    assert.equal(ref.row, 1048575);
+    assert.equal(ref.col, 0);
   });
 });
 

--- a/test/plugins/spreadsheet/engine/test_ifBranchEvaluation.ts
+++ b/test/plugins/spreadsheet/engine/test_ifBranchEvaluation.ts
@@ -8,10 +8,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const evaluate = (rows: (string | number)[][], row: number, col: number): unknown => {
   const sheet: SheetData = { name: "S", data: rows.map((cells) => cells.map((value) => ({ v: value }))) };
-  return new SpreadsheetEngine().calculate(sheet).data[row][col];
+  return cellAt(new SpreadsheetEngine().calculate(sheet).data, row, col);
 };
 
 describe("IF evaluates a nested function branch, whatever the function", () => {

--- a/test/plugins/spreadsheet/engine/test_ifsInjection.ts
+++ b/test/plugins/spreadsheet/engine/test_ifsInjection.ts
@@ -8,11 +8,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const marker = globalThis as Record<string, unknown>;
 
 const calculate = (cellValue: string, formula: string): unknown =>
-  new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: cellValue }, { v: formula }]] } satisfies SheetData).data[0][1];
+  cellAt(new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: cellValue }, { v: formula }]] } satisfies SheetData).data, 0, 1);
 
 describe("IFS — normal use", () => {
   it("returns the first matching branch", () => {
@@ -137,11 +138,11 @@ describe("IFS — a cell value ending in a backslash substitutes intact", () => 
   });
 
   it("matches two cells that both end in a backslash", () => {
-    assert.equal(new SpreadsheetEngine().calculate(trailingBackslashSheet("a\\")).data[0][1], "eq");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(trailingBackslashSheet("a\\")).data, 0, 1), "eq");
   });
 
   it("does not match a backslash cell against different text", () => {
-    assert.equal(new SpreadsheetEngine().calculate(trailingBackslashSheet("ab")).data[0][1], "ne");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(trailingBackslashSheet("ab")).data, 0, 1), "ne");
   });
 
   it("treats a bare backslash-bearing cell as truthy text", () => {
@@ -160,7 +161,7 @@ describe("IFS — a reference inside a string literal stays literal text", () =>
         [{ v: 0 }, { v: 99 }],
       ],
     };
-    assert.equal(new SpreadsheetEngine().calculate(sheet).data[0][1], "hit", "A1's text equals the literal B2");
+    assert.equal(cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1), "hit", "A1's text equals the literal B2");
   });
 });
 

--- a/test/plugins/spreadsheet/engine/test_logicalFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_logicalFunctions.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
 import { coerceToBoolean } from "../../../../src/plugins/spreadsheet/engine/coerce-boolean.ts";
+import { cellAt } from "./cellAccess.ts";
 
 describe("coerceToBoolean", () => {
   it("passes booleans through", () => {
@@ -51,7 +52,8 @@ describe("coerceToBoolean", () => {
 });
 
 describe("IF and AND/OR/NOT agree on the same value", () => {
-  const evalFormula = (formula: string): unknown => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
+  const evalFormula = (formula: string): unknown =>
+    cellAt(new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data, 0, 0);
 
   // Each value should send IF down the false branch exactly when AND/OR/NOT read
   // it as false. Previously IF("0") returned 1 while AND("0") returned false.

--- a/test/plugins/spreadsheet/engine/test_lookupBounds.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupBounds.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { resolveTableOffset } from "../../../../src/plugins/spreadsheet/engine/formulaRefs.ts";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 // A1:B2 = [a, 1] / [b, 2]; the formula sits in C1.
 const table = (formula: string): unknown => {
@@ -17,7 +18,7 @@ const table = (formula: string): unknown => {
       [{ v: "b" }, { v: 2 }],
     ],
   };
-  return new SpreadsheetEngine().calculate(sheet).data[0][2];
+  return cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 2);
 };
 
 describe("resolveTableOffset", () => {
@@ -103,7 +104,7 @@ describe("single-line tables still reject index 0", () => {
       name: "S",
       data: [[{ v: "a" }, { v: formula }], [{ v: "b" }]],
     };
-    return new SpreadsheetEngine().calculate(sheet).data[0][1];
+    return cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1);
   };
 
   it("is #REF! for VLOOKUP with index 0 on a single-column table", () => {

--- a/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
@@ -7,13 +7,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 /** Calculate `formula` in cell A-after-the-data of a single sheet built from `rows`. */
 const evalInSheet = (rows: (string | number)[][], formula: string): unknown => {
   const data = rows.map((row) => row.map((value) => ({ v: value })));
   data.push([{ v: formula }]);
   const result = new SpreadsheetEngine().calculate({ name: "S", data });
-  return result.data[data.length - 1][0];
+  return cellAt(result.data, data.length - 1, 0);
 };
 
 describe("VLOOKUP — same sheet", () => {
@@ -54,7 +55,8 @@ describe("VLOOKUP — cross-sheet table array (#2390: no longer throws)", () => 
     };
     const main: SheetData = { name: "Main", data: [[{ v: '=VLOOKUP("Bob", Data!A1:B3, 2, FALSE)' }]] };
     const [mainResult] = new SpreadsheetEngine().calculateWorkbook([main, data]);
-    assert.equal(mainResult.data[0][0], 20);
+    assert.ok(mainResult);
+    assert.equal(cellAt(mainResult.data, 0, 0), 20);
   });
 });
 

--- a/test/plugins/spreadsheet/engine/test_mathematicalFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_mathematicalFunctions.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../../src/plugins/spreadsheet/engine/math-ops.ts";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
 import { DIV_ZERO_ERROR, NUM_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const closeTo = (actual: number, expected: number, eps = 1e-9): boolean => Math.abs(actual - expected) <= eps;
 
@@ -135,7 +136,8 @@ describe("logWithBase — number and base domain", () => {
 });
 
 describe("the handlers surface the errors end-to-end", () => {
-  const evalFormula = (formula: string): unknown => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
+  const evalFormula = (formula: string): unknown =>
+    cellAt(new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data, 0, 0);
 
   it("displays the Excel error codes through the engine", () => {
     assert.equal(evalFormula("=FLOOR(-2.5, 2)"), "#NUM!");

--- a/test/plugins/spreadsheet/engine/test_midValue.ts
+++ b/test/plugins/spreadsheet/engine/test_midValue.ts
@@ -8,10 +8,11 @@ import assert from "node:assert/strict";
 import { takeMid, parseValueText } from "../../../../src/plugins/spreadsheet/engine/functions/text.ts";
 import { VALUE_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const evaluate = (formula: string, cell: string | number = "Hello"): unknown => {
   const sheet: SheetData = { name: "S", data: [[{ v: cell }, { v: formula }]] };
-  return new SpreadsheetEngine().calculate(sheet).data[0][1];
+  return cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1);
 };
 
 describe("takeMid — bounds", () => {

--- a/test/plugins/spreadsheet/engine/test_multiRangeAggregates.ts
+++ b/test/plugins/spreadsheet/engine/test_multiRangeAggregates.ts
@@ -6,6 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 // A = 1,2 ; B = 3,4 ; the formula sits in C1.
 const evaluate = (formula: string): unknown => {
@@ -16,7 +17,7 @@ const evaluate = (formula: string): unknown => {
       [{ v: 2 }, { v: 4 }],
     ],
   };
-  return new SpreadsheetEngine().calculate(sheet).data[0][2];
+  return cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 2);
 };
 
 describe("aggregates accept several ranges", () => {
@@ -60,7 +61,7 @@ describe("a single cell reference is read as a range, not a scalar", () => {
       name: "S",
       data: [[{ v: 5 }, { v: formula }], [{ v: "txt" }]],
     };
-    return new SpreadsheetEngine().calculate(sheet).data[0][1];
+    return cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1);
   };
 
   it("does not count an out-of-bounds cell", () => {

--- a/test/plugins/spreadsheet/engine/test_npvArgs.ts
+++ b/test/plugins/spreadsheet/engine/test_npvArgs.ts
@@ -9,6 +9,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const closeTo = (actual: number, expected: number, eps = 0.01): boolean => Math.abs(actual - expected) <= eps;
 
@@ -21,7 +22,7 @@ describe("NPV — sequential periods across mixed range and scalar arguments", (
       name: "S",
       data: [[{ v: 100 }, { v: 400 }, { v: "=NPV(0.1, A1:A3, B1)" }], [{ v: 200 }], [{ v: 300 }]],
     };
-    const result = new SpreadsheetEngine().calculate(sheet).data[0][2] as number;
+    const result = cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 2) as number;
     assert.ok(closeTo(result, 754.7967), `NPV mixed args = ${result}, expected ~754.80 (sequential)`);
   });
 
@@ -31,7 +32,7 @@ describe("NPV — sequential periods across mixed range and scalar arguments", (
       name: "S",
       data: [[{ v: 100 }, { v: "=NPV(0.1, A1:A3)" }], [{ v: 200 }], [{ v: 300 }]],
     };
-    const result = new SpreadsheetEngine().calculate(sheet).data[0][1] as number;
+    const result = cellAt(new SpreadsheetEngine().calculate(sheet).data, 0, 1) as number;
     assert.ok(closeTo(result, 481.5928), `NPV single range = ${result}, expected ~481.59`);
   });
 });

--- a/test/plugins/spreadsheet/engine/test_npvFunction.ts
+++ b/test/plugins/spreadsheet/engine/test_npvFunction.ts
@@ -6,6 +6,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const closeTo = (actual: unknown, expected: number, eps = 1e-6): boolean => typeof actual === "number" && Math.abs(actual - expected) <= eps;
 
@@ -17,13 +18,15 @@ describe("NPV — range followed by a scalar (#2390)", () => {
     };
     const result = new SpreadsheetEngine().calculate(sheet);
     const expected = 100 / 1.1 + 200 / 1.1 ** 2 + 300 / 1.1 ** 3 + 500 / 1.1 ** 4;
-    assert.ok(closeTo(result.data[3][0], expected), `NPV ≈ ${expected}, got ${result.data[3][0]}`);
+    const actual = cellAt(result.data, 3, 0);
+    assert.ok(closeTo(actual, expected), `NPV ≈ ${expected}, got ${String(actual)}`);
   });
 
   it("matches the all-scalar form when there is no range", () => {
     const sheet = { name: "S", data: [[{ v: "=NPV(0.1, 100, 200, 300, 500)" }]] };
     const result = new SpreadsheetEngine().calculate(sheet);
     const expected = 100 / 1.1 + 200 / 1.1 ** 2 + 300 / 1.1 ** 3 + 500 / 1.1 ** 4;
-    assert.ok(closeTo(result.data[0][0], expected), `NPV ≈ ${expected}, got ${result.data[0][0]}`);
+    const actual = cellAt(result.data, 0, 0);
+    assert.ok(closeTo(actual, expected), `NPV ≈ ${expected}, got ${String(actual)}`);
   });
 });

--- a/test/plugins/spreadsheet/engine/test_numericFunctions2391.ts
+++ b/test/plugins/spreadsheet/engine/test_numericFunctions2391.ts
@@ -5,6 +5,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 // Column A holds `colA` (one value per row); `formula` goes in a row below it so a
 // range like A1:A3 never overlaps the formula cell.
@@ -12,7 +13,7 @@ const evalWithColumnA = (formula: string, colA: (string | number)[] = []): unkno
   const data: { v: string | number }[][] = colA.map((value) => [{ v: value }]);
   data.push([{ v: formula }]);
   const result = new SpreadsheetEngine().calculate({ name: "S", data } as SheetData);
-  return result.data[data.length - 1][0];
+  return cellAt(result.data, data.length - 1, 0);
 };
 
 describe("ABS / SIGN — scalar coercion (#2391)", () => {

--- a/test/plugins/spreadsheet/engine/test_rangeFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_rangeFunctions.ts
@@ -5,6 +5,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine, type SheetData } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 /** A single column of numbers with `formula` beside the first cell. */
 const column = (values: number[], formula: string): SheetData => ({
@@ -12,7 +13,7 @@ const column = (values: number[], formula: string): SheetData => ({
   data: values.map((value, index) => (index === 0 ? [{ v: value }, { v: formula }] : [{ v: value }])),
 });
 
-const result = (values: number[], formula: string): unknown => new SpreadsheetEngine().calculate(column(values, formula)).data[0][1];
+const result = (values: number[], formula: string): unknown => cellAt(new SpreadsheetEngine().calculate(column(values, formula)).data, 0, 1);
 
 describe("range references that used to return 0", () => {
   it("sums an absolute range", () => {

--- a/test/plugins/spreadsheet/engine/test_statisticalFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_statisticalFunctions.ts
@@ -6,13 +6,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 /** Calculate `formula` in the cell just below a single column of `values`. */
 const evalOverColumn = (values: (string | number)[], formula: string): unknown => {
   const data: { v: string | number }[][] = values.map((value) => [{ v: value }]);
   data.push([{ v: formula }]);
   const result = new SpreadsheetEngine().calculate({ name: "S", data });
-  return result.data[data.length - 1][0];
+  return cellAt(result.data, data.length - 1, 0);
 };
 
 // {2,4,4,4,5,5,7,9}: mean 5, Σ(x-μ)² = 32.

--- a/test/plugins/spreadsheet/engine/test_textFormat.ts
+++ b/test/plugins/spreadsheet/engine/test_textFormat.ts
@@ -14,9 +14,10 @@ import assert from "node:assert/strict";
 import { formatWithPattern, parseNumberPattern } from "../../../../src/plugins/spreadsheet/engine/textFormat.ts";
 import { groupThousands } from "../../../../src/plugins/spreadsheet/engine/formatter.ts";
 import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 const engine = new SpreadsheetEngine();
-const evalFormula = (formula: string): unknown => engine.calculate(engine.createSheet("S", [[`=${formula}`]])).data[0][0];
+const evalFormula = (formula: string): unknown => cellAt(engine.calculate(engine.createSheet("S", [[`=${formula}`]])).data, 0, 0);
 
 describe("formatWithPattern — the cases reported in #2360", () => {
   it("groups digits for a currency pattern", () => {
@@ -240,7 +241,7 @@ describe("TEXT — end to end through SpreadsheetEngine", () => {
 
   it("formats a cell reference the same way", () => {
     const sheet = engine.createSheet("S", [[{ v: 1234.5 }, { v: '=TEXT(A1,"$#,##0.00")' }]]);
-    assert.equal(engine.calculate(sheet).data[0][1], "$1,234.50");
+    assert.equal(cellAt(engine.calculate(sheet).data, 0, 1), "$1,234.50");
   });
 
   it("returns the value's own text for a format code it does not render", () => {

--- a/test/plugins/spreadsheet/engine/test_textFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_textFunctions.ts
@@ -14,13 +14,14 @@ import assert from "node:assert/strict";
 import { substituteText, takeLeft, takeRight, toProperCase } from "../../../../src/plugins/spreadsheet/engine/functions/text.ts";
 import { SpreadsheetEngine } from "../../../../src/plugins/spreadsheet/engine/index.ts";
 import { VALUE_ERROR } from "../../../../src/plugins/spreadsheet/engine/spreadsheet-errors.ts";
+import { cellAt } from "./cellAccess.ts";
 
 // The engine's display pass renders an error VALUE back to its code, so the
 // end-to-end assertions compare against the string a cell shows.
 const VALUE_ERROR_TEXT = VALUE_ERROR.code;
 
 const engine = new SpreadsheetEngine();
-const evalFormula = (formula: string): unknown => engine.calculate(engine.createSheet("S", [[`=${formula}`]])).data[0][0];
+const evalFormula = (formula: string): unknown => cellAt(engine.calculate(engine.createSheet("S", [[`=${formula}`]])).data, 0, 0);
 
 describe("substituteText — empty old_text", () => {
   it("returns the text unchanged instead of inserting between characters", () => {

--- a/test/plugins/spreadsheet/engine/test_translateFormula.ts
+++ b/test/plugins/spreadsheet/engine/test_translateFormula.ts
@@ -18,6 +18,7 @@ import {
   SpreadsheetEngine,
   type SheetData,
 } from "../../../../src/plugins/spreadsheet/engine/index.ts";
+import { cellAt } from "./cellAccess.ts";
 
 describe("caretToPow", () => {
   it("rewrites a single caret to the JS exponentiation operator", () => {
@@ -166,7 +167,7 @@ describe("isSafeComparison", () => {
 // to the exact behaviour observed before the extraction. Includes the
 // intentionally-wrong cases so the eventual #2359 fix shows up as a diff here.
 describe("translation through the engine (characterization)", () => {
-  const calc = (formula: string): unknown => new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data[0][0];
+  const calc = (formula: string): unknown => cellAt(new SpreadsheetEngine().calculate({ name: "S", data: [[{ v: formula }]] } satisfies SheetData).data, 0, 0);
 
   it("exponentiates (and keeps the JS-associativity quirk)", () => {
     assert.equal(calc("=2^3"), 8);

--- a/test/plugins/spreadsheet/test_cellHighlights.ts
+++ b/test/plugins/spreadsheet/test_cellHighlights.ts
@@ -49,6 +49,14 @@ function makeTable(rowsAndCols: number[][]): {
   };
 }
 
+function cellOf(rows: ReturnType<typeof makeRow>[], rowIndex: number, colIndex: number): ReturnType<typeof makeCell> {
+  const row = rows[rowIndex];
+  assert.ok(row, `mock table has no row ${rowIndex}`);
+  const cell = row.cells[colIndex];
+  assert.ok(cell, `mock row ${rowIndex} has no cell ${colIndex}`);
+  return cell;
+}
+
 // Build a HighlightableContainer with the given querySelector /
 // querySelectorAll responses. Arrays are already iterable so we can
 // return them directly.
@@ -70,8 +78,8 @@ describe("highlightCell", () => {
   it("adds className to the correct cell", () => {
     const { table, rows } = makeTable([[1, 2, 3]]);
     highlightCell(table, { row: 0, col: 1 }, "cell-editing");
-    assert.ok(rows[0].cells[1].classes.has("cell-editing"));
-    assert.ok(!rows[0].cells[0].classes.has("cell-editing"));
+    assert.ok(cellOf(rows, 0, 1).classes.has("cell-editing"));
+    assert.ok(!cellOf(rows, 0, 0).classes.has("cell-editing"));
   });
 
   it("is a no-op for a null table", () => {
@@ -81,14 +89,14 @@ describe("highlightCell", () => {
   it("is a no-op when row is out of range", () => {
     const { table, rows } = makeTable([[1]]);
     highlightCell(table, { row: 5, col: 0 }, "x");
-    assert.equal(rows[0].cells[0].classes.size, 0);
+    assert.equal(cellOf(rows, 0, 0).classes.size, 0);
   });
 
   it("is a no-op when col is out of range", () => {
     const { table, rows } = makeTable([[1, 2]]);
     highlightCell(table, { row: 0, col: 99 }, "x");
-    assert.equal(rows[0].cells[0].classes.size, 0);
-    assert.equal(rows[0].cells[1].classes.size, 0);
+    assert.equal(cellOf(rows, 0, 0).classes.size, 0);
+    assert.equal(cellOf(rows, 0, 1).classes.size, 0);
   });
 });
 
@@ -130,8 +138,8 @@ describe("applyCellHighlights", () => {
       onQuerySelector: (sel) => (sel === "#spreadsheet-table" ? table : null),
     });
     applyCellHighlights(container, { row: 0, col: 1 }, [{ row: 1, col: 2 }]);
-    assert.ok(rows[0].cells[1].classes.has("cell-editing"));
-    assert.ok(rows[1].cells[2].classes.has("cell-referenced"));
+    assert.ok(cellOf(rows, 0, 1).classes.has("cell-editing"));
+    assert.ok(cellOf(rows, 1, 2).classes.has("cell-referenced"));
   });
 
   it("no-op when container is null", () => {
@@ -149,7 +157,7 @@ describe("applyCellHighlights", () => {
       onQuerySelector: () => table,
     });
     applyCellHighlights(container, null, [{ row: 0, col: 1 }]);
-    assert.ok(!rows[0].cells[0].classes.has("cell-editing"));
-    assert.ok(rows[0].cells[1].classes.has("cell-referenced"));
+    assert.ok(!cellOf(rows, 0, 0).classes.has("cell-editing"));
+    assert.ok(cellOf(rows, 0, 1).classes.has("cell-referenced"));
   });
 });

--- a/test/plugins/test_bookmarks_integration.ts
+++ b/test/plugins/test_bookmarks_integration.ts
@@ -108,19 +108,25 @@ describe("Bookmarks plugin — end-to-end through the loader", () => {
     if (!res.bookmark) throw new Error("add must return a bookmark");
     assert.equal(res.bookmark.url, "https://example.com/");
     assert.equal(published.length, 1, "add must publish exactly one changed event");
-    assert.equal(published[0].channel, `plugin:${PKG_NAME}:changed`);
+    const [addEvent] = published;
+    assert.ok(addEvent);
+    assert.equal(addEvent.channel, `plugin:${PKG_NAME}:changed`);
 
     // 3. List returns the bookmark.
     res = (await plugin.execute({}, { kind: "list" })) as BookmarkResult;
     assert.equal(res.bookmarks?.length, 1);
     if (!res.bookmarks) throw new Error("list must return bookmarks array");
-    const [{ id }] = res.bookmarks;
+    const [listed] = res.bookmarks;
+    assert.ok(listed);
+    const { id } = listed;
 
     // 4. Remove the bookmark — should publish "changed" again.
     res = (await plugin.execute({}, { kind: "remove", id })) as BookmarkResult;
     assert.deepEqual(res, { ok: true });
     assert.equal(published.length, 2);
-    assert.equal(published[1].channel, `plugin:${PKG_NAME}:changed`);
+    const [, removeEvent] = published;
+    assert.ok(removeEvent);
+    assert.equal(removeEvent.channel, `plugin:${PKG_NAME}:changed`);
 
     // 5. List again — back to empty.
     res = (await plugin.execute({}, { kind: "list" })) as BookmarkResult;
@@ -172,7 +178,9 @@ describe("Bookmarks plugin — end-to-end through the loader", () => {
     assert.deepEqual(res, { ok: true });
 
     assert.equal(published.length, 1);
-    assert.equal(published[0].channel, `plugin:${PKG_NAME}:prefs-changed`);
+    const [prefsEvent] = published;
+    assert.ok(prefsEvent);
+    assert.equal(prefsEvent.channel, `plugin:${PKG_NAME}:prefs-changed`);
 
     // The prefs file should land under the config root, NOT data.
     const sanitisedSeg = encodeURIComponent(PKG_NAME);

--- a/test/plugins/test_dev_loader.ts
+++ b/test/plugins/test_dev_loader.ts
@@ -73,18 +73,23 @@ describe("parseDevPluginsEnv", () => {
     const value = [inputA, inputB].join(path.delimiter);
     const result = parseDevPluginsEnv(value, cwd);
     assert.equal(result.length, 2);
-    assert.equal(result[0].rawInput, inputA);
-    assert.equal(result[0].absPath, inputA);
-    assert.equal(result[1].rawInput, inputB);
-    assert.equal(result[1].absPath, inputB);
+    const [entryA, entryB] = result;
+    assert.ok(entryA);
+    assert.ok(entryB);
+    assert.equal(entryA.rawInput, inputA);
+    assert.equal(entryA.absPath, inputA);
+    assert.equal(entryB.rawInput, inputB);
+    assert.equal(entryB.absPath, inputB);
   });
 
   it("resolves relative paths against the supplied cwd", () => {
     const cwd = path.resolve("/tmp/cwd");
     const result = parseDevPluginsEnv("./local", cwd);
     assert.equal(result.length, 1);
-    assert.equal(result[0].rawInput, "./local");
-    assert.equal(result[0].absPath, path.resolve(cwd, "local"));
+    const [entry] = result;
+    assert.ok(entry);
+    assert.equal(entry.rawInput, "./local");
+    assert.equal(entry.absPath, path.resolve(cwd, "local"));
   });
 
   it("ignores empty segments (consecutive delimiters)", () => {
@@ -151,9 +156,11 @@ describe("loadDevPlugins", () => {
     const { plugins, errors } = await loadDevPlugins([{ rawInput: dir, absPath: dir }]);
     assert.deepEqual(errors, []);
     assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, "@fixture/dev-plugin");
-    assert.equal(plugins[0].version, DEV_VERSION);
-    assert.equal(plugins[0].cachePath, dir);
+    const [loaded] = plugins;
+    assert.ok(loaded);
+    assert.equal(loaded.name, "@fixture/dev-plugin");
+    assert.equal(loaded.version, DEV_VERSION);
+    assert.equal(loaded.cachePath, dir);
   });
 
   it("collects errors for invalid inputs without throwing", async () => {
@@ -161,7 +168,9 @@ describe("loadDevPlugins", () => {
     const { plugins, errors } = await loadDevPlugins([{ rawInput: ghost, absPath: ghost }]);
     assert.deepEqual(plugins, []);
     assert.equal(errors.length, 1);
-    assert.match(errors[0], /does not exist/);
+    const [error] = errors;
+    assert.ok(error);
+    assert.match(error, /does not exist/);
   });
 
   it("loads multiple plugins independently — failure of one does not block the other", async () => {
@@ -172,7 +181,9 @@ describe("loadDevPlugins", () => {
       { rawInput: okDir, absPath: okDir },
     ]);
     assert.equal(plugins.length, 1);
-    assert.equal(plugins[0].name, "@fixture/ok-one");
+    const [loaded] = plugins;
+    assert.ok(loaded);
+    assert.equal(loaded.name, "@fixture/ok-one");
     assert.equal(errors.length, 1);
   });
 });
@@ -199,8 +210,10 @@ describe("detectDevCollisions", () => {
     const dev = [fakePlugin("@a/dup", "/dev/first"), fakePlugin("@a/dup", "/dev/second")];
     const collisions = detectDevCollisions(dev, []);
     assert.equal(collisions.length, 1);
-    assert.equal(collisions[0].name, "@a/dup");
-    assert.deepEqual(collisions[0].sources, ["/dev/first", "/dev/second"]);
+    const [collision] = collisions;
+    assert.ok(collision);
+    assert.equal(collision.name, "@a/dup");
+    assert.deepEqual(collision.sources, ["/dev/first", "/dev/second"]);
   });
 
   it("flags a dev plugin colliding with an installed plugin and tags the prod source", () => {
@@ -208,8 +221,10 @@ describe("detectDevCollisions", () => {
     const prod = [fakePlugin("@a/conflict", "/prod/cache/conflict")];
     const collisions = detectDevCollisions(dev, prod);
     assert.equal(collisions.length, 1);
-    assert.equal(collisions[0].name, "@a/conflict");
-    assert.deepEqual(collisions[0].sources, ["/dev/here", "(installed) /prod/cache/conflict"]);
+    const [collision] = collisions;
+    assert.ok(collision);
+    assert.equal(collision.name, "@a/conflict");
+    assert.deepEqual(collision.sources, ["/dev/here", "(installed) /prod/cache/conflict"]);
   });
 
   it("reports both kinds of collision in one pass", () => {
@@ -233,7 +248,9 @@ describe("evaluateDevPluginGate", () => {
     assert.equal(verdict.ok, true);
     if (verdict.ok) {
       assert.equal(verdict.plugins.length, 1);
-      assert.equal(verdict.plugins[0].name, "@a/one");
+      const [gated] = verdict.plugins;
+      assert.ok(gated);
+      assert.equal(gated.name, "@a/one");
     }
   });
 
@@ -243,8 +260,11 @@ describe("evaluateDevPluginGate", () => {
     assert.equal(verdict.ok, false);
     if (!verdict.ok) {
       assert.equal(verdict.fatalMessages.length, 2);
-      assert.match(verdict.fatalMessages[0], /dist\/index\.js not found/);
-      assert.match(verdict.fatalMessages[1], /refusing to start/);
+      const [loadFailure, summary] = verdict.fatalMessages;
+      assert.ok(loadFailure);
+      assert.ok(summary);
+      assert.match(loadFailure, /dist\/index\.js not found/);
+      assert.match(summary, /refusing to start/);
     }
   });
 

--- a/test/plugins/test_dev_watcher.ts
+++ b/test/plugins/test_dev_watcher.ts
@@ -54,6 +54,12 @@ function recorder() {
   };
 }
 
+function onlyCall(calls: PublishCall[]): PublishCall {
+  const [call] = calls;
+  assert.ok(call, "expected at least one publish call");
+  return call;
+}
+
 interface TestRig {
   fire: (relativePath: string) => void;
   watcher: FakeWatcher;
@@ -94,12 +100,9 @@ describe("watchDevPlugins — debounce", () => {
     rig.fire("vue.js"); // duplicate file in burst — still 1 publish
     await sleep(150);
     assert.equal(rig.rec.calls.length, 1, `expected 1 publish; got ${rig.rec.calls.length}`);
-    assert.equal(rig.rec.calls[0].name, "@test/burst");
-    assert.deepEqual(
-      rig.rec.calls[0].changedFiles.sort(),
-      ["definition-Dvdjo6Xe.js", "style.css", "vue.js"],
-      "publish should include every distinct file in the burst",
-    );
+    const burst = onlyCall(rig.rec.calls);
+    assert.equal(burst.name, "@test/burst");
+    assert.deepEqual(burst.changedFiles.sort(), ["definition-Dvdjo6Xe.js", "style.css", "vue.js"], "publish should include every distinct file in the burst");
     rig.close();
   });
 
@@ -132,7 +135,7 @@ describe("watchDevPlugins — server-side classification", () => {
     rig.fire("vue.js");
     await sleep(80);
     assert.equal(rig.rec.calls.length, 1);
-    assert.equal(rig.rec.calls[0].serverSideChange, true);
+    assert.equal(onlyCall(rig.rec.calls).serverSideChange, true);
     assert.deepEqual(rig.rec.warns, ["@test/server-side"]);
     rig.close();
   });
@@ -144,7 +147,7 @@ describe("watchDevPlugins — server-side classification", () => {
     rig.fire("style.css");
     await sleep(80);
     assert.equal(rig.rec.calls.length, 1);
-    assert.equal(rig.rec.calls[0].serverSideChange, false);
+    assert.equal(onlyCall(rig.rec.calls).serverSideChange, false);
     assert.deepEqual(rig.rec.warns, []);
     rig.close();
   });
@@ -171,7 +174,7 @@ describe("watchDevPlugins — server-side classification", () => {
     rig.fire("vue.js");
     await sleep(80);
     assert.equal(rig.rec.calls.length, 1);
-    assert.equal(rig.rec.calls[0].serverSideChange, false);
+    assert.equal(onlyCall(rig.rec.calls).serverSideChange, false);
     assert.deepEqual(rig.rec.warns, []);
     rig.close();
   });
@@ -185,7 +188,7 @@ describe("watchDevPlugins — server-side classification", () => {
     rig.fire("assets\\index.js");
     await sleep(80);
     assert.equal(rig.rec.calls.length, 1);
-    assert.equal(rig.rec.calls[0].serverSideChange, false);
+    assert.equal(onlyCall(rig.rec.calls).serverSideChange, false);
     rig.close();
   });
 });
@@ -234,8 +237,10 @@ describe("watchDevPlugins — error isolation", () => {
     const boom = new Error("ENOENT: dist disappeared");
     watcher.emit("error", boom);
     assert.equal(errorEvents.length, 1);
-    assert.equal(errorEvents[0].name, "@test/error");
-    assert.equal(errorEvents[0].error.message, "ENOENT: dist disappeared");
+    const [errorEvent] = errorEvents;
+    assert.ok(errorEvent);
+    assert.equal(errorEvent.name, "@test/error");
+    assert.equal(errorEvent.error.message, "ENOENT: dist disappeared");
     assert.equal(watcher.closed, true, "watcher should self-close on error");
   });
 
@@ -257,7 +262,9 @@ describe("watchDevPlugins — error isolation", () => {
         return watcher as unknown as import("node:fs").FSWatcher;
       },
     });
-    captured[0]("vue.js"); // queues a debounced publish
+    const [fireChange] = captured;
+    assert.ok(fireChange, "watcherFactory must have been called");
+    fireChange("vue.js"); // queues a debounced publish
     watcher.emit("error", new Error("simulated"));
     await sleep(60);
     assert.equal(rec.calls.length, 0, "no publish after error wiped the buffer");

--- a/test/plugins/test_execute.ts
+++ b/test/plugins/test_execute.ts
@@ -81,6 +81,12 @@ function restoreFetch(): void {
   lastBackendError.value = null;
 }
 
+function firstCall(): MockCall {
+  const [call] = calls;
+  assert.ok(call, "expected at least one fetch call");
+  return call;
+}
+
 describe("makeRouteExecute — success", () => {
   beforeEach(() => {
     installEndpoints();
@@ -108,9 +114,10 @@ describe("makeRouteExecute — success", () => {
     await execute({}, { name: "thing", count: 2 });
 
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].url, "/api/thing");
-    assert.equal(calls[0].init?.method, "POST");
-    assert.equal(calls[0].init?.body, JSON.stringify({ name: "thing", count: 2 }));
+    const call = firstCall();
+    assert.equal(call.url, "/api/thing");
+    assert.equal(call.init?.method, "POST");
+    assert.equal(call.init?.body, JSON.stringify({ name: "thing", count: 2 }));
   });
 
   it("uses the route key it was given, not the first route in the group", async () => {
@@ -119,8 +126,9 @@ describe("makeRouteExecute — success", () => {
 
     await execute({}, undefined);
 
-    assert.equal(calls[0].url, "/api/thing/list");
-    assert.equal(calls[0].init?.method, "GET");
+    const call = firstCall();
+    assert.equal(call.url, "/api/thing/list");
+    assert.equal(call.init?.method, "GET");
   });
 
   it("overrides a toolName / uuid the server put in the body", async () => {
@@ -150,7 +158,7 @@ describe("makeRouteExecute — success", () => {
 
     await execute({}, undefined);
 
-    assert.equal(calls[0].init?.body, undefined);
+    assert.equal(firstCall().init?.body, undefined);
   });
 
   it("passes an empty-object body through as {}", async () => {
@@ -159,7 +167,7 @@ describe("makeRouteExecute — success", () => {
 
     await execute({}, {});
 
-    assert.equal(calls[0].init?.body, "{}");
+    assert.equal(firstCall().init?.body, "{}");
   });
 });
 
@@ -227,9 +235,10 @@ describe("makePostExecute", () => {
 
     const result = await execute({}, { prompt: "make it blue" });
 
-    assert.equal(calls[0].url, "/api/image/edit");
-    assert.equal(calls[0].init?.method, "POST");
-    assert.equal(calls[0].init?.body, JSON.stringify({ prompt: "make it blue" }));
+    const call = firstCall();
+    assert.equal(call.url, "/api/image/edit");
+    assert.equal(call.init?.method, "POST");
+    assert.equal(call.init?.body, JSON.stringify({ prompt: "make it blue" }));
     assert.deepEqual(result.data, { filePath: "artifacts/images/a.png" });
     assert.equal(result.toolName, TOOL_NAME);
   });
@@ -260,7 +269,7 @@ describe("endpoint resolution", () => {
     const result = await execute({}, {});
 
     assert.equal(result.message, "ok");
-    assert.equal(calls[0].url, "/api/thing");
+    assert.equal(firstCall().url, "/api/thing");
   });
 
   it("throws on an unknown scope rather than calling an undefined URL", async () => {

--- a/test/plugins/test_plugin_runtime.ts
+++ b/test/plugins/test_plugin_runtime.ts
@@ -163,8 +163,10 @@ describe("makePluginRuntime — scoped tasks (Phase 1 of Encore plan)", () => {
     });
     const tasks = taskManager.listTasks();
     assert.equal(tasks.length, 1);
-    assert.equal(tasks[0].id, pluginTaskId("@example/foo"));
-    assert.equal(tasks[0].id, "plugin:@example/foo");
+    const [task] = tasks;
+    assert.ok(task);
+    assert.equal(task.id, pluginTaskId("@example/foo"));
+    assert.equal(task.id, "plugin:@example/foo");
   });
 
   it("forwards the schedule verbatim", () => {
@@ -176,6 +178,7 @@ describe("makePluginRuntime — scoped tasks (Phase 1 of Encore plan)", () => {
       run: async () => undefined,
     });
     const [task] = taskManager.listTasks();
+    assert.ok(task);
     assert.deepEqual(task.schedule, { type: "daily", time: "09:00" });
   });
 
@@ -384,7 +387,9 @@ describe("makePluginRuntime — scoped logger payload", () => {
     const runtime = makeTestRuntime("@example/foo");
     runtime.log.warn("msg-none");
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].data, undefined);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.data, undefined);
   });
 
   it("does not wrap an Error payload — it is already a record", () => {
@@ -392,7 +397,9 @@ describe("makePluginRuntime — scoped logger payload", () => {
     const failure = Object.assign(new Error("boom"), { code: "ENOENT" });
     runtime.log.error("msg-error", failure);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].data, failure);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.data, failure);
   });
 
   it("scopes the prefix per plugin", () => {

--- a/test/plugins/test_recipe_book_integration.ts
+++ b/test/plugins/test_recipe_book_integration.ts
@@ -132,7 +132,9 @@ describe("Recipe Book plugin — end-to-end through the loader", () => {
     assert.equal(res.ok, true);
     assert.equal(res.recipe?.slug, "stuffed-peppers");
     assert.equal(published.length, 1);
-    assert.equal(published[0].channel, `plugin:${PKG_NAME}:changed`);
+    const [saveEvent] = published;
+    assert.ok(saveEvent);
+    assert.equal(saveEvent.channel, `plugin:${PKG_NAME}:changed`);
 
     // 3. Read returns the full recipe with all frontmatter + body
     res = (await plugin.execute({}, { kind: "read", slug: "stuffed-peppers" })) as RecipeResult;
@@ -151,9 +153,12 @@ describe("Recipe Book plugin — end-to-end through the loader", () => {
 
     // 4. List returns one summary (body / prep / cook stripped)
     res = (await plugin.execute({}, { kind: "list" })) as RecipeResult;
-    assert.equal(res.recipes?.length, 1);
-    assert.equal(res.recipes?.[0].slug, "stuffed-peppers");
-    assert.equal(res.recipes?.[0].servings, 4);
+    assert.ok(res.recipes);
+    assert.equal(res.recipes.length, 1);
+    const [summary] = res.recipes;
+    assert.ok(summary);
+    assert.equal(summary.slug, "stuffed-peppers");
+    assert.equal(summary.servings, 4);
 
     // 5. Read on missing slug → not_found
     res = (await plugin.execute({}, { kind: "read", slug: "ghost" })) as RecipeResult;

--- a/test/plugins/test_runtime_registry.ts
+++ b/test/plugins/test_runtime_registry.ts
@@ -40,8 +40,10 @@ describe("runtime-registry", () => {
     const result = registerRuntimePlugins(new Set(["builtin"]), [fakePlugin("@x/a", "1.0.0", "builtin")]);
     assert.equal(result.registered.length, 0);
     assert.equal(result.collisions.length, 1);
-    assert.equal(result.collisions[0].reason, "static");
-    assert.equal(result.collisions[0].existingTool, "builtin");
+    const [collision] = result.collisions;
+    assert.ok(collision);
+    assert.equal(collision.reason, "static");
+    assert.equal(collision.existingTool, "builtin");
   });
 
   it("static set must include MCP tool names too — `notify` collision skipped", () => {
@@ -53,8 +55,10 @@ describe("runtime-registry", () => {
     const result = registerRuntimePlugins(staticSet, [fakePlugin("@x/notify-clone", "1.0.0", "notify")]);
     assert.equal(result.registered.length, 0);
     assert.equal(result.collisions.length, 1);
-    assert.equal(result.collisions[0].reason, "static");
-    assert.equal(result.collisions[0].existingTool, "notify");
+    const [collision] = result.collisions;
+    assert.ok(collision);
+    assert.equal(collision.reason, "static");
+    assert.equal(collision.existingTool, "notify");
   });
 
   it("runtime-vs-runtime collision: first-loaded wins, second skipped with reason=runtime", () => {
@@ -62,10 +66,14 @@ describe("runtime-registry", () => {
     const second = fakePlugin("@y/b", "1.0.0", "shared");
     const result = registerRuntimePlugins(new Set(), [first, second]);
     assert.equal(result.registered.length, 1);
-    assert.equal(result.registered[0].name, "@x/a");
+    const [registered] = result.registered;
+    assert.ok(registered);
+    assert.equal(registered.name, "@x/a");
     assert.equal(result.collisions.length, 1);
-    assert.equal(result.collisions[0].reason, "runtime");
-    assert.equal(result.collisions[0].plugin.name, "@y/b");
+    const [collision] = result.collisions;
+    assert.ok(collision);
+    assert.equal(collision.reason, "runtime");
+    assert.equal(collision.plugin.name, "@y/b");
   });
 
   it("getRuntimePluginByToolName resolves registered tool names", () => {

--- a/test/plugins/wiki/history/test_diff.ts
+++ b/test/plugins/wiki/history/test_diff.ts
@@ -15,14 +15,16 @@ describe("renderUnifiedDiff", () => {
     const right = "a\nB\nc\n";
     const hunks = renderUnifiedDiff(left, right, 3);
     assert.equal(hunks.length, 1);
-    const kinds = hunks[0].lines.map((line) => line.kind);
+    const [hunk] = hunks;
+    assert.ok(hunk);
+    const kinds = hunk.lines.map((line) => line.kind);
     // Whole file fits inside ±3 context, so we see all three "rows":
     // del+add for the changed line, surrounded by context.
     assert.ok(kinds.includes("del"));
     assert.ok(kinds.includes("add"));
     assert.ok(kinds.includes("context"));
-    assert.equal(hunks[0].hiddenBefore, 0);
-    assert.equal(hunks[0].hiddenAfter, 0);
+    assert.equal(hunk.hiddenBefore, 0);
+    assert.equal(hunk.hiddenAfter, 0);
   });
 
   it("collapses long unchanged runs at the head and tail of the file", () => {
@@ -33,15 +35,17 @@ describe("renderUnifiedDiff", () => {
 
     const hunks = renderUnifiedDiff(left, right, 3);
     assert.equal(hunks.length, 1, "single change → single hunk");
+    const [hunk] = hunks;
+    assert.ok(hunk);
     // The hunk shows ±3 context lines around the change.
-    const kinds = hunks[0].lines.map((line) => line.kind);
+    const kinds = hunk.lines.map((line) => line.kind);
     assert.equal(kinds.filter((kind) => kind === "del").length, 1);
     assert.equal(kinds.filter((kind) => kind === "add").length, 1);
     assert.equal(kinds.filter((kind) => kind === "context").length, 6, "3 above + 3 below");
 
     // Everything outside the ±3 window is hidden.
-    assert.equal(hunks[0].hiddenBefore, 17, "20 head lines minus the 3 surfaced as context");
-    assert.equal(hunks[0].hiddenAfter, 17, "20 tail lines minus the 3 surfaced as context");
+    assert.equal(hunk.hiddenBefore, 17, "20 head lines minus the 3 surfaced as context");
+    assert.equal(hunk.hiddenAfter, 17, "20 tail lines minus the 3 surfaced as context");
   });
 
   it("merges two nearby changes into one hunk when context windows overlap", () => {
@@ -54,8 +58,10 @@ describe("renderUnifiedDiff", () => {
     // windows reach into each other → single merged hunk.
     const hunks = renderUnifiedDiff(left, `${rightLines.join("\n")}\n`, 3);
     assert.equal(hunks.length, 1);
-    const adds = hunks[0].lines.filter((line) => line.kind === "add");
-    const dels = hunks[0].lines.filter((line) => line.kind === "del");
+    const [hunk] = hunks;
+    assert.ok(hunk);
+    const adds = hunk.lines.filter((line) => line.kind === "add");
+    const dels = hunk.lines.filter((line) => line.kind === "del");
     assert.equal(adds.length, 2);
     assert.equal(dels.length, 2);
   });
@@ -77,7 +83,9 @@ describe("renderUnifiedDiff", () => {
     }
     // Gap between hunks (20 - 6 unchanged from each window = 14)
     // shows up as the second hunk's `hiddenBefore`.
-    assert.ok(hunks[1].hiddenBefore > 0);
+    const [, secondHunk] = hunks;
+    assert.ok(secondHunk);
+    assert.ok(secondHunk.hiddenBefore > 0);
   });
 
   it("respects a custom context size", () => {
@@ -87,24 +95,32 @@ describe("renderUnifiedDiff", () => {
     rightLines[10] = "TEN";
     const hunks0 = renderUnifiedDiff(left, `${rightLines.join("\n")}\n`, 0);
     const hunks5 = renderUnifiedDiff(left, `${rightLines.join("\n")}\n`, 5);
+    const [hunk0] = hunks0;
+    const [hunk5] = hunks5;
+    assert.ok(hunk0);
+    assert.ok(hunk5);
     // 0 context = only the changed lines surface.
-    assert.equal(hunks0[0].lines.filter((line) => line.kind === "context").length, 0);
+    assert.equal(hunk0.lines.filter((line) => line.kind === "context").length, 0);
     // 5 context = 5 above + 5 below.
-    assert.equal(hunks5[0].lines.filter((line) => line.kind === "context").length, 10);
+    assert.equal(hunk5.lines.filter((line) => line.kind === "context").length, 10);
   });
 
   it("handles pure-add and pure-delete (one side is empty)", () => {
     const addOnly = renderUnifiedDiff("", "x\ny\n", 3);
     assert.equal(addOnly.length, 1);
+    const [addHunk] = addOnly;
+    assert.ok(addHunk);
     assert.equal(
-      addOnly[0].lines.every((line) => line.kind === "add"),
+      addHunk.lines.every((line) => line.kind === "add"),
       true,
     );
 
     const delOnly = renderUnifiedDiff("x\ny\n", "", 3);
     assert.equal(delOnly.length, 1);
+    const [delHunk] = delOnly;
+    assert.ok(delHunk);
     assert.equal(
-      delOnly[0].lines.every((line) => line.kind === "del"),
+      delHunk.lines.every((line) => line.kind === "del"),
       true,
     );
   });

--- a/test/plugins/wiki/test_helpers.ts
+++ b/test/plugins/wiki/test_helpers.ts
@@ -28,6 +28,12 @@ function taskRoot(count: number): { root: HTMLElement; inputs: HTMLInputElement[
   return { root, inputs: [...root.querySelectorAll<HTMLInputElement>("input.md-task")] };
 }
 
+function taskInput(inputs: HTMLInputElement[], index: number): HTMLInputElement {
+  const input = inputs[index];
+  assert.ok(input, `expected a task checkbox at index ${index}`);
+  return input;
+}
+
 describe("renderWikiLinks", () => {
   it("replaces a simple wiki link", () => {
     assert.equal(renderWikiLinks("See [[Home]] for details."), 'See <span class="wiki-link" data-page="Home">Home</span> for details.');
@@ -279,35 +285,35 @@ describe("computeToggledContent", () => {
   it("toggles an unchecked task on", () => {
     const content = "- [ ] first\n- [x] second";
     const { root, inputs } = taskRoot(2);
-    const result = computeToggledContent(inputs[0], root, content);
+    const result = computeToggledContent(taskInput(inputs, 0), root, content);
     assert.deepEqual(result, { status: "toggled", content: "- [x] first\n- [x] second" });
   });
 
   it("toggles a checked task off", () => {
     const content = "- [ ] first\n- [x] second";
     const { root, inputs } = taskRoot(2);
-    const result = computeToggledContent(inputs[1], root, content);
+    const result = computeToggledContent(taskInput(inputs, 1), root, content);
     assert.deepEqual(result, { status: "toggled", content: "- [ ] first\n- [ ] second" });
   });
 
   it("leaves non-task lines and untoggled tasks untouched", () => {
     const content = "intro\n- [ ] a\nmiddle\n- [ ] b\noutro";
     const { root, inputs } = taskRoot(2);
-    const result = computeToggledContent(inputs[0], root, content);
+    const result = computeToggledContent(taskInput(inputs, 0), root, content);
     assert.deepEqual(result, { status: "toggled", content: "intro\n- [x] a\nmiddle\n- [ ] b\noutro" });
   });
 
   it("preserves the frontmatter prefix when toggling the body", () => {
     const content = "---\ntitle: T\n---\n\n- [ ] task";
     const { root, inputs } = taskRoot(1);
-    const result = computeToggledContent(inputs[0], root, content);
+    const result = computeToggledContent(taskInput(inputs, 0), root, content);
     assert.deepEqual(result, { status: "toggled", content: "---\ntitle: T\n---\n\n- [x] task" });
   });
 
   it("reports a mismatch when the DOM task count differs from the source", () => {
     const content = "- [ ] a\n- [ ] b";
     const { root, inputs } = taskRoot(1);
-    const result = computeToggledContent(inputs[0], root, content);
+    const result = computeToggledContent(taskInput(inputs, 0), root, content);
     assert.deepEqual(result, { status: "mismatch" });
   });
 

--- a/test/plugins/wiki/test_taskSaveQueue.ts
+++ b/test/plugins/wiki/test_taskSaveQueue.ts
@@ -109,7 +109,9 @@ describe("createTaskSaveQueue — failure + generation invalidation", () => {
     queue.queueSave("page-a", "c1");
     await flush();
     assert.equal(harness.errors.length, 1);
-    assert.match(harness.errors[0], /Wiki save failed \(500\)/);
+    const [firstError] = harness.errors;
+    assert.ok(firstError);
+    assert.match(firstError, /Wiki save failed \(500\)/);
     assert.equal(harness.refreshCalls, 1);
     assert.equal(harness.successes, 0);
   });

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -267,6 +267,8 @@ describe("checkWorkspaceDrift (auto-detection)", () => {
       fetchPublishedSource: offlineRegistry,
     });
     assert.equal(results.length, 1);
-    assert.equal(results[0].status, "ok");
+    const [onlyResult] = results;
+    assert.ok(onlyResult);
+    assert.equal(onlyResult.status, "ok");
   });
 });

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -86,7 +86,9 @@ describe("auditLauncherSync — invariant 1: root ↔ launcher common dep", () =
       const findings = await sync.auditLauncherSync({ root });
       const mismatches = findings.filter((finding) => finding.kind === "root-launcher-mismatch");
       assert.equal(mismatches.length, 1);
-      assert.match(mismatches[0].message, /gui-chat-protocol.*root=0\.4\.0.*launcher=\^0\.3\.0/);
+      const [mismatch] = mismatches;
+      assert.ok(mismatch);
+      assert.match(mismatch.message, /gui-chat-protocol.*root=0\.4\.0.*launcher=\^0\.3\.0/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -118,7 +120,9 @@ describe("auditLauncherSync — invariant 2: workspace source vs launcher range"
       const findings = await sync.auditLauncherSync({ root });
       const drifts = findings.filter((finding) => finding.kind === "workspace-source-drift");
       assert.equal(drifts.length, 1);
-      assert.match(drifts[0].message, /form-plugin.*0\.1\.4.*\^0\.2\.0/);
+      const [drift] = drifts;
+      assert.ok(drift);
+      assert.match(drift.message, /form-plugin.*0\.1\.4.*\^0\.2\.0/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -147,7 +151,9 @@ describe("auditLauncherSync — invariant 3: plugin peer dep vs launcher pin (#1
       const findings = await sync.auditLauncherSync({ root });
       const violations = findings.filter((finding) => finding.kind === "peer-dep-violation");
       assert.equal(violations.length, 1);
-      assert.match(violations[0].message, /form-plugin.*gui-chat-protocol.*\^0\.3\.0.*0\.4\.0/);
+      const [violation] = violations;
+      assert.ok(violation);
+      assert.match(violation.message, /form-plugin.*gui-chat-protocol.*\^0\.3\.0.*0\.4\.0/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -213,7 +219,9 @@ describe("auditLauncherSync — invariant 4: workspace-source strict lockstep", 
       const findings = await sync.auditLauncherSync({ root });
       const lockstep = findings.filter((finding) => finding.kind === "workspace-lockstep");
       assert.equal(lockstep.length, 1);
-      assert.match(lockstep[0].message, /foo-plugin.*0\.1\.5.*\^0\.1\.4/);
+      const [lockstepFinding] = lockstep;
+      assert.ok(lockstepFinding);
+      assert.match(lockstepFinding.message, /foo-plugin.*0\.1\.5.*\^0\.1\.4/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -261,7 +269,9 @@ describe("auditLauncherSync — invariant 5: gui-chat-protocol peer dep lockstep
       const findings = await sync.auditLauncherSync({ root });
       const lockstep = findings.filter((finding) => finding.kind === "peer-dep-lockstep");
       assert.equal(lockstep.length, 1);
-      assert.match(lockstep[0].message, /foo-plugin.*gui-chat-protocol.*\^1\.4\.0.*1\.5\.0/);
+      const [lockstepFinding] = lockstep;
+      assert.ok(lockstepFinding);
+      assert.match(lockstepFinding.message, /foo-plugin.*gui-chat-protocol.*\^1\.4\.0.*1\.5\.0/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/scripts/mulmoclaude/test_smoke.ts
+++ b/test/scripts/mulmoclaude/test_smoke.ts
@@ -92,10 +92,12 @@ describe("runSmoke — fail-fast ordering", () => {
     });
     assert.equal(result.ok, false);
     assert.equal(result.stages.length, 1);
-    assert.equal(result.stages[0].name, "deps");
+    const [depsStage] = result.stages;
+    assert.ok(depsStage);
+    assert.equal(depsStage.name, "deps");
     assert.equal(driftCalls, 0, "drift must not run when deps failed");
     assert.equal(tarballSpy.callCount(), 0, "tarball must not run when deps failed");
-    assert.deepEqual(result.stages[0].details.missing, ["mammoth", "puppeteer"]);
+    assert.deepEqual(depsStage.details.missing, ["mammoth", "puppeteer"]);
   });
 
   it("stops after drift fails — tarball never runs", async () => {
@@ -110,9 +112,11 @@ describe("runSmoke — fail-fast ordering", () => {
     });
     assert.equal(result.ok, false);
     assert.equal(result.stages.length, 2);
-    assert.equal(result.stages[1].name, "drift");
+    const [, driftStage] = result.stages;
+    assert.ok(driftStage);
+    assert.equal(driftStage.name, "drift");
     assert.equal(tarballSpy.callCount(), 0, "tarball must not run when drift failed");
-    assert.deepEqual(result.stages[1].details.drifted, ["protocol"]);
+    assert.deepEqual(driftStage.details.drifted, ["protocol"]);
   });
 
   it("reports tarball failure with the lastError from the smoke result", async () => {
@@ -123,8 +127,10 @@ describe("runSmoke — fail-fast ordering", () => {
     });
     assert.equal(result.ok, false);
     assert.equal(result.stages.length, 3);
-    assert.equal(result.stages[2].name, "tarball");
-    assert.match(result.stages[2].summary, /ECONNREFUSED/);
+    const [, , tarballStage] = result.stages;
+    assert.ok(tarballStage);
+    assert.equal(tarballStage.name, "tarball");
+    assert.match(tarballStage.summary, /ECONNREFUSED/);
   });
 });
 

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -231,6 +231,7 @@ describe("packWorkspaceOverrides", () => {
     const packedDirs: string[] = [];
     const runCommandImpl = async (_cmd: string, args: string[]) => {
       const [, dir] = args; // ["pack", <dir>, "--ignore-scripts", ...]
+      assert.ok(dir, `expected a pack directory in args: ${args.join(" ")}`);
       packedDirs.push(dir);
       const base = dir.split("/").pop();
       return { code: 0, timedOut: false, stdout: JSON.stringify([{ filename: `${base}-1.0.0.tgz` }]), stderr: "" };

--- a/test/scripts/test_devWatchIgnore.ts
+++ b/test/scripts/test_devWatchIgnore.ts
@@ -134,7 +134,11 @@ describe("createDevWatchIgnore — path normalisation", () => {
 // than silently bringing the reload storms back.
 describe("createDevWatchIgnore — stays in sync with the real workspace layout", () => {
   const ignore = ignoreFor({ workspacePath: ROOT });
-  const topLevelOf = (workspaceRelative: string): string => workspaceRelative.split("/")[0];
+  const topLevelOf = (workspaceRelative: string): string => {
+    const [topLevel] = workspaceRelative.split("/");
+    if (topLevel === undefined) throw new Error(`cannot take the top level of ${workspaceRelative}`);
+    return topLevel;
+  };
 
   // Top-level entries the watcher deliberately keeps watching: both are tracked
   // repo directories here as well as workspace dirs, so pruning them would stop

--- a/test/services/google/test_calendarCollectionSync.ts
+++ b/test/services/google/test_calendarCollectionSync.ts
@@ -674,7 +674,9 @@ describe("syncCalendarForCollection (#2427 manual refresh)", () => {
       loadGroups: () => Promise.resolve(groupByCalendar([collectionOn("my-schedule", "work"), collectionOn("team", "work"), collectionOn("private", "home")])),
     });
     const outcome = await syncCalendarForCollection("my-schedule", "/ws", fake);
-    assert.deepEqual([...fake.ranWith[0].keys()], ["work"]);
+    const [ranGroups] = fake.ranWith;
+    assert.ok(ranGroups);
+    assert.deepEqual([...ranGroups.keys()], ["work"]);
     assert.deepEqual(outcome.kind === "synced" ? outcome.results.map((entry) => entry.slug).sort() : [], ["my-schedule", "team"]);
   });
 });

--- a/test/services/google/test_calendarStateLock.ts
+++ b/test/services/google/test_calendarStateLock.ts
@@ -92,7 +92,9 @@ describe("withCalendarStateLock (#2679 cross-process read-modify-write)", () => 
         order.push(`${name}:end`);
       };
       await Promise.all([withCalendarStateLock(lock, mutation("a"), fastClock()), withCalendarStateLock(lock, mutation("b"), fastClock())]);
-      const [first] = order[0].split(":");
+      const [firstEntry] = order;
+      assert.ok(firstEntry);
+      const [first] = firstEntry.split(":");
       assert.deepEqual(order, [`${first}:start`, `${first}:end`, ...order.slice(2)]);
       assert.equal(order.length, 4);
     });

--- a/test/services/google/test_calendarSync.ts
+++ b/test/services/google/test_calendarSync.ts
@@ -17,6 +17,7 @@ function stubFetch(pages: { status?: number; body?: unknown }[]): void {
   globalThis.fetch = (async (url: string | URL) => {
     requestedUrls.push(String(url));
     const page = pages[Math.min(call, pages.length - 1)];
+    assert.ok(page, "stubFetch needs at least one queued page");
     call += 1;
     const status = page.status ?? 200;
     return new Response(JSON.stringify(page.body ?? {}), { status, headers: { "Content-Type": "application/json" } });
@@ -44,6 +45,7 @@ describe("syncCalendarEvents (#2095)", () => {
     stubFetch([{ body: { items: [], nextSyncToken: "tok-1" } }]);
     await syncCalendarEvents("access-token", {});
     const [url] = requestedUrls;
+    assert.ok(url);
     assert.ok(url.includes("showDeleted=true"), `expected showDeleted, got: ${url}`);
     assert.ok(url.includes("singleEvents=true"), `expected singleEvents, got: ${url}`);
     assert.ok(!url.includes("timeMin"), `timeMin is forbidden with syncToken, got: ${url}`);
@@ -53,12 +55,16 @@ describe("syncCalendarEvents (#2095)", () => {
   it("omits syncToken on a full sync and sends it on an incremental one", async () => {
     stubFetch([{ body: { items: [], nextSyncToken: "tok-1" } }]);
     await syncCalendarEvents("access-token", {});
-    assert.ok(!requestedUrls[0].includes("syncToken"), "first sync must not send a token");
+    const [fullSyncUrl] = requestedUrls;
+    assert.ok(fullSyncUrl);
+    assert.ok(!fullSyncUrl.includes("syncToken"), "first sync must not send a token");
 
     requestedUrls = [];
     stubFetch([{ body: { items: [], nextSyncToken: "tok-2" } }]);
     await syncCalendarEvents("access-token", { syncToken: "tok-1" });
-    assert.ok(requestedUrls[0].includes("syncToken=tok-1"), `expected the stored token, got: ${requestedUrls[0]}`);
+    const [incrementalUrl] = requestedUrls;
+    assert.ok(incrementalUrl);
+    assert.ok(incrementalUrl.includes("syncToken=tok-1"), `expected the stored token, got: ${incrementalUrl}`);
   });
 
   it("returns the token from the LAST page and accumulates events across pages", async () => {
@@ -71,14 +77,19 @@ describe("syncCalendarEvents (#2095)", () => {
     );
     assert.equal(result.nextSyncToken, "tok-final");
     assert.equal(result.fullResyncRequired, false);
-    assert.ok(requestedUrls[1].includes("pageToken=p2"), "second page must carry the page token");
+    const [, secondPageUrl] = requestedUrls;
+    assert.ok(secondPageUrl);
+    assert.ok(secondPageUrl.includes("pageToken=p2"), "second page must carry the page token");
   });
 
   it("surfaces deletions as cancelled events rather than dropping them", async () => {
     stubFetch([{ body: { items: [event("gone", "cancelled"), event("kept")], nextSyncToken: "tok" } }]);
     const result = await syncCalendarEvents("access-token", { syncToken: "old" });
-    assert.equal(result.events.filter((entry) => entry.status === "cancelled").length, 1);
-    assert.equal(result.events.filter((entry) => entry.status === "cancelled")[0].id, "gone");
+    const cancelled = result.events.filter((entry) => entry.status === "cancelled");
+    assert.equal(cancelled.length, 1);
+    const [cancelledEvent] = cancelled;
+    assert.ok(cancelledEvent);
+    assert.equal(cancelledEvent.id, "gone");
   });
 
   it("maps an expired token (410 GONE) to fullResyncRequired instead of throwing", async () => {
@@ -97,6 +108,8 @@ describe("syncCalendarEvents (#2095)", () => {
   it("targets the requested calendar, url-encoded", async () => {
     stubFetch([{ body: { items: [], nextSyncToken: "tok" } }]);
     await syncCalendarEvents("access-token", { calendarId: "team cal@group.calendar.google.com" });
-    assert.ok(requestedUrls[0].includes(encodeURIComponent("team cal@group.calendar.google.com")), `got: ${requestedUrls[0]}`);
+    const [url] = requestedUrls;
+    assert.ok(url);
+    assert.ok(url.includes(encodeURIComponent("team cal@group.calendar.google.com")), `got: ${url}`);
   });
 });

--- a/test/services/google/test_googleCalendar.ts
+++ b/test/services/google/test_googleCalendar.ts
@@ -157,7 +157,9 @@ describe("collectCalendarPages", () => {
     const seenTokens: (string | undefined)[] = [];
     const calendars = await collectCalendarPages(async (pageToken) => {
       seenTokens.push(pageToken);
-      return pages[seenTokens.length - 1];
+      const page = pages[seenTokens.length - 1];
+      assert.ok(page, `no stub page queued for request #${seenTokens.length}`);
+      return page;
     });
     assert.deepEqual(
       calendars.map((cal) => cal.id),

--- a/test/services/translation/test_translate.ts
+++ b/test/services/translation/test_translate.ts
@@ -46,7 +46,9 @@ describe("translation service — cold/warm/partial", () => {
     });
     assert.deepEqual(translations, ["[ja]Hello", "[ja]World"]);
     assert.equal(mock.calls.length, 1);
-    assert.deepEqual([...mock.calls[0].sentences].sort(), ["Hello", "World"]);
+    const [batch] = mock.calls;
+    assert.ok(batch);
+    assert.deepEqual([...batch.sentences].sort(), ["Hello", "World"]);
     assert.deepEqual(readDict(root, "cold"), {
       sentences: {
         Hello: { ja: "[ja]Hello" },
@@ -78,7 +80,9 @@ describe("translation service — cold/warm/partial", () => {
     });
     assert.deepEqual(translations, ["[ja]Hello", "[ja]Foo", "[ja]World", "[ja]Bar"]);
     assert.equal(mock.calls.length, 1);
-    assert.deepEqual([...mock.calls[0].sentences].sort(), ["Bar", "Foo"]);
+    const [batch] = mock.calls;
+    assert.ok(batch);
+    assert.deepEqual([...batch.sentences].sort(), ["Bar", "Foo"]);
   });
 
   it("merge: adding a new language preserves existing one", async () => {
@@ -305,7 +309,10 @@ describe("translation service — single-flight serialization", () => {
 
     // First mock invocation handled "Hello"; second should have been called only with "World".
     assert.equal(calls.length, 2);
-    assert.deepEqual([...calls[0].sentences], ["Hello"]);
-    assert.deepEqual([...calls[1].sentences], ["World"]);
+    const [firstBatch, secondBatch] = calls;
+    assert.ok(firstBatch);
+    assert.ok(secondBatch);
+    assert.deepEqual([...firstBatch.sentences], ["Hello"]);
+    assert.deepEqual([...secondBatch.sentences], ["World"]);
   });
 });

--- a/test/utils/canvas/test_stackGrouping.ts
+++ b/test/utils/canvas/test_stackGrouping.ts
@@ -39,13 +39,15 @@ describe("buildStackDisplayItems", () => {
       { uuid: "c", group: "g1" },
     ]);
     assert.equal(items.length, 1);
-    assert.equal(items[0].isGroup, true);
+    const [card] = items;
+    assert.ok(card);
+    assert.equal(card.isGroup, true);
     assert.deepEqual(
-      items[0].members.map((member) => member.uuid),
+      card.members.map((member) => member.uuid),
       ["a", "b", "c"],
     );
-    assert.equal(items[0].head.uuid, "c", "head is the latest member");
-    assert.equal(items[0].key, "group:g1");
+    assert.equal(card.head.uuid, "c", "head is the latest member");
+    assert.equal(card.key, "group:g1");
   });
 
   it("merges NON-contiguous same-group results at the first occurrence (Codex #1504)", () => {
@@ -59,14 +61,17 @@ describe("buildStackDisplayItems", () => {
       { uuid: "c", group: "g1" },
     ]);
     assert.equal(items.length, 2, "C merges into the existing g1 card, not a new one");
-    assert.equal(items[0].key, "group:g1");
+    const [groupCard, bCard] = items;
+    assert.ok(groupCard);
+    assert.ok(bCard);
+    assert.equal(groupCard.key, "group:g1");
     assert.deepEqual(
-      items[0].members.map((member) => member.uuid),
+      groupCard.members.map((member) => member.uuid),
       ["a", "c"],
     );
-    assert.equal(items[0].head.uuid, "c", "head follows the latest call");
-    assert.equal(items[1].head.uuid, "b");
-    assert.equal(items[1].isGroup, false);
+    assert.equal(groupCard.head.uuid, "c", "head follows the latest call");
+    assert.equal(bCard.head.uuid, "b");
+    assert.equal(bCard.isGroup, false);
   });
 
   it("keeps distinct groups as distinct cards in first-occurrence order", () => {
@@ -81,12 +86,15 @@ describe("buildStackDisplayItems", () => {
       items.map((item) => item.key),
       ["group:g1", "group:g2"],
     );
+    const [g1Card, g2Card] = items;
+    assert.ok(g1Card);
+    assert.ok(g2Card);
     assert.deepEqual(
-      items[0].members.map((member) => member.uuid),
+      g1Card.members.map((member) => member.uuid),
       ["a", "c"],
     );
     assert.deepEqual(
-      items[1].members.map((member) => member.uuid),
+      g2Card.members.map((member) => member.uuid),
       ["b", "d"],
     );
   });
@@ -94,8 +102,10 @@ describe("buildStackDisplayItems", () => {
   it("treats a lone grouped result as a (single-member) group card", () => {
     const items = build([{ uuid: "a", group: "g1" }]);
     assert.equal(items.length, 1);
-    assert.equal(items[0].isGroup, true);
-    assert.equal(items[0].members.length, 1);
+    const [card] = items;
+    assert.ok(card);
+    assert.equal(card.isGroup, true);
+    assert.equal(card.members.length, 1);
   });
 });
 

--- a/test/utils/collections/test_calendarGrid.ts
+++ b/test/utils/collections/test_calendarGrid.ts
@@ -131,27 +131,38 @@ describe("buildMonthGrid", () => {
     // June 2026: the 1st is a Monday. Sunday-start grid → one leading day
     // (May 31), then June 1-30, then trailing July days.
     const grid = buildMonthGrid(2026, 6, 0);
-    assert.equal(grid[0].key, "2026-05-31");
-    assert.equal(grid[0].inMonth, false);
-    assert.equal(grid[1].key, "2026-06-01");
-    assert.equal(grid[1].inMonth, true);
+    const [leadingCell, secondCell] = grid;
+    assert.ok(leadingCell);
+    assert.ok(secondCell);
+    assert.equal(leadingCell.key, "2026-05-31");
+    assert.equal(leadingCell.inMonth, false);
+    assert.equal(secondCell.key, "2026-06-01");
+    assert.equal(secondCell.inMonth, true);
     const inMonth = grid.filter((cell) => cell.inMonth);
     assert.equal(inMonth.length, 30);
-    assert.equal(inMonth[0].key, "2026-06-01");
-    assert.equal(inMonth[29].key, "2026-06-30");
+    const [firstOfMonth] = inMonth;
+    const lastOfMonth = inMonth.at(-1);
+    assert.ok(firstOfMonth);
+    assert.ok(lastOfMonth);
+    assert.equal(firstOfMonth.key, "2026-06-01");
+    assert.equal(lastOfMonth.key, "2026-06-30");
   });
 
   it("honours a Monday week start", () => {
     // June 1 2026 is a Monday → no leading days with weekStartsOn=1.
     const grid = buildMonthGrid(2026, 6, 1);
-    assert.equal(grid[0].key, "2026-06-01");
-    assert.equal(grid[0].inMonth, true);
+    const [leadingCell] = grid;
+    assert.ok(leadingCell);
+    assert.equal(leadingCell.key, "2026-06-01");
+    assert.equal(leadingCell.inMonth, true);
   });
 
   it("handles a leap February", () => {
     const inMonth = buildMonthGrid(2024, 2).filter((cell) => cell.inMonth);
     assert.equal(inMonth.length, 29);
-    assert.equal(inMonth[28].key, "2024-02-29");
+    const leapDay = inMonth.at(-1);
+    assert.ok(leapDay);
+    assert.equal(leapDay.key, "2024-02-29");
   });
 
   it("produces 42 contiguous days with no gaps or repeats", () => {

--- a/test/utils/collections/test_ids.ts
+++ b/test/utils/collections/test_ids.ts
@@ -14,6 +14,7 @@ function sequence(...ids: string[]): () => string {
   let index = 0;
   return () => {
     const picked = ids[Math.min(index, ids.length - 1)];
+    if (picked === undefined) throw new Error("sequence() needs at least one id");
     index++;
     return picked;
   };

--- a/test/utils/collections/test_ontologyGraph.ts
+++ b/test/utils/collections/test_ontologyGraph.ts
@@ -87,7 +87,9 @@ describe("buildOntologyGraph — edges", () => {
       entry("clients", [{ field: "invoiceLinks", kind: "backlinks", to: "invoices", via: "clientId" }]),
     ]);
     assert.equal(forwardFirst.edges.length, 1);
-    assert.deepEqual(forwardFirst.edges[0].reverseFields, ["invoiceLinks"]);
+    const [edge] = forwardFirst.edges;
+    assert.ok(edge);
+    assert.deepEqual(edge.reverseFields, ["invoiceLinks"]);
   });
 
   it("collapses each rollup onto ITS via edge when several refs link the same pair (matches.homeTeam vs awayTeam)", () => {

--- a/test/utils/collections/test_presentSeed.ts
+++ b/test/utils/collections/test_presentSeed.ts
@@ -81,7 +81,9 @@ describe("reconcileSyntheticCollection", () => {
     reconcileSyntheticCollection(session, realResult("clients"));
 
     assert.equal(session.toolResults.length, 1);
-    assert.equal(session.toolResults[0].uuid, placeholder.uuid);
+    const [remaining] = session.toolResults;
+    assert.ok(remaining);
+    assert.equal(remaining.uuid, placeholder.uuid);
   });
 
   it("ignores a synthetic incoming result (no self-reconcile)", () => {

--- a/test/utils/files/test_filename.ts
+++ b/test/utils/files/test_filename.ts
@@ -81,6 +81,8 @@ describe("buildPdfFilename", () => {
     const expectedDates = new Set([formatLocalDate(before), formatLocalDate(after)]);
     const match = /^x-(\d{4}-\d{2}-\d{2})\.pdf$/.exec(filename);
     assert.ok(match, `filename did not match expected shape: ${filename}`);
-    assert.ok(expectedDates.has(match[1]), `unexpected date in filename: ${filename}`);
+    const [, datePart] = match;
+    assert.ok(datePart !== undefined, `filename did not capture a date: ${filename}`);
+    assert.ok(expectedDates.has(datePart), `unexpected date in filename: ${filename}`);
   });
 });

--- a/test/utils/files/test_markdownImageFill.ts
+++ b/test/utils/files/test_markdownImageFill.ts
@@ -56,7 +56,11 @@ describe("buildImagePlaceholderReplacement", () => {
 
 describe("IMAGE_PLACEHOLDER regex", () => {
   function findAll(markdown: string): string[] {
-    return [...markdown.matchAll(IMAGE_PLACEHOLDER)].map((match) => match[1]);
+    return [...markdown.matchAll(IMAGE_PLACEHOLDER)].map((match) => {
+      const [, alt] = match;
+      assert.ok(alt !== undefined, "IMAGE_PLACEHOLDER must capture the alt text");
+      return alt;
+    });
   }
 
   it("matches the plain form `![alt](__too_be_replaced_image_path__)`", () => {

--- a/test/utils/files/test_session_io.ts
+++ b/test/utils/files/test_session_io.ts
@@ -160,8 +160,11 @@ describe("appendSessionLine", () => {
     assert.ok(raw);
     const lines = raw.split("\n").filter(Boolean);
     assert.equal(lines.length, 2);
-    assert.deepEqual(JSON.parse(lines[0]), { a: 1 });
-    assert.deepEqual(JSON.parse(lines[1]), { b: 2 });
+    const [firstLine, secondLine] = lines;
+    assert.ok(firstLine);
+    assert.ok(secondLine);
+    assert.deepEqual(JSON.parse(firstLine), { a: 1 });
+    assert.deepEqual(JSON.parse(secondLine), { b: 2 });
   });
 
   it("normalizes missing trailing newline", async () => {

--- a/test/utils/image/test_rewriteMarkdownImageRefs.ts
+++ b/test/utils/image/test_rewriteMarkdownImageRefs.ts
@@ -437,7 +437,9 @@ describe("rewriteImgSrcAttrsInHtml — adversarial input", () => {
     // Inspect the section between the opening `src='` and the next `'`.
     const match = /src='([^']*)'/.exec(out);
     assert.ok(match, "expected a single-quoted src attribute in the output");
-    assert.ok(!match[1].includes('"'), `unexpected " inside src value: ${match[1]}`);
+    const [, srcValue] = match;
+    assert.ok(srcValue !== undefined, "expected a captured src value");
+    assert.ok(!srcValue.includes('"'), `unexpected " inside src value: ${srcValue}`);
   });
 
   it("URL-encodes < and > when the src is well-formed", () => {

--- a/test/utils/launcher/test_bundleImports.ts
+++ b/test/utils/launcher/test_bundleImports.ts
@@ -51,10 +51,12 @@ const unresolvedImports = (entry: string): MissingImport[] => {
     seen.add(file);
     const source = readFileSync(file, "utf8");
     for (const match of source.matchAll(IMPORT_PATTERN)) {
-      if (isTypeOnly(match[1])) continue;
-      const target = resolve(dirname(file), match[1]);
+      const [, specifier] = match;
+      assert.ok(specifier !== undefined, `IMPORT_PATTERN matched without a specifier in ${file}`);
+      if (isTypeOnly(specifier)) continue;
+      const target = resolve(dirname(file), specifier);
       if (existsSync(target)) queue.push(target);
-      else missing.push({ from: file, specifier: match[1] });
+      else missing.push({ from: file, specifier });
     }
   }
   return missing;

--- a/test/utils/launcher/test_createApp.ts
+++ b/test/utils/launcher/test_createApp.ts
@@ -34,6 +34,7 @@ describe("renderNodeMissingText", () => {
     LAUNCHER_LOCALES.forEach((locale) => {
       const [title, second] = renderNodeMissingText(locale).split("\n");
       assert.equal(title, launcherMessages(locale).nodeMissing.title, locale);
+      assert.ok(second !== undefined, `${locale}: the text has no second line at all`);
       assert.ok(second.length > 0, `${locale}: blank second line would open the alert with an empty paragraph`);
     });
   });

--- a/test/utils/launcher/test_windowsIcon.ts
+++ b/test/utils/launcher/test_windowsIcon.ts
@@ -57,14 +57,18 @@ describe("packIco", () => {
     assert.equal(entries.length, images.length);
     entries.forEach((entry, i) => {
       const slice = ico.subarray(entry.offset, entry.offset + entry.byteLength);
-      assert.deepEqual(slice, images[i].png, `entry ${i} does not point at its own bytes`);
+      const image = images[i];
+      assert.ok(image, `entry ${i} has no source image`);
+      assert.deepEqual(slice, image.png, `entry ${i} does not point at its own bytes`);
     });
   });
 
   it("spells 256 as 0 — the dimension fields are single bytes", () => {
     const { entries } = parseIco(packIco([{ size: 256, png: fakePng(0x01, 20) }]));
-    assert.equal(entries[0].width, 0);
-    assert.equal(entries[0].height, 0);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.width, 0);
+    assert.equal(entry.height, 0);
   });
 
   it("leaves no gap or overlap between images", () => {

--- a/test/utils/launcher/test_windowsLauncher.ts
+++ b/test/utils/launcher/test_windowsLauncher.ts
@@ -90,7 +90,9 @@ describe("writeWindowsMessages", () => {
       assert.equal(text, renderNodeMissingText("ja"));
       // Guards the encoding end to end: a codepage guess would turn the
       // Japanese title into mojibake in the one dialog that matters.
-      assert.ok(text.split("\n")[0].length > 0);
+      const [titleLine] = text.split("\n");
+      assert.ok(titleLine !== undefined, "decoded text has no first line");
+      assert.ok(titleLine.length > 0);
     });
   });
 

--- a/test/utils/launcher/test_windowsShortcutIntegration.ts
+++ b/test/utils/launcher/test_windowsShortcutIntegration.ts
@@ -67,6 +67,8 @@ describe("createWindowsShortcut (Windows)", () => {
         "Write-Output $link.Arguments",
       ].join("\n");
       const [target, args] = powershell(script).split(/\r?\n/);
+      assert.ok(target !== undefined, "WScript.Shell returned no TargetPath line");
+      assert.ok(args !== undefined, "WScript.Shell returned no Arguments line");
 
       assert.match(target, /wscript\.exe$/i, "a console window would appear if this were node.exe or cmd.exe");
       assert.match(args, /launch\.vbs"$/, "the stub path must stay quoted — %LOCALAPPDATA% contains the account name");

--- a/test/utils/markdown/test_marpCustomSize.ts
+++ b/test/utils/markdown/test_marpCustomSize.ts
@@ -17,6 +17,14 @@ function makeFakeMarp(): { themeSet: FakeThemeSet } {
   };
 }
 
+// Every CSS assertion below inspects the first registered theme; narrow it
+// once here so a missing registration fails loudly instead of at each site.
+function firstThemeCss(marp: { themeSet: FakeThemeSet }): string {
+  const [css] = marp.themeSet.calls;
+  assert.ok(css, "no theme was registered");
+  return css;
+}
+
 describe("applyCustomMarpSize — pass-through cases", () => {
   it("returns the input unchanged when there is no frontmatter", () => {
     const marp = makeFakeMarp();
@@ -60,8 +68,8 @@ describe("applyCustomMarpSize — numeric WxH", () => {
     const source = "---\nmarp: true\nsize: 1080x1920\n---\n# slide";
     const out = applyCustomMarpSize(marp, source);
     assert.equal(marp.themeSet.calls.length, 1);
-    assert.match(marp.themeSet.calls[0], /@theme mc_size_default_1080x1920/);
-    assert.match(marp.themeSet.calls[0], /section \{ width: 1080px; height: 1920px;/);
+    assert.match(firstThemeCss(marp), /@theme mc_size_default_1080x1920/);
+    assert.match(firstThemeCss(marp), /section \{ width: 1080px; height: 1920px;/);
     assert.match(out, /theme: mc_size_default_1080x1920/);
     assert.doesNotMatch(out, /^size:/m);
   });
@@ -78,7 +86,7 @@ describe("applyCustomMarpSize — numeric WxH", () => {
     const marp = makeFakeMarp();
     const source = "---\nmarp: true\ntheme: gaia\nsize: 1080x1920\n---\n# x";
     const out = applyCustomMarpSize(marp, source);
-    assert.match(marp.themeSet.calls[0], /@import "gaia"/);
+    assert.match(firstThemeCss(marp), /@import "gaia"/);
     assert.match(out, /theme: mc_size_gaia_1080x1920/);
   });
 
@@ -125,7 +133,7 @@ describe("applyCustomMarpSize — aspect-ratio presets", () => {
     const marp = makeFakeMarp();
     const source = "---\nmarp: true\nsize: 9:16\n---\n# x";
     const out = applyCustomMarpSize(marp, source);
-    assert.match(marp.themeSet.calls[0], /width: 1080px; height: 1920px/);
+    assert.match(firstThemeCss(marp), /width: 1080px; height: 1920px/);
     assert.match(out, /theme: mc_size_default_1080x1920/);
   });
 
@@ -133,7 +141,7 @@ describe("applyCustomMarpSize — aspect-ratio presets", () => {
     const marp = makeFakeMarp();
     const source = "---\nmarp: true\nsize: 16:10\n---\n# x";
     const out = applyCustomMarpSize(marp, source);
-    assert.match(marp.themeSet.calls[0], /width: 1280px; height: 800px/);
+    assert.match(firstThemeCss(marp), /width: 1280px; height: 800px/);
     assert.match(out, /theme: mc_size_default_1280x800/);
   });
 
@@ -141,7 +149,7 @@ describe("applyCustomMarpSize — aspect-ratio presets", () => {
     const marp = makeFakeMarp();
     const source = "---\nmarp: true\nsize: 1:1\n---\n# x";
     applyCustomMarpSize(marp, source);
-    assert.match(marp.themeSet.calls[0], /width: 1080px; height: 1080px/);
+    assert.match(firstThemeCss(marp), /width: 1080px; height: 1080px/);
   });
 });
 
@@ -158,8 +166,8 @@ describe("applyCustomMarpSize — theme injection guard", () => {
     assert.equal(marp.themeSet.calls.length, 1);
     // The composed CSS must NOT carry the attacker's payload — the
     // unsafe theme should have been collapsed back to "default".
-    assert.doesNotMatch(marp.themeSet.calls[0], /evil\.example\.com/);
-    assert.match(marp.themeSet.calls[0], /@import "default"/);
+    assert.doesNotMatch(firstThemeCss(marp), /evil\.example\.com/);
+    assert.match(firstThemeCss(marp), /@import "default"/);
     assert.match(out, /theme: mc_size_default_1080x1920/);
   });
 
@@ -167,7 +175,7 @@ describe("applyCustomMarpSize — theme injection guard", () => {
     const marp = makeFakeMarp();
     const source = `---\nmarp: true\ntheme: gaia_2\nsize: 1080x1920\n---\n# x`;
     applyCustomMarpSize(marp, source);
-    assert.match(marp.themeSet.calls[0], /@import "gaia_2"/);
+    assert.match(firstThemeCss(marp), /@import "gaia_2"/);
   });
 
   it("rejects theme names with whitespace, dots, or other CSS-relevant chars", () => {

--- a/test/utils/role/test_merge.ts
+++ b/test/utils/role/test_merge.ts
@@ -34,10 +34,13 @@ describe("mergeRoles", () => {
     const out = mergeRoles([role("a", "Built-in A"), role("b", "Built-in B")], [role("a", "Custom A")]);
     assert.equal(out.length, 2);
     // The built-in 'a' is dropped, the custom 'a' is appended at the end
-    assert.equal(out[0].id, "b");
-    assert.equal(out[0].name, "Built-in B");
-    assert.equal(out[1].id, "a");
-    assert.equal(out[1].name, "Custom A");
+    const [kept, overridden] = out;
+    assert.ok(kept);
+    assert.ok(overridden);
+    assert.equal(kept.id, "b");
+    assert.equal(kept.name, "Built-in B");
+    assert.equal(overridden.id, "a");
+    assert.equal(overridden.name, "Custom A");
   });
 
   it("returns custom only when built-ins are empty", () => {

--- a/test/utils/session/test_assistantTextInterrupt.ts
+++ b/test/utils/session/test_assistantTextInterrupt.ts
@@ -58,6 +58,7 @@ describe("applyTextEvent — tool calls split assistant text into separate cards
     applyTextEvent(session, "Your portfolio is live: total $119,157.", "assistant");
 
     const last = session.toolResults[session.toolResults.length - 1];
+    assert.ok(last);
     assert.equal((last.data as { text?: string }).text, "Your portfolio is live: total $119,157.");
     // Single-pane canvas follows `selectedResultUuid` — it must land on
     // the summary, not the first "I'll create…" card.

--- a/test/utils/session/test_mergeSessions.ts
+++ b/test/utils/session/test_mergeSessions.ts
@@ -64,6 +64,14 @@ function makeUserTextResult(message: string): ToolResultComplete {
   } as unknown as ToolResultComplete;
 }
 
+/** Narrows a positional lookup: a list too short to hold `index` is a test
+ *  failure, so this throws rather than handing back `undefined`. */
+function entryAt<T>(list: T[], index: number): T {
+  const entry = list[index];
+  assert.ok(entry, `expected a session entry at index ${index}`);
+  return entry;
+}
+
 describe("compareSessionsByRecency", () => {
   it("returns negative when a is more recently updated", () => {
     const sessA = makeSummary({ updatedAt: "2026-04-12T10:00:00.000Z" });
@@ -114,10 +122,11 @@ describe("mergeSessionLists — basic cases", () => {
     });
     const result = mergeSessionLists([live], []);
     assert.equal(result.length, 1);
-    assert.equal(result[0].id, "live-1");
-    assert.equal(result[0].preview, "hello");
-    assert.equal(result[0].summary, undefined);
-    assert.equal(result[0].keywords, undefined);
+    const merged = entryAt(result, 0);
+    assert.equal(merged.id, "live-1");
+    assert.equal(merged.preview, "hello");
+    assert.equal(merged.summary, undefined);
+    assert.equal(merged.keywords, undefined);
   });
 });
 
@@ -135,12 +144,13 @@ describe("mergeSessionLists — live + server overlap", () => {
     });
     const result = mergeSessionLists([live], [server]);
     assert.equal(result.length, 1, "session should not be duplicated");
-    assert.equal(result[0].id, "both");
+    const merged = entryAt(result, 0);
+    assert.equal(merged.id, "both");
     // Server preview wins over first-user-message heuristic — the
     // AI-generated title is more informative
-    assert.equal(result[0].preview, "server preview");
+    assert.equal(merged.preview, "server preview");
     // updatedAt comes from the live side (it's the fresher source)
-    assert.equal(result[0].updatedAt, "2026-04-12T10:00:00.000Z");
+    assert.equal(merged.updatedAt, "2026-04-12T10:00:00.000Z");
   });
 
   it("carries over server summary + keywords to the live entry", () => {
@@ -152,9 +162,10 @@ describe("mergeSessionLists — live + server overlap", () => {
       keywords: ["plan", "project"],
     });
     const result = mergeSessionLists([live], [server]);
-    assert.equal(result[0].preview, "Plan a project");
-    assert.equal(result[0].summary, "User wants help planning.");
-    assert.deepEqual(result[0].keywords, ["plan", "project"]);
+    const merged = entryAt(result, 0);
+    assert.equal(merged.preview, "Plan a project");
+    assert.equal(merged.summary, "User wants help planning.");
+    assert.deepEqual(merged.keywords, ["plan", "project"]);
   });
 
   it("falls back to first-user-message when server preview is empty", () => {
@@ -164,14 +175,14 @@ describe("mergeSessionLists — live + server overlap", () => {
     });
     const server = makeSummary({ id: "both", preview: "" });
     const result = mergeSessionLists([live], [server]);
-    assert.equal(result[0].preview, "hello from live");
+    assert.equal(entryAt(result, 0).preview, "hello from live");
   });
 
   it("uses empty preview when neither server nor live has text", () => {
     const live = makeActive({ id: "both", toolResults: [] });
     const server = makeSummary({ id: "both", preview: "" });
     const result = mergeSessionLists([live], [server]);
-    assert.equal(result[0].preview, "");
+    assert.equal(entryAt(result, 0).preview, "");
   });
 });
 
@@ -319,8 +330,8 @@ describe("applySessionDiff — sort + immutability", () => {
     const cache = [makeSummary({ id: "old", updatedAt: "2026-04-10T00:00:00.000Z" })];
     const diff = [makeSummary({ id: "new", updatedAt: "2026-04-17T00:00:00.000Z" })];
     const out = applySessionDiff(cache, diff, []);
-    assert.equal(out[0].id, "new");
-    assert.equal(out[1].id, "old");
+    assert.equal(entryAt(out, 0).id, "new");
+    assert.equal(entryAt(out, 1).id, "old");
   });
 
   it("does not mutate cache or diff inputs", () => {

--- a/test/utils/session/test_sessionEntries.ts
+++ b/test/utils/session/test_sessionEntries.ts
@@ -9,6 +9,14 @@ import type { ToolResultComplete } from "gui-chat-protocol/vue";
 
 // --- parseSessionEntries ------------------------------------------
 
+/** Narrows a positional lookup: a shorter list than the test expects is a
+ *  failure, so this throws instead of yielding `undefined`. */
+function resultAt(results: ToolResultComplete[], index: number): ToolResultComplete {
+  const result = results[index];
+  assert.ok(result, `expected a tool result at index ${index}`);
+  return result;
+}
+
 describe("parseSessionEntries", () => {
   it("returns empty array for empty input", () => {
     assert.deepEqual(parseSessionEntries([]), []);
@@ -34,7 +42,7 @@ describe("parseSessionEntries", () => {
     ];
     const out = parseSessionEntries(entries);
     assert.equal(out.length, 1);
-    assert.equal(out[0].toolName, "text-response");
+    assert.equal(resultAt(out, 0).toolName, "text-response");
   });
 
   it("converts assistant text entries", () => {
@@ -47,7 +55,7 @@ describe("parseSessionEntries", () => {
     ];
     const out = parseSessionEntries(entries);
     assert.equal(out.length, 1);
-    assert.equal(out[0].toolName, "text-response");
+    assert.equal(resultAt(out, 0).toolName, "text-response");
   });
 
   it("passes tool_result entries through verbatim", () => {
@@ -79,9 +87,9 @@ describe("parseSessionEntries", () => {
     ];
     const out = parseSessionEntries(entries);
     assert.equal(out.length, 3);
-    assert.equal(out[0].toolName, "text-response");
+    assert.equal(resultAt(out, 0).toolName, "text-response");
     assert.equal(out[1], toolResult);
-    assert.equal(out[2].toolName, "text-response");
+    assert.equal(resultAt(out, 2).toolName, "text-response");
   });
 
   it("skips entries that are neither text nor tool_result", () => {
@@ -106,13 +114,13 @@ describe("parseSessionEntries", () => {
   it("does NOT mark seededByPlugin when sessionOrigin is undefined", () => {
     const entries: SessionEntry[] = [{ source: "user", type: "text", message: "hi" }];
     const out = parseSessionEntries(entries, undefined);
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, undefined);
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, undefined);
   });
 
   it("does NOT mark seededByPlugin for non-plugin origins", () => {
     const entries: SessionEntry[] = [{ source: "user", type: "text", message: "hi" }];
     const out = parseSessionEntries(entries, "scheduler");
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, undefined);
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, undefined);
   });
 
   it("marks the FIRST user turn with seededByPlugin when origin is plugin:<pkg>", () => {
@@ -121,8 +129,8 @@ describe("parseSessionEntries", () => {
       { source: "assistant", type: "text", message: "Have you received your W-2?" },
     ];
     const out = parseSessionEntries(entries, "plugin:@mulmoclaude/encore-plugin");
-    const userData = out[0].data as Record<string, unknown>;
-    const assistantData = out[1].data as Record<string, unknown>;
+    const userData = resultAt(out, 0).data as Record<string, unknown>;
+    const assistantData = resultAt(out, 1).data as Record<string, unknown>;
     assert.equal(userData.seededByPlugin, "@mulmoclaude/encore-plugin");
     // Assistant turn must NOT be marked.
     assert.equal(assistantData.seededByPlugin, undefined);
@@ -135,15 +143,15 @@ describe("parseSessionEntries", () => {
       { source: "user", type: "text", message: "second user reply" },
     ];
     const out = parseSessionEntries(entries, "plugin:@mulmoclaude/encore-plugin");
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, "@mulmoclaude/encore-plugin");
-    assert.equal((out[2].data as Record<string, unknown>).seededByPlugin, undefined);
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, "@mulmoclaude/encore-plugin");
+    assert.equal((resultAt(out, 2).data as Record<string, unknown>).seededByPlugin, undefined);
   });
 
   it("rejects plugin:<empty-pkg> as a non-plugin origin", () => {
     const entries: SessionEntry[] = [{ source: "user", type: "text", message: "hi" }];
     // `plugin:` with empty pkg should not match the plugin-tag regex.
     const out = parseSessionEntries(entries, "plugin:" as never);
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, undefined);
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, undefined);
   });
 
   // --- meta-row fallback for sessionOrigin (Codex review on PR #1237) -
@@ -156,7 +164,7 @@ describe("parseSessionEntries", () => {
       { source: "user", type: "text", message: "seed" },
     ];
     const out = parseSessionEntries(entries);
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, "@mulmoclaude/encore-plugin");
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, "@mulmoclaude/encore-plugin");
   });
 
   it("explicit sessionOrigin wins over session_meta.origin", () => {
@@ -168,13 +176,13 @@ describe("parseSessionEntries", () => {
       { source: "user", type: "text", message: "seed" },
     ];
     const out = parseSessionEntries(entries, "plugin:@b/p");
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, "@b/p");
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, "@b/p");
   });
 
   it("does NOT fall back when meta.origin is missing", () => {
     const entries: SessionEntry[] = [{ type: "session_meta", roleId: "general" } as SessionEntry, { source: "user", type: "text", message: "seed" }];
     const out = parseSessionEntries(entries);
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, undefined);
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, undefined);
   });
 
   it("ignores malformed meta.origin (not a SessionOrigin)", () => {
@@ -183,7 +191,7 @@ describe("parseSessionEntries", () => {
       { source: "user", type: "text", message: "seed" },
     ];
     const out = parseSessionEntries(entries);
-    assert.equal((out[0].data as Record<string, unknown>).seededByPlugin, undefined);
+    assert.equal((resultAt(out, 0).data as Record<string, unknown>).seededByPlugin, undefined);
   });
 });
 

--- a/test/utils/session/test_sessionEntries_skill.ts
+++ b/test/utils/session/test_sessionEntries_skill.ts
@@ -23,12 +23,16 @@ describe("parseSessionEntries — skill entries (#1218)", () => {
   it('dispatches a skill entry to a `toolName: "skill"` envelope', () => {
     const out = parseSessionEntries([skillEntry]);
     assert.equal(out.length, 1);
-    assert.equal(out[0].toolName, "skill");
+    const [envelope] = out;
+    assert.ok(envelope);
+    assert.equal(envelope.toolName, "skill");
   });
 
   it("preserves skill metadata in the envelope's `data` field", () => {
     const out = parseSessionEntries([skillEntry]);
-    const data = out[0].data as Record<string, unknown>;
+    const [envelope] = out;
+    assert.ok(envelope);
+    const data = envelope.data as Record<string, unknown>;
     assert.equal(data.skillName, "mc-library");
     assert.equal(data.skillScope, "project");
     assert.equal(data.skillPath, "/Users/test/mulmoclaude/.claude/skills/mc-library/SKILL.md");
@@ -40,12 +44,16 @@ describe("parseSessionEntries — skill entries (#1218)", () => {
   it("envelope's `message` falls back to skillName when description missing", () => {
     const noDesc: SessionEntry = { ...skillEntry, skillDescription: null } as SessionEntry;
     const out = parseSessionEntries([noDesc]);
-    assert.equal(out[0].message, "mc-library");
+    const [envelope] = out;
+    assert.ok(envelope);
+    assert.equal(envelope.message, "mc-library");
   });
 
   it("title is the prefixed skill name so chat-history previews are scannable", () => {
     const out = parseSessionEntries([skillEntry]);
-    assert.equal(out[0].title, "Skill: mc-library");
+    const [envelope] = out;
+    assert.ok(envelope);
+    assert.equal(envelope.title, "Skill: mc-library");
   });
 
   it('legacy `type:"text"` skill bodies (pre-#1218 sessions) stay text-response — no auto-detection by prefix', () => {
@@ -62,7 +70,9 @@ describe("parseSessionEntries — skill entries (#1218)", () => {
       message: "Base directory for this skill: /old\n\n# Personal book journal\n\n...",
     } as SessionEntry;
     const out = parseSessionEntries([legacy]);
-    assert.equal(out[0].toolName, "text-response");
+    const [envelope] = out;
+    assert.ok(envelope);
+    assert.equal(envelope.toolName, "text-response");
   });
 
   it("invalid skill entry (missing skillName) doesn't reach the dispatcher branch", () => {

--- a/test/utils/share/test_rewriteAssets.ts
+++ b/test/utils/share/test_rewriteAssets.ts
@@ -70,19 +70,25 @@ describe("rewriteHtmlAssets", () => {
 
   it("strips query/hash when deriving the bundle filename", () => {
     const { assets } = rewriteHtmlAssets(`<img src="foo.png?v=2">`);
-    assert.equal(assets[0].bundlePath, "assets/foo.png");
+    const [asset] = assets;
+    assert.ok(asset);
+    assert.equal(asset.bundlePath, "assets/foo.png");
   });
 
   it("preserves a #fragment on the rewritten url (svg sprite)", () => {
     const { html, assets } = rewriteHtmlAssets(`<svg><use href="sprite.svg#icon"></use></svg>`);
-    assert.equal(assets[0].bundlePath, "assets/sprite.svg");
+    const [asset] = assets;
+    assert.ok(asset);
+    assert.equal(asset.bundlePath, "assets/sprite.svg");
     assert.match(html, /href="assets\/sprite\.svg#icon"/);
   });
 
   it("preserves ?query on the url and dedups the underlying file", () => {
     const { html, assets } = rewriteHtmlAssets(`<img src="a.png?v=1"><img src="a.png?v=2">`);
     assert.equal(assets.length, 1);
-    assert.equal(assets[0].bundlePath, "assets/a.png");
+    const [asset] = assets;
+    assert.ok(asset);
+    assert.equal(asset.bundlePath, "assets/a.png");
     assert.match(html, /src="assets\/a\.png\?v=1"/);
     assert.match(html, /src="assets\/a\.png\?v=2"/);
   });
@@ -90,12 +96,16 @@ describe("rewriteHtmlAssets", () => {
   it("sanitizes a backslash-containing ref to a safe bundle name (zip-slip)", () => {
     const { html, assets } = rewriteHtmlAssets(`<img src="..\\..\\evil.png">`);
     assert.equal(assets.length, 1);
-    assert.equal(assets[0].bundlePath, "assets/evil.png");
+    const [asset] = assets;
+    assert.ok(asset);
+    assert.equal(asset.bundlePath, "assets/evil.png");
     assert.doesNotMatch(html, /\.\.[\\/]/);
   });
 
   it("collapses an all-traversal ref to a neutral name", () => {
     const { assets } = rewriteHtmlAssets(`<img src="../../..">`);
-    assert.equal(assets[0].bundlePath, "assets/asset");
+    const [asset] = assets;
+    assert.ok(asset);
+    assert.equal(asset.bundlePath, "assets/asset");
   });
 });

--- a/test/utils/test_api.ts
+++ b/test/utils/test_api.ts
@@ -42,6 +42,14 @@ function getHeader(call: MockCall, name: string): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
+// Every test below drives a single request, so the captured call must be
+// there — a missing one is a failure, not something to read past.
+function firstCall(): MockCall {
+  const [call] = calls;
+  assert.ok(call, "expected the api module to have issued a fetch");
+  return call;
+}
+
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -66,7 +74,7 @@ describe("apiCall — happy path", () => {
   it("POST serializes body as JSON and sets Content-Type", async () => {
     nextResponse = jsonResponse(200, { ok: true });
     await apiPost("/api/thing", { a: 1, b: "two" });
-    const [call] = calls;
+    const call = firstCall();
     assert.equal(call.init?.method, "POST");
     assert.equal(getHeader(call, "Content-Type"), "application/json");
     assert.equal(call.init?.body, JSON.stringify({ a: 1, b: "two" }));
@@ -75,14 +83,15 @@ describe("apiCall — happy path", () => {
   it("PUT forwards the method", async () => {
     nextResponse = jsonResponse(200, {});
     await apiPut("/api/thing", { x: 1 });
-    assert.equal(calls[0].init?.method, "PUT");
+    assert.equal(firstCall().init?.method, "PUT");
   });
 
   it("DELETE accepts an optional body", async () => {
     nextResponse = jsonResponse(200, {});
     await apiDelete("/api/thing/1");
-    assert.equal(calls[0].init?.method, "DELETE");
-    assert.equal(calls[0].init?.body, undefined);
+    const call = firstCall();
+    assert.equal(call.init?.method, "DELETE");
+    assert.equal(call.init?.body, undefined);
   });
 });
 
@@ -148,35 +157,36 @@ describe("apiCall — query and headers", () => {
   it("appends a query string from the query object", async () => {
     nextResponse = jsonResponse(200, {});
     await apiGet("/api/search", { q: "hello", limit: 10 });
-    assert.match(calls[0].url, /\/api\/search\?/);
-    assert.match(calls[0].url, /q=hello/);
-    assert.match(calls[0].url, /limit=10/);
+    const { url } = firstCall();
+    assert.match(url, /\/api\/search\?/);
+    assert.match(url, /q=hello/);
+    assert.match(url, /limit=10/);
   });
 
   it("drops undefined query values", async () => {
     nextResponse = jsonResponse(200, {});
     await apiGet("/api/search", { q: "x", missing: undefined });
-    assert.doesNotMatch(calls[0].url, /missing=/);
+    assert.doesNotMatch(firstCall().url, /missing=/);
   });
 
   it("percent-encodes query values", async () => {
     nextResponse = jsonResponse(200, {});
     await apiGet("/api/search", { q: "a b&c" });
-    assert.match(calls[0].url, /q=a%20b%26c/);
+    assert.match(firstCall().url, /q=a%20b%26c/);
   });
 
   it("includes the bearer token when set", async () => {
     setAuthToken("secret123");
     nextResponse = jsonResponse(200, {});
     await apiGet("/api/thing");
-    assert.equal(getHeader(calls[0], "Authorization"), "Bearer secret123");
+    assert.equal(getHeader(firstCall(), "Authorization"), "Bearer secret123");
   });
 
   it("omits Authorization when no token set", async () => {
     setAuthToken(null);
     nextResponse = jsonResponse(200, {});
     await apiGet("/api/thing");
-    assert.equal(getHeader(calls[0], "Authorization"), undefined);
+    assert.equal(getHeader(firstCall(), "Authorization"), undefined);
   });
 
   it("caller-provided headers survive", async () => {
@@ -185,7 +195,7 @@ describe("apiCall — query and headers", () => {
       method: "GET",
       headers: { "X-Custom": "1" },
     });
-    assert.equal(getHeader(calls[0], "X-Custom"), "1");
+    assert.equal(getHeader(firstCall(), "X-Custom"), "1");
   });
 });
 

--- a/test/utils/test_cliFlags.ts
+++ b/test/utils/test_cliFlags.ts
@@ -83,7 +83,8 @@ describe("cli-flags cliFlagHelpLines", () => {
     for (const line of cliFlagHelpLines().split("\n")) {
       const match = line.match(/^ {2}(\S+) +(\S.*)$/);
       assert.ok(match, `line shape: ${JSON.stringify(line)}`);
-      const helpText = match === null ? "" : match[2];
+      const [, , helpText] = match;
+      assert.ok(helpText !== undefined, `no help text captured: ${JSON.stringify(line)}`);
       assert.equal(line.indexOf(helpText), 2 + width + 2, "help column constant");
     }
   });

--- a/test/utils/test_devPluginArgs.ts
+++ b/test/utils/test_devPluginArgs.ts
@@ -33,8 +33,10 @@ describe("parseDevPluginArgs — extraction", () => {
     assert.equal(result.ok, true);
     if (result.ok) {
       assert.equal(result.resolved.length, 1);
-      assert.equal(result.resolved[0].rawInput, FIXTURE_ABS_FOO);
-      assert.equal(result.resolved[0].absPath, FIXTURE_ABS_FOO);
+      const [entry] = result.resolved;
+      assert.ok(entry);
+      assert.equal(entry.rawInput, FIXTURE_ABS_FOO);
+      assert.equal(entry.absPath, FIXTURE_ABS_FOO);
     }
   });
 
@@ -43,8 +45,11 @@ describe("parseDevPluginArgs — extraction", () => {
     assert.equal(result.ok, true);
     if (result.ok) {
       assert.equal(result.resolved.length, 2);
-      assert.equal(result.resolved[0].rawInput, FIXTURE_ABS_A);
-      assert.equal(result.resolved[1].rawInput, FIXTURE_ABS_B);
+      const [first, second] = result.resolved;
+      assert.ok(first);
+      assert.ok(second);
+      assert.equal(first.rawInput, FIXTURE_ABS_A);
+      assert.equal(second.rawInput, FIXTURE_ABS_B);
     }
   });
 
@@ -53,7 +58,9 @@ describe("parseDevPluginArgs — extraction", () => {
     assert.equal(result.ok, true);
     if (result.ok) {
       assert.equal(result.resolved.length, 1);
-      assert.equal(result.resolved[0].absPath, FIXTURE_ABS_P);
+      const [entry] = result.resolved;
+      assert.ok(entry);
+      assert.equal(entry.absPath, FIXTURE_ABS_P);
     }
   });
 });
@@ -63,8 +70,10 @@ describe("parseDevPluginArgs — path resolution", () => {
     const result = parseDevPluginArgs(["--dev-plugin", "./my-plugin"], FIXTURE_CWD);
     assert.equal(result.ok, true);
     if (result.ok) {
-      assert.equal(result.resolved[0].rawInput, "./my-plugin");
-      assert.equal(result.resolved[0].absPath, path.resolve(FIXTURE_CWD, "my-plugin"));
+      const [entry] = result.resolved;
+      assert.ok(entry);
+      assert.equal(entry.rawInput, "./my-plugin");
+      assert.equal(entry.absPath, path.resolve(FIXTURE_CWD, "my-plugin"));
     }
   });
 
@@ -72,14 +81,20 @@ describe("parseDevPluginArgs — path resolution", () => {
     const result = parseDevPluginArgs(["--dev-plugin", "../sibling"], FIXTURE_CWD);
     assert.equal(result.ok, true);
     if (result.ok) {
-      assert.equal(result.resolved[0].absPath, path.resolve(FIXTURE_CWD, "../sibling"));
+      const [entry] = result.resolved;
+      assert.ok(entry);
+      assert.equal(entry.absPath, path.resolve(FIXTURE_CWD, "../sibling"));
     }
   });
 
   it("leaves absolute paths unchanged regardless of cwd", () => {
     const result = parseDevPluginArgs(["--dev-plugin", FIXTURE_ELSEWHERE], path.resolve("/Users/somewhere/else"));
     assert.equal(result.ok, true);
-    if (result.ok) assert.equal(result.resolved[0].absPath, FIXTURE_ELSEWHERE);
+    if (result.ok) {
+      const [entry] = result.resolved;
+      assert.ok(entry);
+      assert.equal(entry.absPath, FIXTURE_ELSEWHERE);
+    }
   });
 });
 

--- a/test/utils/test_id.ts
+++ b/test/utils/test_id.ts
@@ -49,6 +49,7 @@ describe("makeId", () => {
   it("ends with 6 hex characters", () => {
     const generatedId = makeId("test");
     const [, , hex] = generatedId.split("_");
+    assert.ok(hex !== undefined, `id has no hex segment: ${generatedId}`);
     assert.equal(hex.length, 6);
     assert.match(hex, /^[0-9a-f]{6}$/);
   });


### PR DESCRIPTION
## Summary

Drives `noUncheckedIndexedAccess` (NUIA) to **zero** across five test directories — `test/plugins/**`, `test/utils/**`, `test/composables/**`, `test/services/**`, `test/scripts/**`.

Measured with `npx vue-tsc -p test/tsconfig.json --noEmit --pretty false --noUncheckedIndexedAccess`:

| scope | before | after |
|---|---:|---:|
| my five directories | 425 | **0** |
| repo-wide (this tsconfig) | 906 | 481 |

The 481 remaining are the rest of `test/` plus a handful in `packages/*/src` that this tsconfig also pulls in — a different slice's ownership. **No tsconfig is changed here**; the flag stays off until every area is at zero.

95 files, +823 / −387. Test files only; nothing under `src/`, `server/` or `packages/` is touched.

## Items to Confirm / Review

The reason this needs a human eye is not difficulty — it is that the work is mechanical enough to do on autopilot, and an autopilot fix silently weakens a test. Please look at these decisions specifically:

1. **The anti-weakening rule, and how it was enforced.** Every fix had to satisfy: *it must not make a test pass in a case where it previously would have failed.* Concretely that meant `const [row] = rows; assert.ok(row); assert.equal(row.foo, 1)` — never `if (row) { assert… }`, which turns a missing row from a failure into a silent pass and is strictly worse than the unchecked index it replaces. **There is no such `if`-guard in the diff.** Verification beyond reading it end to end:
   - a per-file check that no file lost an `assert.` call site (a dropped assertion is the weakening signature) — clean;
   - a per-file diff of the string/number literals appearing on `assert.` lines, so a changed *expected value* would surface — every difference traced to an index literal moving off the assertion line into a `const`, or to a new assertion message;
   - **ten mutation spot-checks** spread across all five directories: corrupt one expected value, confirm the rewritten assertion still fails. All ten mutants killed;
   - two "the element is genuinely absent" probes: emptying the recorded-call array (`onlyCall` → `AssertionError: expected runtime.fetch to have been called`) and indexing a calculated grid row out of range (`cellAt` → `Error: calculated sheet has no row 99`). Both fail loudly.

2. **`assert.ok` vs an explicit `undefined` check — the one judgement call that repeats.** `assert.ok(x)` rejects every falsy value, so using it on a value that can legitimately be `0`, `""`, `false` or `null` would reject a *correct* answer. That case is real here: spreadsheet cells (`CellValue = number | string | boolean | SpreadsheetError`), regex capture groups, and `split()` segments. Those sites use an explicit `x === undefined` throw or `assert.ok(x !== undefined)` instead. Worth confirming the split was drawn in the right place — the spreadsheet helper is `test/plugins/spreadsheet/engine/cellAccess.ts`.

3. **One new file: `test/plugins/spreadsheet/engine/cellAccess.ts`.** The same `calculate(sheet).data[r][c]` shape appeared at 28 sites across 27 files, so it is one shared `rowAt` / `cellAt` rather than 27 copies (DRY, per CLAUDE.md). It is not matched by the `test_*.ts` runner glob, so it never runs as a suite. Say the word if you would rather have it inlined per file.

4. **Smaller per-file helpers.** Where one shape recurred inside a single file, it became a local throw-on-absence helper instead of repeated boilerplate: `onlyCall` / `callAt` (spotify, dev-watcher), `firstCall` (`test_api.ts`, `test_execute.ts`), `entryAt` / `resultAt` (session + spotify normalisers), `specOf` (collection schemas), `taskInput` (wiki task checkboxes), `firstThemeCss` (marp), `cellOf` (spreadsheet highlight mocks). Each throws on absence, so none of them can convert a failure into a pass.

5. **Two latent test-side traps found and made loud** (neither is a production bug, but both were previously silent):
   - `test/utils/collections/test_ids.ts` — the `sequence()` fixture computes `ids[Math.min(index, ids.length - 1)]`, which is `ids[-1]` for a zero-argument call. Now throws. One caller passes `sequence("", "ok")`, where `""` is meaningful, so this uses an explicit `undefined` check rather than `assert.ok`.
   - `test/utils/test_cliFlags.ts` — carried a dead `const helpText = match === null ? "" : match[2];` immediately after `assert.ok(match, …)`. Had it ever fired, `line.indexOf("")` returns `0` and the help-column assertion would have compared garbage instead of failing.

6. **Pre-existing `?.` / `??` / `as` were carried over, not added.** Several rewritten lines still contain optional chaining (`call.init?.method`, `rows.find(...)?.display`) or casts (`data as Record<string, unknown>`, `as number`) — all of them were on the original line and relocate unchanged. Nothing in the diff adds a new one; a grep of the added lines confirms it.

## Constraints honoured

No `as`, no `!` (`@typescript-eslint/no-non-null-assertion` is at `error`), no `@ts-ignore` / `@ts-expect-error` / `eslint-disable`, no new `let`, no magic numbers, no tsconfig change.

## Real bugs

**None in this scope.** The tell to watch for was an index that is out of range because the *production* code returns fewer items than the test assumes. Every index touched here is bounded by an adjacent length assertion, by a fixture the test constructs literally in the same function, or by a regex whose capture group is non-optional — consistent with all tests passing unchanged. Three test-harness-internal spots had unproven bounds and now fail loudly rather than handing `undefined` to the code under test: `stubFetch` in `test_calendarSync.ts`, the page stub in `test_googleCalendar.ts`, and `runCommandImpl`'s `args[1]` in `test_tarball.ts`.

One item flagged for a future pass, deliberately **not** changed here because tightening it is a test change rather than a NUIA fix: `test/plugins/spreadsheet/engine/test_crossSheetReference.ts:32-33` compares `cross[0]` against `same[1]`, which would pass vacuously if both rows were empty. The rows themselves can no longer be missing (`rowAt` throws), so the vacuous case is now much narrower.

## Verification

```
yarn build:packages   ok
yarn format           ok (produced no reformatting)
yarn lint             0 errors, 51 warnings — none in test/
yarn typecheck        exit 0, 0 errors
yarn build            exit 0
yarn test             exit 0 — 9026 tests, 0 fail (root suite) + all workspace suites green
```

Scoped NUIA measurement after the change:

```
$ npx vue-tsc -p test/tsconfig.json --noEmit --pretty false --noUncheckedIndexedAccess \
    | grep "error TS" | grep -cE '^test/(plugins|utils|composables|services|scripts)/'
0
```

(`--pretty false` is load-bearing: without it the ANSI escapes split the string `error TS` and the grep reports a false zero. `vue-tsc` rather than `tsc` for the same reason `.vue` findings were missed earlier in this issue.)

## User Prompt

Adopt `noUncheckedIndexedAccess` (#2736) for the test directories `test/plugins/**`, `test/utils/**`, `test/composables/**`, `test/services/**`, `test/scripts/**`. Do not enable the flag in any tsconfig — `test/tsconfig.json` also covers other directories, so it cannot reach zero from this work alone. Watch for real bugs while doing it: in a test file the tell is an index that is out of range because the production code returns fewer items than the test assumes, and any such case should be filed on #2736 with a reproduction. Above all, a fix must not make a test pass in a case where it previously would have failed — never `if (row) { assert… }`, and no optional chaining in an assertion.

#2736

work in mulmoclaude3

## Summary by Sourcery

Tighten tests across plugins, utils, composables, services, and scripts to be compatible with noUncheckedIndexedAccess by making indexed accesses explicit and fail-fast while introducing small shared helpers for recurring patterns.

Enhancements:
- Add small test-only helpers (e.g., firstCall/onlyCall/entryAt/resultAt/specOf/cellAccess utilities) to centralize and strengthen assertions around indexed and positional lookups.
- Refine existing tests to use destructuring plus explicit presence checks instead of bare array or map indexing, improving clarity of expectations without changing behaviour.

Tests:
- Update numerous test suites to assert on explicitly validated entries rather than unchecked indexes, ensuring missing data now fails loudly instead of passing silently.
- Add a new spreadsheet engine helper module used by engine tests to safely access calculated rows and cells without relying on unchecked indices.