### PR TITLE
fix: enable noUncheckedIndexedAccess + exactOptionalPropertyTypes across packages/*

### DIFF
--- a/config/tsconfig.packages.json
+++ b/config/tsconfig.packages.json
@@ -5,6 +5,8 @@
     "moduleResolution": "bundler",
     "declaration": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["node"]

--- a/packages/bridges/bluesky/src/index.ts
+++ b/packages/bridges/bluesky/src/index.ts
@@ -113,10 +113,11 @@ function chatHeaders(accessJwt: string): Record<string, string> {
 async function doChatFetch(method: "GET" | "POST", url: string, body: JsonRecord | undefined, accessJwt: string): Promise<Response> {
   const headers = chatHeaders(accessJwt);
   if (method === "POST") headers["Content-Type"] = "application/json";
+  const payload = method === "POST" && body ? JSON.stringify(body) : undefined;
   return fetch(url, {
     method,
     headers,
-    body: method === "POST" && body ? JSON.stringify(body) : undefined,
+    ...(payload !== undefined ? { body: payload } : {}),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
 }

--- a/packages/bridges/chatwork/src/index.ts
+++ b/packages/bridges/chatwork/src/index.ts
@@ -86,15 +86,12 @@ function parseRetryAfter(headerValue: string | null): number {
 async function cwFetch(method: "GET" | "POST" | "PUT", path: string, form?: Record<string, string>): Promise<unknown> {
   await waitForRateLimit();
   const headers: Record<string, string> = { "X-ChatWorkToken": apiToken };
-  let body: string | undefined;
-  if (form) {
-    headers["Content-Type"] = "application/x-www-form-urlencoded";
-    body = new URLSearchParams(form).toString();
-  }
+  if (form) headers["Content-Type"] = "application/x-www-form-urlencoded";
+  const body = form ? new URLSearchParams(form).toString() : undefined;
   const res = await fetch(`${API_BASE}${path}`, {
     method,
     headers,
-    body,
+    ...(body !== undefined ? { body } : {}),
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (res.status === 204) {

--- a/packages/bridges/irc/src/index.ts
+++ b/packages/bridges/irc/src/index.ts
@@ -47,7 +47,7 @@ irc.connect({
   port,
   nick,
   tls: useTls,
-  password: password ?? undefined,
+  ...(password !== undefined ? { password } : {}),
 });
 
 irc.on("registered", () => {

--- a/packages/bridges/telegram/src/api.ts
+++ b/packages/bridges/telegram/src/api.ts
@@ -68,9 +68,9 @@ export interface TelegramApiOptions {
 }
 
 export interface GetUpdatesOptions {
-  offset?: number;
-  timeoutSec?: number;
-  signal?: AbortSignal;
+  offset?: number | undefined;
+  timeoutSec?: number | undefined;
+  signal?: AbortSignal | undefined;
 }
 
 export interface TelegramApi {
@@ -101,7 +101,7 @@ export function createTelegramApi(opts: TelegramApiOptions): TelegramApi {
       }
       const url = `${base}/getUpdates?${params.toString()}`;
 
-      const res = await fetchImpl(url, { signal: gu.signal });
+      const res = await fetchImpl(url, gu.signal !== undefined ? { signal: gu.signal } : {});
       if (!res.ok) {
         throw new Error(`getUpdates failed: ${res.status} ${await safeText(res)}`);
       }

--- a/packages/bridges/telegram/src/router.ts
+++ b/packages/bridges/telegram/src/router.ts
@@ -50,6 +50,9 @@ interface AttachmentResult {
   failed: boolean;
 }
 
+/** One media slot of a message: downloaded, absent, or download failed. */
+type MediaOutcome = { attachment: Attachment } | { failed: true } | null;
+
 // Minimum interval between editMessageText calls to avoid Telegram
 // rate limits. 1 second is conservative; Telegram allows ~30 edits
 // per minute per chat.
