### PR TITLE
fix: #2736 スイープが残した実バグの根本原因を直す（scheduler の無言死・バッチ全滅、accounting の未検証 period）

### DIFF
--- a/packages/core/src/collection/core/calendarGrid.ts
+++ b/packages/core/src/collection/core/calendarGrid.ts
@@ -317,16 +317,20 @@ interface ClusterState {
 /** Cut the start-ordered blocks into overlap clusters: a new cluster begins at
  *  the first block that starts at or after every earlier block has ended. */
 function splitClusters(ordered: readonly PositionedSpan[]): PositionedSpan[][] {
+  // Appends into the accumulator's arrays rather than rebuilding them. The
+  // spread form read well but copied both arrays on every block, so a day
+  // whose blocks all overlap cost O(n²) allocations to lay out (#2765).
   const initial: ClusterState = { done: [], current: [], end: Number.NEGATIVE_INFINITY };
   const state = ordered.reduce<ClusterState>((acc, block) => {
-    const breaks = acc.current.length > 0 && block.span.startMin >= acc.end;
-    return {
-      done: breaks ? [...acc.done, acc.current] : acc.done,
-      current: breaks ? [block] : [...acc.current, block],
-      end: breaks ? block.span.endMin : Math.max(acc.end, block.span.endMin),
-    };
+    if (acc.current.length > 0 && block.span.startMin >= acc.end) {
+      acc.done.push(acc.current);
+      return { done: acc.done, current: [block], end: block.span.endMin };
+    }
+    acc.current.push(block);
+    return { done: acc.done, current: acc.current, end: Math.max(acc.end, block.span.endMin) };
   }, initial);
-  return state.current.length > 0 ? [...state.done, state.current] : state.done;
+  if (state.current.length > 0) state.done.push(state.current);
+  return state.done;
 }
 
 /** Greedy lane packing inside one cluster: reuse the first lane already free at

--- a/packages/core/src/scheduler/task-manager.ts
+++ b/packages/core/src/scheduler/task-manager.ts
@@ -122,6 +122,25 @@ function dailyTargetMs(time: string): number | null {
   return hours * ONE_HOUR_MS + minutes * ONE_MINUTE_MS;
 }
 
+/** The `time` of a daily schedule this manager can never fire, or null when the
+ *  schedule is fine. Returning the offending value (not a boolean) is what lets
+ *  the caller name it in the log. */
+function unfireableDailyTime(schedule: TaskSchedule): string | null {
+  if (schedule.type !== SCHEDULE_TYPES.daily) return null;
+  return dailyTargetMs(schedule.time) === null ? schedule.time : null;
+}
+
+/** Say out loud that this schedule can never fire. The task is still accepted —
+ *  `isDue` answers false forever, which is the safe outcome — but silence here
+ *  is what made "the task I scheduled has never run once" a bug with no
+ *  evidence anywhere to start from (#2765). Deliberately not a throw: a
+ *  consumer whose task has been quietly dead would get a boot crash instead. */
+function reportUnfireable(log: SchedulerLogger, taskId: string, schedule: TaskSchedule): void {
+  const time = unfireableDailyTime(schedule);
+  if (time === null) return;
+  log.error("daily time is not HH:MM — this task will never run", { id: taskId, time });
+}
+
 /** Split the due tasks into those that may run immediately and those gated
  *  behind a `dependsOn` edge (resolved later in the same tick cycle). */
 export function collectDueTasks(
@@ -257,6 +276,7 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
       if (registry.has(def.id)) {
         throw new Error(`[task-manager] Task "${def.id}" is already registered`);
       }
+      reportUnfireable(log, def.id, def.schedule);
       registry.set(def.id, def);
       log.info("registered", { id: def.id });
     },
@@ -264,6 +284,9 @@ export function createTaskManager(options?: TaskManagerOptions): ITaskManager {
     updateSchedule(taskId: string, schedule: TaskSchedule): boolean {
       const def = registry.get(taskId);
       if (!def) return false;
+      // Checked here as well as at registration: an override applied at run
+      // time (`applyScheduleOverride`) never passes through `registerTask`.
+      reportUnfireable(log, taskId, schedule);
       def.schedule = schedule;
       log.info("schedule updated", { id: taskId });
       return true;

--- a/packages/core/test/scheduler/test_scheduler.ts
+++ b/packages/core/test/scheduler/test_scheduler.ts
@@ -395,3 +395,45 @@ test("start(): a rejected tick is logged and later ticks keep running", async ()
   assert.ok(nowCalls >= 2, `interval stopped after the first rejection (${nowCalls} tick(s))`);
   assert.ok(errors.includes("tick failed"), `expected a "tick failed" log, got ${JSON.stringify(errors)}`);
 });
+
+// A daily task whose `time` isn't "HH:MM" is never due — safe, but until
+// #2765 it was also completely silent: no log, no error, and `registerTask`
+// accepted it. "The task I scheduled has never run once" is the worst
+// failure mode to have to debug from nothing. The manager now says so; it
+// still registers the task, because throwing would turn a consumer's
+// long-dead task into a boot crash.
+test("a daily task with a malformed time is reported, not silently dead (#2765)", async () => {
+  const errors: { message: string; data?: unknown }[] = [];
+  const manager = createTaskManager({
+    tickMs: 60_000,
+    now: () => new Date(Date.UTC(2026, 0, 1, 9, 0, 0)),
+    log: { info: () => {}, warn: () => {}, error: (message, data) => errors.push({ message, data }) },
+  });
+
+  const ran: string[] = [];
+  manager.registerTask({ id: "typo", schedule: { type: SCHEDULE_TYPES.daily, time: "9" }, run: async () => void ran.push("typo") });
+
+  assert.equal(errors.length, 1, "registering a malformed daily time must report it");
+  assert.match(errors[0]?.message ?? "", /never run|never fire/i);
+  assert.deepEqual(errors[0]?.data, { id: "typo", time: "9" });
+
+  // Behaviour is unchanged: still registered, still never due.
+  await manager.tick();
+  assert.deepEqual(ran, [], "a malformed daily time must stay never-due");
+});
+
+test("updateSchedule reports a malformed daily time too (#2765)", () => {
+  const errors: unknown[] = [];
+  const manager = createTaskManager({
+    tickMs: 60_000,
+    now: () => new Date(Date.UTC(2026, 0, 1, 9, 0, 0)),
+    log: { info: () => {}, warn: () => {}, error: (_message, data) => errors.push(data) },
+  });
+  manager.registerTask({ id: "ok", schedule: { type: SCHEDULE_TYPES.daily, time: "09:00" }, run: async () => {} });
+  assert.deepEqual(errors, [], "a well-formed time must not be reported");
+
+  // The override path (`applyScheduleOverride`) reaches this at run time, so
+  // checking only at registration would miss a bad value applied later.
+  manager.updateSchedule("ok", { type: SCHEDULE_TYPES.daily, time: "0900" });
+  assert.deepEqual(errors, [{ id: "ok", time: "0900" }]);
+});

--- a/packages/plugins/accounting-plugin/src/server/bodyFields.ts
+++ b/packages/plugins/accounting-plugin/src/server/bodyFields.ts
@@ -15,15 +15,43 @@ export const optionalString = (value: unknown): string | undefined => (typeof va
 
 export const optionalRecord = (value: unknown): Record<string, unknown> | undefined => (isRecord(value) ? value : undefined);
 
+const YEAR_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+const YEAR_MONTH_DAY_RE = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+
+/** `YYYY-MM-DD` that names a day the calendar actually has. The regex alone
+ *  admits `2026-02-30`, and `Date.UTC` rolls that forward to March instead of
+ *  refusing it, so the round trip is what says the date is real. */
+const isCalendarDate = (value: string): boolean => {
+  if (!YEAR_MONTH_DAY_RE.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number);
+  if (year === undefined || month === undefined || day === undefined) return false;
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDate() === day;
+};
+
 /** Rebuilt field by field rather than narrowed with a predicate, so the
  *  returned object is one this function actually proved. A half-formed
  *  `{ kind: "month" }` reads as absent and the caller raises its own
  *  "period is required" — previously it reached the report builders and
- *  produced an `undefined-01` date. */
+ *  produced an `undefined-01` date.
+ *
+ *  The FORMAT is checked here too, not just the type: `typeof === "string"`
+ *  let `{ kind: "month", period: "banana" }` through, which came back as a
+ *  balance sheet dated `"banana-NaN"` and made the snapshot cache write
+ *  `banana.json` / `0NaN-NaN.json` into the book (#2765). Malformed reads as
+ *  absent so it lands on the caller's existing 400, which already spells out
+ *  both accepted shapes for the LLM to repair its payload from. */
 export const optionalReportPeriod = (value: unknown): ReportPeriod | undefined => {
   const period = optionalRecord(value);
-  if (period?.kind === "month" && typeof period.period === "string") return { kind: "month", period: period.period };
-  if (period?.kind === "range" && typeof period.from === "string" && typeof period.to === "string") {
+  if (period?.kind === "month" && typeof period.period === "string" && YEAR_MONTH_RE.test(period.period)) {
+    return { kind: "month", period: period.period };
+  }
+  if (
+    period?.kind === "range" &&
+    typeof period.from === "string" &&
+    typeof period.to === "string" &&
+    isCalendarDate(period.from) &&
+    isCalendarDate(period.to)
+  ) {
     return { kind: "range", from: period.from, to: period.to };
   }
   return undefined;

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -103,7 +103,11 @@ async function handleGetReport(rest: ActionRest): Promise<unknown> {
   // `ledger` treats an absent period as "full history", which would turn a
   // period the caller DID send but got wrong into a silently wider answer
   // than they asked for. Sent-but-unusable is an error for every kind (#2765).
-  if (rest.period !== undefined && !periodInput) throw periodRequired(`getReport ${kind || "(no kind)"}`);
+  // `null` counts as NOT sent: it is how a JSON caller spells "I am not using
+  // this optional field", and rejecting it would break ledger calls that work
+  // today.
+  const periodSent = rest.period !== undefined && rest.period !== null;
+  if (periodSent && !periodInput) throw periodRequired(`getReport ${kind || "(no kind)"}`);
   if (kind === "balance") {
     if (!periodInput) throw periodRequired("getReport balance");
     return getBalanceSheetReport({ bookId, period: periodInput });

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -100,6 +100,10 @@ async function handleGetReport(rest: ActionRest): Promise<unknown> {
   // the LLM repairs its own payload from this text.
   const periodRequired = (label: string) =>
     new AccountingError(400, `${label}: period is required — { kind: "month", period: "YYYY-MM" } or { kind: "range", from: "YYYY-MM-DD", to: "YYYY-MM-DD" }`);
+  // `ledger` treats an absent period as "full history", which would turn a
+  // period the caller DID send but got wrong into a silently wider answer
+  // than they asked for. Sent-but-unusable is an error for every kind (#2765).
+  if (rest.period !== undefined && !periodInput) throw periodRequired(`getReport ${kind || "(no kind)"}`);
   if (kind === "balance") {
     if (!periodInput) throw periodRequired("getReport balance");
     return getBalanceSheetReport({ bookId, period: periodInput });

--- a/packages/plugins/accounting-plugin/test/accounting/test_bodyFields.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_bodyFields.ts
@@ -88,3 +88,41 @@ describe("describeEntry", () => {
     assert.deepEqual(describeEntry({ id: 7, date: 20260105 }), { id: undefined, date: undefined });
   });
 });
+
+// The shape check ("is it a string?") was never a format check, so an LLM's
+// `{ kind: "month", period: "banana" }` reached the engine intact (#2765).
+// Two measured consequences: the balance sheet's `asOf` came back
+// `"banana-NaN"`, and `previousPeriod` returned `"0NaN-NaN"` — which
+// `getOrBuildSnapshot` then wrote to disk as `banana.json` / `0NaN-NaN.json`.
+// A malformed period now reads as absent, which is the state the router
+// already turns into a 400 naming both accepted shapes.
+describe("optionalReportPeriod — format (#2765)", () => {
+  it("reads a month period that isn't YYYY-MM as absent", () => {
+    for (const period of ["banana", "2026", "2026-1", "26-01", "2026-13", "2026-00", "2026-01-15", ""]) {
+      assert.equal(optionalReportPeriod({ kind: "month", period }), undefined, JSON.stringify(period));
+    }
+  });
+
+  it("reads a range bound that isn't YYYY-MM-DD as absent", () => {
+    // `endDateOfPeriod` returns `period.to` verbatim as the report's `asOf`,
+    // so an unchecked bound lands in the statement the same way.
+    assert.equal(optionalReportPeriod({ kind: "range", from: "2026-01-01", to: "banana" }), undefined);
+    assert.equal(optionalReportPeriod({ kind: "range", from: "2026-01", to: "2026-03-31" }), undefined);
+    assert.equal(optionalReportPeriod({ kind: "range", from: "2026-01-01", to: "2026-02-30" }), undefined);
+  });
+
+  it("still accepts every well-formed period", () => {
+    assert.deepEqual(optionalReportPeriod({ kind: "month", period: "2026-12" }), { kind: "month", period: "2026-12" });
+    assert.deepEqual(optionalReportPeriod({ kind: "range", from: "2026-01-01", to: "2026-12-31" }), {
+      kind: "range",
+      from: "2026-01-01",
+      to: "2026-12-31",
+    });
+    // Leap day — a calendar check must not reject a real date.
+    assert.deepEqual(optionalReportPeriod({ kind: "range", from: "2028-02-29", to: "2028-02-29" }), {
+      kind: "range",
+      from: "2028-02-29",
+      to: "2028-02-29",
+    });
+  });
+});

--- a/packages/plugins/accounting-plugin/test/accounting/test_router.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_router.ts
@@ -141,6 +141,46 @@ describe("getReport period validation", () => {
     });
     assert.equal(status, 200);
   });
+
+  // `ledger` reads an absent period as "full history". A period the caller
+  // DID send but got wrong must not quietly widen the answer to that (#2765).
+  it("rejects a malformed period on ledger instead of silently returning full history", async () => {
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "ledger",
+      bookId,
+      accountCode: "1000",
+      period: { kind: "month", period: "banana" },
+    });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /period is required/);
+  });
+
+  // ...but `null` is how a JSON caller spells "not using this optional
+  // field", so it must keep meaning "no period", not become an error.
+  it("treats an explicit null period on ledger as absent", async () => {
+    const { status } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "ledger",
+      bookId,
+      accountCode: "1000",
+      period: null,
+    });
+    assert.equal(status, 200);
+  });
+
+  it("rejects a month period that is not YYYY-MM", async () => {
+    // Regression: 200 with `asOf: "banana-NaN"`, and the snapshot cache
+    // wrote `banana.json` / `0NaN-NaN.json` into the book.
+    const { status, body } = await dispatch({
+      action: ACCOUNTING_ACTIONS.getReport,
+      kind: "balance",
+      bookId,
+      period: { kind: "month", period: "banana" },
+    });
+    assert.equal(status, 400);
+    assert.match(String(body.error), /period is required/);
+  });
 });
 
 // #2695: the payloads below reached a validator that assumed its

