### PR TITLE
fix(settings): Map タブの API キー入力を読み込み完了まで編集不可にする（e2e (2) の CI 失敗の根本原因）

### DIFF
--- a/e2e/tests/settings-target-narrowing.spec.ts
+++ b/e2e/tests/settings-target-narrowing.spec.ts
@@ -18,14 +18,21 @@ interface ConfigState {
 
 const GMAIL_SERVER: McpEntry = { id: "gmail", spec: { type: "http", url: "https://gmail.mcp.claude.com/mcp", enabled: true } };
 
+/** Long enough that the tab is observably still loading after it mounts. */
+const SLOW_CONFIG_GET_MS = 1000;
+
 /** `/api/config` GET plus the two patch endpoints, reflecting writes back. */
-async function mockConfig(page: Page, initial: ConfigState): Promise<ConfigState> {
+async function mockConfig(page: Page, initial: ConfigState, getDelayMs = 0): Promise<ConfigState> {
   await mockAllApis(page);
   const state: ConfigState = JSON.parse(JSON.stringify(initial));
 
   await page.route(
     (url) => url.pathname === "/api/config",
-    (route) => (route.request().method() === "GET" ? route.fulfill({ json: state }) : route.fallback()),
+    async (route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      if (getDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, getDelayMs));
+      return route.fulfill({ json: state });
+    },
   );
   await page.route(
     (url) => url.pathname === "/api/config/settings",
@@ -66,6 +73,23 @@ test.describe("Settings — handlers that narrow event.target", () => {
     // The handler blurs the input; the blur listener is what saves.
     await expect(input).not.toBeFocused();
     await expect.poll(() => state.settings.googleMapsApiKey).toBe("AIzaTestKey123");
+  });
+
+  // The tab mounts before its config GET resolves. Left editable in that
+  // window, a key typed into it is overwritten by the arriving stored value
+  // and the save that follows sees no change — the key vanishes silently.
+  test("the Maps API key field is not editable until the stored key has loaded", async ({ page }) => {
+    const state = await mockConfig(page, { settings: { extraAllowedTools: [] }, mcp: { servers: [] } }, SLOW_CONFIG_GET_MS);
+    await page.goto("/chat");
+    await openTab(page, "map");
+
+    const input = page.locator('[data-testid="settings-map-api-key-input"]');
+    await expect(input).toBeDisabled();
+    await expect(input).toBeEnabled();
+
+    await input.fill("AIzaLateLoad456");
+    await input.press("Enter");
+    await expect.poll(() => state.settings.googleMapsApiKey).toBe("AIzaLateLoad456");
   });
 
   test("unchecking an MCP server's enable box persists enabled: false", async ({ page }) => {

--- a/plans/fix-2763-settings-map-load-race.md
+++ b/plans/fix-2763-settings-map-load-race.md
@@ -1,0 +1,79 @@
+# fix #2763 — Map タブの API キー入力が読み込み完了前に編集可能
+
+## 背景
+
+main の CI `e2e (2)` が
+[run 30768313410](https://github.com/receptron/mulmoclaude/actions/runs/30768313410/job/91551517146)
+で失敗した。
+
+失敗テストは `e2e/tests/settings-target-narrowing.spec.ts` の
+*Enter in the Maps API key field commits the key and drops focus* で、
+`state.settings.googleMapsApiKey` が `undefined` のまま（= 保存 PUT が飛んでいない）。
+
+## 根本原因
+
+`SettingsMapTab` は `SettingsModal.vue:166` で `v-else-if="activeTab === 'map'"`。
+つまり **Map タブをクリックした瞬間にマウント**され、`reloadToken` の
+`immediate: true` watch から `GET /api/config` が飛ぶ。
+入力欄はこの GET を待たずに最初から編集可能になっている。
+
+`load()` は完了時に無条件で `apiKeyDraft.value = storedKey.value` を代入するため、
+**「入力 → GET 到着 → Enter」の順**に並ぶと打った内容が空文字で上書きされる。
+続く `save()` は `if (trimmed === storedKey.value) return;` に当たって早期 return し、
+**エラーも出さずに保存しない**。
+
+CI の失敗時スナップショット（`error-context.md`）もこれと整合する:
+ステータスは "Not configured"、`settings-map-error` は非表示 =
+`save()` が黙って no-op しただけの状態。
+
+テストだけの問題ではなく、**サーバー応答が遅いときに実ユーザーが入力キーを失う実バグ**。
+
+## 再現（外部 ground truth）
+
+`/api/config` の GET を「`fill` と `press("Enter")` の間」に着地させる probe spec を
+一時的に置いて実行 → CI と同一の
+
+```
+Expected: "AIzaTestKey123"
+Received: undefined
+```
+
+で確定的に再現した。固定 delay（1.5s）では **再現しない**ことも確認済み
+（その場合 save が先に走ってしまうため）。窓は「fill と Enter の間」だけ。
+
+## 対応
+
+`src/components/SettingsMapTab.vue`
+
+- `loading` ref を追加（初期値 `true`）。`load()` の前後で true / false にする。
+  失敗パスでも false に戻るよう `apiGet` の直後に置く（`loaded` は成功時のみ true のままなので、
+  読み込み失敗後も入力・保存はできる）。
+- 入力欄に `:disabled="loading"` と disabled 時の Tailwind ユーティリティを追加。
+
+これで「まだ届いていない値の上に書ける」窓自体が消える。
+Playwright の `fill()` は要素が enabled になるまで待つので、e2e 側の race も同時に消える。
+
+## テスト
+
+`e2e/tests/settings-target-narrowing.spec.ts`
+
+- `mockConfig` に `getDelayMs` を追加（既定 0 = 従来どおり）。
+- 回帰テスト
+  *the Maps API key field is not editable until the stored key has loaded* を追加。
+  GET を 1s 遅らせ、`toBeDisabled()` → `toBeEnabled()` → 入力 → Enter → 保存到達 を検証。
+
+### 確認済み
+
+- 修正なし + 新テスト → `Expected: disabled / Received: enabled` で落ちる（ガードが効いている）。
+  同時に既存の失敗テストもローカルで確定的に落ちるようになった。
+- 修正あり → `settings-target-narrowing` 3件 pass。
+- `settings.spec` / `accounting-settings` 併せて 27 件 pass。
+- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn build` すべて通過。
+
+## スコープ外（別途検討）
+
+`reloadToken` を使う他の Settings タブ（Notifications / Voice / ChatIndex / Photos /
+Journal / Model）も同じ「マウント後に load が値を上書きする」形だが、
+いずれも checkbox / select で、
+「自由入力 + Enter で確定 + 変化なしなら no-op」という今回の組み合わせは持たない。
+今回は Map タブに限定する。

--- a/src/components/SettingsMapTab.vue
+++ b/src/components/SettingsMapTab.vue
@@ -10,8 +10,9 @@
         type="password"
         autocomplete="off"
         spellcheck="false"
-        class="w-full px-3 py-2 text-sm font-mono rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        class="w-full px-3 py-2 text-sm font-mono rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
         :placeholder="t('settingsModal.mapTab.apiKeyPlaceholder')"
+        :disabled="loading"
         data-testid="settings-map-api-key-input"
         @blur="save"
         @keydown.enter.prevent="onEnterKey"
@@ -65,6 +66,10 @@ interface SettingsResponse {
 
 const apiKeyDraft = ref("");
 const storedKey = ref("");
+// The field stays disabled until the stored key has arrived: a load that
+// resolves after the user started typing would overwrite the draft, and the
+// save that follows then sees no change and silently does nothing.
+const loading = ref(true);
 const loaded = ref(false);
 const saving = ref(false);
 const errorMessage = ref("");
@@ -88,7 +93,9 @@ const statusColour = computed(() => {
 
 async function load(): Promise<void> {
   errorMessage.value = "";
+  loading.value = true;
   const response = await apiGet<SettingsResponse>(API_ROUTES.config.base);
+  loading.value = false;
   if (!response.ok) {
     errorMessage.value = response.error || t("settingsModal.mapTab.loadError");
     return;


### PR DESCRIPTION
## Summary

main の CI `e2e (2)` が
[run 30768313410](https://github.com/receptron/mulmoclaude/actions/runs/30768313410/job/91551517146)
で落ちていた件の修正。**フレークではなく実バグ**だった。

`SettingsMapTab` は `SettingsModal.vue:166` の `v-else-if` なので **Map タブをクリックした瞬間にマウント**され、
そこから `GET /api/config` が飛ぶ。入力欄はその GET を待たずに最初から編集可能になっている。
`load()` は完了時に無条件で `apiKeyDraft.value = storedKey.value` を代入するため、
**「入力 → GET 到着 → Enter」** の順に並ぶと打った内容が空文字で上書きされ、
続く `save()` は `if (trimmed === storedKey.value) return;` に当たって
**エラーも出さずに保存しない**。

読み込みが終わるまで入力欄を `disabled` にして、「まだ届いていない値の上に書ける」窓自体を無くした。
Playwright の `fill()` は enabled になるまで待つので、e2e 側の race も同時に消える。

## Items to Confirm / Review

- **入力欄を `disabled` にする方針でよいか。** 代替案は「ユーザーが編集済みなら `load()` が上書きしない」
  (dirty フラグ) だが、状態が増えるので不変条件が単純な disabled を選んだ。
- **読み込み失敗時に操作不能にならないこと。** `loading` は `apiGet` の直後に `false` に戻すので、
  GET が失敗しても入力・保存はできる（`loaded` は成功時のみ true のままで、ステータス表示の制御に使われる）。
- **`SLOW_CONFIG_GET_MS = 1000`** で CI が遅いときに `toBeDisabled()` が先にすり抜けないか。
  タブ click 直後の 1 アサーションなので余裕はあると判断したが、CI での実挙動を見てほしい。
- **スコープ**: `reloadToken` を使う他タブ（Notifications / Voice / ChatIndex / Photos / Journal / Model）も
  「マウント後に load が値を上書きする」同じ形だが、いずれも checkbox / select で、
  「自由入力 + Enter 確定 + 変化なしなら no-op」という今回の組み合わせは持たないため対象外にした。

## User Prompt

> この問題残っていたら直して
> https://github.com/receptron/mulmoclaude/actions/runs/30768313410/job/91551517146

## 根本原因の特定と再現（外部 ground truth）

CI の失敗時スナップショット (`error-context.md`) はステータス "Not configured"、`settings-map-error` 非表示 =
`save()` が黙って no-op しただけの状態で、上記の筋と整合する。

`/api/config` の GET を **`fill` と `press("Enter")` の間**に着地させる probe spec を一時的に置いて実行し、
CI と同一のエラーで確定的に再現した:

```
Expected: "AIzaTestKey123"
Received: undefined
```

固定 delay（1.5s）では **再現しない**ことも確認した — その場合 save が先に走ってしまうため。
窓は「fill と Enter の間」だけである。

## 変更内容

**`src/components/SettingsMapTab.vue`**

- `loading` ref を追加（初期値 `true`）。`load()` の `apiGet` 前後で true / false にする。
- 入力欄に `:disabled="loading"` と disabled 時の Tailwind ユーティリティを追加。

**`e2e/tests/settings-target-narrowing.spec.ts`**

- `mockConfig` に `getDelayMs` を追加（既定 0 = 従来どおりの挙動）。
- 回帰テスト *the Maps API key field is not editable until the stored key has loaded* を追加。
  GET を 1s 遅らせ、`toBeDisabled()` → `toBeEnabled()` → 入力 → Enter → 保存到達 を検証する。

**`plans/fix-2763-settings-map-load-race.md`** — 調査と方針。

## ローカル検証

- 修正を外して新テストを実行 → `Expected: disabled / Received: enabled` で落ちる（ガードが効いている）。
  同時に **CI で落ちていた既存テストもローカルで確定的に落ちる**ようになった。
- 修正あり → `settings-target-narrowing` 3 件 pass。
- `settings.spec` / `accounting-settings` 併せて **27 件 pass**。
- `yarn format` / `yarn lint`（0 errors, 既存 warning のみ）/ `yarn typecheck` / `yarn build` 通過。

注記: 上記のローカル実行は base `f0e3531e7`（CI が落ちた commit）+ 本修正で行った。
その後 base を最新 main (`6d443cdef`) に進めている。差分の 2 commit は本 PR が触る
`SettingsMapTab.vue` / `settings-target-narrowing.spec.ts` を変更していないことを確認済みで、
最終 base での全体検証は本 PR の CI に委ねる。

refs #2763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

## Summary by Sourcery

Prevent loss of the Maps API key when the config load races with user input and add regression coverage for the scenario.

Bug Fixes:
- Disable the Maps API key input until the stored key has been loaded to avoid silent discarding of user-entered keys when the config GET resolves late.

Enhancements:
- Track a loading state for the Maps tab to control input availability and improve UX feedback via disabled styling.

Documentation:
- Document the root cause, reproduction, and chosen fix for the Maps API key load race in a new plan markdown file.

Tests:
- Extend the config mocking helper with an optional GET delay and add an e2e regression test verifying the Maps API key field is disabled during load and correctly saves after enabling.