### PR TITLE
fix(e2e): make the plugin mocks return the envelope the real routes return

### DIFF
--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -133,9 +133,13 @@ export async function mockAllApis(page: Page, opts: MockApiOptions = {}): Promis
 
   // Defensive defaults for the broader runtime-plugin surface — the
   // boot path queries these on every page load. Empty responses are
-  // safe for tests that don't exercise plugin install / diagnostics.
-  await page.route(urlEndsWith("/api/plugins/runtime/list"), (route) => route.fulfill({ json: [] }));
-  await page.route(urlEndsWith("/api/plugins/diagnostics"), (route) => route.fulfill({ json: [] }));
+  // safe for tests that don't exercise plugin install / diagnostics,
+  // but they have to carry the real envelope: a bare `[]` made
+  // `loadRuntimePlugins` throw on `result.data.plugins.length` before
+  // it loaded anything, so every spec ran with the plugin boot path
+  // dead rather than merely empty.
+  await page.route(urlEndsWith("/api/plugins/runtime/list"), (route) => route.fulfill({ json: { plugins: [] } }));
+  await page.route(urlEndsWith("/api/plugins/diagnostics"), (route) => route.fulfill({ json: { diagnostics: [] } }));
 
   // Notifier engine — every page load primes via list + listHistory.
   // Empty defaults keep specs that don't care about notifications


### PR DESCRIPTION
## Summary

e2e のプラグイン系モック2つが、実ルートと**違う形**を返していました。無関係な CI 失敗を追う過程で見つけたものです。

| | 実際のレスポンス | モックが返していたもの |
|---|---|---|
| `/api/plugins/runtime/list` | `res.json({ plugins })` | `[]` |
| `/api/plugins/diagnostics` | `res.json({ diagnostics })` | `[]` |

その結果、毎回の e2e 実行で次が出ていました:

```
[runtime-plugin] boot loader threw
  TypeError: Cannot read properties of undefined (reading 'length')
  at loadRuntimePlugins (src/tools/runtimeLoader.ts)
```

`result.data.plugins` が `undefined` になり、最初に触る `.length` で throw します。**本番は影響を受けません** — サーバは常に envelope を返します。

## Items to Confirm / Review

**1. 問題はログが汚れることではありません。** `loadRuntimePlugins` が何も読み込む前に throw していたため、**全 spec でプラグイン起動経路が「空」ではなく「死んでいた」**。スイートは runtime plugin を検証しているように見えて、実際には一度も通っていませんでした。修正によりこの経路が初めて実際に走ります。

**2. 差分を読み直すのではなく、外部の ground truth で検証しました。** 同一マシンでフルスイートを変更あり/なしで実行:

```
変更あり  453 passed, 1 failed, "boot loader threw" 0件
変更なし  453 passed, 1 failed, "boot loader threw" 発生
```

**3. 残る1件は本 PR とは無関係の既存問題です。** `today-journal-button.spec.ts:67` が両方の実行で同一に落ち、2回とも再現します。**単体実行では 3 passed** なので、フルラン時のみ顕在化する spec 間の相互作用です。main 側の既存問題なので本 PR では触っていません。別途追う価値があります。

## 検証

`main` @ `da896861d` から分岐。

```
yarn format 0 / lint 0 / typecheck 0 / build 0 / test 0  (11093 tests, fail 0)
e2e full    453 passed / 1 failed（main のベースラインと同一）
```

work in mulmoclaude3

## Summary by Sourcery

Align e2e plugin API mocks with the real server responses so runtime plugin loading behaves correctly during tests.

Bug Fixes:
- Fix e2e plugin runtime list and diagnostics mocks to return enveloped data objects instead of bare arrays, preventing runtime plugin loader errors and ensuring the plugin boot path is exercised in specs.

Tests:
- Restore meaningful coverage of the runtime plugin boot path in e2e tests by returning correctly shaped mock responses for plugin APIs.