### PR TITLE
fix(tsconfig): enable noUncheckedIndexedAccess for the remaining four projects (#2736)

### DIFF
--- a/e2e-live/tsconfig.json
+++ b/e2e-live/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "useUnknownInCatchVariables": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "useUnknownInCatchVariables": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -10,6 +10,7 @@
     "rootDir": "..",
     "strict": true,
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "useUnknownInCatchVariables": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -13,6 +13,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "useUnknownInCatchVariables": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Summary

`server` / `test` / `e2e` / `e2e-live` の4プロジェクトで `noUncheckedIndexedAccess` を有効化します。#2757（`src` と `node`）に続く完了分です。

対象が0件になったのは #2756（server + packages、127件 + plain `tsc` では見えない `.vue` 内17件）、#2760・#2761（`test/` の765件と `e2e` の31件）がマージされたためです。

これで `noUncheckedIndexedAccess` は**ホスト側6プロジェクト全部**で有効になります。

## Items to Confirm / Review

**1. 4プロジェクトそれぞれで後戻りを捕まえることを実証済み。** typecheck が緑でも、フラグが黙って適用されていない場合と見分けがつきません。`xs[0].length` を読む probe を各プロジェクトに置き、そのプロジェクト自身のチェッカでコンパイルしました:

```
server     検出    test       検出
e2e        検出    e2e-live   検出
```

（`test` は vue-tsc、他3つは tsc。probe は削除済み。）

**2. `packages/*` は対象外です — 別途の判断が要ります。** パッケージ群は独立した tsconfig チェーンで、`config/tsconfig.packages.json` を extends していません。そのため **`noUncheckedIndexedAccess` も `exactOptionalPropertyTypes` も入っていません**。

パッケージの**ソース自体は既に両方に対してクリーン**です（#2756 と #2749 が到達させた）。しかし**それを保つものが何もありません** — 明日 `arr[i]` が入っても誰も止めません。約50個の manifest にまたがる変更なので、この PR の1行では済みません。

## 検証

`main` @ `ba7a75a6a` から分岐。

```
yarn format 0 / lint 0 / typecheck 0 / build 0 / test 0  (11107 tests, fail 0)
```

refs #2736

work in mulmoclaude3