--- a/packages/scheduler/src/windows.ts
+++ b/packages/scheduler/src/windows.ts
@@ -32,12 +32,19 @@ export function nextWindowAfter(schedule: TaskSchedule, afterMs: number): number
     return Math.ceil(afterMs / intervalMs) * intervalMs;
   }
 
-  if (schedule.type === SCHEDULE_TYPES.daily) {
-    return nextDailyWindow(parseTimeToMs(schedule.time), afterMs);
-  }
-
-  if (schedule.type === SCHEDULE_TYPES.weekly) {
-    return nextWeeklyWindow(schedule.daysOfWeek, parseTimeToMs(schedule.time), afterMs);
+  // A `time` this library cannot parse has no window — NOT a NaN one.
+  // `TaskSchedule.time` is a bare string on a published package and only some
+  // hosts validate it, so a malformed value does arrive here. Answering NaN
+  // let it escape into arithmetic where every comparison is false: the
+  // `listMissedWindows` loop could not detect the end of its range and filled
+  // itself to the cap, after which one unparseable task threw
+  // `RangeError: Invalid time value` for the whole catch-up batch (#2765).
+  // `null` is the value the callers already handle — it means "nothing to run".
+  if (schedule.type === SCHEDULE_TYPES.daily || schedule.type === SCHEDULE_TYPES.weekly) {
+    const timeOfDayMs = parseTimeToMs(schedule.time);
+    if (!Number.isFinite(timeOfDayMs)) return null;
+    if (schedule.type === SCHEDULE_TYPES.daily) return nextDailyWindow(timeOfDayMs, afterMs);
+    return nextWeeklyWindow(schedule.daysOfWeek, timeOfDayMs, afterMs);
   }
 
   if (schedule.type === SCHEDULE_TYPES.once) {

--- a/packages/scheduler/test/test_windows.ts
+++ b/packages/scheduler/test/test_windows.ts
@@ -144,3 +144,52 @@ describe("isDueAt", () => {
     assert.equal(isDueAt(schedule, hour(8, 0), 60_000), false);
   });
 });
