### PR TITLE
fix: make test/ (non-plugin dirs), e2e/ and e2e-live/ noUncheckedIndexedAccess-clean

### DIFF
--- a/e2e-live/fixtures/live-chat.ts
+++ b/e2e-live/fixtures/live-chat.ts
@@ -744,8 +744,8 @@ export async function readImgNaturalSizeInWiki(page: Page, imgSelector: string):
  * navigation, or while sitting on /wiki).
  */
 export function getCurrentSessionId(page: Page): string | null {
-  const match = /\/chat\/([^/?#]+)/.exec(page.url());
-  return match ? decodeURIComponent(match[1]) : null;
+  const [, sessionId] = /\/chat\/([^/?#]+)/.exec(page.url()) ?? [];
+  return sessionId === undefined ? null : decodeURIComponent(sessionId);
 }
 
 /**
@@ -1096,6 +1096,7 @@ export async function startGuaranteedNewSession(page: Page): Promise<string> {
     const match = SESSION_ID_FROM_PATH_RE.exec(url.pathname);
     if (!match) return false;
     const [, candidateId] = match;
+    if (candidateId === undefined) return false;
     return candidateId !== priorSessionId && !baselineIds.has(candidateId);
   });
   const newSessionId = getCurrentSessionId(page);

--- a/e2e-live/fixtures/staging-skill-path.ts
+++ b/e2e-live/fixtures/staging-skill-path.ts
@@ -56,9 +56,8 @@ export const STAGING_SKILL_WRITE_PATH_RE = /(?:^|[/\\])data[/\\]skills[/\\]([a-z
  * run.
  */
 export function stagingSkillSlugFromWritePath(filePath: string, hostWorkspaceRoot: string): string | null {
-  const match = STAGING_SKILL_WRITE_PATH_RE.exec(filePath);
-  if (!match) return null;
-  const [, slug] = match;
+  const [, slug] = STAGING_SKILL_WRITE_PATH_RE.exec(filePath) ?? [];
+  if (slug === undefined) return null;
   // Re-validate against the canonical server rule (the kebab regex
   // does not enforce the 1-120 char bound `isValidSlug` adds).
   if (!isValidSlug(slug)) return null;

--- a/e2e-live/tests/fresh-boot.spec.ts
+++ b/e2e-live/tests/fresh-boot.spec.ts
@@ -85,7 +85,7 @@ test.describe("fresh-user smoke (real LLM)", () => {
       const html = await indexResponse.text();
       const metaMatch = /<meta\s+name="mulmoclaude-auth"\s+content="([^"]*)"/.exec(html);
       expect(metaMatch, "<meta name=mulmoclaude-auth> tag must be present in served index.html").not.toBeNull();
-      const tokenInHtml = metaMatch === null ? "" : metaMatch[1];
+      const tokenInHtml = metaMatch?.[1] ?? "";
       expect(tokenInHtml.length, "auth token content attribute must not be empty").toBeGreaterThan(0);
       expect(tokenInHtml.includes("__MULMOCLAUDE_AUTH_TOKEN__"), "placeholder must be replaced with the real bearer token before serving").toBe(false);
 

--- a/e2e-live/tests/skills.spec.ts
+++ b/e2e-live/tests/skills.spec.ts
@@ -393,6 +393,9 @@ test.describe("skills (real LLM / static)", () => {
       // because we have a UI gate (`skill-item-<slug>` visibility)
       // that masks the fast-path race waitForAssistantTurn guards.
       const [runSlug] = createdSlugs;
+      if (runSlug === undefined) {
+        throw new Error("collectL32MarkedSlugs returned no marker-bearing slug — the length assertion above should have failed first");
+      }
       await openSkillsPanel(page);
       const skillRow = page.getByTestId(`skill-item-${runSlug}`);
       await expect(

--- a/e2e-live/tests/wiki-lint.spec.ts
+++ b/e2e-live/tests/wiki-lint.spec.ts
@@ -130,7 +130,7 @@ test.describe("wiki lint diagnostics (real workspace)", () => {
     // et al.) may also surface here while they run. That is fine:
     // the assertion is scoped to our unique slug via `:has-text`,
     // not to a total orphan count.
-    const testLabel = testInfo.title.split(":")[0].trim().toLowerCase();
+    const testLabel = (testInfo.title.split(":")[0] ?? "").trim().toLowerCase();
     const nonce = `${testLabel}-${Date.now()}-${randomUUID().slice(0, 6)}`;
     const orphanSlug = `e2e-live-wiki-lint-orphan-${testInfo.project.name}-${nonce}`;
     try {
@@ -176,7 +176,7 @@ test.describe("wiki lint diagnostics (real workspace)", () => {
       // `restoreWikiIndex` round trip (see L-16's iter-2 fix in
       // wiki-nav.spec.ts for the null-vs-empty restore semantics
       // this inherits).
-      const testLabel = testInfo.title.split(":")[0].trim().toLowerCase();
+      const testLabel = (testInfo.title.split(":")[0] ?? "").trim().toLowerCase();
       const nonce = `${testLabel}-${Date.now()}-${randomUUID().slice(0, 6)}`;
       const bogusSlug = `e2e-live-wiki-lint-missing-${testInfo.project.name}-${nonce}`;
       // Sentinel page so `pages/` is non-empty when the lint route
@@ -231,7 +231,7 @@ test.describe("wiki lint diagnostics (real workspace)", () => {
       //
       // Both the page body and the index row need to be seeded.
       // The shared `data/wiki/index.md` is mutated → serial block.
-      const testLabel = testInfo.title.split(":")[0].trim().toLowerCase();
+      const testLabel = (testInfo.title.split(":")[0] ?? "").trim().toLowerCase();
       const nonce = `${testLabel}-${Date.now()}-${randomUUID().slice(0, 6)}`;
       const slug = `e2e-live-wiki-lint-drift-${testInfo.project.name}-${nonce}`;
       // Tag tokens use only lowercase ASCII + hyphens + digits so

--- a/e2e-live/tests/wiki-nav.spec.ts
+++ b/e2e-live/tests/wiki-nav.spec.ts
@@ -207,7 +207,7 @@ test.describe("wiki navigation (real workspace)", () => {
     // wiki page filename の規約は `[a-z0-9-]+` (`wikiSlugify` 出力)
     // で、大文字が混ざると resolver の `wikiSlugify(target)` と
     // on-disk key の case mismatch で fuzzy match が全滅する。
-    const testLabel = testInfo.title.split(":")[0].trim().toLowerCase();
+    const testLabel = (testInfo.title.split(":")[0] ?? "").trim().toLowerCase();
     const nonce = `${testLabel}-${Date.now()}-${randomUUID().slice(0, 6)}`;
     const targetSlug = `日本語タイトル-${projectSlug}-${nonce}`;
     const sourceSlug = `e2e-live-l15b-source-${projectSlug}-${nonce}`;

--- a/e2e/fixtures/accounting.ts
+++ b/e2e/fixtures/accounting.ts
@@ -209,10 +209,9 @@ function handleUpdateBook(state: AccountingState, body: DispatchBody): MockRespo
 function handleDeleteBook(state: AccountingState, body: DispatchBody): MockResponse {
   const bookId = typeof body.bookId === "string" ? body.bookId : "";
   if (body.confirm !== true) return err(400, "deleteBook requires confirm: true");
-  const idx = state.books.findIndex((book) => book.id === bookId);
-  if (idx < 0) return err(404, `book ${JSON.stringify(bookId)} not found`);
-  const target = state.books[idx];
-  state.books.splice(idx, 1);
+  const target = state.books.find((book) => book.id === bookId);
+  if (!target) return err(404, `book ${JSON.stringify(bookId)} not found`);
+  state.books.splice(state.books.indexOf(target), 1);
   state.accountsByBook.delete(bookId);
   state.entriesByBook.delete(bookId);
   return ok({ deletedBookId: bookId, deletedBookName: target.name });

--- a/e2e/tests/chat-flow.spec.ts
+++ b/e2e/tests/chat-flow.spec.ts
@@ -225,7 +225,7 @@ test.describe("sending a chat message", () => {
       (route) => {
         if (route.request().method() !== "GET") return route.fallback();
         const sessionId = route.request().url().split("/api/sessions/").pop() ?? "";
-        [capturedSessionId] = sessionId.split("?"); // strip query
+        capturedSessionId = sessionId.split("?")[0] ?? null; // strip query
         return route.fulfill({
           json: [
             {

--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -198,8 +198,7 @@ test.describe("file explorer path in URL", () => {
 
     await expect(() => {
       expect(putRequests).toHaveLength(1);
-      expect(putRequests[0].path).toBe("wiki/hello.md");
-      expect(putRequests[0].content).toBe("# Hello\n\nEdited by the test.");
+      expect(putRequests).toMatchObject([{ path: "wiki/hello.md", content: "# Hello\n\nEdited by the test." }]);
     }).toPass({ timeout: 5 * ONE_SECOND_MS });
   });
 

--- a/e2e/tests/files-json-edit.spec.ts
+++ b/e2e/tests/files-json-edit.spec.ts
@@ -120,8 +120,7 @@ test.describe("Files Explorer — JSON inline editor (#833)", () => {
 
     await expect(() => {
       expect(puts).toHaveLength(1);
-      expect(puts[0].path).toBe(EDITABLE);
-      expect(puts[0].content).toBe('{\n  "theme": "light"\n}');
+      expect(puts).toMatchObject([{ path: EDITABLE, content: '{\n  "theme": "light"\n}' }]);
     }).toPass({ timeout: 5 * ONE_SECOND_MS });
 
     // Successful save exits edit mode (read-only pre returns).

--- a/e2e/tests/notifications.spec.ts
+++ b/e2e/tests/notifications.spec.ts
@@ -142,8 +142,8 @@ function stripNotificationId(url: URL): string {
  *  toHaveURL assertion. Returns undefined for non-chat targets. */
 function extractChatSessionId(navigateTarget: string | undefined): string | undefined {
   if (!navigateTarget) return undefined;
-  const match = navigateTarget.match(/^\/chat\/([^/?#]+)/);
-  return match ? decodeURIComponent(match[1]) : undefined;
+  const [, sessionId] = navigateTarget.match(/^\/chat\/([^/?#]+)/) ?? [];
+  return sessionId === undefined ? undefined : decodeURIComponent(sessionId);
 }
 
 test.describe("notification bell — navigation", () => {
@@ -265,9 +265,17 @@ async function primeNotifierHistory(page: Page, history: readonly NotifierHistor
 
 test.describe("notification bell — history more / less toggle", () => {
   const HISTORY_INITIAL_VISIBLE = 5;
+  const HISTORY_OVERFLOW_TOTAL = 8;
+  // The tail entry is built on its own so assertions can name it
+  // directly instead of indexing the generated array.
+  const buildOverflowHistory = (): { history: NotifierHistoryFixture[]; tail: NotifierHistoryFixture } => {
+    const tail = buildHistoryEntry(HISTORY_OVERFLOW_TOTAL - 1);
+    const head = Array.from({ length: HISTORY_OVERFLOW_TOTAL - 1 }, (_, index) => buildHistoryEntry(index));
+    return { history: [...head, tail], tail };
+  };
 
   test("hides entries beyond the initial cap behind a toggle", async ({ page }) => {
-    const history = Array.from({ length: 8 }, (_, index) => buildHistoryEntry(index));
+    const { history } = buildOverflowHistory();
     await mockAllApis(page, { sessions: [] });
     await primeNotifierHistory(page, history);
 
@@ -276,11 +284,11 @@ test.describe("notification bell — history more / less toggle", () => {
     await expect(page.getByTestId("notification-panel")).toBeVisible();
 
     // First 5 entries render; the rest are hidden until expanded.
-    for (let index = 0; index < HISTORY_INITIAL_VISIBLE; index += 1) {
-      await expect(page.getByTestId(`notification-history-${history[index].id}`)).toBeVisible();
+    for (const entry of history.slice(0, HISTORY_INITIAL_VISIBLE)) {
+      await expect(page.getByTestId(`notification-history-${entry.id}`)).toBeVisible();
     }
-    for (let index = HISTORY_INITIAL_VISIBLE; index < history.length; index += 1) {
-      await expect(page.getByTestId(`notification-history-${history[index].id}`)).toHaveCount(0);
+    for (const entry of history.slice(HISTORY_INITIAL_VISIBLE)) {
+      await expect(page.getByTestId(`notification-history-${entry.id}`)).toHaveCount(0);
     }
 
     const toggle = page.getByTestId("notification-history-toggle");
@@ -294,13 +302,13 @@ test.describe("notification bell — history more / less toggle", () => {
     await expect(toggle).not.toHaveText(/3/);
 
     await toggle.click();
-    for (let index = HISTORY_INITIAL_VISIBLE; index < history.length; index += 1) {
-      await expect(page.getByTestId(`notification-history-${history[index].id}`)).toHaveCount(0);
+    for (const entry of history.slice(HISTORY_INITIAL_VISIBLE)) {
+      await expect(page.getByTestId(`notification-history-${entry.id}`)).toHaveCount(0);
     }
   });
 
   test("collapses again after closing and reopening the popup", async ({ page }) => {
-    const history = Array.from({ length: 8 }, (_, index) => buildHistoryEntry(index));
+    const { history, tail } = buildOverflowHistory();
     await mockAllApis(page, { sessions: [] });
     await primeNotifierHistory(page, history);
 
@@ -308,7 +316,7 @@ test.describe("notification bell — history more / less toggle", () => {
     await page.getByTestId("notification-bell").click();
     await page.getByTestId("notification-history-toggle").click();
     // Confirm we're expanded before the close-reopen cycle.
-    await expect(page.getByTestId(`notification-history-${history[7].id}`)).toBeVisible();
+    await expect(page.getByTestId(`notification-history-${tail.id}`)).toBeVisible();
 
     // Click outside the bell to close (App-level outside-click handler).
     await page.mouse.click(10, 10);
@@ -317,18 +325,19 @@ test.describe("notification bell — history more / less toggle", () => {
     await page.getByTestId("notification-bell").click();
     await expect(page.getByTestId("notification-panel")).toBeVisible();
     // The hidden tail entry should be gone again — state reset on close.
-    await expect(page.getByTestId(`notification-history-${history[7].id}`)).toHaveCount(0);
+    await expect(page.getByTestId(`notification-history-${tail.id}`)).toHaveCount(0);
     await expect(page.getByTestId("notification-history-toggle")).toBeVisible();
   });
 
   test("toggle is absent when history is at or under the initial cap", async ({ page }) => {
-    const history = Array.from({ length: HISTORY_INITIAL_VISIBLE }, (_, index) => buildHistoryEntry(index));
+    const firstEntry = buildHistoryEntry(0);
+    const history = [firstEntry, ...Array.from({ length: HISTORY_INITIAL_VISIBLE - 1 }, (_, index) => buildHistoryEntry(index + 1))];
     await mockAllApis(page, { sessions: [] });
     await primeNotifierHistory(page, history);
 
     await page.goto("/files");
     await page.getByTestId("notification-bell").click();
-    await expect(page.getByTestId(`notification-history-${history[0].id}`)).toBeVisible();
+    await expect(page.getByTestId(`notification-history-${firstEntry.id}`)).toBeVisible();
     await expect(page.getByTestId("notification-history-toggle")).toHaveCount(0);
   });
 
@@ -345,14 +354,14 @@ function buildHistoryEntryWithBody(index: number, body: string, navigateTarget?:
 
 test.describe("notification bell — history body expansion", () => {
   test("clicking a history row with body expands and collapses the body", async ({ page }) => {
-    const history = [buildHistoryEntryWithBody(0, "Detailed body text for testing")];
+    const entry = buildHistoryEntryWithBody(0, "Detailed body text for testing");
     await mockAllApis(page, { sessions: [] });
-    await primeNotifierHistory(page, history);
+    await primeNotifierHistory(page, [entry]);
 
     await page.goto("/todos");
     await page.getByTestId("notification-bell").click();
 
-    const row = page.getByTestId(`notification-history-${history[0].id}`);
+    const row = page.getByTestId(`notification-history-${entry.id}`);
     await expect(row).toBeVisible();
     await expect(page.getByTestId("notification-history-body")).toHaveCount(0);
 
@@ -365,13 +374,13 @@ test.describe("notification bell — history body expansion", () => {
   });
 
   test("expanded body state resets when the panel closes", async ({ page }) => {
-    const history = [buildHistoryEntryWithBody(0, "Body resets on close")];
+    const entry = buildHistoryEntryWithBody(0, "Body resets on close");
     await mockAllApis(page, { sessions: [] });
-    await primeNotifierHistory(page, history);
+    await primeNotifierHistory(page, [entry]);
 
     await page.goto("/todos");
     await page.getByTestId("notification-bell").click();
-    await page.getByTestId(`notification-history-${history[0].id}`).click();
+    await page.getByTestId(`notification-history-${entry.id}`).click();
     await expect(page.getByTestId("notification-history-body")).toBeVisible();
 
     await page.mouse.click(10, 10);
@@ -387,15 +396,16 @@ test.describe("notification bell — history body expansion", () => {
     // doesn't. Expanding both proves the icon ONLY surfaces for the
     // row that carries the link — covering presence + absence in one
     // fixture without paying the panel-open overhead twice.
-    const history = [buildHistoryEntryWithBody(0, "Body with link", "/calendar"), buildHistoryEntryWithBody(1, "Body without link")];
+    const linkedEntry = buildHistoryEntryWithBody(0, "Body with link", "/calendar");
+    const unlinkedEntry = buildHistoryEntryWithBody(1, "Body without link");
     await mockAllApis(page, { sessions: [] });
-    await primeNotifierHistory(page, history);
+    await primeNotifierHistory(page, [linkedEntry, unlinkedEntry]);
 
     await page.goto("/todos");
     await page.getByTestId("notification-bell").click();
 
-    const withLink = page.getByTestId(`notification-history-${history[0].id}`);
-    const withoutLink = page.getByTestId(`notification-history-${history[1].id}`);
+    const withLink = page.getByTestId(`notification-history-${linkedEntry.id}`);
+    const withoutLink = page.getByTestId(`notification-history-${unlinkedEntry.id}`);
     // Collapsed: no navigate icon visible anywhere.
     await expect(page.getByTestId("notification-history-navigate")).toHaveCount(0);
 
@@ -413,14 +423,13 @@ test.describe("notification bell — history body expansion", () => {
 
   test("history row without body or navigateTarget has no expand button", async ({ page }) => {
     const { body: __noBody, ...withoutBody } = buildHistoryEntry(0);
-    const history = [withoutBody];
     await mockAllApis(page, { sessions: [] });
-    await primeNotifierHistory(page, history);
+    await primeNotifierHistory(page, [withoutBody]);
 
     await page.goto("/todos");
     await page.getByTestId("notification-bell").click();
 
-    const row = page.getByTestId(`notification-history-${history[0].id}`);
+    const row = page.getByTestId(`notification-history-${withoutBody.id}`);
     await expect(row).toBeVisible();
     await expect(row.getByTestId("notification-history-expand")).toHaveCount(0);
   });

--- a/e2e/tests/wiki-history-ui.spec.ts
+++ b/e2e/tests/wiki-history-ui.spec.ts
@@ -100,7 +100,7 @@ function setupRoutes(page: Page, state: WikiState): Promise<void> {
     page.route(
       (url) => url.pathname.startsWith(`/api/wiki/pages/${SLUG}/history/`) && !url.pathname.endsWith("/restore"),
       (route) => {
-        const stamp = decodeURIComponent(route.request().url().split("/history/")[1]);
+        const stamp = decodeURIComponent(route.request().url().split("/history/")[1] ?? "");
         if (stamp === SNAPSHOT_NEWER.stamp) {
           return route.fulfill({ json: { slug: SLUG, snapshot: SNAPSHOT_NEWER_CONTENT } });
         }

--- a/test/agent/test_activeTools.ts
+++ b/test/agent/test_activeTools.ts
@@ -124,7 +124,9 @@ describe("getActiveToolDescriptors — single source of truth", () => {
     const descriptors = getActiveToolDescriptors(role);
     const matches = descriptors.filter((descriptor) => descriptor.name === "presentMulmoScript");
     assert.equal(matches.length, 1, "name should appear once even with a runtime collision");
-    assert.equal(matches[0].source, "static-gui", "static wins over runtime in the unified list");
+    const [match] = matches;
+    assert.ok(match);
+    assert.equal(match.source, "static-gui", "static wins over runtime in the unified list");
   });
 
   it("surfaces an `alwaysActive` MCP tool even when the role lists nothing", () => {

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -175,7 +175,7 @@ describe("buildCliArgs", () => {
     const allowedIdx = args.indexOf("--allowedTools");
     assert.ok(allowedIdx >= 0, "--allowedTools flag must exist");
     const allowedStr = args[allowedIdx + 1];
-    assert.equal(typeof allowedStr, "string");
+    assert.ok(typeof allowedStr === "string", "--allowedTools must be followed by a value");
     assert.ok(allowedStr.includes("mcp__mulmoclaude__manageBookmarks"));
     assert.ok(allowedStr.includes("Bash"));
   });
@@ -186,6 +186,7 @@ describe("buildCliArgs", () => {
     // error + Glob fallback). See plans/done/fix-skill-tool-allowlist.md.
     const args = buildCliArgs({ systemPromptPath: "/tmp/sp.md", activePlugins: [] });
     const allowedStr = args[args.indexOf("--allowedTools") + 1];
+    assert.ok(typeof allowedStr === "string", "--allowedTools must be followed by a value");
     const tools = allowedStr.split(",");
     assert.ok(tools.includes("Skill"), `--allowedTools must list "Skill" (got: ${allowedStr})`);
   });
@@ -1015,6 +1016,7 @@ describe("buildCliArgs — extraAllowedTools", () => {
     });
     const idx = args.indexOf("--allowedTools");
     const list = args[idx + 1];
+    assert.ok(typeof list === "string", "--allowedTools must be followed by a value");
     assert.ok(list.includes("mcp__claude_ai_Gmail"));
     assert.ok(list.includes("mcp__claude_ai_Google_Calendar"));
   });

--- a/test/agent/test_agent_prompt.ts
+++ b/test/agent/test_agent_prompt.ts
@@ -464,7 +464,9 @@ describe("buildPluginPromptSections", () => {
     // on a fixed length.
     const role = makeRole({ availablePlugins: ["openCanvas"] });
     const sections = buildPluginPromptSections(role);
-    assert.ok(sections[0].includes("mcp__mulmoclaude__"), "first entry is the prefix hint");
+    const [prefixHint] = sections;
+    assert.ok(prefixHint, "plugin prompt sections must not be empty");
+    assert.ok(prefixHint.includes("mcp__mulmoclaude__"), "first entry is the prefix hint");
     const openCanvas = sections.find((section) => section.startsWith("- **mcp__mulmoclaude__openCanvas**: "));
     assert.ok(openCanvas, "openCanvas renders as a compact bullet");
     assert.ok(!openCanvas.includes("\n"));
@@ -476,7 +478,9 @@ describe("buildPluginPromptSections", () => {
     // survives.
     const role = makeRole({ availablePlugins: ["presentDocument"] });
     const sections = buildPluginPromptSections(role);
-    assert.ok(sections[0].includes("mcp__mulmoclaude__"), "first entry is the prefix hint");
+    const [prefixHint] = sections;
+    assert.ok(prefixHint, "plugin prompt sections must not be empty");
+    assert.ok(prefixHint.includes("mcp__mulmoclaude__"), "first entry is the prefix hint");
     const doc = sections.find((section) => section.startsWith("### mcp__mulmoclaude__presentDocument\n\n"));
     assert.ok(doc, "presentDocument renders in heading form");
     // Body retains its paragraph break
@@ -489,7 +493,9 @@ describe("buildPluginPromptSections", () => {
     // meaningful and the section is present.
     const role = makeRole({ availablePlugins: [] });
     const sections = buildPluginPromptSections(role);
-    assert.ok(sections[0].includes("mcp__mulmoclaude__"), "prefix hint present");
+    const [prefixHint] = sections;
+    assert.ok(prefixHint, "plugin prompt sections must not be empty");
+    assert.ok(prefixHint.includes("mcp__mulmoclaude__"), "prefix hint present");
     assert.ok(
       sections.some((section) => section.includes("mcp__mulmoclaude__spawnBackgroundChat")),
       "always-active spawnBackgroundChat section present even with no role plugins",

--- a/test/agent/test_agent_stream.ts
+++ b/test/agent/test_agent_stream.ts
@@ -167,10 +167,10 @@ describe("parseStreamEvent", () => {
     };
     const result = parseStreamEvent(event);
     assert.equal(result.length, 1);
-    assert.equal(result[0].type, "tool_call_result");
-    if (result[0].type === "tool_call_result") {
-      assert.equal(result[0].content, '{"key":"value"}');
-    }
+    const [first] = result;
+    assert.ok(first);
+    assert.ok(first.type === "tool_call_result", `expected a tool_call_result event, got ${first.type}`);
+    assert.equal(first.content, '{"key":"value"}');
   });
 
   it("skips tool_result blocks without tool_use_id", () => {

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -623,8 +623,10 @@ describe("manageCollection — deleteItems", () => {
     assert.deepEqual(result.deleted, []);
     const rejected = result.rejected as { id: string; problem: string }[];
     assert.equal(rejected.length, 1);
-    assert.equal(rejected[0].id, "ghost");
-    assert.match(rejected[0].problem, /not found/);
+    const [ghost] = rejected;
+    assert.ok(ghost);
+    assert.equal(ghost.id, "ghost");
+    assert.match(ghost.problem, /not found/);
   });
 
   it("keeps a partially-bad batch partial — good ids still go", async () => {
@@ -637,7 +639,9 @@ describe("manageCollection — deleteItems", () => {
   it("rejects a path-traversal id without touching the filesystem", async () => {
     const result = await runJson({ action: "deleteItems", slug: "portfolio", ids: ["../../../etc/passwd"] });
     assert.deepEqual(result.deleted, []);
-    assert.match((result.rejected as { problem: string }[])[0].problem, /not a valid record id/);
+    const [traversal] = result.rejected as { problem: string }[];
+    assert.ok(traversal, "the traversal id must be reported as rejected");
+    assert.match(traversal.problem, /not a valid record id/);
     assert.equal(existsSync(recordPath("h1")), true, "nothing else was deleted");
   });
 

--- a/test/agent/test_mcpFailureMonitor.ts
+++ b/test/agent/test_mcpFailureMonitor.ts
@@ -130,8 +130,10 @@ describe("createMcpFailureMonitor — threshold + notification", () => {
       monitor.track(toolCallResult(`id-${String(callIndex)}`, true));
     }
     assert.equal(publishes.length, 1, "exactly one bell entry per server");
-    assert.equal(publishes[0].id, "mcp-failure-notion");
-    assert.match(publishes[0].body, /notion/);
+    const [entry] = publishes;
+    assert.ok(entry);
+    assert.equal(entry.id, "mcp-failure-notion");
+    assert.match(entry.body, /notion/);
     assert.equal(warns.length, 1);
   });
 
@@ -194,7 +196,9 @@ describe("createMcpFailureMonitor — per-server isolation", () => {
       monitor.track(toolCallResult(`g-${String(i)}`, false));
     }
     assert.equal(publishes.length, 1);
-    assert.equal(publishes[0].id, "mcp-failure-notion");
+    const [entry] = publishes;
+    assert.ok(entry);
+    assert.equal(entry.id, "mcp-failure-notion");
   });
 
   it("interleaved failures across servers don't interfere", () => {
@@ -213,7 +217,9 @@ describe("createMcpFailureMonitor — per-server isolation", () => {
     monitor.track(toolCallResult("n3", true));
     // notion crossed threshold (3), github only at 2
     assert.equal(publishes.length, 1);
-    assert.equal(publishes[0].id, "mcp-failure-notion");
+    const [entry] = publishes;
+    assert.ok(entry);
+    assert.equal(entry.id, "mcp-failure-notion");
   });
 });
 

--- a/test/agent/test_mcpPreflight.ts
+++ b/test/agent/test_mcpPreflight.ts
@@ -151,8 +151,10 @@ describe("preflightUserServers", () => {
     const result = preflightUserServers(userServers);
     assert.deepEqual(Object.keys(result.ready).sort(), ["my-custom", "notion"]);
     assert.equal(result.skipped.length, 1);
-    assert.equal(result.skipped[0].serverId, "slack");
-    assert.deepEqual(result.skipped[0].missing.sort(), ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.equal(skipped.serverId, "slack");
+    assert.deepEqual(skipped.missing.sort(), ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
   });
 });
 
@@ -194,7 +196,9 @@ describe("logPreflightResult — snapshot diffing (Codex review on #1355)", () =
       logPreflightResult(notionSkipped, "agent-run");
       logPreflightResult(notionSkipped, "agent-run");
       assert.equal(calls.length, 1);
-      assert.equal(calls[0].serverId, "notion");
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.serverId, "notion");
     } finally {
       restore();
     }
@@ -225,7 +229,9 @@ describe("logPreflightResult — snapshot diffing (Codex review on #1355)", () =
       logPreflightResult(skipResult("slack", ["SLACK_BOT_TOKEN"]), "agent-run");
       logPreflightResult(skipResult("slack", ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]), "agent-run");
       assert.equal(calls.length, 2);
-      assert.deepEqual(calls[1].missing, ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
+      const [, secondCall] = calls;
+      assert.ok(secondCall);
+      assert.deepEqual(secondCall.missing, ["SLACK_BOT_TOKEN", "SLACK_TEAM_ID"]);
     } finally {
       restore();
     }

--- a/test/agent/test_notify_tool.ts
+++ b/test/agent/test_notify_tool.ts
@@ -48,9 +48,11 @@ describe("notify MCP tool — happy path", () => {
     const result = await tool.handler({ title: "Build done" });
     assert.match(result, /Notification sent: Build done/);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].title, "Build done");
-    assert.equal(calls[0].body, undefined);
-    assert.equal(calls[0].kind, NOTIFICATION_KINDS.push);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.title, "Build done");
+    assert.equal(call.body, undefined);
+    assert.equal(call.kind, NOTIFICATION_KINDS.push);
   });
 
   it("appends the body line when supplied", async () => {
@@ -58,7 +60,9 @@ describe("notify MCP tool — happy path", () => {
     const tool = makeNotifyTool({ publish });
     const result = await tool.handler({ title: "Build done", body: "All 12 steps green" });
     assert.equal(result, "Notification sent: Build done\nAll 12 steps green");
-    assert.equal(calls[0].body, "All 12 steps green");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.body, "All 12 steps green");
   });
 
   it("trims surrounding whitespace from title and body", async () => {
@@ -66,8 +70,10 @@ describe("notify MCP tool — happy path", () => {
     const tool = makeNotifyTool({ publish });
     const result = await tool.handler({ title: "  hi  ", body: "  there  " });
     assert.equal(result, "Notification sent: hi\nthere");
-    assert.equal(calls[0].title, "hi");
-    assert.equal(calls[0].body, "there");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.title, "hi");
+    assert.equal(call.body, "there");
   });
 
   it("treats a whitespace-only body as missing", async () => {
@@ -75,7 +81,9 @@ describe("notify MCP tool — happy path", () => {
     const tool = makeNotifyTool({ publish });
     const result = await tool.handler({ title: "hi", body: "   " });
     assert.equal(result, "Notification sent: hi");
-    assert.equal(calls[0].body, undefined);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.body, undefined);
   });
 });
 
@@ -85,7 +93,9 @@ describe("notify MCP tool — chat session linkback", () => {
     const tool = makeNotifyTool({ publish });
     await tool.handler({ title: "Build done" }, { sessionId: "sess-abc-123" });
     assert.equal(calls.length, 1);
-    assert.deepEqual(calls[0].action, {
+    const [call] = calls;
+    assert.ok(call);
+    assert.deepEqual(call.action, {
       type: NOTIFICATION_ACTION_TYPES.navigate,
       target: { view: NOTIFICATION_VIEWS.chat, sessionId: "sess-abc-123" },
     });
@@ -96,7 +106,9 @@ describe("notify MCP tool — chat session linkback", () => {
     const tool = makeNotifyTool({ publish });
     await tool.handler({ title: "Build done" });
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].action, undefined);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.action, undefined);
   });
 
   it("omits the action when sessionId is empty string", async () => {
@@ -104,7 +116,9 @@ describe("notify MCP tool — chat session linkback", () => {
     const tool = makeNotifyTool({ publish });
     await tool.handler({ title: "Build done" }, { sessionId: "" });
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].action, undefined);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.action, undefined);
   });
 });
 

--- a/test/agent/test_sandboxMounts.ts
+++ b/test/agent/test_sandboxMounts.ts
@@ -34,12 +34,14 @@ describe("buildAllowedConfigMounts", () => {
   });
 
   it("maps names to stable host paths under the given home", () => {
-    const allowed = buildAllowedConfigMounts("/fake/home");
-    assert.equal(allowed.gh.hostPath, path.join("/fake/home", ".config", "gh"));
-    assert.equal(allowed.gh.containerPath, "/home/node/.config/gh");
-    assert.equal(allowed.gh.kind, "dir");
-    assert.equal(allowed.gitconfig.hostPath, path.join("/fake/home", ".gitconfig"));
-    assert.equal(allowed.gitconfig.kind, "file");
+    const { gh, gitconfig } = buildAllowedConfigMounts("/fake/home");
+    assert.ok(gh);
+    assert.ok(gitconfig);
+    assert.equal(gh.hostPath, path.join("/fake/home", ".config", "gh"));
+    assert.equal(gh.containerPath, "/home/node/.config/gh");
+    assert.equal(gh.kind, "dir");
+    assert.equal(gitconfig.hostPath, path.join("/fake/home", ".gitconfig"));
+    assert.equal(gitconfig.kind, "file");
   });
 });
 
@@ -71,21 +73,27 @@ describe("resolveMountNames", () => {
     assert.equal(out.unknown.length, 0);
     assert.equal(out.resolved.length, 0);
     assert.equal(out.missing.length, 1);
-    assert.equal(out.missing[0].name, "gh");
+    const [missing] = out.missing;
+    assert.ok(missing);
+    assert.equal(missing.name, "gh");
   });
 
   it("resolves a present dir", () => {
     const home = makeFixtureHome({ gh: true });
     const out = resolveMountNames(["gh"], buildAllowedConfigMounts(home));
     assert.equal(out.resolved.length, 1);
-    assert.equal(out.resolved[0].name, "gh");
+    const [resolved] = out.resolved;
+    assert.ok(resolved);
+    assert.equal(resolved.name, "gh");
   });
 
   it("resolves a present file", () => {
     const home = makeFixtureHome({ gitconfig: true });
     const out = resolveMountNames(["gitconfig"], buildAllowedConfigMounts(home));
     assert.equal(out.resolved.length, 1);
-    assert.equal(out.resolved[0].name, "gitconfig");
+    const [resolved] = out.resolved;
+    assert.ok(resolved);
+    assert.equal(resolved.name, "gitconfig");
   });
 
   it("rejects dir when host path is a file and vice versa", () => {
@@ -113,11 +121,14 @@ describe("configMountArgs", () => {
     const home = makeFixtureHome({ gh: true, gitconfig: true });
     const { resolved } = resolveMountNames(["gh", "gitconfig"], buildAllowedConfigMounts(home));
     const args = configMountArgs(resolved);
-    assert.equal(args[0], "-v");
-    assert.match(args[1], /:\/home\/node\/\.config\/gh:ro$/);
-    assert.equal(args[2], "-v");
-    assert.match(args[3], /:\/home\/node\/\.gitconfig:ro$/);
     assert.equal(args.length, 4);
+    const [ghFlag, ghMount, gitconfigFlag, gitconfigMount] = args;
+    assert.ok(ghMount);
+    assert.ok(gitconfigMount);
+    assert.equal(ghFlag, "-v");
+    assert.match(ghMount, /:\/home\/node\/\.config\/gh:ro$/);
+    assert.equal(gitconfigFlag, "-v");
+    assert.match(gitconfigMount, /:\/home\/node\/\.gitconfig:ro$/);
   });
 
   it("empty input → empty args", () => {

--- a/test/agent/test_skillTagging.ts
+++ b/test/agent/test_skillTagging.ts
@@ -58,14 +58,18 @@ describe("applySkillEvent (#1218) — replace streamed assistant text in place",
     applySkillEvent(session, skillPayload);
 
     assert.equal(session.toolResults.length, 1, "no new card pushed when one was replaced in place");
-    assert.equal(session.toolResults[0].toolName, "skill");
-    assert.equal(session.toolResults[0].uuid, originalUuid, "uuid preserved so view bindings stay attached");
+    const [card] = session.toolResults;
+    assert.ok(card);
+    assert.equal(card.toolName, "skill");
+    assert.equal(card.uuid, originalUuid, "uuid preserved so view bindings stay attached");
   });
 
   it("pushes a new skill card when no streamed assistant text precedes it", () => {
     applySkillEvent(session, skillPayload);
     assert.equal(session.toolResults.length, 1);
-    assert.equal(session.toolResults[0].toolName, "skill");
+    const [card] = session.toolResults;
+    assert.ok(card);
+    assert.equal(card.toolName, "skill");
   });
 
   it("does NOT replace a trailing user text-response (would corrupt the user's message)", () => {
@@ -73,8 +77,11 @@ describe("applySkillEvent (#1218) — replace streamed assistant text in place",
     session.toolResults.push(userMsg);
     applySkillEvent(session, skillPayload);
     assert.equal(session.toolResults.length, 2, "user text stays, skill is appended");
-    assert.equal(session.toolResults[0].toolName, "text-response");
-    assert.equal(session.toolResults[1].toolName, "skill");
+    const [userCard, skillCard] = session.toolResults;
+    assert.ok(userCard);
+    assert.ok(skillCard);
+    assert.equal(userCard.toolName, "text-response");
+    assert.equal(skillCard.toolName, "skill");
   });
 
   it("does NOT replace a non-text-response trailing card (e.g. image / wiki result)", () => {
@@ -87,14 +94,18 @@ describe("applySkillEvent (#1218) — replace streamed assistant text in place",
     });
     applySkillEvent(session, skillPayload);
     assert.equal(session.toolResults.length, 2);
-    assert.equal(session.toolResults[1].toolName, "skill");
+    const [, skillCard] = session.toolResults;
+    assert.ok(skillCard);
+    assert.equal(skillCard.toolName, "skill");
   });
 
   it("populates the envelope's `data` with all skill metadata", () => {
     const streamed = makeTextResult("partial body", "assistant");
     session.toolResults.push(streamed);
     applySkillEvent(session, skillPayload);
-    const data = session.toolResults[0].data as Record<string, unknown>;
+    const [card] = session.toolResults;
+    assert.ok(card);
+    const data = card.data as Record<string, unknown>;
     assert.equal(data.skillName, "mc-library");
     assert.equal(data.skillScope, "project");
     assert.equal(data.skillDescription, "Personal book journal");
@@ -113,6 +124,8 @@ describe("applySkillEvent (#1218) — replace streamed assistant text in place",
     session.runStartIndex = 1;
     applySkillEvent(session, skillPayload);
     assert.equal(session.toolResults.length, 2);
-    assert.equal(session.selectedResultUuid, session.toolResults[1].uuid);
+    const [, skillCard] = session.toolResults;
+    assert.ok(skillCard);
+    assert.equal(session.selectedResultUuid, skillCard.uuid);
   });
 });

--- a/test/agent/test_spawnBackgroundChat.ts
+++ b/test/agent/test_spawnBackgroundChat.ts
@@ -74,10 +74,12 @@ describe("spawnBackgroundChat — origin mapping", () => {
       const result = await tool.handler({ message: "author lesson 2", role: "tutor", hidden: true });
       chatId = chatIdFrom(result);
       assert.equal(calls.length, 1);
-      assert.equal(calls[0].origin, SESSION_ORIGINS.system);
-      assert.equal(calls[0].roleId, "tutor");
-      assert.equal(calls[0].chatSessionId, chatId);
-      assert.equal(calls[0].message, "author lesson 2");
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.origin, SESSION_ORIGINS.system);
+      assert.equal(call.roleId, "tutor");
+      assert.equal(call.chatSessionId, chatId);
+      assert.equal(call.message, "author lesson 2");
     } finally {
       if (chatId) releaseBackgroundSession(chatId);
     }
@@ -89,7 +91,9 @@ describe("spawnBackgroundChat — origin mapping", () => {
     const result = await tool.handler({ message: "open a chat", role: "general", hidden: false });
     chatIdFrom(result);
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].origin, SESSION_ORIGINS.skill);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.origin, SESSION_ORIGINS.skill);
   });
 
   it("trims message and role before passing them to startChat", async () => {
@@ -99,8 +103,10 @@ describe("spawnBackgroundChat — origin mapping", () => {
     try {
       const result = await tool.handler({ message: "  go  ", role: "  tutor  ", hidden: true });
       chatId = chatIdFrom(result);
-      assert.equal(calls[0].message, "go");
-      assert.equal(calls[0].roleId, "tutor");
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.message, "go");
+      assert.equal(call.roleId, "tutor");
     } finally {
       if (chatId) releaseBackgroundSession(chatId);
     }

--- a/test/agent/test_streamParser.ts
+++ b/test/agent/test_streamParser.ts
@@ -78,7 +78,9 @@ describe("createStreamParser — delta streaming", () => {
       session_id: "sess-1",
     });
     assert.equal(events.length, 1);
-    assert.equal(events[0].type, EVENT_TYPES.claudeSessionId);
+    const [event] = events;
+    assert.ok(event);
+    assert.equal(event.type, EVENT_TYPES.claudeSessionId);
   });
 });
 
@@ -91,7 +93,9 @@ describe("createStreamParser — no deltas (fallback)", () => {
     });
     const textEvents = events.filter((evt) => evt.type === EVENT_TYPES.text);
     assert.equal(textEvents.length, 1);
-    assert.equal(textEvents[0].message, "direct reply");
+    const [textEvent] = textEvents;
+    assert.ok(textEvent);
+    assert.equal(textEvent.message, "direct reply");
   });
 
   it("suppresses result text after assistant block emitted text", () => {
@@ -118,11 +122,13 @@ describe("createStreamParser — no deltas (fallback)", () => {
       session_id: "s1",
     });
     assert.equal(events.length, 2);
-    assert.deepEqual(events[0], {
+    const [textEvent, sessionIdEvent] = events;
+    assert.deepEqual(textEvent, {
       type: EVENT_TYPES.text,
       message: "fallback text",
     });
-    assert.equal(events[1].type, EVENT_TYPES.claudeSessionId);
+    assert.ok(sessionIdEvent);
+    assert.equal(sessionIdEvent.type, EVENT_TYPES.claudeSessionId);
   });
 });
 
@@ -146,7 +152,9 @@ describe("createStreamParser — multi-turn reset", () => {
     });
     const textEvents = events.filter((evt) => evt.type === EVENT_TYPES.text);
     assert.equal(textEvents.length, 1);
-    assert.equal(textEvents[0].message, "turn2");
+    const [textEvent] = textEvents;
+    assert.ok(textEvent);
+    assert.equal(textEvent.message, "turn2");
   });
 });
 

--- a/test/api/routes/test_agentAttachmentFilename.ts
+++ b/test/api/routes/test_agentAttachmentFilename.ts
@@ -74,8 +74,10 @@ describe("prepareRequestExtras — original filename (#2308)", () => {
   it("still loads the bytes for the model alongside the name", async () => {
     const out = await prepareRequestExtras([{ path: STORED_PATH, filename: ORIGINAL_NAME }]);
     assert.equal(out.attachments?.length, 1);
-    assert.equal(out.attachments?.[0].mimeType, "text/csv");
-    assert.ok(out.attachments?.[0].data, "bytes should be loaded off disk");
+    const attachment = out.attachments?.[0];
+    assert.ok(attachment);
+    assert.equal(attachment.mimeType, "text/csv");
+    assert.ok(attachment.data, "bytes should be loaded off disk");
   });
 
   it("produces the marker line the model reads, end to end", async () => {

--- a/test/api/routes/test_collectionsViewCors.ts
+++ b/test/api/routes/test_collectionsViewCors.ts
@@ -43,7 +43,9 @@ describe("viewDataCors", () => {
     for (const method of ["GET", "PUT", "POST", "OPTIONS"]) {
       assert.ok(VIEW_DATA_CORS_METHODS.includes(method), `${method} must be preflight-allowed`);
     }
-    assert.ok(headers["Access-Control-Allow-Headers"].includes("Authorization"));
+    const allowedHeaders = headers["Access-Control-Allow-Headers"];
+    assert.ok(allowedHeaders);
+    assert.ok(allowedHeaders.includes("Authorization"));
   });
 });
 

--- a/test/api/routes/test_hookLog.ts
+++ b/test/api/routes/test_hookLog.ts
@@ -36,7 +36,8 @@ function getPostHandler(router: Router): (req: Request, res: Response) => void {
   const internals = router as unknown as RouterInternals;
   for (const layer of internals.stack) {
     if (layer.route && layer.route.path === API_ROUTES.hooks.log) {
-      return layer.route.stack[0].handle;
+      const [first] = layer.route.stack;
+      if (first) return first.handle;
     }
   }
   throw new Error(`POST ${API_ROUTES.hooks.log} handler not found in router stack`);
@@ -101,19 +102,23 @@ describe("POST /api/hooks/log", () => {
     const res = await callHandler({ namespace: "skill-bridge", message: "mirrored foo" });
     assert.equal(res.statusCode, 204);
     assert.equal(captured.length, 1);
-    assert.equal(captured[0].level, "info");
+    const [entry] = captured;
+    assert.ok(entry);
+    assert.equal(entry.level, "info");
     // The `hook:` prefix lets the user grep for hook-side noise
     // separately from server-side `skill-bridge` log lines (if a
     // server module ever uses that namespace).
-    assert.equal(captured[0].namespace, "hook:skill-bridge");
-    assert.equal(captured[0].message, "mirrored foo");
+    assert.equal(entry.namespace, "hook:skill-bridge");
+    assert.equal(entry.message, "mirrored foo");
   });
 
   it("honours explicit level and forwards data", async () => {
     const res = await callHandler({ namespace: "skill-bridge", message: "mirror failed", level: "error", data: { slug: "foo", op: "write" } });
     assert.equal(res.statusCode, 204);
-    assert.equal(captured[0].level, "error");
-    assert.deepEqual(captured[0].data, { slug: "foo", op: "write" });
+    const [entry] = captured;
+    assert.ok(entry);
+    assert.equal(entry.level, "error");
+    assert.deepEqual(entry.data, { slug: "foo", op: "write" });
   });
 
   it("rejects missing namespace / message with 400", async () => {
@@ -130,6 +135,8 @@ describe("POST /api/hooks/log", () => {
     // info so the log line still shows up.
     const res = await callHandler({ namespace: "x", message: "y", level: "debug" });
     assert.equal(res.statusCode, 204);
-    assert.equal(captured[0].level, "info");
+    const [entry] = captured;
+    assert.ok(entry);
+    assert.equal(entry.level, "info");
   });
 });

--- a/test/api/routes/test_parseConnectors.ts
+++ b/test/api/routes/test_parseConnectors.ts
@@ -21,9 +21,7 @@ describe("parseConnectors", () => {
     ].join("\n");
 
     const result = parseConnectors(stdout);
-    assert.equal(result.length, 1);
-    assert.equal(result[0].name, "Google Calendar");
-    assert.equal(result[0].connected, true);
+    assert.deepEqual(result, [{ name: "Google Calendar", connected: true }]);
   });
 
   it("returns empty array for empty input", () => {
@@ -65,13 +63,17 @@ describe("parseConnectors", () => {
     const stdout = ["claude.ai MalformedEntry", "claude.ai Gmail: https://gmail.example.com - ✓ Connected"].join("\n");
     const result = parseConnectors(stdout);
     assert.equal(result.length, 1);
-    assert.equal(result[0].name, "Gmail");
+    const [entry] = result;
+    assert.ok(entry);
+    assert.equal(entry.name, "Gmail");
   });
 
   it("handles trailing newlines", () => {
     const stdout = "claude.ai Gmail: https://gmail.example.com - ✓ Connected\n\n";
     const result = parseConnectors(stdout);
     assert.equal(result.length, 1);
-    assert.equal(result[0].name, "Gmail");
+    const [entry] = result;
+    assert.ok(entry);
+    assert.equal(entry.name, "Gmail");
   });
 });

--- a/test/api/routes/test_runtimePluginRoot.ts
+++ b/test/api/routes/test_runtimePluginRoot.ts
@@ -157,8 +157,10 @@ describe("POST /api/plugins/runtime/:pkg/dispatch — call signature", () => {
       });
       assert.equal(res.status, 200, await res.text());
       assert.equal(calls.length, 1);
-      assert.deepEqual(calls[0].args, { areaCode: "130000" }, "args must arrive as the SECOND parameter");
-      assert.ok(calls[0].context !== undefined, "context must be a defined value (empty object is fine), not omitted");
+      const [call] = calls;
+      assert.ok(call);
+      assert.deepEqual(call.args, { areaCode: "130000" }, "args must arrive as the SECOND parameter");
+      assert.ok(call.context !== undefined, "context must be a defined value (empty object is fine), not omitted");
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
@@ -204,7 +206,9 @@ describe("GET /api/plugins/runtime/oauth-callback/:alias", () => {
       assert.match(res.headers.get("content-type") ?? "", /text\/html/);
       assert.match(await res.text(), /Connected!/);
       assert.equal(calls.length, 1);
-      assert.deepEqual(calls[0].args, {
+      const [call] = calls;
+      assert.ok(call);
+      assert.deepEqual(call.args, {
         kind: "oauthCallback",
         code: "auth-code-123",
         state: "state-xyz",
@@ -262,7 +266,9 @@ describe("GET /api/plugins/runtime/oauth-callback/:alias", () => {
       const { port } = server.address() as AddressInfo;
       const res = await fetch(`http://127.0.0.1:${port}/api/plugins/runtime/oauth-callback/fixture-alias?error=access_denied`);
       assert.equal(res.status, 400);
-      assert.deepEqual(calls[0].args, { kind: "oauthCallback", code: undefined, state: undefined, error: "access_denied" });
+      const [call] = calls;
+      assert.ok(call);
+      assert.deepEqual(call.args, { kind: "oauthCallback", code: undefined, state: undefined, error: "access_denied" });
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
@@ -318,8 +324,10 @@ describe("GET /api/plugins/runtime/oauth-callback/:alias", () => {
     // second's alias is dropped.
     assert.equal(result.registered.length, 2);
     assert.equal(result.oauthAliasCollisions.length, 1);
-    assert.equal(result.oauthAliasCollisions[0].plugin.name, "@fixture/second");
-    assert.equal(result.oauthAliasCollisions[0].alias, "shared");
-    assert.equal(result.oauthAliasCollisions[0].existingPlugin, "@fixture/first");
+    const [collision] = result.oauthAliasCollisions;
+    assert.ok(collision);
+    assert.equal(collision.plugin.name, "@fixture/second");
+    assert.equal(collision.alias, "shared");
+    assert.equal(collision.existingPlugin, "@fixture/first");
   });
 });

--- a/test/chat-index/test_indexer.ts
+++ b/test/chat-index/test_indexer.ts
@@ -117,11 +117,15 @@ describe("indexSession — happy path", () => {
     // Manifest upserted.
     const manifest = await readManifest(workspace);
     assert.equal(manifest.entries.length, 1);
-    assert.equal(manifest.entries[0].id, "sess-A");
+    const [manifestEntry] = manifest.entries;
+    assert.ok(manifestEntry);
+    assert.equal(manifestEntry.id, "sess-A");
 
     // Summarizer was called once with the extracted transcript.
     assert.equal(stub.calls.length, 1);
-    assert.match(stub.calls[0], /Can you help me plan a project/);
+    const [summarizeCall] = stub.calls;
+    assert.ok(summarizeCall);
+    assert.match(summarizeCall, /Can you help me plan a project/);
   });
 });
 
@@ -295,7 +299,9 @@ describe("indexSession — manifest upsert and ordering", () => {
 
     const manifest = await readManifest(workspace);
     assert.equal(manifest.entries.length, 1);
-    assert.equal(manifest.entries[0].title, "second");
+    const [manifestEntry] = manifest.entries;
+    assert.ok(manifestEntry);
+    assert.equal(manifestEntry.title, "second");
   });
 
   it("sorts manifest entries newest-startedAt first", async () => {

--- a/test/chat-index/test_summarizer.ts
+++ b/test/chat-index/test_summarizer.ts
@@ -250,7 +250,9 @@ describe("buildSummarizeCliArgs", () => {
     assert.equal(args[args.indexOf("--output-format") + 1], "json");
     assert.ok(args.includes("--json-schema"));
     // the schema arg is valid JSON carrying the title/summary/keywords shape
-    const schema = JSON.parse(args[args.indexOf("--json-schema") + 1]);
+    const schemaArg = args[args.indexOf("--json-schema") + 1];
+    assert.ok(schemaArg);
+    const schema = JSON.parse(schemaArg);
     assert.deepEqual(Object.keys(schema.properties).sort(), ["keywords", "summary", "title"]);
   });
 });

--- a/test/events/test_persistToolCalls.ts
+++ b/test/events/test_persistToolCalls.ts
@@ -108,8 +108,11 @@ describe("persistToolCallEvent — schema", () => {
       const contents = await readFile(jsonlPath, "utf8");
       const lines = contents.trim().split("\n");
       assert.equal(lines.length, 2);
-      const first = JSON.parse(lines[0]) as Record<string, unknown>;
-      const second = JSON.parse(lines[1]) as Record<string, unknown>;
+      const [firstLine, secondLine] = lines;
+      assert.ok(firstLine);
+      assert.ok(secondLine);
+      const first = JSON.parse(firstLine) as Record<string, unknown>;
+      const second = JSON.parse(secondLine) as Record<string, unknown>;
       assert.equal(first.toolUseId, "u1");
       assert.equal(second.toolUseId, "u2");
     } finally {
@@ -152,8 +155,11 @@ describe("enqueueJsonlAppend — FIFO ordering across awaited / unawaited caller
 
       const lines = (await readFile(jsonlPath, "utf8")).trim().split("\n");
       assert.equal(lines.length, 2);
-      assert.equal((JSON.parse(lines[0]) as Record<string, unknown>).type, "tool_call", "tool_call must land first");
-      assert.equal((JSON.parse(lines[1]) as Record<string, unknown>).type, "tool_result", "tool_result must land second");
+      const [callLine, resultLine] = lines;
+      assert.ok(callLine);
+      assert.ok(resultLine);
+      assert.equal((JSON.parse(callLine) as Record<string, unknown>).type, "tool_call", "tool_call must land first");
+      assert.equal((JSON.parse(resultLine) as Record<string, unknown>).type, "tool_result", "tool_result must land second");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/test/events/test_photo_locations_change.ts
+++ b/test/events/test_photo_locations_change.ts
@@ -33,7 +33,9 @@ describe("photo-locations change publisher", () => {
     initPhotoLocationsChangePublisher(fakePubSub(sink));
     publishPhotoLocationsChanged();
     assert.equal(sink.length, 1);
-    assert.equal(sink[0].channel, PUBSUB_CHANNELS.locationsChanged);
+    const [published] = sink;
+    assert.ok(published);
+    assert.equal(published.channel, PUBSUB_CHANNELS.locationsChanged);
   });
 
   it("publishes on the exact channel the plugin META declares", () => {
@@ -90,6 +92,8 @@ describe("photo-locations change publisher — write-path integration", () => {
     const { capturePhotoLocationWithParser } = await import("../../server/workspace/photo-locations/index.js");
     await capturePhotoLocationWithParser(photoPath, "data/attachments/2026/07/pic.jpg", "image/jpeg", () => Promise.resolve(FAKE_GPS_EXIF));
     assert.equal(sink.length, 1, "a sidecar write should publish exactly one change event");
-    assert.equal(sink[0].channel, PUBSUB_CHANNELS.locationsChanged);
+    const [published] = sink;
+    assert.ok(published);
+    assert.equal(published.channel, PUBSUB_CHANNELS.locationsChanged);
   });
 });

--- a/test/events/test_relayClient.ts
+++ b/test/events/test_relayClient.ts
@@ -104,11 +104,13 @@ describe("handleRelayMessage", () => {
     await handleRelayMessage(JSON.stringify(validMessage), { relay, logger, sendResponse });
 
     assert.equal(captured.length, 1);
-    assert.equal(captured[0].transportId, "relay");
-    assert.equal(captured[0].externalChatId, "line__c-1");
-    assert.equal(captured[0].text, "hello");
-    assert.equal(typeof captured[0].bridgeOptions, "object");
-    assert.notEqual(captured[0].bridgeOptions, null);
+    const [params] = captured;
+    assert.ok(params);
+    assert.equal(params.transportId, "relay");
+    assert.equal(params.externalChatId, "line__c-1");
+    assert.equal(params.text, "hello");
+    assert.equal(typeof params.bridgeOptions, "object");
+    assert.notEqual(params.bridgeOptions, null);
 
     assert.deepEqual(responses, [{ platform: "line", chatId: "c-1", text: "pong", replyToken: "tok-1" }]);
   });
@@ -121,8 +123,10 @@ describe("handleRelayMessage", () => {
     await handleRelayMessage(JSON.stringify(validMessage), { relay, logger, sendResponse });
 
     assert.equal(responses.length, 1);
-    assert.equal(responses[0].text, "Error: nope");
-    assert.equal(responses[0].replyToken, "tok-1");
+    const [response] = responses;
+    assert.ok(response);
+    assert.equal(response.text, "Error: nope");
+    assert.equal(response.replyToken, "tok-1");
   });
 
   it("relay throws → sends the fallback error reply and logs the failure", async () => {
@@ -151,7 +155,9 @@ describe("handleRelayMessage", () => {
     await handleRelayMessage(JSON.stringify(noToken), { relay, logger, sendResponse });
 
     assert.equal(responses.length, 1);
-    assert.equal(responses[0].replyToken, undefined);
+    const [response] = responses;
+    assert.ok(response);
+    assert.equal(response.replyToken, undefined);
   });
 });
 
@@ -164,7 +170,7 @@ function scriptedTrySend(results: boolean[]) {
   let idx = 0;
   const trySend = (response: RelayResponseLike): boolean => {
     seen.push(response);
-    const result = idx < results.length ? results[idx] : false;
+    const result = results[idx] ?? false;
     idx += 1;
     return result;
   };
@@ -253,8 +259,12 @@ describe("createResponseQueue", () => {
 
     queue.flush();
     assert.equal(delivered.length, QUEUE_CAP);
-    assert.equal(delivered[0].chatId, "c-2");
-    assert.equal(delivered[QUEUE_CAP - 1].chatId, `c-${QUEUE_CAP + 1}`);
+    const [oldestDelivered] = delivered;
+    const newestDelivered = delivered[QUEUE_CAP - 1];
+    assert.ok(oldestDelivered);
+    assert.ok(newestDelivered);
+    assert.equal(oldestDelivered.chatId, "c-2");
+    assert.equal(newestDelivered.chatId, `c-${QUEUE_CAP + 1}`);
     assert.ok(!delivered.some((res) => res.chatId === "c-1"));
   });
 
@@ -392,7 +402,9 @@ describe("attemptSocketSend", () => {
     const state: RelayState = { socket: socket as unknown as RelayState["socket"], reconnectMs: 1000, reconnectTimer: null, stopped: false };
     const result = attemptSocketSend(state, makeResp(7), logger, () => {});
     assert.equal(result, true);
-    assert.deepEqual(JSON.parse(socket.sent[0]), makeResp(7));
+    const [sentPayload] = socket.sent;
+    assert.ok(sentPayload);
+    assert.deepEqual(JSON.parse(sentPayload), makeResp(7));
   });
 
   it("re-enqueues via onEnqueue when the async send callback reports an error and state.stopped is false", () => {

--- a/test/events/test_session_store.ts
+++ b/test/events/test_session_store.ts
@@ -241,17 +241,25 @@ describe("pushSessionEvent — malformed payload fields", () => {
     pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolUseId: "t1", toolName: "Bash", args: { cmd: "ls" } });
     pushSessionEvent("s1", { type: EVENT_TYPES.toolCallResult, toolUseId: "t1", content: "out" });
     assert.equal(history().length, 1);
-    assert.equal(history()[0].toolUseId, "t1");
-    assert.equal(history()[0].toolName, "Bash");
-    assert.equal(history()[0].result, "out");
+    const [call] = history();
+    assert.ok(call);
+    assert.equal(call.toolUseId, "t1");
+    assert.equal(call.toolName, "Bash");
+    assert.equal(call.result, "out");
   });
 
   it("leaves result undefined when tool_call_result content is absent or not a string", () => {
     pushSessionEvent("s1", { type: EVENT_TYPES.toolCall, toolUseId: "t1", toolName: "Bash", args: {} });
     pushSessionEvent("s1", { type: EVENT_TYPES.toolCallResult, toolUseId: "t1" });
-    assert.equal(history()[0].result, undefined);
+    // Re-read after each push — the second assertion must see the
+    // state the SECOND event produced, not a hoisted snapshot.
+    const [afterAbsentContent] = history();
+    assert.ok(afterAbsentContent);
+    assert.equal(afterAbsentContent.result, undefined);
     pushSessionEvent("s1", { type: EVENT_TYPES.toolCallResult, toolUseId: "t1", content: { nested: true } });
-    assert.equal(history()[0].result, undefined);
+    const [afterNonStringContent] = history();
+    assert.ok(afterNonStringContent);
+    assert.equal(afterNonStringContent.result, undefined);
   });
 
   it("falls back to an empty statusMessage when status.message is absent or not a string", () => {

--- a/test/helpers/test_vueTemplateProbe.ts
+++ b/test/helpers/test_vueTemplateProbe.ts
@@ -50,28 +50,33 @@ describe("findVHtmlBindings — element association", () => {
 
 describe("findVHtmlBindings — binding syntax variants", () => {
   it("recognises the long-form v-on:click", () => {
-    const bindings = findVHtmlBindings(sfc(`<div v-on:click="handleExternalLinkClick" v-html="body"></div>`));
-    assert.deepEqual(bindings[0].clickHandlers, ["handleExternalLinkClick"]);
+    const [binding] = findVHtmlBindings(sfc(`<div v-on:click="handleExternalLinkClick" v-html="body"></div>`));
+    assert.ok(binding);
+    assert.deepEqual(binding.clickHandlers, ["handleExternalLinkClick"]);
   });
 
   it("recognises a click handler carrying modifiers (@click.capture)", () => {
-    const bindings = findVHtmlBindings(sfc(`<div @click.capture="handleExternalLinkClick" v-html="body"></div>`));
-    assert.deepEqual(bindings[0].clickHandlers, ["handleExternalLinkClick"]);
+    const [binding] = findVHtmlBindings(sfc(`<div @click.capture="handleExternalLinkClick" v-html="body"></div>`));
+    assert.ok(binding);
+    assert.deepEqual(binding.clickHandlers, ["handleExternalLinkClick"]);
   });
 
   it("keeps the raw expression for an inline arrow handler", () => {
-    const bindings = findVHtmlBindings(sfc(`<div @click="(e) => handleExternalLinkClick(e)" v-html="body"></div>`));
-    assert.deepEqual(bindings[0].clickHandlers, ["(e) => handleExternalLinkClick(e)"]);
+    const [binding] = findVHtmlBindings(sfc(`<div @click="(e) => handleExternalLinkClick(e)" v-html="body"></div>`));
+    assert.ok(binding);
+    assert.deepEqual(binding.clickHandlers, ["(e) => handleExternalLinkClick(e)"]);
   });
 
   it("ignores non-click listeners on the v-html element", () => {
-    const bindings = findVHtmlBindings(sfc(`<div @mousedown="handleExternalLinkClick" @keyup="onKey" v-html="body"></div>`));
-    assert.deepEqual(bindings[0].clickHandlers, []);
+    const [binding] = findVHtmlBindings(sfc(`<div @mousedown="handleExternalLinkClick" @keyup="onKey" v-html="body"></div>`));
+    assert.ok(binding);
+    assert.deepEqual(binding.clickHandlers, []);
   });
 
   it("does not treat a dynamic event argument as a click binding", () => {
-    const bindings = findVHtmlBindings(sfc(`<div @[eventName]="handleExternalLinkClick" v-html="body"></div>`));
-    assert.deepEqual(bindings[0].clickHandlers, []);
+    const [binding] = findVHtmlBindings(sfc(`<div @[eventName]="handleExternalLinkClick" v-html="body"></div>`));
+    assert.ok(binding);
+    assert.deepEqual(binding.clickHandlers, []);
   });
 });
 
@@ -85,8 +90,9 @@ describe("findVHtmlBindings — empty / edge inputs", () => {
   });
 
   it("tolerates comments, text nodes and interpolation around the v-html element", () => {
-    const bindings = findVHtmlBindings(sfc(`<!-- note --> text {{ value }} <div v-html="body" @click="handleExternalLinkClick"></div>`));
-    assert.deepEqual(bindings[0].clickHandlers, ["handleExternalLinkClick"]);
+    const [binding] = findVHtmlBindings(sfc(`<!-- note --> text {{ value }} <div v-html="body" @click="handleExternalLinkClick"></div>`));
+    assert.ok(binding);
+    assert.deepEqual(binding.clickHandlers, ["handleExternalLinkClick"]);
   });
 
   it("reports a v-html element with no expression rather than skipping it", () => {

--- a/test/journal/test_dailyPass.ts
+++ b/test/journal/test_dailyPass.ts
@@ -486,7 +486,9 @@ describe("parseJsonlEvents", () => {
     const raw = ["", "not json", JSON.stringify({ source: "user", type: "text", message: "hi" }), "{", ""].join("\n");
     const out = parseJsonlEvents(raw, 10);
     assert.equal(out.length, 1);
-    assert.equal(out[0].excerpt.content, "hi");
+    const [event] = out;
+    assert.ok(event);
+    assert.equal(event.excerpt.content, "hi");
   });
 
   it("skips session_meta and claude_session_id entries", () => {
@@ -497,7 +499,9 @@ describe("parseJsonlEvents", () => {
     ].join("\n");
     const out = parseJsonlEvents(raw, 10);
     assert.equal(out.length, 1);
-    assert.equal(out[0].excerpt.content, "real");
+    const [event] = out;
+    assert.ok(event);
+    assert.equal(event.excerpt.content, "real");
   });
 
   it("honours the maxEvents cap", () => {
@@ -505,10 +509,15 @@ describe("parseJsonlEvents", () => {
     for (let i = 0; i < 20; i++) {
       lines.push(JSON.stringify({ source: "user", type: "text", message: `m${i}` }));
     }
-    const out = parseJsonlEvents(lines.join("\n"), 5);
-    assert.equal(out.length, 5);
-    assert.equal(out[0].excerpt.content, "m0");
-    assert.equal(out[4].excerpt.content, "m4");
+    const MAX_EVENTS = 5;
+    const out = parseJsonlEvents(lines.join("\n"), MAX_EVENTS);
+    assert.equal(out.length, MAX_EVENTS);
+    const [firstEvent] = out;
+    const lastEvent = out[MAX_EVENTS - 1];
+    assert.ok(firstEvent);
+    assert.ok(lastEvent);
+    assert.equal(firstEvent.excerpt.content, "m0");
+    assert.equal(lastEvent.excerpt.content, "m4");
   });
 
   it("returns excerpts with artifact paths populated via parseEntry", () => {
@@ -523,7 +532,9 @@ describe("parseJsonlEvents", () => {
     });
     const out = parseJsonlEvents(raw, 10);
     assert.equal(out.length, 1);
-    assert.deepEqual(out[0].artifactPaths, ["stories/x.json"]);
+    const [event] = out;
+    assert.ok(event);
+    assert.deepEqual(event.artifactPaths, ["stories/x.json"]);
   });
 
   it("skips non-object JSON values (null, arrays, primitives)", () => {
@@ -535,7 +546,9 @@ describe("parseJsonlEvents", () => {
     const raw = ["null", "[1,2,3]", '"just a string"', "42", "true", JSON.stringify({ source: "user", type: "text", message: "real" })].join("\n");
     const out = parseJsonlEvents(raw, 10);
     assert.equal(out.length, 1);
-    assert.equal(out[0].excerpt.content, "real");
+    const [event] = out;
+    assert.ok(event);
+    assert.equal(event.excerpt.content, "real");
   });
 });
 

--- a/test/logger/test_logger.ts
+++ b/test/logger/test_logger.ts
@@ -47,8 +47,11 @@ describe("createLogger level filtering", () => {
       process.stderr.write = originalErr;
     }
     assert.equal(captured.length, 2);
-    assert.equal(captured[0].message, "kept-warn");
-    assert.equal(captured[1].message, "kept-error");
+    const [warnRecord, errorRecord] = captured;
+    assert.ok(warnRecord);
+    assert.ok(errorRecord);
+    assert.equal(warnRecord.message, "kept-warn");
+    assert.equal(errorRecord.message, "kept-error");
   });
 
   it("produces no output when all sinks are disabled", () => {

--- a/test/logger/test_sinks.ts
+++ b/test/logger/test_sinks.ts
@@ -44,8 +44,11 @@ describe("createFileSink", () => {
     const contents = await readFile(path.join(dir, "server-2026-04-13.log"), "utf-8");
     const lines = contents.trim().split("\n");
     assert.equal(lines.length, 2);
-    const parsed0: { message: string } = JSON.parse(lines[0]);
-    const parsed1: { message: string } = JSON.parse(lines[1]);
+    const [firstLine, secondLine] = lines;
+    assert.ok(firstLine);
+    assert.ok(secondLine);
+    const parsed0: { message: string } = JSON.parse(firstLine);
+    const parsed1: { message: string } = JSON.parse(secondLine);
     assert.equal(parsed0.message, "first");
     assert.equal(parsed1.message, "second");
   });

--- a/test/remoteHost/test_dataHandlers.ts
+++ b/test/remoteHost/test_dataHandlers.ts
@@ -51,7 +51,9 @@ describe("createGetCollection", () => {
   it("resolves record-local derived formulas before paging", async () => {
     const handler = createGetCollection(collectionDeps([{ id: "r0", won: 2 } as unknown as { id: string }]));
     const result = (await handler({ slug: "clients" })) as { items: { id: string; points?: number }[] };
-    assert.equal(result.items[0].points, 6);
+    const [item] = result.items;
+    assert.ok(item);
+    assert.equal(item.points, 6);
   });
 
   it("throws when the collection is not found", async () => {
@@ -86,7 +88,9 @@ describe("createGetCollection", () => {
     const seenAt = new Date("2026-01-02T03:04:05.000Z");
     const handler = createGetCollection(collectionDeps([{ id: "r0", seenAt } as unknown as { id: string }]));
     const result = (await handler({ slug: "clients" })) as { items: { seenAt: string }[] };
-    assert.equal(result.items[0].seenAt, seenAt.toISOString());
+    const [item] = result.items;
+    assert.ok(item);
+    assert.equal(item.seenAt, seenAt.toISOString());
   });
 });
 
@@ -187,7 +191,9 @@ describe("createListFeeds", () => {
       workspaceRoot: "/ws",
     };
     const result = (await createListFeeds(deps)({})) as { feeds: { kind: string; schedule: string }[] };
-    assert.equal(result.feeds[0].kind, "rss");
-    assert.equal(result.feeds[0].schedule, "on-demand");
+    const [feed] = result.feeds;
+    assert.ok(feed);
+    assert.equal(feed.kind, "rss");
+    assert.equal(feed.schedule, "on-demand");
   });
 });

--- a/test/remoteHost/test_remoteViewItems.ts
+++ b/test/remoteHost/test_remoteViewItems.ts
@@ -66,7 +66,9 @@ describe("createRemoteViewItems", () => {
     if (result.kind !== "ok") return;
     assert.equal(result.inlined, 2);
     assert.equal(result.omitted, 0);
-    assert.match(String(result.page.items[0].photo), /^data:image\/jpeg;base64,/);
+    const [item] = result.page.items;
+    assert.ok(item);
+    assert.match(String(item.photo), /^data:image\/jpeg;base64,/);
   });
 
   it("does not inline a declared field the projection dropped", async () => {
@@ -75,7 +77,9 @@ describe("createRemoteViewItems", () => {
     assert.equal(result.kind, "ok");
     if (result.kind !== "ok") return;
     assert.equal(result.inlined, 0);
-    assert.equal(result.page.items[0].photo, undefined); // dropped by projection, nothing to inline
+    const [item] = result.page.items;
+    assert.ok(item);
+    assert.equal(item.photo, undefined); // dropped by projection, nothing to inline
   });
 
   it("ignores a declared field that is not image-type", async () => {
@@ -85,8 +89,10 @@ describe("createRemoteViewItems", () => {
     assert.equal(result.kind, "ok");
     if (result.kind !== "ok") return;
     assert.equal(result.inlined, 0);
-    assert.equal(result.page.items[0].note, "n1"); // untouched
-    assert.equal(result.page.items[0].photo, "images/a.png"); // photo not declared → left as path
+    const [item] = result.page.items;
+    assert.ok(item);
+    assert.equal(item.note, "n1"); // untouched
+    assert.equal(item.photo, "images/a.png"); // photo not declared → left as path
   });
 
   it("stops inlining once the page byte budget is exceeded, leaving the rest as paths", async () => {
@@ -98,8 +104,11 @@ describe("createRemoteViewItems", () => {
     if (result.kind !== "ok") return;
     assert.equal(result.inlined, 1);
     assert.equal(result.omitted, 1);
-    assert.equal(result.page.items[0].photo, big); // inlined
-    assert.equal(result.page.items[1].photo, "images/b.png"); // left as path (over budget)
+    const [firstItem, secondItem] = result.page.items;
+    assert.ok(firstItem);
+    assert.ok(secondItem);
+    assert.equal(firstItem.photo, big); // inlined
+    assert.equal(secondItem.photo, "images/b.png"); // left as path (over budget)
   });
 
   it("serves host-resolved computed fields (ref-crossing derived, etc.) the resolver produced", async () => {

--- a/test/remoteHost/test_startChat.ts
+++ b/test/remoteHost/test_startChat.ts
@@ -57,8 +57,10 @@ describe("createStartChat — free-text form (current clients)", () => {
     const result = await createStartChat(deps)({ message: "who is overdue?" });
     assert.deepEqual(result, { started: true, chatId: "chat-1" });
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].message, "who is overdue?");
-    assert.equal(calls[0].hidden, false);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.message, "who is overdue?");
+    assert.equal(call.hidden, false);
     // The collection engine is NOT consulted when no slug is sent.
     assert.equal(loadCalls.length, 0);
   });
@@ -66,13 +68,17 @@ describe("createStartChat — free-text form (current clients)", () => {
   it("trims surrounding whitespace from the message", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-2" });
     await createStartChat(deps)({ message: "  hello  " });
-    assert.equal(calls[0].message, "hello");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.message, "hello");
   });
 
   it("passes a slash-command message through untouched (the host does not interpret it)", async () => {
     const { deps, calls, loadCalls } = makeDeps({ ok: true, chatId: "chat-3" });
     await createStartChat(deps)({ message: "/clients id=acme draft a follow-up" });
-    assert.equal(calls[0].message, "/clients id=acme draft a follow-up");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.message, "/clients id=acme draft a follow-up");
     assert.equal(loadCalls.length, 0);
   });
 
@@ -121,14 +127,18 @@ describe("createStartChat — legacy slug form", () => {
     const { deps, calls, loadCalls } = makeDeps({ ok: true, chatId: "chat-1" });
     const result = await createStartChat(deps)({ slug: "clients", itemId: "acme", message: "  hello  " });
     assert.deepEqual(result, { started: true, chatId: "chat-1" });
-    assert.equal(calls[0].message, "/clients id=acme hello");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.message, "/clients id=acme hello");
     assert.deepEqual(loadCalls, ["clients"]);
   });
 
   it("omits id= when itemId is absent", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-2" });
     await createStartChat(deps)({ slug: "clients", message: "hi" });
-    assert.equal(calls[0].message, "/clients hi");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.message, "/clients hi");
   });
 
   it("refuses feeds (no /<slug> command) without spawning", async () => {
@@ -162,18 +172,22 @@ describe("createStartChat — file attachments", () => {
     const result = await createStartChat(deps)({ message: "look at these", attachments: [{ storage_id: "aaa" }, { storage_id: "bbb" }] });
     assert.deepEqual(result, { started: true, chatId: "chat-1" });
     assert.deepEqual(ingestCalls, [["aaa", "bbb"]]);
-    assert.deepEqual(calls[0].attachments, [
+    const [call] = calls;
+    assert.ok(call);
+    assert.deepEqual(call.attachments, [
       { path: "data/attachments/aaa.jpg", mimeType: "image/jpeg" },
       { path: "data/attachments/bbb.jpg", mimeType: "image/jpeg" },
     ]);
-    assert.equal(calls[0].message, "look at these");
+    assert.equal(call.message, "look at these");
   });
 
   it("passes an empty attachment list when none are sent (text-only parity)", async () => {
     const { deps, calls, ingestCalls } = makeDeps({ ok: true, chatId: "chat-2" });
     await createStartChat(deps)({ message: "hi" });
     assert.deepEqual(ingestCalls, [[]]);
-    assert.deepEqual(calls[0].attachments, []);
+    const [call] = calls;
+    assert.ok(call);
+    assert.deepEqual(call.attachments, []);
   });
 
   it("rejects a malformed attachments payload without spawning", async () => {
@@ -198,7 +212,9 @@ describe("createStartChat — role selection", () => {
   it("defaults to the general role when no role is sent", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-1" });
     await createStartChat(deps)({ message: "hi" });
-    assert.equal(calls[0].roleId, "general");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.roleId, "general");
   });
 
   it("treats null / empty-string role as absent (default role)", async () => {
@@ -214,7 +230,9 @@ describe("createStartChat — role selection", () => {
   it("runs the chat in a known role when one is sent", async () => {
     const { deps, calls } = makeDeps({ ok: true, chatId: "chat-3" });
     await createStartChat(deps)({ message: "record today's receipt", role: "accounting" });
-    assert.equal(calls[0].roleId, "accounting");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.roleId, "accounting");
   });
 
   it("rejects an unknown role without spawning", async () => {

--- a/test/routes/test_attachmentUpload_heic.ts
+++ b/test/routes/test_attachmentUpload_heic.ts
@@ -248,6 +248,7 @@ describe("POST /api/attachments — HEIC → JPEG conversion (#1996)", () => {
     assert.ok(heicCalls.length >= 1, "hook saw at least one image/heic call");
     assert.equal(jpegCalls.length, 0, "hook was NOT fired for the JPEG companion");
     const latest = heicCalls[heicCalls.length - 1];
+    assert.ok(latest);
     assert.ok(latest.relativePath.endsWith(".heic"), "hook received .heic path");
   });
 });

--- a/test/routes/test_wikiHelpers.ts
+++ b/test/routes/test_wikiHelpers.ts
@@ -488,9 +488,11 @@ describe("findTagDrift", () => {
     const frontmatter = new Map<string, string[]>([["foo", ["a", "b", "c"]]]);
     const issues = findTagDrift(entries, frontmatter);
     assert.equal(issues.length, 1);
-    assert.match(issues[0], /Tag drift.*foo\.md/);
-    assert.match(issues[0], /\[a, b, c\]/);
-    assert.match(issues[0], /\[a, b\]/);
+    const [issue] = issues;
+    assert.ok(issue);
+    assert.match(issue, /Tag drift.*foo\.md/);
+    assert.match(issue, /\[a, b, c\]/);
+    assert.match(issue, /\[a, b\]/);
   });
 
   it("flags empty index tags against non-empty frontmatter", () => {

--- a/test/routes/test_wikiHistoryRoute.ts
+++ b/test/routes/test_wikiHistoryRoute.ts
@@ -166,7 +166,9 @@ describe("GET /api/wiki/pages/:slug/history/:stamp", () => {
     await writeWikiPage(slug, "hello body\n", { editor: "user", reason: "first" });
     const snapshots = await listSnapshots(slug);
     assert.ok(snapshots.length >= 1);
-    const [{ stamp }] = snapshots;
+    const [newest] = snapshots;
+    assert.ok(newest);
+    const { stamp } = newest;
 
     const { state, res } = mockRes();
     await readHandler(makeReq({ slug, stamp }), res);
@@ -215,7 +217,9 @@ describe("POST /api/wiki/pages/:slug/history/:stamp/restore", () => {
     // History grew by one entry (the restore itself).
     const afterRestore = await listSnapshots(slug);
     assert.equal(afterRestore.length, beforeRestore.length + 1, "restore should add a new snapshot");
-    assert.match(afterRestore[0].reason ?? "", /^Restored from /);
+    const [restoreSnapshot] = afterRestore;
+    assert.ok(restoreSnapshot);
+    assert.match(restoreSnapshot.reason ?? "", /^Restored from /);
   });
 
   it("returns 404 when the stamp doesn't exist", async () => {

--- a/test/routes/test_wikiInternalSnapshotRoute.ts
+++ b/test/routes/test_wikiInternalSnapshotRoute.ts
@@ -132,10 +132,12 @@ describe("POST /api/wiki/internal/snapshot", () => {
 
     const snapshots = await listSnapshots(slug);
     assert.equal(snapshots.length, 1, "endpoint should have written exactly one snapshot");
-    assert.equal(snapshots[0].editor, "llm", "hook always tags as llm — user-driven writes go through writeWikiPage");
+    const [snapshot] = snapshots;
+    assert.ok(snapshot);
+    assert.equal(snapshot.editor, "llm", "hook always tags as llm — user-driven writes go through writeWikiPage");
     // The hook never supplies `reason` (the LLM has no natural source
     // for one) — the field is absent from this code path.
-    assert.equal(snapshots[0].reason, undefined);
+    assert.equal(snapshot.reason, undefined);
   });
 
   it("propagates sessionId when the hook supplies one", async () => {
@@ -148,7 +150,9 @@ describe("POST /api/wiki/internal/snapshot", () => {
     assert.equal(state.status, 200);
 
     const snapshots = await listSnapshots(slug);
-    assert.equal(snapshots[0].sessionId, "chat-abc-123");
+    const [snapshot] = snapshots;
+    assert.ok(snapshot);
+    assert.equal(snapshot.sessionId, "chat-abc-123");
   });
 
   // Stage 3a (#963): the snapshot endpoint also publishes a synthetic

--- a/test/server/notifier/test_engine.ts
+++ b/test/server/notifier/test_engine.ts
@@ -67,6 +67,7 @@ describe("publish", () => {
     });
     assert.equal(emittedEvents.length, 1);
     const [event] = emittedEvents;
+    assert.ok(event);
     assert.equal(event.type, "published");
     if (event.type === "published") {
       assert.equal(event.entry.id, id);
@@ -241,7 +242,9 @@ describe("listFor", () => {
     assert.equal(aEntries.length, 2);
     assert.equal(bEntries.length, 1);
     assert.deepEqual(aEntries.map((entry) => entry.title).sort(), ["a1", "a2"]);
-    assert.deepEqual(bEntries[0].title, "b1");
+    const [bEntry] = bEntries;
+    assert.ok(bEntry);
+    assert.deepEqual(bEntry.title, "b1");
   });
 
   it("returns [] when nothing matches", async () => {
@@ -271,7 +274,9 @@ describe("listAll", () => {
     await clear(cleared);
     const entries = await listAll();
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].id, kept);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.id, kept);
   });
 });
 
@@ -287,14 +292,17 @@ describe("write coordination under concurrency", () => {
   });
 
   it("interleaved publish + clear leaves the expected residual set", async () => {
-    const published = await Promise.all(Array.from({ length: 5 }, (_unused, index) => publish({ pluginPkg: "concur", severity: "info", title: `t-${index}` })));
+    const PUBLISHED_COUNT = 5;
+    const CLEARED_COUNT = 3;
+    const published = await Promise.all(
+      Array.from({ length: PUBLISHED_COUNT }, (_unused, index) => publish({ pluginPkg: "concur", severity: "info", title: `t-${index}` })),
+    );
+    assert.equal(published.length, PUBLISHED_COUNT);
     // Concurrently clear three of them while two more publishes are
     // in flight; the queue's drainer batches them into one or two
     // load/save cycles. End state must reflect every operation.
     await Promise.all([
-      clear(published[0].id),
-      clear(published[1].id),
-      clear(published[2].id),
+      ...published.slice(0, CLEARED_COUNT).map((entry) => clear(entry.id)),
       publish({ pluginPkg: "concur", severity: "info", title: "extra-1" }),
       publish({ pluginPkg: "concur", severity: "info", title: "extra-2" }),
     ]);
@@ -355,15 +363,18 @@ describe("history", () => {
     await clear(id);
     const history = await listHistory();
     assert.equal(history.length, 1);
-    assert.equal(history[0].id, id);
-    assert.equal(history[0].terminalType, "cleared");
-    assert.match(history[0].terminalAt, /\d{4}-\d{2}-\d{2}T/);
+    const [head] = history;
+    assert.ok(head);
+    assert.equal(head.id, id);
+    assert.equal(head.terminalType, "cleared");
+    assert.match(head.terminalAt, /\d{4}-\d{2}-\d{2}T/);
   });
 
   it("captures cancelled entries with `cancelled` terminal type", async () => {
     const { id } = await publish({ pluginPkg: "x", severity: "info", title: "to cancel" });
     await cancel(id);
     const [head] = await listHistory();
+    assert.ok(head);
     assert.equal(head.terminalType, "cancelled");
   });
 
@@ -379,6 +390,7 @@ describe("history", () => {
     });
     await clear(id);
     const [head] = await listHistory();
+    assert.ok(head);
     assert.equal(head.title, "preserve me");
     assert.equal(head.severity, "urgent");
     assert.equal(head.lifecycle, "action");
@@ -402,6 +414,7 @@ describe("history", () => {
   });
 
   it("caps at 50 entries (FIFO eviction)", async () => {
+    const HISTORY_CAP = 50;
     const total = 55;
     const ids: string[] = [];
     for (let index = 0; index < total; index += 1) {
@@ -410,10 +423,14 @@ describe("history", () => {
     }
     for (const entryId of ids) await clear(entryId);
     const history = await listHistory();
-    assert.equal(history.length, 50);
+    assert.equal(history.length, HISTORY_CAP);
     // Newest at index 0; oldest 5 (titles t-0..t-4) should be evicted.
-    assert.equal(history[0].title, "t-54");
-    assert.equal(history[49].title, "t-5");
+    const [newest] = history;
+    const oldest = history[HISTORY_CAP - 1];
+    assert.ok(newest);
+    assert.ok(oldest);
+    assert.equal(newest.title, "t-54");
+    assert.equal(oldest.title, "t-5");
   });
 
   it("survives a path rebind (persists to disk)", async () => {
@@ -422,7 +439,9 @@ describe("history", () => {
     _setFilePathsForTesting({ active: activeFile, history: historyFile });
     const history = await listHistory();
     assert.equal(history.length, 1);
-    assert.equal(history[0].id, id);
+    const [head] = history;
+    assert.ok(head);
+    assert.equal(head.id, id);
   });
 
   it("does not record no-op clears (unknown id)", async () => {
@@ -561,7 +580,9 @@ describe("emit safety (pubsub fan-out failure isolation)", () => {
     await clear(idA);
     const entries = await listAll();
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].id, idB);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.id, idB);
   });
 });
 
@@ -571,6 +592,7 @@ describe("clearForPlugin (per-plugin isolation)", () => {
     await clearForPlugin("@scope/owner", id);
     assert.equal(await get(id), undefined);
     const [terminal] = await listHistory();
+    assert.ok(terminal);
     assert.equal(terminal.id, id);
     assert.equal(terminal.terminalType, "cleared");
   });
@@ -635,6 +657,7 @@ describe("updateForPlugin (in-place state refresh)", () => {
     await updateForPlugin("@scope/owner", id, { title: "t2" });
     assert.equal(emittedEvents.length, 1);
     const [event] = emittedEvents;
+    assert.ok(event);
     assert.equal(event.type, "updated");
     if (event.type === "updated") {
       assert.equal(event.entry.id, id);
@@ -720,6 +743,7 @@ describe("updateForPlugin (in-place state refresh)", () => {
     await clearForPlugin("@scope/owner", id);
     assert.equal(await get(id), undefined, "entry removed by clear");
     const [terminal] = await listHistory();
+    assert.ok(terminal);
     assert.equal(terminal.id, id);
     assert.equal(terminal.title, "t2", "history records the LAST seen title before clear");
   });

--- a/test/server/utils/test_diagnostics_report.ts
+++ b/test/server/utils/test_diagnostics_report.ts
@@ -26,6 +26,7 @@ describe("redactSettings", () => {
 
   it("withholds the plaintext Google Maps key", () => {
     const [entry] = redactSettings({ googleMapsApiKey: SECRET }, ["googleMapsApiKey"]);
+    assert.ok(entry);
     assert.equal(entry.value, REDACTED_PRESENT);
     assert.equal(entry.redacted, true);
     assert.ok(!entry.value.includes(SECRET));
@@ -35,6 +36,7 @@ describe("redactSettings", () => {
     // The regression that matters most: a future `AppSettings` field reaches
     // this function before anyone adds it to SAFE_SETTINGS_KEYS.
     const [entry] = redactSettings({ someFutureToken: SECRET }, ["someFutureToken"]);
+    assert.ok(entry);
     assert.equal(entry.value, REDACTED_PRESENT);
     assert.equal(entry.redacted, true);
   });
@@ -50,13 +52,16 @@ describe("redactSettings", () => {
     // A settings object parsed from JSON still inherits `constructor`; `in`
     // would report it present and the report would gain a phantom line.
     const [entry] = redactSettings({}, ["constructor"]);
+    assert.ok(entry);
     assert.equal(entry.value, REDACTED_ABSENT);
   });
 
   it("renders non-string values as JSON", () => {
-    const rendered = redactSettings({ extraAllowedTools: ["mcp__claude_ai_Gmail"], pushEnabled: false }, ["extraAllowedTools", "pushEnabled"]);
-    assert.equal(rendered[0].value, '["mcp__claude_ai_Gmail"]');
-    assert.equal(rendered[1].value, "false");
+    const [toolsEntry, pushEntry] = redactSettings({ extraAllowedTools: ["mcp__claude_ai_Gmail"], pushEnabled: false }, ["extraAllowedTools", "pushEnabled"]);
+    assert.ok(toolsEntry);
+    assert.ok(pushEntry);
+    assert.equal(toolsEntry.value, '["mcp__claude_ai_Gmail"]');
+    assert.equal(pushEntry.value, "false");
   });
 
   it("still returns a string for values JSON cannot represent", () => {

--- a/test/skills/test_discovery.ts
+++ b/test/skills/test_discovery.ts
@@ -40,12 +40,14 @@ describe("collectSkillsFromDir", () => {
     await writeSkill(root, "ci_enable", "Enable CI", "## Steps\n1. Do it");
     const skills = await collectSkillsFromDir(root, "user");
     assert.equal(skills.length, 1);
-    assert.equal(skills[0].name, "ci_enable");
-    assert.equal(skills[0].description, "Enable CI");
-    assert.equal(skills[0].source, "user");
-    assert.match(skills[0].body, /## Steps/);
+    const [skill] = skills;
+    assert.ok(skill);
+    assert.equal(skill.name, "ci_enable");
+    assert.equal(skill.description, "Enable CI");
+    assert.equal(skill.source, "user");
+    assert.match(skill.body, /## Steps/);
     // Path uses `/` on POSIX and `\` on Windows; accept either.
-    assert.match(skills[0].path, /[\\/]ci_enable[\\/]SKILL\.md$/);
+    assert.match(skill.path, /[\\/]ci_enable[\\/]SKILL\.md$/);
   });
 
   it("skips directories without a SKILL.md", async () => {
@@ -54,7 +56,9 @@ describe("collectSkillsFromDir", () => {
     await writeSkill(root, "real_skill", "Real one");
     const skills = await collectSkillsFromDir(root, "user");
     assert.equal(skills.length, 1);
-    assert.equal(skills[0].name, "real_skill");
+    const [skill] = skills;
+    assert.ok(skill);
+    assert.equal(skill.name, "real_skill");
   });
 
   it("skips hidden entries (.DS_Store, .gitkeep)", async () => {
@@ -63,7 +67,9 @@ describe("collectSkillsFromDir", () => {
     await writeSkill(root, "visible", "Visible");
     const skills = await collectSkillsFromDir(root, "user");
     assert.equal(skills.length, 1);
-    assert.equal(skills[0].name, "visible");
+    const [skill] = skills;
+    assert.ok(skill);
+    assert.equal(skill.name, "visible");
   });
 
   it("skips entries where SKILL.md has no frontmatter", async () => {
@@ -73,7 +79,9 @@ describe("collectSkillsFromDir", () => {
     await writeSkill(root, "ok", "Fine");
     const skills = await collectSkillsFromDir(root, "user");
     assert.equal(skills.length, 1);
-    assert.equal(skills[0].name, "ok");
+    const [skill] = skills;
+    assert.ok(skill);
+    assert.equal(skill.name, "ok");
   });
 
   it("follows a symlinked skill directory", async () => {
@@ -84,8 +92,10 @@ describe("collectSkillsFromDir", () => {
       await symlink(join(target, "linked-inner"), join(root, "linked"));
       const skills = await collectSkillsFromDir(root, "user");
       assert.equal(skills.length, 1);
-      assert.equal(skills[0].name, "linked");
-      assert.equal(skills[0].description, "From target");
+      const [skill] = skills;
+      assert.ok(skill);
+      assert.equal(skill.name, "linked");
+      assert.equal(skill.description, "From target");
     } finally {
       rmSync(target, { recursive: true, force: true });
     }
@@ -104,10 +114,12 @@ describe("collectSkillsFromDir", () => {
 
   it("tags results with the given source", async () => {
     await writeSkill(root, "a", "A");
-    const userSkills = await collectSkillsFromDir(root, "user");
-    const projectSkills = await collectSkillsFromDir(root, "project");
-    assert.equal(userSkills[0].source, "user");
-    assert.equal(projectSkills[0].source, "project");
+    const [userSkill] = await collectSkillsFromDir(root, "user");
+    const [projectSkill] = await collectSkillsFromDir(root, "project");
+    assert.ok(userSkill);
+    assert.ok(projectSkill);
+    assert.equal(userSkill.source, "user");
+    assert.equal(projectSkill.source, "project");
   });
 
   it("gracefully handles an unreadable SKILL.md", async (ctx) => {

--- a/test/skills/test_skill_scheduler.ts
+++ b/test/skills/test_skill_scheduler.ts
@@ -62,7 +62,9 @@ describe("skill scheduler visibility + manual run (#2012)", () => {
       const chatSessionId = await runScheduledSkillNow("skill.news-filter");
       assert.ok(chatSessionId, "run returns a chat session id");
       assert.equal(calls.length, 1);
-      assert.equal(calls[0].message, "/news-filter");
+      const [call] = calls;
+      assert.ok(call);
+      assert.equal(call.message, "/news-filter");
 
       // B: a successful DISPATCH does not record a run yet — the outcome is
       // recorded from the turn's completion hook, not at spawn time (#2057), so

--- a/test/skills/test_user_tasks.ts
+++ b/test/skills/test_user_tasks.ts
@@ -40,7 +40,9 @@ describe("loadUserTasks", () => {
     writeFileSync(path.join(root, "config", "scheduler", "tasks.json"), JSON.stringify(data));
     const tasks = loadUserTasks(root);
     assert.equal(tasks.length, 1);
-    assert.equal(tasks[0].name, "Test");
+    const [task] = tasks;
+    assert.ok(task);
+    assert.equal(task.name, "Test");
   });
 
   it("returns empty array for corrupted JSON", () => {
@@ -165,7 +167,9 @@ describe("applyUpdate", () => {
     const result = applyUpdate([...baseTasks], "t1", { name: "Updated" });
     assert.equal(result.kind, "ok");
     if (result.kind === "ok") {
-      assert.equal(result.tasks[0].name, "Updated");
+      const [task] = result.tasks;
+      assert.ok(task);
+      assert.equal(task.name, "Updated");
     }
   });
 
@@ -173,7 +177,9 @@ describe("applyUpdate", () => {
     const result = applyUpdate([...baseTasks], "t1", { enabled: false });
     assert.equal(result.kind, "ok");
     if (result.kind === "ok") {
-      assert.equal(result.tasks[0].enabled, false);
+      const [task] = result.tasks;
+      assert.ok(task);
+      assert.equal(task.enabled, false);
     }
   });
 
@@ -189,7 +195,9 @@ describe("applyUpdate", () => {
     assert.equal(result.kind, "ok");
     if (result.kind === "ok") {
       // Schedule unchanged
-      assert.equal(result.tasks[0].schedule.type, SCHEDULE_TYPES.daily);
+      const [task] = result.tasks;
+      assert.ok(task);
+      assert.equal(task.schedule.type, SCHEDULE_TYPES.daily);
     }
   });
 });

--- a/test/system/test_macosNotify.ts
+++ b/test/system/test_macosNotify.ts
@@ -74,10 +74,14 @@ describe("pushToMacosReminderWithDeps — spawn arguments", () => {
     respond(0);
     await promise;
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].command, "osascript");
-    assert.equal(calls[0].args[0], "-e");
-    assert.match(calls[0].args[1] as string, /on run argv/);
-    assert.match(calls[0].args[1] as string, /tell application "Reminders"/);
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.command, "osascript");
+    const [flag, script] = call.args;
+    assert.equal(flag, "-e");
+    assert.ok(script);
+    assert.match(script, /on run argv/);
+    assert.match(script, /tell application "Reminders"/);
   });
 
   it("forwards title and body as argv (Unicode-safe path)", async () => {
@@ -90,9 +94,12 @@ describe("pushToMacosReminderWithDeps — spawn arguments", () => {
     respond(0);
     await promise;
     // argv layout: [-e, SCRIPT, --, title, body]
-    assert.equal(calls[0].args[2], "--");
-    assert.equal(calls[0].args[3], 'Title with "quotes" and \\backslash and 日本語');
-    assert.equal(calls[0].args[4], "Body line 1\nBody line 2 — 文字化け確認");
+    const [call] = calls;
+    assert.ok(call);
+    const [, , separator, title, body] = call.args;
+    assert.equal(separator, "--");
+    assert.equal(title, 'Title with "quotes" and \\backslash and 日本語');
+    assert.equal(body, "Body line 1\nBody line 2 — 文字化け確認");
   });
 
   it("sends an empty-string body when none is supplied", async () => {
@@ -100,7 +107,9 @@ describe("pushToMacosReminderWithDeps — spawn arguments", () => {
     const promise = pushToMacosReminderWithDeps({ spawner, platform: "darwin", disabled: false }, "Title only");
     respond(0);
     await promise;
-    assert.equal(calls[0].args[4], "");
+    const [call] = calls;
+    assert.ok(call);
+    assert.equal(call.args[4], "");
   });
 });
 

--- a/test/system/test_optionalDeps_degradation.ts
+++ b/test/system/test_optionalDeps_degradation.ts
@@ -40,10 +40,10 @@ interface RouterInternals {
 
 function getHandler(router: Router, url: string): (req: Request, res: Response) => unknown {
   const internals = router as unknown as RouterInternals;
-  for (const layer of internals.stack) {
-    if (layer.route && layer.route.path === url) return layer.route.stack[0].handle;
-  }
-  throw new Error(`handler for ${url} not found in router stack`);
+  const layer = internals.stack.find((candidate) => candidate.route?.path === url);
+  const [first] = layer?.route?.stack ?? [];
+  if (!first) throw new Error(`handler for ${url} not found in router stack`);
+  return first.handle;
 }
 
 interface MockResponse {

--- a/test/system/test_shadowedEnv_bell.ts
+++ b/test/system/test_shadowedEnv_bell.ts
@@ -71,6 +71,7 @@ describe("announceShadowedEnv", () => {
   it("never puts a secret VALUE in the bell — the launcher sends names only", async () => {
     await announceShadowedEnv("GEMINI_API_KEY");
     const [entry] = await activeEntries(1);
+    assert.ok(entry);
     assert.ok(!`${entry.title}${entry.body ?? ""}`.includes("="));
   });
 
@@ -87,8 +88,10 @@ describe("announceShadowedEnv", () => {
     await announceShadowedEnv("A", ["B"]);
     const entries = await activeEntries(1);
     assert.equal(entries.length, 1, "two sources must not produce two notifications");
-    assert.match(entries[0].body ?? "", /A/);
-    assert.match(entries[0].body ?? "", /B/);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.match(entry.body ?? "", /A/);
+    assert.match(entry.body ?? "", /B/);
   });
 
   it("raises the notification from the server's own load alone — the yarn dev case", async () => {
@@ -111,8 +114,10 @@ describe("announceShadowedEnv", () => {
     await announceShadowedEnv("A"); // user unset B in their shell
     const entries = await activeEntries(1);
     assert.equal(entries.length, 1, "the old two-key entry must not survive alongside the new one");
-    assert.match(entries[0].body ?? "", /A/);
-    assert.ok(!(entries[0].body ?? "").includes("B"), "the fixed key must not still be named");
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.match(entry.body ?? "", /A/);
+    assert.ok(!(entry.body ?? "").includes("B"), "the fixed key must not still be named");
   });
 
   it("clears the entry once the conflict is gone entirely", async () => {

--- a/test/tool-trace/test_index.ts
+++ b/test/tool-trace/test_index.ts
@@ -85,9 +85,11 @@ describe("recordToolEvent", () => {
     );
     const lines = readJsonlLines(await harness.readJsonl());
     assert.equal(lines.length, 1);
-    assert.equal(lines[0].type, "tool_call");
-    assert.equal(lines[0].toolName, "Bash");
-    assert.deepEqual(lines[0].args, { command: "ls" });
+    const [record] = lines;
+    assert.ok(record);
+    assert.equal(record.type, "tool_call");
+    assert.equal(record.toolName, "Bash");
+    assert.deepEqual(record.args, { command: "ls" });
     assert.equal(harness.deps.argsCache.size, 1);
   });
 
@@ -115,7 +117,9 @@ describe("recordToolEvent", () => {
     assert.ok(String(resultLine?.contentRef).startsWith("conversations/searches/2026-04-13/"));
     assert.equal(resultLine?.content, undefined);
     assert.equal(harness.savedSearches.length, 1);
-    assert.equal(harness.savedSearches[0].query, "foo bar");
+    const [savedSearch] = harness.savedSearches;
+    assert.ok(savedSearch);
+    assert.equal(savedSearch.query, "foo bar");
   });
 
   it("Read tool_call_result records a pointer to args.file_path", async () => {
@@ -184,9 +188,11 @@ describe("recordToolEvent", () => {
     );
     const lines = readJsonlLines(await harness.readJsonl());
     assert.equal(lines.length, 1);
-    assert.equal(lines[0].type, "tool_call_result");
-    assert.equal(lines[0].content, "mystery output");
-    assert.equal(lines[0].toolName, "");
+    const [record] = lines;
+    assert.ok(record);
+    assert.equal(record.type, "tool_call_result");
+    assert.equal(record.content, "mystery output");
+    assert.equal(record.toolName, "");
   });
 
   it("saveSearch throwing falls back to inline content (never kills the turn)", async () => {

--- a/test/workspace/collections/test_notifications.ts
+++ b/test/workspace/collections/test_notifications.ts
@@ -573,7 +573,9 @@ describe("reconcileItem — notifyWhen severity", () => {
     await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const before = await activeCompletionEntries();
     assert.equal(before.length, 1);
-    assert.equal(before[0].severity, "urgent");
+    const [beforeEntry] = before;
+    assert.ok(beforeEntry);
+    assert.equal(beforeEntry.severity, "urgent");
 
     // urgent → high: still flagged, so the entry persists but must re-colour
     // to amber — and keep the SAME id (in-place update, not clear+republish).
@@ -581,8 +583,10 @@ describe("reconcileItem — notifyWhen severity", () => {
     await reconcileItem(asCollection(SLUG, schema, dataDir), "a", { workspaceRoot: workdir });
     const after = await activeCompletionEntries();
     assert.equal(after.length, 1);
-    assert.equal(after[0].severity, "nudge");
-    assert.equal(after[0].priority, "normal");
-    assert.equal(after[0].id, before[0].id);
+    const [afterEntry] = after;
+    assert.ok(afterEntry);
+    assert.equal(afterEntry.severity, "nudge");
+    assert.equal(afterEntry.priority, "normal");
+    assert.equal(afterEntry.id, beforeEntry.id);
   });
 });

--- a/test/workspace/feeds/test_feedSummaries.ts
+++ b/test/workspace/feeds/test_feedSummaries.ts
@@ -36,30 +36,34 @@ describe("buildFeedSummaries", () => {
   });
 
   it("keeps a declared kind and still defaults the missing schedule", async () => {
-    const summaries = await buildFeedSummaries([feedNamed("blog", { kind: "atom" })], readerReturning(), WORKSPACE_ROOT);
+    const [summary] = await buildFeedSummaries([feedNamed("blog", { kind: "atom" })], readerReturning(), WORKSPACE_ROOT);
 
-    assert.equal(summaries[0].kind, "atom");
-    assert.equal(summaries[0].schedule, "on-demand");
+    assert.ok(summary);
+    assert.equal(summary.kind, "atom");
+    assert.equal(summary.schedule, "on-demand");
   });
 
   it("keeps a declared schedule and still defaults the missing kind", async () => {
-    const summaries = await buildFeedSummaries([feedNamed("hourly-feed", { schedule: "hourly" })], readerReturning(), WORKSPACE_ROOT);
+    const [summary] = await buildFeedSummaries([feedNamed("hourly-feed", { schedule: "hourly" })], readerReturning(), WORKSPACE_ROOT);
 
-    assert.equal(summaries[0].kind, "rss");
-    assert.equal(summaries[0].schedule, "hourly");
+    assert.ok(summary);
+    assert.equal(summary.kind, "rss");
+    assert.equal(summary.schedule, "hourly");
   });
 
   it("carries both through when the ingest block is complete", async () => {
-    const summaries = await buildFeedSummaries([feedNamed("papers", { kind: "http-json", schedule: "daily" })], readerReturning(), WORKSPACE_ROOT);
+    const [summary] = await buildFeedSummaries([feedNamed("papers", { kind: "http-json", schedule: "daily" })], readerReturning(), WORKSPACE_ROOT);
 
-    assert.equal(summaries[0].kind, "http-json");
-    assert.equal(summaries[0].schedule, "daily");
+    assert.ok(summary);
+    assert.equal(summary.kind, "http-json");
+    assert.equal(summary.schedule, "daily");
   });
 
   it("reports lastFetchedAt as null for a feed that was never fetched", async () => {
-    const summaries = await buildFeedSummaries([feedNamed("fresh")], readerReturning(), WORKSPACE_ROOT);
+    const [summary] = await buildFeedSummaries([feedNamed("fresh")], readerReturning(), WORKSPACE_ROOT);
 
-    assert.equal(summaries[0].lastFetchedAt, null);
+    assert.ok(summary);
+    assert.equal(summary.lastFetchedAt, null);
   });
 
   it("returns an empty list for zero feeds without calling the reader", async () => {

--- a/test/workspace/hooks/handlers/test_configRefresh.ts
+++ b/test/workspace/hooks/handlers/test_configRefresh.ts
@@ -49,7 +49,9 @@ describe("handleConfigRefresh", () => {
       tool_input: { file_path: path.join(workspace, ".claude", "skills", "foo", "SKILL.md") },
     });
     assert.equal(captured.length, 1);
-    assert.ok(captured[0].endsWith("/api/config/refresh"));
+    const [refreshUrl] = captured;
+    assert.ok(refreshUrl);
+    assert.ok(refreshUrl.endsWith("/api/config/refresh"));
   });
 
   it("fires refresh on config/scheduler/tasks.json", async () => {
@@ -58,7 +60,9 @@ describe("handleConfigRefresh", () => {
       tool_input: { file_path: path.join(workspace, "config", "scheduler", "tasks.json") },
     });
     assert.equal(captured.length, 1);
-    assert.ok(captured[0].endsWith("/api/config/refresh"));
+    const [refreshUrl] = captured;
+    assert.ok(refreshUrl);
+    assert.ok(refreshUrl.endsWith("/api/config/refresh"));
   });
 
   it("does NOT fire on data/skills/<slug>/SKILL.md (skillBridge owns that)", async () => {

--- a/test/workspace/hooks/test_provision.ts
+++ b/test/workspace/hooks/test_provision.ts
@@ -46,14 +46,16 @@ describe("provisionDispatcherHook — first install", () => {
     const entries = settings.hooks?.PostToolUse ?? [];
     assert.equal(entries.length, 1);
     const [entry] = entries;
+    assert.ok(entry);
     assert.equal(entry.matcher, "Write|Edit|Bash");
-    const hook = entry.hooks?.[0];
-    assert.equal(hook?.type, "command");
+    const [hook] = entry.hooks ?? [];
+    assert.ok(hook);
+    assert.equal(hook.type, "command");
     // Command must use $CLAUDE_PROJECT_DIR so the same settings.json
     // works on the host AND inside the Docker container, where the
     // workspace lives at a different absolute path.
-    assert.match(hook?.command ?? "", /node "\$CLAUDE_PROJECT_DIR\/\.claude\/hooks\/mulmoclaude-dispatcher\.mjs"/);
-    assert.equal(hook?.[OWNER_MARKER], true);
+    assert.match(hook.command ?? "", /node "\$CLAUDE_PROJECT_DIR\/\.claude\/hooks\/mulmoclaude-dispatcher\.mjs"/);
+    assert.equal(hook[OWNER_MARKER], true);
 
     const scriptBody = await readFile(path.join(root, ".claude", "hooks", "mulmoclaude-dispatcher.mjs"), "utf-8");
     // Anchor on the shebang and a substring from the bundled
@@ -201,7 +203,11 @@ describe("provisionDispatcherHook — descriptor-level stripping", () => {
     // Just the dispatcher entry — the now-empty Write|Edit entry
     // is gone, not a no-hooks zombie.
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].hooks?.[0]?.[OWNER_MARKER], true);
+    const [dispatcherEntry] = entries;
+    assert.ok(dispatcherEntry);
+    const [dispatcherHook] = dispatcherEntry.hooks ?? [];
+    assert.ok(dispatcherHook);
+    assert.equal(dispatcherHook[OWNER_MARKER], true);
 
     await rm(root, { recursive: true, force: true });
   });

--- a/test/workspace/memory/test_io.ts
+++ b/test/workspace/memory/test_io.ts
@@ -38,6 +38,7 @@ describe("memory/io — write + read round-trip", () => {
     const all = await loadAllMemoryEntries(workspaceRoot);
     assert.equal(all.length, 1);
     const [loaded] = all;
+    assert.ok(loaded);
     assert.equal(loaded.name, entry.name);
     assert.equal(loaded.description, entry.description);
     assert.equal(loaded.type, entry.type);
@@ -71,7 +72,9 @@ describe("memory/io — reader tolerance", () => {
 
     const all = await loadAllMemoryEntries(scopedRoot);
     assert.equal(all.length, 1);
-    assert.equal(all[0].slug, "interest_impressionism");
+    const [loaded] = all;
+    assert.ok(loaded);
+    assert.equal(loaded.slug, "interest_impressionism");
   });
 
   it("skips MEMORY.md and dotfiles in the directory listing", async () => {

--- a/test/workspace/memory/test_llm_classifier.ts
+++ b/test/workspace/memory/test_llm_classifier.ts
@@ -82,9 +82,11 @@ describe("memory/llm-classifier — makeLlmMemoryClassifier", () => {
     const verdict = await classifier(candidate);
     assert.deepEqual(verdict, { type: "preference", description: "yarn only" });
     assert.equal(summarized.length, 1);
-    assert.match(summarized[0].user, /yarn を使う/);
-    assert.match(summarized[0].user, /Preferences/);
-    assert.match(summarized[0].system, /preference/);
+    const [call] = summarized;
+    assert.ok(call);
+    assert.match(call.user, /yarn を使う/);
+    assert.match(call.user, /Preferences/);
+    assert.match(call.system, /preference/);
   });
 
   it("returns null when the summarize callback throws", async () => {

--- a/test/workspace/memory/test_migrate.ts
+++ b/test/workspace/memory/test_migrate.ts
@@ -134,7 +134,9 @@ describe("memory/migrate — edge cases", () => {
       assert.equal(result.writeErrors, 0);
       const all = await loadAllMemoryEntries(fresh);
       assert.equal(all.length, 1);
-      assert.equal(all[0].type, "fact");
+      const [written] = all;
+      assert.ok(written);
+      assert.equal(written.type, "fact");
     } finally {
       await rm(fresh, { recursive: true, force: true });
     }

--- a/test/workspace/memory/test_topic_cluster.ts
+++ b/test/workspace/memory/test_topic_cluster.ts
@@ -16,10 +16,16 @@ describe("memory/topic-cluster — parseClusterMap", () => {
     const out = parseClusterMap(raw);
     assert.ok(out !== null);
     assert.equal(out.preference.length, 1);
-    assert.equal(out.preference[0].topic, "dev");
-    assert.deepEqual(out.preference[0].unsectionedBullets, ["yarn"]);
+    const [preferenceTopic] = out.preference;
+    assert.ok(preferenceTopic);
+    assert.equal(preferenceTopic.topic, "dev");
+    assert.deepEqual(preferenceTopic.unsectionedBullets, ["yarn"]);
     assert.equal(out.interest.length, 1);
-    assert.equal(out.interest[0].sections?.[0].heading, "Rock");
+    const [interestTopic] = out.interest;
+    assert.ok(interestTopic);
+    const [firstSection] = interestTopic.sections ?? [];
+    assert.ok(firstSection);
+    assert.equal(firstSection.heading, "Rock");
   });
 
   it("strips a leading code fence", () => {
@@ -52,7 +58,9 @@ describe("memory/topic-cluster — parseClusterMap", () => {
     const out = parseClusterMap(raw);
     assert.ok(out !== null);
     assert.equal(out.preference.length, 1);
-    assert.equal(out.preference[0].topic, "real");
+    const [kept] = out.preference;
+    assert.ok(kept);
+    assert.equal(kept.topic, "real");
   });
 
   it("normalises an unsafe topic name via slugify", () => {
@@ -64,7 +72,9 @@ describe("memory/topic-cluster — parseClusterMap", () => {
     });
     const out = parseClusterMap(raw);
     assert.ok(out !== null);
-    assert.equal(out.preference[0].topic, "ai-research-papers");
+    const [slugified] = out.preference;
+    assert.ok(slugified);
+    assert.equal(slugified.topic, "ai-research-papers");
   });
 
   it("drops topics whose name slugs to nothing safe", () => {

--- a/test/workspace/memory/test_topic_io.ts
+++ b/test/workspace/memory/test_topic_io.ts
@@ -40,6 +40,7 @@ describe("memory/topic-io — write + read round-trip", () => {
     const all = await loadAllTopicFiles(workspaceRoot);
     assert.equal(all.length, 1);
     const [loaded] = all;
+    assert.ok(loaded);
     assert.equal(loaded.type, "interest");
     assert.equal(loaded.topic, "music");
     assert.deepEqual(loaded.sections, ["Rock / Metal", "Punk / Melodic"]);
@@ -84,7 +85,9 @@ describe("memory/topic-io — reader tolerance", () => {
     await writeFile(path.join(root, "interest", "art.md"), "---\ntype: interest\ntopic: art\n---\n\n# Art\n\n- Impressionism", "utf-8");
     const all = await loadAllTopicFiles(scoped);
     assert.equal(all.length, 1);
-    assert.equal(all[0].topic, "art");
+    const [loaded] = all;
+    assert.ok(loaded);
+    assert.equal(loaded.topic, "art");
   });
 
   it("skips files whose frontmatter topic disagrees with the filename", async () => {

--- a/test/workspace/memory/test_topic_migrate.ts
+++ b/test/workspace/memory/test_topic_migrate.ts
@@ -290,6 +290,7 @@ describe("memory/topic-migrate — edge cases", () => {
         const match = /interest\/([^.]+)\.md/.exec(line);
         assert.ok(match, `line should reference a real file: ${line}`);
         const [, slug] = match;
+        assert.ok(slug);
         assert.ok(slug.length <= 60, `slug "${slug}" exceeds the 60-char cap`);
         const filePath = path.join(interestDir, `${slug}.md`);
         const content = await readFile(filePath, "utf-8");

--- a/test/workspace/skills/external/test_catalog.ts
+++ b/test/workspace/skills/external/test_catalog.ts
@@ -47,8 +47,10 @@ describe("listExternalCatalogEntries", () => {
     const entries = await listExternalCatalogEntries({ workspaceRoot: workdir });
     assert.equal(entries.length, 2);
     assert.deepEqual(entries.map((entry) => entry.activeId).sort(), ["anthropics-excel-builder", "anthropics-pdf-form-filler"]);
-    assert.equal(entries[0].repoId, "anthropics-skills");
-    assert.equal(entries[0].repoUrl, "https://github.com/anthropics/skills");
+    const [first] = entries;
+    assert.ok(first);
+    assert.equal(first.repoId, "anthropics-skills");
+    assert.equal(first.repoUrl, "https://github.com/anthropics/skills");
   });
 
   it("returns one entry with skillFolder='.' for a single-skill-at-root repo", async () => {
@@ -57,8 +59,10 @@ describe("listExternalCatalogEntries", () => {
     });
     const entries = await listExternalCatalogEntries({ workspaceRoot: workdir });
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].skillFolder, ".");
-    assert.equal(entries[0].activeId, "foo-cool");
+    const [first] = entries;
+    assert.ok(first);
+    assert.equal(first.skillFolder, ".");
+    assert.equal(first.activeId, "foo-cool");
   });
 
   it("flags alreadyActive when .claude/skills/<activeId>/ exists", async () => {
@@ -66,8 +70,9 @@ describe("listExternalCatalogEntries", () => {
       "SKILL.md": "---\ndescription: cool\n---\nbody",
     });
     mkdirSync(path.join(workdir, ".claude/skills/foo-cool"), { recursive: true });
-    const entries = await listExternalCatalogEntries({ workspaceRoot: workdir });
-    assert.equal(entries[0].alreadyActive, true);
+    const [first] = await listExternalCatalogEntries({ workspaceRoot: workdir });
+    assert.ok(first);
+    assert.equal(first.alreadyActive, true);
   });
 
   it("skips repos whose metadata is missing the url", async () => {
@@ -91,7 +96,9 @@ describe("listExternalCatalogEntries", () => {
     writeFileSync(path.join(repoDir, "ok-skill", "SKILL.md"), "---\ndescription: ok\n---\n");
     const entries = await listExternalCatalogEntries({ workspaceRoot: workdir });
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].skillFolder, "ok-skill");
+    const [first] = entries;
+    assert.ok(first);
+    assert.equal(first.skillFolder, "ok-skill");
   });
 });
 

--- a/test/workspace/skills/external/test_install.ts
+++ b/test/workspace/skills/external/test_install.ts
@@ -365,8 +365,10 @@ describe("listInstalledRepos", () => {
     );
     const repos = await listInstalledRepos({ workspaceRoot: workdir });
     assert.equal(repos.length, 1);
-    assert.equal(repos[0].repoId, "foo-bar");
-    assert.equal(repos[0].url, "https://github.com/foo/bar");
+    const [repo] = repos;
+    assert.ok(repo);
+    assert.equal(repo.repoId, "foo-bar");
+    assert.equal(repo.url, "https://github.com/foo/bar");
   });
 
   it("skips repos with missing or malformed metadata", async () => {

--- a/test/workspace/skills/test_catalog.ts
+++ b/test/workspace/skills/test_catalog.ts
@@ -66,8 +66,10 @@ describe("listCatalogEntries", () => {
       entries.map((entry) => entry.slug),
       ["mc-bar", "mc-foo"], // sorted
     );
-    assert.equal(entries[0].source, "preset");
-    assert.equal(entries[0].description, "bar desc");
+    const [first] = entries;
+    assert.ok(first);
+    assert.equal(first.source, "preset");
+    assert.equal(first.description, "bar desc");
   });
 
   it("skips entries with missing or malformed SKILL.md", async () => {
@@ -100,14 +102,16 @@ describe("listCatalogEntries", () => {
   it("flags alreadyActive when the slug exists under .claude/skills/", async () => {
     writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\n");
     mkdirSync(path.join(activeDir, "mc-foo"));
-    const entries = await listCatalogEntries({ workspaceRoot: workdir });
-    assert.equal(entries[0].alreadyActive, true);
+    const [first] = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.ok(first);
+    assert.equal(first.alreadyActive, true);
   });
 
   it("alreadyActive is false when only the catalog has the entry", async () => {
     writeCatalogEntry("mc-foo", "---\ndescription: ok\n---\n");
-    const entries = await listCatalogEntries({ workspaceRoot: workdir });
-    assert.equal(entries[0].alreadyActive, false);
+    const [first] = await listCatalogEntries({ workspaceRoot: workdir });
+    assert.ok(first);
+    assert.equal(first.alreadyActive, false);
   });
 });
 

--- a/test/workspace/test_bug_report_faq.ts
+++ b/test/workspace/test_bug_report_faq.ts
@@ -23,7 +23,7 @@ const entries = parseFaqEntries(readFileSync(FAQ_PATH, "utf-8"));
 
 // `voiceInput.enabled` is a legal pointer: the root is what has to exist, the
 // nested field is prose detail the agent reads in the settings file.
-const rootKey = (configKey: string): string => configKey.split(".")[0];
+const rootKey = (configKey: string): string => configKey.split(".")[0] ?? configKey;
 
 describe("bundled bug-report FAQ", () => {
   it("ships and parses into entries", () => {

--- a/test/workspace/test_custom_dirs.ts
+++ b/test/workspace/test_custom_dirs.ts
@@ -37,9 +37,12 @@ describe("loadCustomDirs", () => {
     ]);
     const entries = loadCustomDirs(root);
     assert.equal(entries.length, 2);
-    assert.equal(entries[0].path, "data/customers");
-    assert.equal(entries[0].structure, DIR_STRUCTURES.byName);
-    assert.equal(entries[1].path, "artifacts/reports");
+    const [first, second] = entries;
+    assert.ok(first);
+    assert.ok(second);
+    assert.equal(first.path, "data/customers");
+    assert.equal(first.structure, DIR_STRUCTURES.byName);
+    assert.equal(second.path, "artifacts/reports");
   });
 
   it("rejects path traversal (..)", () => {
@@ -98,15 +101,18 @@ describe("loadCustomDirs", () => {
     writeConfig(root, [{ path: "data/books", description: "Reading notes", structure: "flat" }]);
     const entries = loadCustomDirs(root);
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].path, "data/books");
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.path, "data/books");
   });
 
   it("truncates long descriptions", () => {
     const root = tmpRoot();
     const longDesc = "x".repeat(500);
     writeConfig(root, [{ path: "data/test", description: longDesc, structure: "flat" }]);
-    const entries = loadCustomDirs(root);
-    assert.equal(entries[0].description.length, 200);
+    const [entry] = loadCustomDirs(root);
+    assert.ok(entry);
+    assert.equal(entry.description.length, 200);
   });
 
   it("strips control characters from description", () => {
@@ -118,16 +124,18 @@ describe("loadCustomDirs", () => {
         structure: "flat",
       },
     ]);
-    const entries = loadCustomDirs(root);
-    assert.ok(!entries[0].description.includes("\x00"));
-    assert.ok(!entries[0].description.includes("\n"));
+    const [entry] = loadCustomDirs(root);
+    assert.ok(entry);
+    assert.ok(!entry.description.includes("\x00"));
+    assert.ok(!entry.description.includes("\n"));
   });
 
   it("defaults structure to flat for invalid values", () => {
     const root = tmpRoot();
     writeConfig(root, [{ path: "data/test", description: "test", structure: "invalid" }]);
-    const entries = loadCustomDirs(root);
-    assert.equal(entries[0].structure, DIR_STRUCTURES.flat);
+    const [entry] = loadCustomDirs(root);
+    assert.ok(entry);
+    assert.equal(entry.structure, DIR_STRUCTURES.flat);
   });
 
   it("limits to 100 entries", () => {
@@ -224,8 +232,10 @@ describe("loadCustomDirs — non-string fields", () => {
     writeConfig(root, [{ path: "data/notes", description: { text: "nope" } }]);
     const entries = loadCustomDirs(root);
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].path, "data/notes");
-    assert.equal(entries[0].description, "");
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.path, "data/notes");
+    assert.equal(entry.description, "");
   });
 });
 

--- a/test/workspace/test_faq_entries.ts
+++ b/test/workspace/test_faq_entries.ts
@@ -51,8 +51,9 @@ describe("parseFaqEntries", () => {
   });
 
   it("repeats a field into a list", () => {
-    const entries = parseFaqEntries(["## Two helps", "help: a.md", "help: b.md"].join("\n"));
-    assert.deepEqual(entries[0].helps, ["a.md", "b.md"]);
+    const [entry] = parseFaqEntries(["## Two helps", "help: a.md", "help: b.md"].join("\n"));
+    assert.ok(entry);
+    assert.deepEqual(entry.helps, ["a.md", "b.md"]);
   });
 
   it("splits multiple entries at each heading", () => {
@@ -61,7 +62,9 @@ describe("parseFaqEntries", () => {
       entries.map((entry) => entry.symptom),
       ["First", "Second"],
     );
-    assert.deepEqual(entries[1].configKeys, ["two"]);
+    const [, second] = entries;
+    assert.ok(second);
+    assert.deepEqual(second.configKeys, ["two"]);
   });
 
   it("ignores the format example inside a fenced block", () => {
@@ -73,32 +76,39 @@ describe("parseFaqEntries", () => {
       entries.map((entry) => entry.symptom),
       ["Real symptom"],
     );
-    assert.deepEqual(entries[0].configKeys, ["real"]);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.deepEqual(entry.configKeys, ["real"]);
   });
 
   it("drops pointer lines that appear before the first heading", () => {
     const entries = parseFaqEntries(["configKey: orphan", "## Later", "configKey: kept"].join("\n"));
     assert.equal(entries.length, 1);
-    assert.deepEqual(entries[0].configKeys, ["kept"]);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.deepEqual(entry.configKeys, ["kept"]);
   });
 
   it("ignores prose that merely contains a colon", () => {
-    const entries = parseFaqEntries(["## Symptom", "Note: this sentence is prose, not a pointer.", "configKey: real"].join("\n"));
-    assert.deepEqual(entries[0].configKeys, ["real"]);
-    assert.deepEqual(entries[0].sources, []);
-    assert.deepEqual(entries[0].helps, []);
+    const [entry] = parseFaqEntries(["## Symptom", "Note: this sentence is prose, not a pointer.", "configKey: real"].join("\n"));
+    assert.ok(entry);
+    assert.deepEqual(entry.configKeys, ["real"]);
+    assert.deepEqual(entry.sources, []);
+    assert.deepEqual(entry.helps, []);
   });
 
   it("ignores a field with an empty value", () => {
-    const entries = parseFaqEntries(["## Symptom", "configKey:", "configKey:   "].join("\n"));
-    assert.deepEqual(entries[0].configKeys, []);
+    const [entry] = parseFaqEntries(["## Symptom", "configKey:", "configKey:   "].join("\n"));
+    assert.ok(entry);
+    assert.deepEqual(entry.configKeys, []);
   });
 
   it("does not resolve a field name through the prototype chain", () => {
     // `constructor: x` would hit Object.prototype if the field table were a
     // plain object literal, and push into an undefined list.
-    const entries = parseFaqEntries(["## Symptom", "constructor: boom", "toString: boom", "configKey: real"].join("\n"));
-    assert.deepEqual(entries[0].configKeys, ["real"]);
+    const [entry] = parseFaqEntries(["## Symptom", "constructor: boom", "toString: boom", "configKey: real"].join("\n"));
+    assert.ok(entry);
+    assert.deepEqual(entry.configKeys, ["real"]);
   });
 
   it("returns no entries for empty or heading-free input", () => {
@@ -111,13 +121,18 @@ describe("parseFaqEntries", () => {
     // point of `entryHasPointer`.
     const entries = parseFaqEntries("## Unverifiable\n\nJust prose.\n");
     assert.equal(entries.length, 1);
-    assert.equal(entryHasPointer(entries[0]), false);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entryHasPointer(entry), false);
   });
 
   it("accepts an entry with any single pointer kind", () => {
     const [byConfig] = parseFaqEntries("## A\nconfigKey: k");
     const [bySource] = parseFaqEntries("## B\nsource: s");
     const [byHelp] = parseFaqEntries("## C\nhelp: h.md");
+    assert.ok(byConfig);
+    assert.ok(bySource);
+    assert.ok(byHelp);
     assert.equal(entryHasPointer(byConfig), true);
     assert.equal(entryHasPointer(bySource), true);
     assert.equal(entryHasPointer(byHelp), true);

--- a/test/workspace/test_marp_themes.ts
+++ b/test/workspace/test_marp_themes.ts
@@ -63,9 +63,11 @@ describe("listMarpThemes", () => {
     await writeFile(path.join(themesDir, "corporate.css"), "section { background: navy; }", "utf-8");
     const out = listMarpThemes();
     assert.equal(out.length, 1);
-    assert.equal(out[0].name, "corporate");
-    assert.match(out[0].css, /^\/\* @theme corporate \*\//);
-    assert.match(out[0].css, /section \{ background: navy; \}/);
+    const [theme] = out;
+    assert.ok(theme);
+    assert.equal(theme.name, "corporate");
+    assert.match(theme.css, /^\/\* @theme corporate \*\//);
+    assert.match(theme.css, /section \{ background: navy; \}/);
   });
 
   it("ignores files whose name does not pass the slug validator", async () => {

--- a/test/workspace/test_photo_locations_list.ts
+++ b/test/workspace/test_photo_locations_list.ts
@@ -60,7 +60,9 @@ describe("photo-locations list — defensive sidecar validation", () => {
     writeSidecar("bad.json", "{not json");
     const all = await listAllSidecars();
     assert.equal(all.length, 1);
-    assert.equal(all[0].id, "good");
+    const [row] = all;
+    assert.ok(row);
+    assert.equal(row.id, "good");
   });
 
   it("skips a sidecar missing capturedAt — does NOT throw at sort time", async () => {
@@ -70,7 +72,9 @@ describe("photo-locations list — defensive sidecar validation", () => {
     writeSidecar("missing-time.json", noCapturedAt);
     const all = await listAllSidecars();
     assert.equal(all.length, 1);
-    assert.equal(all[0].id, "good");
+    const [row] = all;
+    assert.ok(row);
+    assert.equal(row.id, "good");
   });
 
   it("skips a sidecar with non-string capturedAt", async () => {
@@ -85,7 +89,9 @@ describe("photo-locations list — defensive sidecar validation", () => {
     writeSidecar("good.json", VALID_SIDECAR);
     const all = await listAllSidecars();
     assert.equal(all.length, 1);
-    assert.equal(all[0].id, "good");
+    const [row] = all;
+    assert.ok(row);
+    assert.equal(row.id, "good");
   });
 
   it("skips a sidecar with malformed photo block", async () => {
@@ -94,7 +100,9 @@ describe("photo-locations list — defensive sidecar validation", () => {
     writeSidecar("good.json", VALID_SIDECAR);
     const all = await listAllSidecars();
     assert.equal(all.length, 1);
-    assert.equal(all[0].id, "good");
+    const [row] = all;
+    assert.ok(row);
+    assert.equal(row.id, "good");
   });
 
   it("returns an empty array when EVERY sidecar is malformed (no crash)", async () => {
@@ -125,6 +133,7 @@ describe("photo-locations list — defensive sidecar validation", () => {
     const exif = { lat: 35.6, lng: 139.7, altitude: 12.5, iso: 100, takenAt: "2026-04-12T08:30:00.000Z", make: "Apple", flashFired: false };
     writeSidecar("good.json", { ...VALID_SIDECAR, exif });
     const [row] = await listAllSidecars();
+    assert.ok(row);
     assert.deepEqual(row.sidecar.exif, exif);
   });
 
@@ -156,12 +165,14 @@ describe("photo-locations list — defensive sidecar validation", () => {
     };
     writeSidecar("full.json", { ...VALID_SIDECAR, exif });
     const [row] = await listAllSidecars();
+    assert.ok(row);
     assert.deepEqual(row.sidecar.exif, exif);
   });
 
   it("drops an exif field whose stored type contradicts PhotoExif", async () => {
     writeSidecar("edited.json", { ...VALID_SIDECAR, exif: { lat: "35.6", lng: 139.7, flashFired: "true", iso: null } });
     const [row] = await listAllSidecars();
+    assert.ok(row);
     // `lat` was reaching consumers typed as `number` while holding a string.
     assert.deepEqual(row.sidecar.exif, { lng: 139.7 });
   });
@@ -170,6 +181,7 @@ describe("photo-locations list — defensive sidecar validation", () => {
     // JSON has no NaN literal, so a hand-edit lands as null.
     writeSidecar("edited.json", { ...VALID_SIDECAR, exif: { lat: null, lng: 139.7 } });
     const [row] = await listAllSidecars();
+    assert.ok(row);
     assert.deepEqual(row.sidecar.exif, { lng: 139.7 });
   });
 
@@ -180,12 +192,15 @@ describe("photo-locations list — defensive sidecar validation", () => {
     writeSidecar("good.json", VALID_SIDECAR);
     const all = await listAllSidecars();
     assert.equal(all.length, 1);
-    assert.equal(all[0].id, "good");
+    const [row] = all;
+    assert.ok(row);
+    assert.equal(row.id, "good");
   });
 
   it("drops keys outside the declared shape", async () => {
     writeSidecar("extra.json", { ...VALID_SIDECAR, note: "hand added", exif: { lat: 1, lng: 2, someFutureField: "x" } });
     const [row] = await listAllSidecars();
+    assert.ok(row);
     assert.deepEqual(row.sidecar.exif, { lat: 1, lng: 2 });
     assert.equal(Object.hasOwn(row.sidecar, "note"), false);
   });

--- a/test/workspace/test_reference_dirs.ts
+++ b/test/workspace/test_reference_dirs.ts
@@ -44,8 +44,10 @@ describe("loadReferenceDirs — non-string fields", () => {
     writeConfig(root, [{ hostPath: target, label: { text: "nope" } }]);
     const entries = loadReferenceDirs(root);
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].label, path.basename(target));
-    assert.doesNotMatch(entries[0].label, /\[object Object\]/);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.label, path.basename(target));
+    assert.doesNotMatch(entry.label, /\[object Object\]/);
   });
 
   it("falls back to the basename when label is an array", () => {
@@ -54,7 +56,9 @@ describe("loadReferenceDirs — non-string fields", () => {
     writeConfig(root, [{ hostPath: target, label: ["a", "b"] }]);
     const entries = loadReferenceDirs(root);
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].label, path.basename(target));
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.label, path.basename(target));
   });
 
   it("keeps a string label as-is", () => {
@@ -63,7 +67,9 @@ describe("loadReferenceDirs — non-string fields", () => {
     writeConfig(root, [{ hostPath: target, label: "docs" }]);
     const entries = loadReferenceDirs(root);
     assert.equal(entries.length, 1);
-    assert.equal(entries[0].label, "docs");
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.label, "docs");
   });
 
   it("rejects an entry whose hostPath is an object", () => {

--- a/test/workspace/test_skills_preset.ts
+++ b/test/workspace/test_skills_preset.ts
@@ -151,10 +151,14 @@ describe("syncPresetSkills — slug guard", () => {
     });
     assert.deepEqual(result.copied, []);
     assert.equal(result.skipped.length, 1);
-    assert.match(result.skipped[0], /library/);
-    assert.match(result.skipped[0], /mc-/);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.match(skipped, /library/);
+    assert.match(skipped, /mc-/);
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0], /library/);
+    const [warning] = warnings;
+    assert.ok(warning);
+    assert.match(warning, /library/);
     assert.equal(existsSync(path.join(destDir, "library")), false);
   });
 
@@ -163,8 +167,10 @@ describe("syncPresetSkills — slug guard", () => {
     const result = syncPresetSkills({ sourceDir, destDir });
     assert.deepEqual(result.copied, []);
     assert.equal(result.skipped.length, 1);
-    assert.match(result.skipped[0], /mc-empty/);
-    assert.match(result.skipped[0], /SKILL\.md/);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.match(skipped, /mc-empty/);
+    assert.match(skipped, /SKILL\.md/);
   });
 
   it("skips a non-directory source entry", () => {
@@ -198,8 +204,10 @@ describe("syncPresetSkills — slug guard", () => {
     });
     assert.deepEqual(result.copied, []);
     assert.equal(result.skipped.length, 1);
-    assert.match(result.skipped[0], /mc-bad-shape/);
-    assert.match(result.skipped[0], /regular file/);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.match(skipped, /mc-bad-shape/);
+    assert.match(skipped, /regular file/);
     assert.equal(warnings.length, 1);
   });
 });
@@ -222,9 +230,13 @@ describe("syncPresetSkills — source resilience", () => {
     assert.deepEqual(result.copied, []);
     assert.deepEqual(result.removed, []);
     assert.equal(result.skipped.length, 1);
-    assert.match(result.skipped[0], /non-directory/);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.match(skipped, /non-directory/);
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0], /preset sync aborted/);
+    const [warning] = warnings;
+    assert.ok(warning);
+    assert.match(warning, /preset sync aborted/);
   });
 });
 
@@ -248,9 +260,13 @@ describe("syncPresetSkills — destination resilience", () => {
     assert.deepEqual(result.copied, []);
     assert.deepEqual(result.removed, []);
     assert.equal(result.skipped.length, 1);
-    assert.match(result.skipped[0], /non-directory/);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.match(skipped, /non-directory/);
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0], /preset sync aborted/);
+    const [warning] = warnings;
+    assert.ok(warning);
+    assert.match(warning, /preset sync aborted/);
   });
 
   it("skips a slug whose dest slot is occupied by a regular file (regression: corruption-tolerant boot)", () => {
@@ -271,8 +287,10 @@ describe("syncPresetSkills — destination resilience", () => {
     // mc-foo is skipped (slot occupied), mc-bar still copies.
     assert.deepEqual(result.copied, ["mc-bar"]);
     assert.equal(result.skipped.length, 1);
-    assert.match(result.skipped[0], /mc-foo/);
-    assert.match(result.skipped[0], /non-directory/);
+    const [skipped] = result.skipped;
+    assert.ok(skipped);
+    assert.match(skipped, /mc-foo/);
+    assert.match(skipped, /non-directory/);
     assert.equal(warnings.length, 1);
     // mc-bar landed normally despite mc-foo's failure.
     assert.ok(existsSync(path.join(destDir, "mc-bar", "SKILL.md")));
@@ -369,7 +387,9 @@ describe("syncActivePresetSkills", () => {
     assert.ok(readFileSync(activeSkillPath, "utf-8").includes("NEW BODY"));
     const backups = readdirSync(path.join(activeDir, "mc-clients")).filter((entry) => entry.startsWith("SKILL.md.bak."));
     assert.equal(backups.length, 1, "expected exactly one .bak file alongside SKILL.md");
-    assert.equal(readFileSync(path.join(activeDir, "mc-clients", backups[0]), "utf-8"), "OLD BODY");
+    const [backup] = backups;
+    assert.ok(backup);
+    assert.equal(readFileSync(path.join(activeDir, "mc-clients", backup), "utf-8"), "OLD BODY");
   });
 
   it("is a no-op when the active copy already matches source (no .bak created)", () => {
@@ -479,8 +499,10 @@ describe("syncActivePresetSkills", () => {
       });
       assert.equal(result.updated.length, 0, "must not report success");
       assert.equal(result.skipped.length, 1);
-      assert.match(result.skipped[0], /mc-clients/);
-      assert.match(result.skipped[0], /symlink|escapes/);
+      const [skipped] = result.skipped;
+      assert.ok(skipped);
+      assert.match(skipped, /mc-clients/);
+      assert.match(skipped, /symlink|escapes/);
       // The outside file must remain untouched (no overwrite, no .bak rename).
       assert.equal(readFileSync(path.join(outsideDir, "SKILL.md"), "utf-8"), "ATTACKER WOULD LOVE TO READ/WRITE THIS");
       assert.deepEqual(

--- a/test/workspace/wiki-pages/test_snapshot.ts
+++ b/test/workspace/wiki-pages/test_snapshot.ts
@@ -143,12 +143,14 @@ describe("appendSnapshot — write + retrieve", () => {
     assert.equal(snapshots.length, 1);
     // Public stamp is `<filenameStamp>-<shortId>` to disambiguate
     // same-millisecond writes (codex iter-1).
-    assert.equal(snapshots[0].stamp, "2026-04-28T01-23-45-789Z-fixedid");
-    assert.equal(snapshots[0].editor, "user");
-    assert.equal(snapshots[0].reason, "first save");
-    assert.equal(snapshots[0].ts, "2026-04-28T01:23:45.789Z");
+    const [snapshot] = snapshots;
+    assert.ok(snapshot);
+    assert.equal(snapshot.stamp, "2026-04-28T01-23-45-789Z-fixedid");
+    assert.equal(snapshot.editor, "user");
+    assert.equal(snapshot.reason, "first save");
+    assert.equal(snapshot.ts, "2026-04-28T01:23:45.789Z");
 
-    const single = await readSnapshot(SLUG, snapshots[0].stamp, { workspaceRoot });
+    const single = await readSnapshot(SLUG, snapshot.stamp, { workspaceRoot });
     assert.ok(single, "expected snapshot to round-trip");
     assert.equal(single.body, "body\n");
     assert.equal(single.meta.title, "hi");
@@ -340,7 +342,9 @@ describe("snapshot reads — symlink protection", () => {
 
     const summaries = await listSnapshots(slug, { workspaceRoot });
     assert.equal(summaries.length, 1, "symlink should be filtered out");
-    assert.equal(summaries[0].stamp, `${realStamp}-real0000`);
+    const [summary] = summaries;
+    assert.ok(summary);
+    assert.equal(summary.stamp, `${realStamp}-real0000`);
 
     await rm(workspaceRoot, { recursive: true, force: true });
   });
@@ -430,7 +434,9 @@ describe("appendSnapshot via writeWikiPage — integration", () => {
     assert.equal(snapshots.length, 2, "two saves with different bodies → two snapshots");
 
     // The newest snapshot's body should match the second save.
-    const newest = await readSnapshot("hello", snapshots[0].stamp, { workspaceRoot });
+    const [newestSummary] = snapshots;
+    assert.ok(newestSummary);
+    const newest = await readSnapshot("hello", newestSummary.stamp, { workspaceRoot });
     assert.ok(newest);
     assert.equal(newest.body, "updated body\n");
 


### PR DESCRIPTION
## Summary

Makes the **`test/` directories outside the plugin/util slice**, plus **all of `e2e/` and `e2e-live/`**, clean under `noUncheckedIndexedAccess` (NUIA). 383 findings removed across 76 files:

| Project | Before | After (my scope) |
|---|---|---|
| `test/` — `agent`, `api`, `routes`, `events`, `system`, `skills`, `remoteHost`, `server`, `logger`, `chat-index`, `tool-trace`, `journal`, `helpers`, `workspace` | 352 | **0** |
| `e2e/` (whole project) | 19 | **0** |
| `e2e-live/` (own files) | 12 | **0** |

**No tsconfig flag is enabled here.** `test/tsconfig.json` also covers `test/plugins`, `test/utils`, `test/composables`, `test/services` and `test/scripts` (a sibling PR), so that project cannot reach zero from this change alone. `e2e/` is at zero outright; `e2e-live/` has 2 residual findings, both in `server/` (owned by the server-side PR), so its own tsconfig cannot flip yet either.

**No production code was touched** — this PR is test-only.

## Items to Confirm / Review

The dominant shape here is `rows[0].foo` after a length assertion — mechanical, and that is the risk. **The specific thing to check is that no assertion was weakened.** The rule applied throughout: *a fix must not make the test pass in a case where it previously would have failed.*

The canonical rewrite narrows without softening (`node:assert`'s `ok` is `asserts value`):

```ts
const row = rows[0];
assert.ok(row);
assert.equal(row.foo, 1);
```

Two shapes were **banned** and do not appear anywhere in the diff:

- `if (row) { assert.equal(…) }` — turns a missing row into a **silent pass**, strictly worse than the unchecked index.
- `assert.equal(row?.foo, …)` / `expect(x?.y)` — optional chaining *inside the asserted value*. This is not theoretical: `test/remoteHost/test_remoteViewItems.ts` asserts `assert.equal(item.photo, undefined)`, so the tempting `items[0]?.photo` fix would have passed on a **missing item**.

Please spot-check these judgement calls:

1. **`test/agent/test_agent_stream.ts`** — the original already had the banned shape (`assert.equal(result[0].type, …)` followed by `if (result[0].type === "tool_call_result") { assert.equal(result[0].content, …) }`). The content assertion is now unconditional, so it always runs.
2. **`test/events/test_session_store.ts`** — this test reads `history()[0]` **twice with a `pushSessionEvent` in between**. Hoisting one `const` (the obvious mechanical fix) would have made the second assertion check stale state and pass regardless. Kept as two separate reads with two `assert.ok`s, with a comment explaining why.
3. **`test/api/routes/test_parseConnectors.ts`** — collapsed `length` + `name` + `connected` into `assert.deepEqual(result, [{…}])`. Stronger (also pins "no extra keys"), but it *is* a change in what is asserted.
4. **`test/server/notifier/test_engine.ts`** — `clear(published[0..2].id)` became `published.slice(0, CLEARED_COUNT).map(…)`. A short array would silently clear *fewer* rather than throw, so `assert.equal(published.length, PUBLISHED_COUNT)` was added to close that gap.
5. **`test/system/test_macosNotify.ts`** — two pre-existing `as string` casts were **removed** in favour of destructuring + `assert.ok`. The argv test destructures positionally rather than switching to `deepEqual` on a slice, so the assertion stays exactly as strong (a `deepEqual` would additionally pin argv length — a change in what is asserted, not just how).
6. **`e2e/tests/file-explorer.spec.ts` / `files-json-edit.spec.ts`** — `expect(puts[0].path)` + `expect(puts[0].content)` became one `expect(puts).toMatchObject([{ path, content }])`, keeping the existing `toHaveLength(1)`.
7. **`e2e/fixtures/accounting.ts`** — `findIndex` + `books[idx]` became `find` + `books.indexOf(target)`; behaviourally identical, drops the index entirely.
8. **`e2e-live/fixtures/live-chat.ts:1099`** — added `if (candidateId === undefined) return false;` inside a `waitForURL` predicate. This is **stricter** than before: previously an undefined capture made the predicate return `true` and the wait settle on the wrong URL.

### Real bugs found: none

Every out-of-range index in this slice turned out to be a type-system gap, not production returning fewer items than the test assumes — each site either had a length assertion immediately above it, or built the fixture array inline. The `test/skills/` scheduler tests were read specifically against the known malformed-`time` failure mode; that path is not exercised there.

## How weakening was guarded against

`yarn test` passing is necessary but **not sufficient** — a weakened assertion also passes. Beyond typecheck, 17 mutation probes were applied and reverted, covering every rewrite style used:

| Probe class | Example | Result |
|---|---|---|
| Array comes back **short** (`all.slice(1)`) | `test_photo_locations_list.ts` ×5, `test_snapshot.ts` | ✖ `assert.ok(row)` fires — not a silent pass |
| Forced empty production result | `test_remoteViewItems.ts` (`listRecords → []`) | ✖ fails; this is the `undefined === undefined` trap site |
| Expected **value** corrupted | `test_reference_dirs.ts`, `test_provision.ts`, `test_parseConnectors.ts`, `test_hookLog.ts`, `test_startChat.ts`, `test_agent_config.ts`, `test_notify_tool.ts`, `test_streamParser.ts`, `test_sandboxMounts.ts` | ✖ all fail — hoisted assertions are live |
| Stale-snapshot check | `test_session_store.ts` (second push given a real body) | ✖ fails — proves the second read is fresh |
| Playwright `toMatchObject` | `file-explorer.spec.ts` (`wiki/hello.md` → `wiki/MUTANT.md`) | ✖ fails |

All probes reverted; suites re-run green afterwards.

## Verification

```
yarn build:packages   OK
yarn format           OK (no reformatting needed)
yarn lint             OK  0 errors, 51 warnings — all pre-existing, all in files this PR does not touch
yarn typecheck        OK  exit 0
yarn build            OK  exit 0
yarn test             OK  11085 tests, 11078 pass, 0 fail, 7 skipped
```

Scoped NUIA measurements (absolute paths, `--pretty false` — without it, ANSI escapes split the string `error TS` and `grep -c` reports a false zero; `vue-tsc` rather than `tsc` for the `test` project, or findings inside `.vue` files are invisible):

```
vue-tsc -p test/tsconfig.json      -> 0 in my scope (551 remain, all in test/{plugins,utils,composables,services,scripts}, server/, packages/)
tsc     -p e2e/tsconfig.json       -> 0
tsc     -p e2e-live/tsconfig.json  -> 2, both in server/ (other PR's scope)
```

The out-of-scope error profile was diffed before vs. after and is **identical**, confirming no collateral changes.

E2E was exercised for real, not just typechecked: the 5 changed `e2e/` specs ran green (37/37) against a **private port** with `reuseExistingServer: false`. The committed `e2e/playwright.config.ts` hardcodes port 45173 with `reuseExistingServer: true`, which was already occupied — running it as-is would have silently attached to another worktree's dev server and exercised the wrong source. The throwaway local config was deleted and is not part of this PR.

## User Prompt

> Issue #2736: adopt `noUncheckedIndexedAccess`. Scope: everything under `test/` except `test/plugins`, `test/utils`, `test/composables`, `test/services`, `test/scripts` (another agent owns those five), plus all of `e2e/**` and `e2e-live/**`. Do not touch `src/`, `server/` or `packages/`.
>
> This scope is mostly mechanical — that is the danger, not the difficulty. The dominant shape is `rows[0].foo` after an assertion. Fixing hundreds on autopilot is how a weakened test slips through. The rule: a fix must not make the test pass in a case where it previously would have failed. Never write `if (row) { assert.equal(...) }` — that turns a missing row from a failure into a silent pass, strictly worse than the unchecked index you started with. In Playwright specs the equivalent trap is `expect(x?.y)`.
>
> No `as`, no `!`, no `@ts-ignore`/`@ts-expect-error`/`eslint-disable`, no `let`, no magic numbers.
>
> Do NOT enable the flag in any tsconfig — `test/tsconfig.json` also covers the other agent's five directories, so it cannot reach zero from this work alone.
>
> Watch for real bugs: in tests the tell is an index out of range because the production code returns fewer items than the test assumes — a real finding, not a typing chore.
>
> Verify with `yarn build:packages && yarn format && yarn lint && yarn typecheck && yarn build && yarn test` plus the scoped measurements at 0. `yarn test` passing is necessary but not sufficient — spot-check a sample by breaking the value under test and confirming the assertion still fails.

work in mulmoclaude3

## Summary by Sourcery

Harden test and e2e code against unchecked indexed access by introducing local bindings and presence assertions, while preserving existing behaviors and tightening a few expectations.

Enhancements:
- Refactor tests and Playwright specs to avoid direct array and match-group indexing by using destructuring, slices, and explicit existence checks.
- Strengthen several assertions (e.g., notifier history, connectors parsing, wiki snapshots, skill catalogs) to validate full objects or stricter invariants rather than individual fields.
- Improve helper and routing utilities used in tests and e2e fixtures to safely handle regex matches, URL/session-id extraction, and path-derived slugs without weakening behaviors.
- Adjust accounting and collection-related fixtures to use value-based operations instead of raw indices, keeping state mutations consistent and resilient.

Tests:
- Update a wide range of unit and integration tests across agent, server, workspace, skills, logger, events, and system modules to be compatible with `noUncheckedIndexedAccess` without reducing test coverage or assertion strength.
- Consolidate some Playwright expectations in e2e specs to assert on full request payloads and ensure robust handling of asynchronous flows and race conditions.