@@ -116,45 +119,39 @@ export function createMessageRouter(deps: RouterDeps): MessageRouter {
   // exclusive (photo OR document), but forwarded messages or future
   // API changes could carry both. We collect all available attachments
   // rather than picking one.
-  async function tryDownloadAttachments(msg: TelegramMessage): Promise<AttachmentResult> {
-    const attachments: Attachment[] = [];
-    let anyFailed = false;
-
+  async function downloadPhoto(msg: TelegramMessage): Promise<MediaOutcome> {
     // Telegram lists photo sizes smallest-first, so the last entry is
     // the highest resolution available.
     const largest = Array.isArray(msg.photo) ? msg.photo[msg.photo.length - 1] : undefined;
-    if (largest) {
-      try {
-        const dataUrl = await api.downloadFile(largest.file_id, "image/jpeg");
-        const parsed = parseDataUrl(dataUrl);
-        if (parsed) {
-          attachments.push({ mimeType: parsed.mimeType, data: parsed.data });
-        }
-      } catch (err) {
-        log.error(`[telegram] photo download failed: ${String(err)}`);
-        anyFailed = true;
-      }
+    if (!largest) return null;
+    try {
+      const parsed = parseDataUrl(await api.downloadFile(largest.file_id, "image/jpeg"));
+      return parsed ? { attachment: { mimeType: parsed.mimeType, data: parsed.data } } : null;
+    } catch (err) {
+      log.error(`[telegram] photo download failed: ${String(err)}`);
+      return { failed: true };
     }
+  }
 
-    if (msg.document) {
-      const doc = msg.document;
-      const fallbackMime = doc.mime_type ?? "application/octet-stream";
-      try {
-        const dataUrl = await api.downloadFile(doc.file_id, fallbackMime);
-        const parsed = parseDataUrl(dataUrl);
-        if (parsed) {
-          attachments.push({
-            mimeType: parsed.mimeType,
-            data: parsed.data,
-            filename: doc.file_name,
-          });
-        }
-      } catch (err) {
-        log.error(`[telegram] document download failed: ${String(err)}`);
-        anyFailed = true;
-      }
+  async function downloadDocument(msg: TelegramMessage): Promise<MediaOutcome> {
+    const doc = msg.document;
+    if (!doc) return null;
+    const fallbackMime = doc.mime_type ?? "application/octet-stream";
+    try {
+      const parsed = parseDataUrl(await api.downloadFile(doc.file_id, fallbackMime));
+      if (!parsed) return null;
+      const filename = doc.file_name !== undefined ? { filename: doc.file_name } : {};
+      return { attachment: { mimeType: parsed.mimeType, data: parsed.data, ...filename } };
+    } catch (err) {
+      log.error(`[telegram] document download failed: ${String(err)}`);
+      return { failed: true };
     }
+  }
 
+  async function tryDownloadAttachments(msg: TelegramMessage): Promise<AttachmentResult> {
+    const outcomes = [await downloadPhoto(msg), await downloadDocument(msg)];
+    const attachments = outcomes.flatMap((outcome) => (outcome && "attachment" in outcome ? [outcome.attachment] : []));
+    const anyFailed = outcomes.some((outcome) => outcome !== null && "failed" in outcome);
     if (attachments.length === 0 && anyFailed) {
       return { attachments: [], failed: true };
     }

--- a/packages/core/src/collection/core/completion.ts
+++ b/packages/core/src/collection/core/completion.ts
@@ -102,8 +102,8 @@ export interface FlagChip {
  *  `itemIsDone` needs for the synthesized chip. */
 export interface ChipMatchSchema {
   fields: Record<string, CollectionFieldSpec>;
-  completionField?: string;
-  completionDoneValues?: readonly string[];
+  completionField?: string | undefined;
+  completionDoneValues?: readonly string[] | undefined;
 }
 
 /** Whether one row satisfies a chip's predicate: `itemIsDone` for the

--- a/packages/core/src/collection/core/presentCollection.ts
+++ b/packages/core/src/collection/core/presentCollection.ts
@@ -16,7 +16,7 @@ export interface PresentCollectionData {
   /** Slug of the collection to display (e.g. "clients", "invoices"). */
   collectionSlug: string;
   /** Optional primary-key value of a single item to open on mount. */
-  itemId?: string;
+  itemId?: string | undefined;
 }
 
 export type PresentCollectionArgs = PresentCollectionData;

--- a/packages/core/src/google/driveFile.ts
+++ b/packages/core/src/google/driveFile.ts
@@ -24,13 +24,13 @@ export interface DriveFileSummary {
 }
 
 export interface ListDriveFilesInput {
-  maxResults?: number;
+  maxResults?: number | undefined;
 }
 
 export interface CreateDriveFileInput {
   name: string;
   content: string;
-  mimeType?: string;
+  mimeType?: string | undefined;
 }
 
 export interface ReadDriveFileInput {

--- a/packages/core/src/google/tasks.ts
+++ b/packages/core/src/google/tasks.ts
@@ -23,34 +23,34 @@ export interface TaskSummary {
 }
 
 export interface ListTasksInput {
-  taskListId?: string;
-  maxResults?: number;
-  showCompleted?: boolean;
+  taskListId?: string | undefined;
+  maxResults?: number | undefined;
+  showCompleted?: boolean | undefined;
 }
 
 export interface CreateTaskInput {
   title: string;
-  notes?: string;
+  notes?: string | undefined;
   /** RFC3339. Google stores a DATE only — the time part is recorded but
    *  ignored by the UI, so callers should not promise time-of-day fidelity. */
-  due?: string;
-  taskListId?: string;
+  due?: string | undefined;
+  taskListId?: string | undefined;
 }
 
 export interface CompleteTaskInput {
   taskId: string;
-  taskListId?: string;
+  taskListId?: string | undefined;
 }
 
 export interface UpdateTaskInput {
   taskId: string;
-  title?: string;
+  title?: string | undefined;
   /** `""` clears the notes; omit to leave them untouched. */
-  notes?: string;
+  notes?: string | undefined;
   /** RFC3339. Same DATE-only caveat as `CreateTaskInput.due`. Google rejects
    *  `""`, so a due date can be changed but not removed through this call. */
-  due?: string;
-  taskListId?: string;
+  due?: string | undefined;
+  taskListId?: string | undefined;
 }
 
 export const toTaskListSummary = (value: unknown): TaskListSummary => {

--- a/packages/core/src/remote-host/server/lifecycle.ts
+++ b/packages/core/src/remote-host/server/lifecycle.ts
@@ -47,7 +47,7 @@ export interface RemoteHostDeps {
   // runner's `onExpire`, which supplies the session `uid` so cleanup targets the
   // right user's Storage path even across a reconnect; absent ⇒ an expired doc is
   // just deleted.
-  onExpire?: (command: Command, uid: string) => void | Promise<void>;
+  onExpire?: ((command: Command, uid: string) => void | Promise<void>) | undefined;
   log?: RemoteHostLogger;
 }
 

--- a/packages/core/test/host/test_hostSlot.ts
+++ b/packages/core/test/host/test_hostSlot.ts
@@ -10,7 +10,7 @@ interface LogCall {
   level: string;
   prefix: string;
   message: string;
-  data?: Record<string, unknown>;
+  data?: Record<string, unknown> | undefined;
 }
 
 function recordingLogger(): { logger: StructuredLogger; calls: LogCall[] } {

--- a/packages/core/test/remote-host/test_lifecycle.ts
+++ b/packages/core/test/remote-host/test_lifecycle.ts
@@ -19,8 +19,8 @@ const HOST_ID = "test-host";
 interface FakeRunner {
   channel: Channel;
   stopped: boolean;
-  onClosed?: () => void;
-  onExpire?: (command: Command, uid: string) => void | Promise<void>;
+  onClosed?: (() => void) | undefined;
+  onExpire?: ((command: Command, uid: string) => void | Promise<void>) | undefined;
   stop: () => void;
 }
 

--- a/packages/core/test/remote-view/test_remote_view.ts
+++ b/packages/core/test/remote-view/test_remote_view.ts
@@ -192,7 +192,7 @@ describe("handleRemoteViewMessage", () => {
   });
 
   it("relays startChat (trimmed prompt, string-only role), swallowing empties", async () => {
-    const chats: { prompt: string; role?: string }[] = [];
+    const chats: { prompt: string; role?: string | undefined }[] = [];
     const handlers = {
       slug: "plan",
       getPage: () => pageFromItems([], { offset: 0, limit: 50 }, "id"),

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/create-mulmoclaude-plugin/tsconfig.json
+++ b/packages/create-mulmoclaude-plugin/tsconfig.json
@@ -8,6 +8,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/accounting-plugin/src/server/bodyFields.ts
+++ b/packages/plugins/accounting-plugin/src/server/bodyFields.ts
@@ -31,7 +31,7 @@ export const optionalReportPeriod = (value: unknown): ReportPeriod | undefined =
 
 /** The two fields the addEntries narration quotes back, read out of a
  *  service payload that is only `unknown` to the router. */
-export const describeEntry = (entry: unknown): { id?: string; date?: string } => {
+export const describeEntry = (entry: unknown): { id?: string | undefined; date?: string | undefined } => {
   const record = optionalRecord(entry);
   return { id: optionalString(record?.id), date: optionalString(record?.date) };
 };

--- a/packages/plugins/accounting-plugin/src/server/journal.ts
+++ b/packages/plugins/accounting-plugin/src/server/journal.ts
@@ -42,8 +42,8 @@ export interface ValidationError {
 export interface ParsedEntry {
   date: string;
   lines: JournalLine[];
-  memo?: string;
-  replacesEntryId?: string;
+  memo?: string | undefined;
+  replacesEntryId?: string | undefined;
 }
 
 export type EntryParseResult = { ok: true; entry: ParsedEntry } | { ok: false; errors: ValidationError[] };
@@ -275,9 +275,9 @@ export function parseEntry(raw: unknown, accounts: readonly Account[]): EntryPar
 export function makeEntry(input: {
   date: string;
   lines: readonly JournalLine[];
-  memo?: string;
-  kind?: JournalEntry["kind"];
-  replacesEntryId?: string;
+  memo?: string | undefined;
+  kind?: JournalEntry["kind"] | undefined;
+  replacesEntryId?: string | undefined;
 }): JournalEntry {
   const entry: JournalEntry = {
     id: randomUUID(),

--- a/packages/plugins/accounting-plugin/src/server/report.ts
+++ b/packages/plugins/accounting-plugin/src/server/report.ts
@@ -182,7 +182,7 @@ function accumulateLedgerEntry(
   }
 }
 
-export function buildLedger(input: { account: Account; entries: readonly JournalEntry[]; from?: string; to?: string }): Ledger {
+export function buildLedger(input: { account: Account; entries: readonly JournalEntry[]; from?: string | undefined; to?: string | undefined }): Ledger {
   // Same rule as `aggregateBalances`: include original and reverse
   // for the math to cancel; exclude markers. The reverse entry
   // itself carries `kind: "void"` so the row is visually

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -60,7 +60,7 @@ interface AccountingErrorResponse extends ErrorBody {
 interface OpenBookToolResult {
   kind: "accounting-app";
   bookId: string;
-  initialTab?: string;
+  initialTab?: string | undefined;
   /** Same shape getBooks returns — included so an LLM that calls
    *  openBook doesn't need a follow-up getBooks round-trip to learn
    *  what other books exist before its next action. */

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -186,7 +186,7 @@ function coerceFiscalYearEndInput(raw: unknown): FiscalYearEnd | undefined {
  *  the first failure so the surrounding function stays under the
  *  cognitive-complexity threshold, and hands back the country to persist:
  *  `undefined` = the field was omitted, `""` = explicit clear. */
-function parseUpdateBookInput(input: { name?: string; country?: string }): SupportedCountryCode | "" | undefined {
+function parseUpdateBookInput(input: { name?: string | undefined; country?: string | undefined }): SupportedCountryCode | "" | undefined {
   if (input.name !== undefined && (typeof input.name !== "string" || input.name.trim() === "")) {
     throw new AccountingError(400, "name must be a non-empty string when supplied");
   }
@@ -202,7 +202,7 @@ function parseUpdateBookInput(input: { name?: string; country?: string }): Suppo
 }
 
 export async function createBook(
-  input: { id?: string; name: string; currency?: string; country?: string; fiscalYearEnd?: unknown },
+  input: { id?: string | undefined; name: string; currency?: string | undefined; country?: string | undefined; fiscalYearEnd?: unknown },
   workspaceRoot?: string,
 ): Promise<{ book: BookSummary }> {
   if (typeof input.name !== "string" || input.name.trim() === "") {
@@ -253,7 +253,7 @@ export async function createBook(
 }
 
 export async function updateBook(
-  input: { bookId: string; name?: string; country?: string; fiscalYearEnd?: unknown },
+  input: { bookId: string; name?: string | undefined; country?: string | undefined; fiscalYearEnd?: unknown },
   workspaceRoot?: string,
 ): Promise<{ book: BookSummary }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -315,7 +315,7 @@ export async function deleteBook(
 
 // ── accounts ───────────────────────────────────────────────────────
 
-export async function listAccounts(input: { bookId?: string }, workspaceRoot?: string): Promise<{ bookId: string; accounts: Account[] }> {
+export async function listAccounts(input: { bookId?: string | undefined }, workspaceRoot?: string): Promise<{ bookId: string; accounts: Account[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   return { bookId, accounts: await readAccounts(bookId, workspaceRoot) };
@@ -358,7 +358,7 @@ function applyAccount(accounts: readonly Account[], account: Account): { next: A
 }
 
 export async function upsertAccount(
-  input: { bookId?: string; account: unknown },
+  input: { bookId?: string | undefined; account: unknown },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; account: Account; accounts: Account[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -418,7 +418,10 @@ function earliestPeriodOf(entries: readonly JournalEntry[]): string {
   return entries.map((entry) => periodFromDate(entry.date)).reduce((min, period) => (period < min ? period : min));
 }
 
-export async function addEntries(input: { bookId?: string; entries: unknown }, workspaceRoot?: string): Promise<{ bookId: string; entries: JournalEntry[] }> {
+export async function addEntries(
+  input: { bookId?: string | undefined; entries: unknown },
+  workspaceRoot?: string,
+): Promise<{ bookId: string; entries: JournalEntry[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   if (!isUnknownArray(input.entries) || input.entries.length === 0) {
@@ -454,7 +457,7 @@ async function findEntryById(bookId: string, entryId: string, workspaceRoot?: st
 }
 
 export async function voidEntry(
-  input: { bookId?: string; entryId: string; reason?: string; voidDate?: string },
+  input: { bookId?: string | undefined; entryId: string; reason?: string | undefined; voidDate?: string | undefined },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; reverseEntry: JournalEntry; markerEntry: JournalEntry }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -477,10 +480,10 @@ export async function voidEntry(
 }
 
 interface ListEntriesInput {
-  bookId?: string;
-  from?: string;
-  to?: string;
-  accountCode?: string;
+  bookId?: string | undefined;
+  from?: string | undefined;
+  to?: string | undefined;
+  accountCode?: string | undefined;
 }
 
 function entryMatchesFilters(entry: JournalEntry, input: ListEntriesInput): boolean {
@@ -517,7 +520,10 @@ export async function listEntries(
 
 // ── opening balances ───────────────────────────────────────────────
 
-export async function getOpeningBalances(input: { bookId?: string }, workspaceRoot?: string): Promise<{ bookId: string; opening: JournalEntry | null }> {
+export async function getOpeningBalances(
+  input: { bookId?: string | undefined },
+  workspaceRoot?: string,
+): Promise<{ bookId: string; opening: JournalEntry | null }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   const all = await readAllEntries(bookId, workspaceRoot);
@@ -525,7 +531,7 @@ export async function getOpeningBalances(input: { bookId?: string }, workspaceRo
 }
 
 export async function setOpeningBalances(
-  input: { bookId?: string; asOfDate: string; lines: unknown; memo?: string },
+  input: { bookId?: string | undefined; asOfDate: string; lines: unknown; memo?: string | undefined },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -576,7 +582,7 @@ function endDateOfPeriod(period: ReportPeriod): string {
 }
 
 export async function getBalanceSheetReport(
-  input: { bookId?: string; period: ReportPeriod },
+  input: { bookId?: string | undefined; period: ReportPeriod },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; balanceSheet: ReturnType<typeof buildBalanceSheet> }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -608,7 +614,7 @@ async function balancesAsOf(bookId: string, period: ReportPeriod, workspaceRoot?
 }
 
 export async function getProfitLossReport(
-  input: { bookId?: string; period: ReportPeriod },
+  input: { bookId?: string | undefined; period: ReportPeriod },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; profitLoss: ReturnType<typeof buildProfitLoss> }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -621,7 +627,7 @@ export async function getProfitLossReport(
 }
 
 export async function getLedgerReport(
-  input: { bookId?: string; accountCode: string; period?: ReportPeriod },
+  input: { bookId?: string | undefined; accountCode: string; period?: ReportPeriod | undefined },
   workspaceRoot?: string,
 ): Promise<{ bookId: string; ledger: ReturnType<typeof buildLedger> }> {
   const config = await loadOrInitConfig(workspaceRoot);
@@ -680,7 +686,7 @@ function resolveAccountCode(metric: TimeSeriesMetric, raw: unknown): string | un
 }
 
 export interface TimeSeriesReportInput {
-  bookId?: string;
+  bookId?: string | undefined;
   metric: unknown;
   granularity: unknown;
   from: unknown;
@@ -750,7 +756,7 @@ export async function getTimeSeriesReport(input: TimeSeriesReportInput, workspac
 
 // ── snapshot admin ─────────────────────────────────────────────────
 
-export async function rebuildSnapshots(input: { bookId?: string }, workspaceRoot?: string): Promise<{ bookId: string; rebuilt: string[] }> {
+export async function rebuildSnapshots(input: { bookId?: string | undefined }, workspaceRoot?: string): Promise<{ bookId: string; rebuilt: string[] }> {
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   const result = await rebuildAllSnapshots(bookId, workspaceRoot);

--- a/packages/plugins/accounting-plugin/src/server/timeSeries.ts
+++ b/packages/plugins/accounting-plugin/src/server/timeSeries.ts
@@ -227,7 +227,7 @@ function valueForBucket(input: {
   entries: readonly JournalEntry[];
   accounts: readonly Account[];
   metric: TimeSeriesMetric;
-  accountCode?: string;
+  accountCode?: string | undefined;
 }): number {
   const accountTypeByCode = new Map(input.accounts.map((acct) => [acct.code, acct.type]));
   if (input.metric === "accountBalance") {
@@ -252,7 +252,7 @@ export function buildTimeSeries(input: {
   entries: readonly JournalEntry[];
   accounts: readonly Account[];
   metric: TimeSeriesMetric;
-  accountCode?: string;
+  accountCode?: string | undefined;
 }): TimeSeriesPoint[] {
   return input.buckets.map((bucket) => ({
     label: bucket.label,

--- a/packages/plugins/accounting-plugin/src/shared/types.ts
+++ b/packages/plugins/accounting-plugin/src/shared/types.ts
@@ -28,14 +28,14 @@ export interface Account {
   type: AccountType;
   /** Optional free-form note (tax bucket, parent group, …). Not
    *  interpreted by the engine — passes through verbatim. */
-  note?: string;
+  note?: string | undefined;
   /** Soft-delete flag. When `false`, the account is hidden from
    *  entry/ledger dropdowns but stays visible in Manage Accounts
    *  and historical entries — accounting integrity requires that
    *  a code referenced by a journal line never disappears. Omitted
    *  (treated as active) by default to keep the JSON files clean
    *  for books created before this field existed. */
-  active?: boolean;
+  active?: boolean | undefined;
 }
 
 export interface BookSummary {
@@ -54,7 +54,7 @@ export interface BookSummary {
    *  persisted. Optional for backward compatibility with books created
    *  before the field was introduced; the UI prompts existing books
    *  to set it. */
-  country?: SupportedCountryCode;
+  country?: SupportedCountryCode | undefined;
   /** Calendar month (1-12) on whose LAST DAY the book's fiscal year
    *  closes — e.g. 8 = August 31, 12 = December 31 (calendar year).
    *  Drives the UI's "current quarter / current year" date-range
@@ -64,7 +64,7 @@ export interface BookSummary {
    *  normalises both via `resolveFiscalYearEnd`, treating an absent
    *  value as December. New books require it at the create boundary;
    *  the default is 12 (December). */
-  fiscalYearEnd?: FiscalYearEnd;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
   createdAt: string;
 }
 
@@ -77,10 +77,10 @@ export interface JournalLine {
    *  numbers. The engine treats them as separate fields rather than
    *  a single signed amount so the input matches a standard
    *  bookkeeping form. */
-  debit?: number;
-  credit?: number;
+  debit?: number | undefined;
+  credit?: number | undefined;
   /** Per-line memo (the entry-level memo lives on JournalEntry). */
-  memo?: string;
+  memo?: string | undefined;
   /** Counterparty's tax-authority-issued registration ID for this
    *  line — Japanese 適格請求書発行事業者登録番号 (T-number), EU
    *  VAT identification number, UK VAT registration number, India
@@ -88,7 +88,7 @@ export interface JournalLine {
    *  eligibility under the Japanese インボイス制度 (effective
    *  2023-10-01) and equivalent regimes elsewhere. Free-form string;
    *  format validation belongs upstream (per-jurisdiction). */
-  taxRegistrationId?: string;
+  taxRegistrationId?: string | undefined;
 }
 
 export interface JournalEntry {
@@ -102,19 +102,19 @@ export interface JournalEntry {
   kind: JournalEntryKind;
   lines: JournalLine[];
   /** Entry-level memo. */
-  memo?: string;
+  memo?: string | undefined;
   /** When `kind === "void-marker"`: id of the entry being voided.
    *  When `kind === "void"`: the system-generated reverse entry
    *  references the original via this field. */
-  voidedEntryId?: string;
+  voidedEntryId?: string | undefined;
   /** Reason supplied by the user when voiding. */
-  voidReason?: string;
+  voidReason?: string | undefined;
   /** When this entry was posted via the "edit" flow (void-then-add),
    *  this is the id of the entry it replaces. The void + new-entry
    *  pair is *not* atomic on the server — the client issues two
    *  sequential calls — but recording the link here makes the
    *  edit chain queryable later (e.g. "what corrected entry X?"). */
-  replacesEntryId?: string;
+  replacesEntryId?: string | undefined;
   /** ISO timestamp the entry was appended to the journal — the
    *  authoritative "when did this hit the books" clock. Distinct
    *  from `date`, which is the user-visible booking date. */
@@ -165,7 +165,7 @@ export interface LedgerRow {
   entryId: string;
   date: string;
   kind: JournalEntryKind;
-  memo?: string;
+  memo?: string | undefined;
   debit: number;
   credit: number;
   /** Running netDebit balance for this account, in entry order. */
@@ -177,7 +177,7 @@ export interface LedgerRow {
    *  src/vue/components/accountNumbering.ts). Carried per row even on
    *  non-tax accounts so a future view that wants to show it
    *  elsewhere doesn't need a server change. */
-  taxRegistrationId?: string;
+  taxRegistrationId?: string | undefined;
 }
 
 export interface Ledger {

--- a/packages/plugins/accounting-plugin/src/vue/api.ts
+++ b/packages/plugins/accounting-plugin/src/vue/api.ts
@@ -56,7 +56,7 @@ export interface OpenAppPayload {
   /** `null` when the workspace has zero books — the View renders the
    *  empty state and prompts for book creation. */
   bookId: string | null;
-  initialTab?: string;
+  initialTab?: string | undefined;
 }
 
 // The single dispatch route this plugin owns — shared with the server
@@ -76,26 +76,26 @@ export function getBooks(): Promise<ApiResult<{ books: BookSummary[] }>> {
 
 export function createBook(input: {
   name: string;
-  currency?: string;
-  country?: SupportedCountryCode;
+  currency?: string | undefined;
+  country?: SupportedCountryCode | undefined;
   /** Closing month 1-12 — required at the form boundary, but the
    *  server silently defaults an absent value to 12 (December). */
-  fiscalYearEnd?: FiscalYearEnd;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
 }): Promise<ApiResult<{ book: BookSummary }>> {
   return call(ACCOUNTING_ACTIONS.createBook, input);
 }
 
 export function updateBook(input: {
   bookId: string;
-  name?: string;
+  name?: string | undefined;
   /** Pass `""` to explicitly clear the country (server treats it as
    *  the "drop the field" sentinel). Any other value must be one of
    *  the curated `SupportedCountryCode`s. */
-  country?: SupportedCountryCode | "";
+  country?: SupportedCountryCode | "" | undefined;
   /** Closing month 1-12 — pure metadata, only changes how the
    *  date-range shortcuts resolve. No "clear" path; absence leaves the
    *  existing value untouched. */
-  fiscalYearEnd?: FiscalYearEnd;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
 }): Promise<ApiResult<{ book: BookSummary }>> {
   return call(ACCOUNTING_ACTIONS.updateBook, input);
 }
@@ -119,12 +119,12 @@ export function upsertAccount(account: Account, bookId: string): Promise<ApiResu
 export interface AddEntriesItemInput {
   date: string;
   lines: JournalLine[];
-  memo?: string;
+  memo?: string | undefined;
   /** When set, marks this entry as the replacement posted via the
    *  "edit" flow. The caller is expected to have voided
    *  `replacesEntryId` separately just before this call — there is
    *  no atomic transaction. */
-  replacesEntryId?: string;
+  replacesEntryId?: string | undefined;
 }
 
 export function addEntries(input: {
@@ -139,16 +139,16 @@ export function addEntries(input: {
 
 export function voidEntry(input: {
   entryId: string;
-  reason?: string;
+  reason?: string | undefined;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; reverseEntry: JournalEntry; markerEntry: JournalEntry }>> {
   return call(ACCOUNTING_ACTIONS.voidEntry, input);
 }
 
 export function getJournalEntries(input: {
-  from?: string;
-  to?: string;
-  accountCode?: string;
+  from?: string | undefined;
+  to?: string | undefined;
+  accountCode?: string | undefined;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; entries: JournalEntry[]; voidedEntryIds: string[] }>> {
   return call(ACCOUNTING_ACTIONS.getJournalEntries, input);
@@ -163,7 +163,7 @@ export function getOpeningBalances(bookId: string): Promise<ApiResult<{ bookId: 
 export function setOpeningBalances(input: {
   asOfDate: string;
   lines: JournalLine[];
-  memo?: string;
+  memo?: string | undefined;
   bookId: string;
 }): Promise<ApiResult<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }>> {
   return call(ACCOUNTING_ACTIONS.setOpeningBalances, input);
@@ -202,7 +202,7 @@ export interface TimeSeriesInput {
   to: string;
   /** Required when metric === "accountBalance"; forbidden otherwise.
    *  The server returns a 400 either way. */
-  accountCode?: string;
+  accountCode?: string | undefined;
 }
 
 export interface TimeSeriesResult {
@@ -211,7 +211,7 @@ export interface TimeSeriesResult {
   granularity: TimeSeriesGranularity;
   from: string;
   to: string;
-  accountCode?: string;
+  accountCode?: string | undefined;
   points: TimeSeriesPoint[];
 }
 

--- a/packages/plugins/accounting-plugin/src/vue/components/BookSettings.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/BookSettings.vue
@@ -125,8 +125,8 @@ const props = defineProps<{
   bookId: string;
   bookName: string;
   currency: string;
-  country?: SupportedCountryCode;
-  fiscalYearEnd?: FiscalYearEnd;
+  country?: SupportedCountryCode | undefined;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
 }>();
 const emit = defineEmits<{ deleted: [bookName: string]; "books-changed": [] }>();
 

--- a/packages/plugins/accounting-plugin/src/vue/components/DateRangePicker.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/DateRangePicker.vue
@@ -71,7 +71,7 @@ const props = defineProps<{
    *  absent the Lifetime option is hidden from the menu. The opening
    *  gate prevents the tabs that mount this picker from rendering
    *  before an opening exists, so in normal use this stays defined. */
-  openingDate?: string;
+  openingDate?: string | undefined;
 }>();
 
 const emit = defineEmits<{

--- a/packages/plugins/accounting-plugin/src/vue/components/JournalEntryForm.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/JournalEntryForm.vue
@@ -184,7 +184,13 @@ import { errorMessage } from "../../shared/errors";
 
 const { t } = useAccountingI18n();
 
-const props = defineProps<{ bookId: string; accounts: Account[]; currency: string; country?: SupportedCountryCode; entryToEdit?: JournalEntry | null }>();
+const props = defineProps<{
+  bookId: string;
+  accounts: Account[];
+  currency: string;
+  country?: SupportedCountryCode | undefined;
+  entryToEdit?: JournalEntry | null | undefined;
+}>();
 const emit = defineEmits<{ submitted: []; cancel: [] }>();
 
 const showAccountsModal = ref(false);

--- a/packages/plugins/accounting-plugin/src/vue/components/JournalList.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/JournalList.vue
@@ -213,19 +213,19 @@ const props = defineProps<{
   bookId: string;
   accounts: Account[];
   currency: string;
-  country?: SupportedCountryCode;
+  country?: SupportedCountryCode | undefined;
   version: number;
-  fiscalYearEnd?: FiscalYearEnd;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
   /** Opening-balance date for the active book — drives the "Lifetime"
    *  shortcut in the date picker (from = openingDate, to = today).
    *  When absent, the picker hides Lifetime; "All" still works. */
-  openingDate?: string;
+  openingDate?: string | undefined;
   /** Entry id to auto-expand and scroll into view. Surfaced by the
    *  parent when an `addEntries` tool result lands so the user sees
    *  the freshly-posted row highlighted. Captured into
    *  `pendingPreselectId` and consumed once the entry actually
    *  appears in the fetched list — refetch can race the prop. */
-  preselectEntryId?: string;
+  preselectEntryId?: string | undefined;
 }>();
 const emit = defineEmits<{ editOpening: []; preselectConsumed: [] }>();
 

--- a/packages/plugins/accounting-plugin/src/vue/components/Ledger.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/Ledger.vue
@@ -81,15 +81,15 @@ const props = defineProps<{
   accounts: Account[];
   currency: string;
   version: number;
-  fiscalYearEnd?: FiscalYearEnd;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
   /** Opening-balance date for the active book — drives the "Lifetime"
    *  shortcut in the date picker (from = openingDate, to = today).
    *  When absent, the picker hides Lifetime; "All" still works. */
-  openingDate?: string;
+  openingDate?: string | undefined;
   /** Optional account to preselect (Accounts tab → click). Updates
    *  via the watcher below — assigning to the local `accountCode`
    *  ref keeps the dropdown's v-model authoritative for user edits. */
-  preselectAccountCode?: string;
+  preselectAccountCode?: string | undefined;
 }>();
 
 const DASH = "—";

--- a/packages/plugins/accounting-plugin/src/vue/components/ProfitLoss.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/ProfitLoss.vue
@@ -93,11 +93,11 @@ const props = defineProps<{
   bookId: string;
   currency: string;
   version: number;
-  fiscalYearEnd?: FiscalYearEnd;
+  fiscalYearEnd?: FiscalYearEnd | undefined;
   /** Opening-balance date for the active book — drives the "Lifetime"
    *  shortcut in the date picker (from = openingDate, to = today).
    *  When absent, the picker hides Lifetime; "All" still works. */
-  openingDate?: string;
+  openingDate?: string | undefined;
 }>();
 
 const emit = defineEmits<{ selectAccount: [code: string] }>();

--- a/packages/plugins/accounting-plugin/tsconfig.json
+++ b/packages/plugins/accounting-plugin/tsconfig.json
@@ -8,6 +8,8 @@
     "jsx": "preserve",
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/bookmarks-plugin/package.json
+++ b/packages/plugins/bookmarks-plugin/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit",
     "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_bookmarks_integration.ts'",
     "lint": "eslint src"
   },
@@ -38,6 +38,7 @@
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
     "vue": "^3.5.40",
+    "vue-tsc": "^3.3.9",
     "zod": "^4.4.3"
   },
   "license": "MIT",

--- a/packages/plugins/bookmarks-plugin/tsconfig.json
+++ b/packages/plugins/bookmarks-plugin/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/chart-plugin/src/core/types.ts
+++ b/packages/plugins/chart-plugin/src/core/types.ts
@@ -23,6 +23,6 @@ export interface ChartArgs {
  *  preview sidebar, and records where the document was persisted. */
 export interface PresentChartData {
   document: ChartDocument;
-  title?: string;
+  title?: string | undefined;
   filePath: string;
 }

--- a/packages/plugins/chart-plugin/tsconfig.json
+++ b/packages/plugins/chart-plugin/tsconfig.json
@@ -12,6 +12,8 @@
     "noEmit": true,
     "jsx": "preserve",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCalendarView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCalendarView.vue
@@ -118,14 +118,14 @@ const props = defineProps<{
   /** The `date`/`datetime` field whose value places each record on the grid. */
   anchorField: string;
   /** Optional second `date`/`datetime` field — records span anchor→end inclusive. */
-  endField?: string;
+  endField?: string | undefined;
   /** Optional free-form time-string field driving the day (time-allocation) view. */
-  timeField?: string;
+  timeField?: string | undefined;
   /** Optional `enum` field tinting each chip by its value's palette colour.
    *  Empty / unset → the default indigo styling. */
-  colorField?: string;
+  colorField?: string | undefined;
   /** Primary-key of the currently-open record (highlighted chip). */
-  selected?: string;
+  selected?: string | undefined;
 }>();
 
 const emit = defineEmits<{

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionCustomView.vue
@@ -49,7 +49,7 @@ const emit = defineEmits<{
   openItem: [payload: { id: string; mode: "view" | "edit" }];
   /** The view called `__MC_VIEW.startChat(prompt, role)` — open a new chat with
    *  `prompt` prefilled as an editable draft (host validates `role`). */
-  startChat: [payload: { prompt: string; role?: string }];
+  startChat: [payload: { prompt: string; role?: string | undefined }];
 }>();
 
 const loading = ref(true);

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionDayView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionDayView.vue
@@ -135,16 +135,16 @@ const props = defineProps<{
   items: CollectionItem[];
   day: Ymd;
   anchorField: string;
-  endField?: string;
-  timeField?: string;
+  endField?: string | undefined;
+  timeField?: string | undefined;
   /** Optional `enum` field tinting each chip by its value's palette colour
    *  (matching the month view). Empty / unset → default indigo/slate styling. */
-  colorField?: string;
-  selected?: string;
+  colorField?: string | undefined;
+  selected?: string | undefined;
   canCreate: boolean;
   /** When true, expand the modal to two columns and render the `#detail`
    *  slot (the selected/created record) to the right of the timeline. */
-  showDetail?: boolean;
+  showDetail?: boolean | undefined;
 }>();
 
 const emit = defineEmits<{

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionKanbanView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionKanbanView.vue
@@ -87,13 +87,13 @@ const props = defineProps<{
   groupField: string;
   items: CollectionItem[];
   /** Primary-key of the currently-open record (highlighted card). */
-  selected?: string;
+  selected?: string | undefined;
   /** Primary-key → active-notification severity. Cards with a notification get
    *  a left accent in the matching bell colour (urgent red / nudge amber). */
-  notified?: Map<string, NotifierSeverity>;
+  notified?: Map<string, NotifierSeverity> | undefined;
   /** Read-only (dataSource) collection: dragging and the card toggle are
    *  off — a move writes the group field, and there is nothing to write. */
-  readonly?: boolean;
+  readonly?: boolean | undefined;
 }>();
 
 const emit = defineEmits<{

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRemoteViewPreview.vue
@@ -57,7 +57,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   /** The view called `__MC_VIEW.startChat(prompt, role)` — open a new chat
    *  with `prompt` prefilled as an editable draft (host validates `role`). */
-  startChat: [payload: { prompt: string; role?: string }];
+  startChat: [payload: { prompt: string; role?: string | undefined }];
 }>();
 
 const loading = ref(true);

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -395,18 +395,18 @@ import {
  *  actions send into the current session instead of spawning a new
  *  chat (see `runAction` / `submitChat`). */
 const props = defineProps<{
-  slug?: string;
-  selected?: string;
-  sendTextMessage?: (text?: string) => void;
+  slug?: string | undefined;
+  selected?: string | undefined;
+  sendTextMessage?: ((text?: string) => void) | undefined;
   /** Embedded mode only: initial view / anchor / group restored from the
    *  card's persisted `viewState` so a switch to calendar or kanban
    *  survives a remount. (The table sort is NOT a card prop — it's a shared
    *  per-collection localStorage preference, read by both modes.) Accepts a
    *  `custom:<id>` mode too so the dashboard can open a tile directly on a
    *  custom view. */
-  initialView?: CollectionViewMode;
-  initialAnchorField?: string;
-  initialGroupField?: string;
+  initialView?: CollectionViewMode | undefined;
+  initialAnchorField?: string | undefined;
+  initialGroupField?: string | undefined;
   /** Hide the header's view-mode toggle (table ↔ calendar ↔ kanban ↔
    *  custom + "add view"). The dashboard sets this because each tile
    *  carries its own view picker, persisting the choice to the dashboard
@@ -1490,7 +1490,7 @@ function onCustomViewOpenItem(payload: { id: string; mode: "view" | "edit" }): v
  *  with the prompt prefilled as an editable draft. The host validates `role`
  *  (falls back to General). The view's code only proposes text; the user
  *  approves / edits / sends, so no capability is required. */
-function onCustomViewStartChat(payload: { prompt: string; role?: string }): void {
+function onCustomViewStartChat(payload: { prompt: string; role?: string | undefined }): void {
   const prompt = payload.prompt.trim();
   if (!prompt) return;
   cui.startNewChatDraft(prompt, payload.role);

--- a/packages/plugins/collection-plugin/src/vue/composables/collectionActionRunners.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/collectionActionRunners.ts
@@ -41,7 +41,7 @@ export interface CollectionActionContext extends CollectionActionState {
   inlineError: Ref<string | null>;
   guard: RunningActionsGuard;
   cui: CollectionUi;
-  props: { sendTextMessage?: (text?: string) => void };
+  props: { sendTextMessage?: ((text?: string) => void) | undefined };
   t: Translate;
 }
 

--- a/packages/plugins/collection-plugin/src/vue/composables/useCollectionActions.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useCollectionActions.ts
@@ -39,7 +39,7 @@ interface UseCollectionActionsParams {
   inlineError: Ref<string | null>;
   cui: CollectionUi;
   /** The chat card's channel into the current session (embedded mode only). */
-  props: { sendTextMessage?: (text?: string) => void };
+  props: { sendTextMessage?: ((text?: string) => void) | undefined };
   t: Translate;
 }
 

--- a/packages/plugins/collection-plugin/src/vue/composables/useCollectionChat.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useCollectionChat.ts
@@ -20,7 +20,7 @@ interface UseCollectionChatParams {
   viewing: Ref<CollectionItem | null>;
   cui: CollectionUi;
   /** The chat card's channel into the current session (embedded mode only). */
-  props: { sendTextMessage?: (text?: string) => void };
+  props: { sendTextMessage?: ((text?: string) => void) | undefined };
   t: Translate;
 }
 

--- a/packages/plugins/collection-plugin/src/vue/composables/useViewMode.ts
+++ b/packages/plugins/collection-plugin/src/vue/composables/useViewMode.ts
@@ -20,7 +20,7 @@ interface UseViewModeParams {
   activeSlug: Readonly<Ref<string | undefined>>;
   /** Embedded cards restore their own persisted mode first (`initialView`); it
    *  wins over the slug's stored preference so a stale card can't clobber it. */
-  props: { initialView?: CollectionViewMode };
+  props: { initialView?: CollectionViewMode | undefined };
   /** Whether the schema has a date / enum field (from the parent's field lists) —
    *  gates whether a stored `calendar` / `kanban` survives `activeView`. */
   hasCalendar: Readonly<Ref<boolean>>;

--- a/packages/plugins/collection-plugin/src/vue/flagFilterDisplay.ts
+++ b/packages/plugins/collection-plugin/src/vue/flagFilterDisplay.ts
@@ -12,8 +12,8 @@ import type { FlagFilterMode, FlagFilterState } from "./collectionViewMode";
  *  satisfies it structurally, and it stays small enough to build in a test. */
 export interface FlagChipSchemaView {
   fields: Record<string, { type: string; label?: string; field?: string; onValue?: string }>;
-  completionField?: string;
-  completionDoneValues?: readonly string[];
+  completionField?: string | undefined;
+  completionDoneValues?: readonly string[] | undefined;
 }
 
 /** Chip key (state/testid/localStorage) for the synthesized legacy-completion

--- a/packages/plugins/collection-plugin/tsconfig.json
+++ b/packages/plugins/collection-plugin/tsconfig.json
@@ -7,6 +7,8 @@
     "jsx": "preserve",
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/debug-plugin/package.json
+++ b/packages/plugins/debug-plugin/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit",
     "test": "echo 'no in-package tests; debug plugin is exercised manually via /debug'",
     "lint": "eslint src"
   },
@@ -34,6 +34,7 @@
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
     "vue": "^3.5.40",
+    "vue-tsc": "^3.3.9",
     "zod": "^4.4.3"
   },
   "license": "MIT",

--- a/packages/plugins/debug-plugin/src/index.ts
+++ b/packages/plugins/debug-plugin/src/index.ts
@@ -84,10 +84,10 @@ function buildAskAndStorePrompt(pendingId: string): string {
 interface MulmoclaudeNotifierApi {
   publish(input: {
     severity: z.infer<typeof NotifierSeverity>;
-    lifecycle?: z.infer<typeof NotifierLifecycle>;
+    lifecycle?: z.infer<typeof NotifierLifecycle> | undefined;
     title: string;
-    body?: string;
-    navigateTarget?: string;
+    body?: string | undefined;
+    navigateTarget?: string | undefined;
     pluginData?: unknown;
   }): Promise<{ id: string }>;
   clear(id: string): Promise<void>;
@@ -98,7 +98,7 @@ interface MulmoclaudeTasksApi {
 }
 
 interface MulmoclaudeChatApi {
-  start(input: { initialMessage: string; role?: string }): Promise<{ chatId: string }>;
+  start(input: { initialMessage: string; role?: string | undefined }): Promise<{ chatId: string }>;
 }
 
 type MulmoclaudeRuntime = PluginRuntime & {

--- a/packages/plugins/debug-plugin/tsconfig.json
+++ b/packages/plugins/debug-plugin/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/edgar-plugin/src/edgar.ts
+++ b/packages/plugins/edgar-plugin/src/edgar.ts
@@ -47,11 +47,11 @@ export interface ResolvedCompany {
 
 export interface EdgarClient {
   resolve(tickerOrCik: string): Promise<ResolvedCompany>;
-  getRecentFilings(cik: string, opts: { formTypes?: string[]; limit?: number }): Promise<{ name: string; filings: FilingSummary[] }>;
+  getRecentFilings(cik: string, opts: { formTypes?: string[] | undefined; limit?: number | undefined }): Promise<{ name: string; filings: FilingSummary[] }>;
   getFilingDocument(cik: string, accessionNumber: string, primaryDocument: string): Promise<{ url: string; text: string }>;
   getCompanyFacts(cik: string): Promise<unknown>;
   getCompanyConcept(cik: string, taxonomy: string, concept: string): Promise<unknown>;
-  fullTextSearch(query: string, opts: { forms?: string[]; dateRange?: { from: string; to: string } }): Promise<unknown>;
+  fullTextSearch(query: string, opts: { forms?: string[] | undefined; dateRange?: { from: string; to: string } | undefined }): Promise<unknown>;
 }
 
 interface EdgarDeps {
@@ -154,7 +154,10 @@ export function createEdgarClient(deps: EdgarDeps): EdgarClient {
     return { cik: padCik(hit.cik_str), name: hit.title, ticker: hit.ticker };
   }
 
-  async function getRecentFilings(cik: string, opts: { formTypes?: string[]; limit?: number } = {}): Promise<{ name: string; filings: FilingSummary[] }> {
+  async function getRecentFilings(
+    cik: string,
+    opts: { formTypes?: string[] | undefined; limit?: number | undefined } = {},
+  ): Promise<{ name: string; filings: FilingSummary[] }> {
     const response = await edgarFetch(`https://data.sec.gov/submissions/CIK${cik}.json`);
     const data = (await response.json()) as {
       name: string;
@@ -205,7 +208,10 @@ export function createEdgarClient(deps: EdgarDeps): EdgarClient {
     return await response.json();
   }
 
-  async function fullTextSearch(query: string, opts: { forms?: string[]; dateRange?: { from: string; to: string } } = {}): Promise<unknown> {
+  async function fullTextSearch(
+    query: string,
+    opts: { forms?: string[] | undefined; dateRange?: { from: string; to: string } | undefined } = {},
+  ): Promise<unknown> {
     const params = new URLSearchParams({ q: query });
     if (opts.forms?.length) params.set("forms", opts.forms.join(","));
     if (opts.dateRange) {

--- a/packages/plugins/edgar-plugin/tsconfig.json
+++ b/packages/plugins/edgar-plugin/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/email-plugin/src/imap.ts
+++ b/packages/plugins/email-plugin/src/imap.ts
@@ -45,11 +45,11 @@ export interface FullMessage {
 }
 
 export interface SearchCriteria {
-  from?: string;
-  subject_contains?: string;
-  since?: string; // ISO date
-  before?: string; // ISO date
-  unread?: boolean;
+  from?: string | undefined;
+  subject_contains?: string | undefined;
+  since?: string | undefined; // ISO date
+  before?: string | undefined; // ISO date
+  unread?: boolean | undefined;
 }
 
 function makeClient(auth: ImapAuth): ImapFlow {

--- a/packages/plugins/email-plugin/src/smtp.ts
+++ b/packages/plugins/email-plugin/src/smtp.ts
@@ -17,7 +17,7 @@ export interface SendDraft {
   to: string;
   subject: string;
   body: string;
-  html?: string;
+  html?: string | undefined;
 }
 
 export interface SendResult {

--- a/packages/plugins/email-plugin/tsconfig.json
+++ b/packages/plugins/email-plugin/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/form-plugin/src/core/types.ts
+++ b/packages/plugins/form-plugin/src/core/types.ts
@@ -73,8 +73,8 @@ export interface NumberField extends BaseField {
 export type FormField = TextField | TextareaField | RadioField | DropdownField | CheckboxField | DateField | TimeField | NumberField;
 
 export interface FormData {
-  title?: string;
-  description?: string;
+  title?: string | undefined;
+  description?: string | undefined;
   fields: FormField[];
 }
 

--- a/packages/plugins/form-plugin/src/core/viewState.ts
+++ b/packages/plugins/form-plugin/src/core/viewState.ts
@@ -11,7 +11,7 @@
 export interface FormViewState {
   userResponses: Record<string, unknown>;
   touched: string[];
-  submitted?: boolean;
+  submitted?: boolean | undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/plugins/form-plugin/tsconfig.json
+++ b/packages/plugins/form-plugin/tsconfig.json
@@ -12,6 +12,8 @@
     "noEmit": true,
     "jsx": "preserve",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/plugins/google-plugin/tsconfig.json
+++ b/packages/plugins/google-plugin/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/html-plugin/src/core/types.ts
+++ b/packages/plugins/html-plugin/src/core/types.ts
@@ -10,7 +10,7 @@ export interface HtmlArgs {
  *  lives on disk (large), so only the workspace-relative `filePath` and an
  *  optional `title` travel in the tool result. */
 export interface PresentHtmlData {
-  title?: string;
+  title?: string | undefined;
   filePath: string;
   /** Host-served URL the View points its iframe at so relative asset refs
    *  (`<img src="../../../images/…">`) resolve against the file's real URL.

--- a/packages/plugins/html-plugin/tsconfig.json
+++ b/packages/plugins/html-plugin/tsconfig.json
@@ -7,6 +7,8 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/MarpSplitEditor.vue
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/MarpSplitEditor.vue
@@ -40,7 +40,7 @@ import MarpView from "./MarpView.vue";
 defineProps<{
   modelValue: string;
   pdfFilename: string;
-  baseDir?: string;
+  baseDir?: string | undefined;
   editorLabel: string;
 }>();
 

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/MarpView.vue
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/MarpView.vue
@@ -54,7 +54,7 @@ const { dispatch } = useRuntime();
 const props = defineProps<{
   markdown: string;
   pdfFilename: string;
-  baseDir?: string;
+  baseDir?: string | undefined;
 }>();
 
 const DEFAULT_SLIDE_WIDTH = 1280;

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/contract.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/contract.ts
@@ -30,10 +30,10 @@ export interface MarpThemeEntry {
 export interface ExportPdfOptions {
   markdown: string;
   filename: string;
-  marp?: boolean;
-  baseDir?: string;
-  format?: "Letter" | "A4";
-  stripFrontmatter?: boolean;
+  marp?: boolean | undefined;
+  baseDir?: string | undefined;
+  format?: "Letter" | "A4" | undefined;
+  stripFrontmatter?: boolean | undefined;
 }
 
 /**

--- a/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
+++ b/packages/plugins/markdown-plugin/src/plugins/markdown/definition.ts
@@ -11,9 +11,9 @@ export interface MarkdownToolData {
   /** The document this result renders, when it is backed by a file. Set for
    *  every result the current executor produces, so an arbitrary document path
    *  (a repo's `README.md`) is never mistaken for inline content. */
-  docPath?: string;
-  pdfPath?: string;
-  filenamePrefix?: string;
+  docPath?: string | undefined;
+  pdfPath?: string | undefined;
+  filenamePrefix?: string | undefined;
 }
 
 /** Args the LLM passes when invoking the tool. Two shapes share this

--- a/packages/plugins/markdown-plugin/tsconfig.json
+++ b/packages/plugins/markdown-plugin/tsconfig.json
@@ -12,6 +12,8 @@
     "noEmit": true,
     "jsx": "preserve",
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -45,7 +45,7 @@ interface CharacterRef {
  *  (MulmoClaude's sidebar). Optional everywhere; hosts without sessions
  *  ignore it. */
 interface SessionTag {
-  chatSessionId?: string;
+  chatSessionId?: string | undefined;
 }
 
 export type MulmoScriptDispatchArgs =

--- a/packages/plugins/mulmoscript-plugin/src/core/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/types.ts
@@ -7,9 +7,9 @@ import type { MulmoScript } from "@mulmocast/types";
  *  by hosts that have a movie backend (the package core ignores it). */
 export interface SaveMulmoScriptArgs {
   script?: unknown;
-  filename?: string;
-  filePath?: string;
-  autoGenerateMovie?: boolean;
+  filename?: string | undefined;
+  filePath?: string | undefined;
+  autoGenerateMovie?: boolean | undefined;
 }
 
 /** Result payload that drives the View. `filePath` is the historical

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -48,7 +48,7 @@ import { resolveWithinRoot } from "@mulmoclaude/core/files";
 import { fileToDataUri, stripDataUri } from "./support";
 import { enableGraphAIErrorCapture, setMulmoErrorCaptureLogger, withMulmoErrorCapture } from "./mulmoErrorCapture";
 import type {
-  GenerateOpArgs,
+  GenerateOpArgsWith,
   MovieGenerationResult,
   MovieProgressEvent,
   MulmoScriptServerBackend,
@@ -107,7 +107,7 @@ export interface RunStoryOpDeps {
 }
 
 export interface RunStoryOpOptions<T> {
-  force?: boolean;
+  force?: boolean | undefined;
   /**
    * Op-specific tag included in the failure log so dashboards can
    * distinguish which op is failing (e.g. `"generate-beat-audio"`).
@@ -476,7 +476,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
 
   // ── Generation ops ────────────────────────────────────────────
 
-  async function renderBeatOp(args: Required<Pick<GenerateOpArgs, "filePath" | "beatIndex">> & GenerateOpArgs): Promise<OpResult<{ image: string }>> {
+  async function renderBeatOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ image: string }>> {
     const { filePath, beatIndex, force, chatSessionId } = args;
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
@@ -489,7 +489,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
         await generateBeatImage({
           index: beatIndex,
           context,
-          args: force ? { forceImage: true } : undefined,
+          ...(force ? { args: { forceImage: true } } : {}),
         });
         const { imagePath } = getBeatPngImagePath(context, beatIndex);
         if (!existsSync(imagePath)) {
@@ -504,7 +504,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
   }
 
-  async function generateBeatAudioOp(args: Required<Pick<GenerateOpArgs, "filePath" | "beatIndex">> & GenerateOpArgs): Promise<OpResult<{ audio: string }>> {
+  async function generateBeatAudioOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ audio: string }>> {
     const { filePath, beatIndex, force, chatSessionId } = args;
     const mapKey = String(beatIndex);
     publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, false);
@@ -545,7 +545,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
   }
 
-  async function renderCharacterOp(args: Required<Pick<GenerateOpArgs, "filePath" | "key">> & GenerateOpArgs): Promise<OpResult<{ image: string }>> {
+  async function renderCharacterOp(args: GenerateOpArgsWith<"filePath" | "key">): Promise<OpResult<{ image: string }>> {
     const { filePath, key, force, chatSessionId } = args;
     publishGeneration(chatSessionId, "characterImage", filePath, key, false);
     let genError: string | undefined;
@@ -568,7 +568,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
           key,
           index,
           image: imageEntry as MulmoImagePromptMedia,
-          force,
+          ...(force !== undefined ? { force } : {}),
         });
         if (!existsSync(imagePath)) {
           return opServerError("Character image was not generated");

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -25,6 +25,13 @@ export interface GenerateOpArgs {
   chatSessionId?: string | undefined;
 }
 
+/** `GenerateOpArgs` with `K` promoted to genuinely required. `Required<Pick<…>>`
+ *  does NOT work here: under `exactOptionalPropertyTypes` the `-?` modifier drops
+ *  only the `?`, leaving the explicitly declared `| undefined` in place, so the
+ *  op body still sees `T | undefined`. `Omit` for the rest, because intersecting
+ *  the whole interface would re-introduce the optional declaration. */
+export type GenerateOpArgsWith<K extends keyof GenerateOpArgs> = { [P in K]-?: Exclude<GenerateOpArgs[P], undefined> } & Omit<GenerateOpArgs, K>;
+
 export type MovieGenerationResult = { ok: true; outputPath: string } | { ok: false; error: string };
 export type PdfGenerationResult = { ok: true; outputPath: string } | { ok: false; error: string };
 

--- a/packages/plugins/mulmoscript-plugin/src/vue/viewTypes.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/viewTypes.ts
@@ -18,9 +18,9 @@ export interface ImageEntry {
  *  prev/next arrows stay hidden for characters. */
 export interface LightboxState {
   src: string;
-  text?: string;
+  text?: string | undefined;
   index: number;
-  isCharacter?: boolean;
+  isCharacter?: boolean | undefined;
 }
 
 export interface MulmoScript {

--- a/packages/plugins/mulmoscript-plugin/tsconfig.json
+++ b/packages/plugins/mulmoscript-plugin/tsconfig.json
@@ -7,6 +7,8 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/recipe-book-plugin/package.json
+++ b/packages/plugins/recipe-book-plugin/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit",
     "test": "echo 'no in-package tests; covered by host integration test test/plugins/test_recipe_book_integration.ts'",
     "lint": "eslint src"
   },
@@ -38,6 +38,7 @@
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
     "vue": "^3.5.40",
+    "vue-tsc": "^3.3.9",
     "zod": "^4.4.3"
   },
   "license": "MIT",

--- a/packages/plugins/recipe-book-plugin/src/View.vue
+++ b/packages/plugins/recipe-book-plugin/src/View.vue
@@ -167,16 +167,16 @@ function renderMarkdownLite(input: string): string {
     }
   };
   for (const line of lines) {
-    const heading = line.match(/^(#{1,6})\s+(.+)$/);
-    if (heading) {
+    const [, hashes, headingText] = line.match(/^(#{1,6})\s+(.+)$/) ?? [];
+    if (hashes !== undefined && headingText !== undefined) {
       flushPara();
       closeLists();
-      const level = heading[1].length;
-      out.push(`<h${level}>${formatInline(heading[2])}</h${level}>`);
+      const level = hashes.length;
+      out.push(`<h${level}>${formatInline(headingText)}</h${level}>`);
       continue;
     }
-    const ul = line.match(/^[-*]\s+(.+)$/);
-    if (ul) {
+    const [, ulItem] = line.match(/^[-*]\s+(.+)$/) ?? [];
+    if (ulItem !== undefined) {
       flushPara();
       if (inOl) {
         out.push("</ol>");
@@ -186,11 +186,11 @@ function renderMarkdownLite(input: string): string {
         out.push("<ul>");
         inUl = true;
       }
-      out.push(`<li>${formatInline(ul[1])}</li>`);
+      out.push(`<li>${formatInline(ulItem)}</li>`);
       continue;
     }
-    const ol = line.match(/^\d+\.\s+(.+)$/);
-    if (ol) {
+    const [, olItem] = line.match(/^\d+\.\s+(.+)$/) ?? [];
+    if (olItem !== undefined) {
       flushPara();
       if (inUl) {
         out.push("</ul>");
@@ -200,7 +200,7 @@ function renderMarkdownLite(input: string): string {
         out.push("<ol>");
         inOl = true;
       }
-      out.push(`<li>${formatInline(ol[1])}</li>`);
+      out.push(`<li>${formatInline(olItem)}</li>`);
       continue;
     }
     if (line.trim().length === 0) {

--- a/packages/plugins/recipe-book-plugin/tsconfig.json
+++ b/packages/plugins/recipe-book-plugin/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/spotify-plugin/package.json
+++ b/packages/plugins/spotify-plugin/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "vue-tsc --noEmit",
     "test": "echo 'no in-package tests; covered by host tests under test/plugins/spotify/'",
     "lint": "eslint src"
   },
@@ -41,6 +41,7 @@
     "vite": "^8.1.5",
     "vite-plugin-dts": "^5.0.3",
     "vue": "^3.5.40",
+    "vue-tsc": "^3.3.9",
     "zod": "^4.4.3"
   },
   "license": "MIT",

--- a/packages/plugins/spotify-plugin/src/Preview.vue
+++ b/packages/plugins/spotify-plugin/src/Preview.vue
@@ -77,8 +77,8 @@ function summariseSearchResult(result: SearchResult): string {
 // label that matches the array's element type so a 5-playlist result
 // doesn't read as "5 tracks" (CodeRabbit review on PR #1166).
 function summariseArray(data: NormalisedTrack[] | NormalisedPlaylist[] | RecentlyPlayedItem[]): string {
-  if (data.length === 0) return t.value.empty;
-  const head = data[0];
+  const [head] = data;
+  if (head === undefined) return t.value.empty;
   if ("trackCount" in head) return `${data.length} ${t.value.tabPlaylists}`;
   if ("playedAt" in head) return `${data.length} ${t.value.tabRecent}`;
   return `${data.length} ${t.value.tracksCount}`;

--- a/packages/plugins/spotify-plugin/tsconfig.json
+++ b/packages/plugins/spotify-plugin/tsconfig.json
@@ -5,6 +5,8 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/plugins/x-plugin/src/client.ts
+++ b/packages/plugins/x-plugin/src/client.ts
@@ -22,25 +22,27 @@ export interface XUser {
 export interface XTweet {
   id: string;
   text: string;
-  author_id?: string;
-  created_at?: string;
+  author_id?: string | undefined;
+  created_at?: string | undefined;
   // Long-form Post (>280 chars): full body lives here, not in `text`.
-  note_tweet?: { text: string };
+  note_tweet?: { text: string } | undefined;
   // X Article (rich long-form, up to 100k chars): `text` only holds the t.co
   // link, so the body must be read from `article.plain_text`.
-  article?: { title?: string; plain_text?: string };
-  public_metrics?: {
-    like_count: number;
-    retweet_count: number;
-    reply_count: number;
-  };
+  article?: { title?: string | undefined; plain_text?: string | undefined } | undefined;
+  public_metrics?:
+    | {
+        like_count: number;
+        retweet_count: number;
+        reply_count: number;
+      }
+    | undefined;
 }
 
 export interface XApiResponse {
-  data?: XTweet | XTweet[];
-  includes?: { users?: XUser[] };
-  errors?: { detail: string }[];
-  meta?: { result_count: number };
+  data?: XTweet | XTweet[] | undefined;
+  includes?: { users?: XUser[] } | undefined;
+  errors?: { detail: string }[] | undefined;
+  meta?: { result_count: number } | undefined;
 }
 
 /** Resolve the X API bearer token from the environment. The host gates the

--- a/packages/plugins/x-plugin/tsconfig.json
+++ b/packages/plugins/x-plugin/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022", "DOM"],
     "types": ["node"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -24,9 +24,9 @@ export interface RelayMessage {
   senderId: string;
   chatId: string;
   text: string;
-  attachments?: RelayAttachment[];
+  attachments?: RelayAttachment[] | undefined;
   receivedAt: string;
-  replyToken?: string;
+  replyToken?: string | undefined;
 }
 
 export interface RelayAttachment {

--- a/packages/relay/src/webhooks/line.ts
+++ b/packages/relay/src/webhooks/line.ts
@@ -24,7 +24,7 @@ export interface ParsedLineEvent {
   chatId: string;
   senderId: string;
   text: string;
-  replyToken?: string;
+  replyToken?: string | undefined;
 }
 
 /**

--- a/packages/relay/src/webhooks/teams.ts
+++ b/packages/relay/src/webhooks/teams.ts
@@ -114,13 +114,15 @@ async function fetchJwks(url: string): Promise<JwkKey[]> {
     .filter((key): key is Record<string, unknown> => isRecord(key) && typeof key.kid === "string" && typeof key.n === "string")
     .map((key): JwkKey => {
       const endorsements = Array.isArray(key.endorsements) ? key.endorsements.filter((entry): entry is string => typeof entry === "string") : undefined;
+      // Absent members are omitted rather than set to `undefined` so the key
+      // stays assignable to the platform's `JsonWebKey` on the importKey path.
       return {
         kid: String(key.kid),
         kty: typeof key.kty === "string" ? key.kty : "RSA",
         n: String(key.n),
         e: typeof key.e === "string" ? key.e : "AQAB",
-        alg: typeof key.alg === "string" ? key.alg : undefined,
-        endorsements,
+        ...(typeof key.alg === "string" ? { alg: key.alg } : {}),
+        ...(endorsements !== undefined ? { endorsements } : {}),
       };
     });
   jwksCache.set(url, { keys, expiresAt: Date.now() + JWKS_CACHE_TTL_MS });

--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["ES2022"],
     "types": ["@cloudflare/workers-types"],
     "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "noImplicitAny": true,
     "skipLibCheck": true,
     "declaration": true,


### PR DESCRIPTION
## Summary

Enables **both** `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` across the whole `packages/*` tsconfig chain, and fixes the 123 findings that surfaced.

The host side already carries both flags in all six of its projects. The 52 package tsconfigs carried **neither**. Package source was already almost clean (#2749, #2756 drove it there) but nothing *held* it clean — an `arr[i]` added tomorrow passed silently.

- Both flags added to `config/tsconfig.packages.json`, covering the **34** configs that extend it (25 bridges, 9 top-level).
- Both flags added **individually** to the **18 standalone** configs.
- **123 findings across 20 packages → 0 across all 52.** Baseline with the flags off was 0 everywhere, so every finding is flag-induced rather than pre-existing.
- All fixes are type-level. No `as`, no `!`, no `@ts-ignore`/`@ts-expect-error`/`eslint-disable`, no `let`, no `any`.

## Items to Confirm / Review

1. **The 18 standalone configs were given the flags individually rather than converted to extend the shared base.** Converting is tidier but would have changed far more than the two flags: the base sets `declaration: true` and `types: ["node"]` and lacks `noEmit`, `jsx: "preserve"` and the DOM libs. Several plugins (bookmarks, chart, debug, form, markdown, recipe-book, spotify) *deliberately* omit `types: ["node"]` because they are browser-side, and `packages/relay` runs on `@cloudflare/workers-types`. Converting would have silently handed all of them Node globals. Flagging in case you would rather unify them in a follow-up.

2. **Four plugins with `.vue` files were typechecking with plain `tsc`** — `bookmarks`, `debug`, `recipe-book`, `spotify`. `tsc` parses no `.vue` file at all, so every template and `<script setup>` body in those packages was checked by **nothing** (the root `typecheck:vue` only covers `src/**`, not `packages/**`). They now use `vue-tsc` like their siblings, plus the matching `vue-tsc` devDependency. **`yarn.lock` is unchanged** — `vue-tsc@^3.3.9` was already resolved for the root and for markdown/chart — so there is no clean-install risk. This is a scope addition; say the word if you would rather split it out.

3. **`mulmoscript-plugin` had a real type-modelling defect** (details below). The fix changes a shared helper type; worth a look.

4. **`packages/relay` `teams.ts`**: absent JWKS members are now omitted rather than set to `undefined`, so the key stays assignable to the platform `JsonWebKey` on the `importKey` path. The object handed to WebCrypto is otherwise untouched — I deliberately backed out an earlier version of this fix that rebuilt the key inside the crypto path.

5. **Three plugin findings were fixed in `packages/core` instead of in the plugin.** In each case the plugin was working around a core type that its own siblings had already widened. Fixing core let the plugin code stay as it was (`google-plugin/src/core/dispatch.ts` and its 6 test expectations, and `collection-plugin`'s `useFlagFilters.ts` / `presentCollectionData.ts`, all reverted to their original form).

## The one real defect

`mulmoscript-plugin/src/server/ops.ts` typed three op signatures as:

```ts
Required<Pick<GenerateOpArgs, "filePath" | "beatIndex">> & GenerateOpArgs
```

Two independent problems:

- Intersecting the **whole** interface re-introduces the optional declaration the `Required<>` just removed.
- More surprising: under `exactOptionalPropertyTypes`, `Required<>` does **not** strip an explicitly written `| undefined`. The `-?` modifier drops only the `?`. I verified this against the compiler rather than assuming it — a standalone probe with `Required<Pick<G, K>> & Omit<G, K>` still failed, and only `{ [P in K]-?: Exclude<G[P], undefined> }` passed.

So the ops advertised `beatIndex` / `key` as required while their bodies still saw `number | undefined` / `string | undefined`. That single defect accounted for **12 of the 23 findings** in the package — every one of the `TS2538 "Type 'undefined' cannot be used as an index type"` reports. Replaced with a named `GenerateOpArgsWith<K>` helper.

This is a type-level defect, not a live runtime bug: callers were still forced to pass the key, so nothing was reaching production with `beatIndex` missing. **No runtime bugs were found in this sweep**, so nothing was filed to #2736.

## Per-package findings (before → after)

Every count below is from running each package **independently** with `--pretty false`, using `vue-tsc` for any package containing `.vue` files. Both details matter: `yarn workspaces run typecheck` stops at the first failing workspace, and ANSI escapes otherwise split the string `error TS` so a naive `grep -c` reports zero.

| Package | Before | After | Checker |
|---|---:|---:|---|
| `plugins/accounting-plugin` | 35 | 0 | vue-tsc |
| `plugins/mulmoscript-plugin` | 23 | 0 | vue-tsc |
| `plugins/collection-plugin` | 12 | 0 | vue-tsc |
| `plugins/markdown-plugin` | 8 | 0 | vue-tsc |
| `plugins/google-plugin` | 7 | 0 | tsc |
| `core` | 4 | 0 | tsc |
| `plugins/recipe-book-plugin` | 4 | 0 | vue-tsc |
| `bridges/telegram` | 3 | 0 | tsc |
| `relay` | 3 | 0 | tsc |
| `plugins/debug-plugin` | 3 | 0 | vue-tsc |
| `plugins/x-plugin` | 3 | 0 | tsc |
| `plugins/edgar-plugin` | 2 | 0 | tsc |
| `plugins/email-plugin` | 2 | 0 | tsc |
| `plugins/form-plugin` | 2 | 0 | vue-tsc |
| `plugins/html-plugin` | 2 | 0 | vue-tsc |
| `plugins/spotify-plugin` | 2 | 0 | vue-tsc |
| `bridges/bluesky` | 1 | 0 | tsc |
| `bridges/chatwork` | 1 | 0 | tsc |
| `bridges/irc` | 1 | 0 | tsc |
| `plugins/chart-plugin` | 1 | 0 | vue-tsc |
| the other 32 packages | 0 | 0 | — |
| **total** | **123** | **0** | |

`accounting` and `mulmoscript` are far larger than a `tsc`-only measurement suggests, because most of their findings live in `.vue` templates.

## Proving the flags actually apply

A flag that silently fails to apply is indistinguishable from one that works, so each config was checked rather than trusted. A probe was dropped into every package:

```ts
export const nuiaProbe = (xs: string[]): number => xs[0].length;
interface EoptProbe { a?: string }
export const eoptProbe = (a: string | undefined): EoptProbe => ({ a });
```

Each package's **own** checker was then run and asserted to reject **both** lines. Result: **52/52 packages BOTH OK**, then every probe removed (verified: zero `__flagprobe` files remain).

## Verification

- `yarn build:packages` ✅
- `yarn format` ✅
- `yarn lint` ✅ — 0 errors. The 51 remaining warnings are pre-existing; the only two in files this PR touches (`accounting-plugin/src/server/service.ts:418`, `relay/src/webhooks/line.ts:79`) were confirmed identical by linting the pre-change versions.
- `yarn typecheck` ✅ — now runs to completion through every workspace
- `yarn build` ✅
- `yarn test` ✅ — every suite reports `fail 0`
- `yarn build:hooks && git diff --exit-code -- server/build/dispatcher.mjs` ✅ — bundle unchanged, and `grep -c "worktrees\|/Users/\|../../../packages"` on it is 0

One lint regression was caught and fixed en route: the `telegram/router.ts` change pushed `tryDownloadAttachments` to cognitive complexity 16 (limit 15). Refactored into two small `downloadPhoto` / `downloadDocument` helpers, which also removed a pre-existing `let`.

Refs #2736

work in mulmoclaude3

## Summary by Sourcery

Enable stricter TypeScript optional and indexed access checking across core, relay, bridges, and plugins, and align package code with the new type guarantees.

Enhancements:
- Refine TypeScript types throughout server, client, and Vue components to model optional properties explicitly under exactOptionalPropertyTypes and noUncheckedIndexedAccess.
- Introduce a GenerateOpArgsWith helper for mulmoscript-plugin generation ops to correctly enforce required keys in type signatures.
- Refactor Telegram bridge attachment downloading into smaller helpers to reduce cognitive complexity and improve error handling paths.
- Adjust various payload and API contracts (e.g., Google tasks, X API, EDGAR, email, collection, accounting, HTML, markdown) so optional fields are consistently represented and safely accessed.
- Tighten JWKS key shaping in relay Teams webhook to omit absent members rather than assigning undefined, preserving JsonWebKey compatibility.
- Simplify construction of optional request bodies in bridges (ChatWork, Bluesky, IRC, Telegram) to only include fields when defined.

Build:
- Enable exactOptionalPropertyTypes and noUncheckedIndexedAccess in shared packages tsconfig and in standalone package configs (core, relay, plugins, create-mulmoclaude-plugin, etc.).

Tests:
- Switch several Vue-based plugins (bookmarks, debug, recipe-book, spotify) from tsc to vue-tsc typechecking and add the corresponding devDependency without changing the lockfile.
- Ensure all updated packages typecheck cleanly under the new compiler flags, with all previously uncovered findings resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional request data, preventing empty or undefined fields from being sent to external services.
  * Improved Telegram attachment processing, including clearer failure handling and more accurate document metadata.
  * Ensured webhook responses omit unavailable values rather than returning empty fields.

* **Refactor**
  * Strengthened type safety across integrations, plugins, accounting, collections, and relay features.
  * Improved type checking for Vue-based plugins and safer handling of indexed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->