+
+// A malformed `time` reaches this library unchecked: `TaskSchedule.time` is a
+// bare string on a published package, and only some hosts validate it. What
+// must never happen is one bad task taking the whole catch-up batch with it
+// (#2765) — `parseTimeToMs` yields NaN, and NaN comparisons are all false, so
+// the window loop used to run to its cap emitting NaN timestamps.
+describe("malformed daily/weekly time (#2765)", () => {
+  const malformed = ["9", "0900", "9:00 AM", ""];
+
+  it("never proposes a window for an unparseable time", () => {
+    for (const time of malformed) {
+      assert.equal(nextWindowAfter({ type: "daily" as const, time }, hour(0, 0)), null, `daily ${JSON.stringify(time)}`);
+      assert.equal(nextWindowAfter({ type: "weekly" as const, daysOfWeek: [0, 1, 2, 3, 4, 5, 6], time }, hour(0, 0)), null, `weekly ${JSON.stringify(time)}`);
+    }
+  });
+
+  // The blast-radius test: the old loop pushed `maxWindows` NaN entries
+  // because `NaN > untilMs` is false, and `new Date(NaN).toISOString()`
+  // downstream threw for every task in the batch.
+  it("lists no missed windows instead of filling the cap with NaN", () => {
+    for (const time of malformed) {
+      const windows = listMissedWindows({ type: "daily" as const, time }, hour(0, 0), hour(23, 0));
+      assert.deepEqual(windows, [], `daily ${JSON.stringify(time)}`);
+    }
+  });
+
+  it("is never due", () => {
+    for (const time of malformed) {
+      assert.equal(isDueAt({ type: "daily" as const, time }, hour(9, 0), 60_000), false, `daily ${JSON.stringify(time)}`);
+    }
+  });
+
+  // A well-formed time must keep working — the guard is about NaN, not about
+  // tightening what the library accepts.
+  it("leaves a well-formed time alone", () => {
+    assert.equal(nextWindowAfter({ type: "daily" as const, time: "08:00" }, hour(0, 0)), hour(8, 0));
+    assert.equal(listMissedWindows({ type: "daily" as const, time: "08:00" }, hour(0, 0), hour(23, 0)).length, 1);
+  });
+
+  // Pinned as KNOWN, not as desirable: these are malformed too, but they parse
+  // to a finite time (`Number("")` is 0), so they schedule a real window rather
+  // than escaping into NaN. Rejecting them would also reject `"08:00:00"`,
+  // which fires today at 08:00 — a working schedule that must not silently
+  // stop. Tightening the accepted FORMAT is a separate behaviour change.
+  it("still accepts malformed-but-finite times, at the time they compute to", () => {
+    assert.equal(nextWindowAfter({ type: "daily" as const, time: "::" }, hour(0, 0)), hour(0, 0));
+    assert.equal(nextWindowAfter({ type: "daily" as const, time: "08:00:00" }, hour(0, 0)), hour(8, 0));
+  });
+});

--- a/plans/fix-2765-nuia-followup-real-bugs.md
+++ b/plans/fix-2765-nuia-followup-real-bugs.md
@@ -1,0 +1,60 @@
+# fix: #2736 スイープが見つけた実バグの根本原因を直す (#2765)
+
+## 背景
+
+PR #2756（NUIA スイープ）が実バグ 6 件を発見したが、方針が「明示化するだけ・挙動は据え置き」
+だったため根本原因が残っている。現 main で実測したところ 3 件が未対応、3 件はスイープの
+「明示化」がそのまま修正になっていた。
+
+| # | 状態 | 備考 |
+|---|---|---|
+| 1 core scheduler 無言死 | **残** | `dailyTargetMs` が null → `isDue` false、ログ無し |
+| 2 task-scheduler バッチ全滅 | **残** | 再現済み: `RangeError: Invalid time value` |
+| 3 mulmoscript | 済 | `if (!beat) return { ok: true, audio: null }` |
+| 4 edgar | 済 | `columnAt` の `?? ""` |
+| 5/6 accounting period | **残** | 再現済み: `{kind:"month",period:"banana"}` が通る |
+
+## 方針（ユーザー判断を反映）
+
+**#1 は `log.error` + never-due**。throw は選ばない — 他 consumer が今「黙って死んでいるタスク」を
+持っていた場合に**起動クラッシュへ変わる**ため。沈黙さえ消えれば、あとはその consumer が直せる。
+
+## 変更点
+
+### 1. `packages/core/src/scheduler/task-manager.ts`
+
+- `dailyTargetMs()` の隣に `isMalformedDailyTime(schedule)` を置き、`registerTask` / `updateSchedule` の
+  両方から呼んで `log.error` を出す。**登録は従来どおり成功**し、`isDue` も従来どおり `false`。
+- 両方に入れる理由: `updateSchedule` は `applyScheduleOverride` 経由で実行時に呼ばれるので、
+  登録時だけ見ていると後から入った不正値を取り逃す。
+
+### 2. `packages/scheduler/src/windows.ts`
+
+- `nextWindowAfter` の daily / weekly 分岐で、`parseTimeToMs` の結果が有限でなければ `null` を返す。
+- これだけで `listMissedWindows` は即 break（0 件）、`isDueAt` は `false`、`catchup.ts` は NaN を見ない。
+- **`parseTimeToMs` の公開シグネチャ (`number`) は変えない** — `@receptron/task-scheduler` は公開パッケージで、
+  戻り値型の変更は破壊的変更になる。NaN を返すこと自体は据え置き、使う側で止める。
+
+### 3. `packages/plugins/accounting-plugin/src/server/bodyFields.ts`
+
+- `optionalReportPeriod` に形式チェックを足す: `month` の `period` は `YYYY-MM`、
+  `range` の `from`/`to` は `YYYY-MM-DD`。
+- 不正な形式は**同ファイルに既にある 400 の枠組み**（#2692/PR #2694 が導入）に合流させ、
+  受理できる形を文言で示す。LLM 呼び出し元が自分でペイロードを直せる形にする。
+- `from`/`to` も `period` と同じ未検証クラスなので併せて締める（`endDateOfPeriod` は `period.to` を
+  そのまま `asOf` に返すため、同じ経路でゴミが載る）。
+
+### 4. `packages/core/src/collection/core/calendarGrid.ts`（nit）
+
+- `splitClusters` の `reduce` が毎要素で配列をコピーしている（O(n²)）ので push ベースに戻す。
+- `assignLanes` は**テストが 1 件も無い**ので、先に**ランダム差分テスト**を足してから触る。
+  現行実装の出力を固定値として持つのではなく、性質（同一クラスタ内でレーンが重ならない・
+  入力順で返る・`lanes` がクラスタの最大レーン数）で検証する。
+
+## 検証
+
+- 各バグに**現状で落ちる**テストを先に足し、修正後に緑になることを確認する
+  （メモリの教訓: 緑のテストは、修正を戻して赤くなるまで何も証明しない）。
+- `yarn format` / `lint` / `typecheck` / `build` / `test`。
+- publish は別途。`@mulmoclaude/core` と `@receptron/task-scheduler` と
+  `@mulmoclaude/accounting-plugin` の 3 本が対象になる。

--- a/test/utils/collections/test_calendarGrid.ts
+++ b/test/utils/collections/test_calendarGrid.ts
@@ -309,6 +309,25 @@ describe("assignLanes", () => {
       { lane: 0, lanes: 2 },
     ]);
   });
+
+  // A cluster stays open on the LONGEST end seen so far, not the previous
+  // block's. Without that running max, C (which the all-day block still
+  // overlaps) breaks into a cluster of its own and renders full-width while
+  // sitting on top of A. Pinned because 20k randomly generated layouts never
+  // produced this shape — only a hand-built one distinguishes the two (#2765).
+  it("keeps a block inside the cluster of a longer block that already contains it", () => {
+    const lanes = assignLanes([
+      { startMin: 540, endMin: 720 }, // A — spans the whole group
+      { startMin: 560, endMin: 580 }, // B — inside A
+      { startMin: 600, endMin: 620 }, // C — inside A, starts after B ended
+    ]);
+    assert.deepEqual(lanes, [
+      { lane: 0, lanes: 2 },
+      { lane: 1, lanes: 2 },
+      // Reuses B's freed lane, and still reports the cluster's full width.
+      { lane: 1, lanes: 2 },
+    ]);
+  });
 });
 
 describe("bucketRecords", () => {


### PR DESCRIPTION
## Summary

#2736 の NUIA スイープ（PR #2756）が見つけた[実バグ 6 件](https://github.com/receptron/mulmoclaude/issues/2736#issuecomment-5160124484)のうち、**根本原因が残っていた 3 件**を直します。スイープは「明示化するだけ・挙動は据え置き」の方針だったためです。おまけで `splitClusters` の O(n²) も戻します。

まず現 main で 6 件の状態を実測しました:

| # | 内容 | 状態 |
|---|---|---|
| 1 | core scheduler: 不正 `time` が無言で永久に発火しない | **本 PR で修正** |
| 2 | task-scheduler: NaN window → `RangeError` でバッチ全滅 | **本 PR で修正** |
| 3 | mulmoscript `beatAudioOp` クラッシュ | #2756 で修正済み |
| 4 | edgar 並列配列の長さ不一致 | #2756 で修正済み |
| 5/6 | accounting `ReportPeriod` 未検証 | **本 PR で修正** |

**各件、先に落ちるテストを書いてから直しています。**

## Items to Confirm / Review

1. **#1 を throw ではなく `log.error` にしました。** 不正な `time` のタスクは従来どおり登録され、never-due のままです。throw を選ばなかったのは、他 consumer（MulmoTerminal 等）が今「黙って死んでいるタスク」を持っていた場合に、**起動クラッシュへ変わる**ためです。沈黙さえ消えれば consumer 側で直せます。この判断でよいか確認をお願いします。
2. **#2 で `parseTimeToMs` の公開シグネチャ（`number`）は変えていません。** `@receptron/task-scheduler` は公開パッケージなので戻り値型の変更は破壊的変更になります。NaN を返すこと自体は据え置き、`nextWindowAfter` 側で有限性を見て `null`（＝呼び出し側が既に扱える「実行するものが無い」）に落としています。
3. **#5/6 は現に通っているペイロードを 400 にします。** `{ kind: "month", period: "banana" }` が今は 200 で通り、`asOf: "banana-NaN"` の貸借対照表と `snapshots/banana.json` を返しています。エラーメッセージは**新設していません** — 不正を「不在」として扱い、#2692/PR #2694 が入れた既存の 400（受理する形を文言で示している）に合流させています。
4. **ledger だけ挙動判断が要りました。** `getReport ledger` は period 任意なので、不正な period が「不在」に落ちると**黙って全履歴に広がります**。要求より広い答えを返すのはまずいので、「渡したのに不正」なら kind によらず 400 にしました。
5. **`"::"` と `"08:00:00"` は今も受理されます**（それぞれ 00:00 / 08:00 として）。これらは crash しない別クラスで、締めると `"08:00:00"` で現に動いているスケジュールが黙って止まります。既知として windows のテストに明記しました。

## 検証

### #2 — 現 main での再現と、修正後

```
# before
parseTimeToMs('9') = NaN
listMissedWindows len = 24 first = NaN
computeCatchUpPlan THREW: RangeError: Invalid time value
```

修正後は `listMissedWindows` が `[]`、`isDueAt` が `false`、catch-up は throw しません。**テストが空振りでないことも確認済み**で、修正を戻すと windows のテストが 2 件赤になります。

### nit — `splitClusters` の書き換えが出力を変えていないこと

固定シードの 20,005 ケース（ランダム 20,000 + 手で足したエッジ 5）で旧実装と**差分 0**。

**このコーパスが回帰を検出できることも確認しました。** 最初 `>=` → `>` の変異で試したところ差分 0 でしたが、これは**変異が実際には出力を変えない**ためでした（接しているブロックはどのみち同じレーンに詰まる）。running max を落とす変異でやり直すと 1 件検出します。ただし検出したのは**手で足した「長いブロックが後続を含む」形だけ**で、ランダム生成 20,000 件は素通しでした — そのため同じ形を**恒久テストとして追加**しています。

### ゲート

`yarn format` / `lint`（0 errors）/ `typecheck`（exit 0）/ `build`（exit 0）/ `yarn test` **11111 passed / 0 failed**。`origin/main` merge 済み。

## User Prompt

> #2736 のコメントに投稿した実バグ 6 件は対応しよう　splitClusters の O(n²) nit も、もし直せるなら直して。

（#1 の扱いは「log.error + never-due」を選択いただきました。）

## publish について

`@mulmoclaude/core` / `@receptron/task-scheduler` / `@mulmoclaude/accounting-plugin` の 3 本にソース変更が入るので、マージ後に publish が必要です。本 PR には version bump を含めていません。

refs #2736
Closes #2765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude2

## Summary by Sourcery

Fix scheduler and accounting bugs uncovered by prior sweep and improve calendar grid performance.

Bug Fixes:
- Ensure malformed daily/weekly times in task schedules do not generate NaN windows, crash catch-up batches, or appear due, returning no windows instead.
- Log an error when registering or updating daily tasks with malformed times while keeping them safely never-due instead of silently failing.
- Validate accounting report periods for monthly and range kinds, treating malformed or non-calendar dates as absent so bad inputs yield existing 400 errors instead of corrupting reports and snapshot files.
- Make ledger report handling reject sent-but-invalid periods with a 400 response rather than silently expanding to full-history results.

Enhancements:
- Optimize calendar grid cluster splitting to use linear-time appends instead of O(n²) array copying while preserving layout semantics.

Tests:
- Add scheduler tests covering malformed daily/weekly times, ensuring no windows are proposed, missed windows lists are empty, and well-formed times still work.
- Add accounting tests for optionalReportPeriod to enforce YYYY-MM / YYYY-MM-DD formats and real-calendar dates, including leap-day coverage.
- Add calendarGrid lane assignment test to pin behavior when shorter events sit inside a longer all-day block, guarding the new clustering logic.