### PR TITLE
fix(spreadsheet): read MATCH / XLOOKUP ranges raw so text cannot shift the rows

### DIFF
--- a/src/plugins/spreadsheet/engine/functions/lookup.ts
+++ b/src/plugins/spreadsheet/engine/functions/lookup.ts
@@ -2,7 +2,7 @@
  * Lookup and Reference Functions
  */
 
-import { functionRegistry, requiredArg, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
+import { functionRegistry, rawRangeReader, requiredArg, toNumber, parseCriteria, type FunctionHandler, type FunctionContext } from "../registry";
 import { indexToColumn } from "../parser";
 import { parseRangeBounds, resolveIndexTarget, resolveTableOffset } from "../formulaRefs";
 import { isApproximateMatch } from "./lookup-math";
@@ -116,7 +116,9 @@ const matchHandler: FunctionHandler = (args, context) => {
   const lookupArrayRange = requiredArg(context, args, 1);
   const matchType = args.length === 3 ? toNumber(context.evaluateFormula(requiredArg(context, args, 2))) : 1;
 
-  const lookupArray = context.getRangeValues(lookupArrayRange);
+  // Raw, not numeric-only: MATCH answers with a POSITION, so a dropped text
+  // cell renumbers everything after it and returns a different row (#2765).
+  const lookupArray = rawRangeReader(context)(lookupArrayRange);
 
   const index = findMatchIndex(lookupValue, lookupArray, matchType);
 
@@ -142,8 +144,13 @@ const xlookupHandler: FunctionHandler = (args, context) => {
   const matchMode = args.length >= 5 ? toNumber(context.evaluateFormula(requiredArg(context, args, 4))) : 0;
   const searchMode = args.length >= 6 ? toNumber(context.evaluateFormula(requiredArg(context, args, 5))) : 1;
 
-  const lookupArray = context.getRangeValues(lookupArrayRange);
-  const returnArray = context.getRangeValues(returnArrayRange);
+  // Both raw, and for a second reason beyond MATCH's: the numeric-only reader
+  // filters these two INDEPENDENTLY, so a text cell in one range shifts it
+  // against the other and the match index reads a different row's value — a
+  // wrong number with no error, which is the worst outcome a formula can have.
+  const readRange = rawRangeReader(context);
+  const lookupArray = readRange(lookupArrayRange);
+  const returnArray = readRange(returnArrayRange);
 
   // XLOOKUP match modes:
   // 0 = Exact match (default)

--- a/src/plugins/spreadsheet/engine/functions/statistical.ts
+++ b/src/plugins/spreadsheet/engine/functions/statistical.ts
@@ -2,7 +2,16 @@
  * Statistical Functions
  */
 
-import { functionRegistry, requiredArg, toNumber, parseCriteria, type FunctionContext, type FunctionHandler, type RangeGetter } from "../registry";
+import {
+  functionRegistry,
+  rawRangeReader,
+  requiredArg,
+  toNumber,
+  parseCriteria,
+  type FunctionContext,
+  type FunctionHandler,
+  type RangeGetter,
+} from "../registry";
 import { computeAverage, computeMedian, computeMode, sampleStdev, sampleVariance } from "./statistical-math";
 import { DIV_ZERO_ERROR } from "../spreadsheet-errors";
 import { holdsNumber } from "../numericCoercion";
@@ -55,8 +64,6 @@ const collectArgumentValues = (args: string[], context: FunctionContext, readRan
 
   return collected;
 };
-
-const rawRangeReader = (context: FunctionContext): RangeGetter => context.getRangeValuesRaw ?? context.getRangeValues;
 
 const collectNumericValues = (args: string[], context: FunctionContext): number[] =>
   collectArgumentValues(args, context, context.getRangeValues).map(({ value }) => toNumber(value));

--- a/src/plugins/spreadsheet/engine/registry.ts
+++ b/src/plugins/spreadsheet/engine/registry.ts
@@ -40,6 +40,19 @@ export const requiredArg = (context: FunctionContext, args: string[], index: num
   return arg;
 };
 
+/** The range reader that keeps every cell, for functions whose answer depends on
+ *  a range's POSITIONS rather than its numbers.
+ *
+ *  `getRangeValues` drops non-numeric cells, which silently renumbers the rows
+ *  underneath: a criteria/value pair read that way falls out of alignment and
+ *  aggregates a different row, and an index returned from it points at the wrong
+ *  one. SUMIF/AVERAGEIF were moved here in #2358; MATCH/XLOOKUP in #2765.
+ *
+ *  Falls back to the numeric reader because `getRangeValuesRaw` is optional on
+ *  `FunctionContext` — a host that predates it keeps its old behaviour rather
+ *  than throwing. */
+export const rawRangeReader = (context: FunctionContext): RangeGetter => context.getRangeValuesRaw ?? context.getRangeValues;
+
 export type FunctionHandler = (args: string[], context: FunctionContext) => CellValue;
 
 export interface FunctionDefinition {

--- a/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
+++ b/test/plugins/spreadsheet/engine/test_lookupFunctions.ts
@@ -136,3 +136,46 @@ describe("INDEX — bounds (#2390)", () => {
     assert.equal(evalInSheet(grid, "=INDEX(A2:B3, 0, 1)"), "#REF!");
   });
 });
+
+// MATCH and XLOOKUP read their ranges through the NUMERIC-ONLY reader, which
+// drops every text cell. #2358 moved SUMIF/AVERAGEIF onto the raw reader for
+// exactly this reason — `calculator.ts` still explains it — and these two were
+// missed, so they carry both halves of that failure: text keys are invisible,
+// and a lookup/return pair filtered independently falls out of row alignment
+// and answers with a DIFFERENT row's value, silently.
+describe("MATCH / XLOOKUP over text (#2765)", () => {
+  const fruit: (string | number)[][] = [
+    ["apple", 1],
+    ["banana", 2],
+    ["cherry", 3],
+  ];
+
+  it("MATCH finds a text key", () => {
+    assert.equal(evalInSheet(fruit, '=MATCH("banana", A1:A3, 0)'), 2);
+  });
+
+  it("XLOOKUP returns the paired value for a text key", () => {
+    assert.equal(evalInSheet(fruit, '=XLOOKUP("banana", A1:A3, B1:B3)'), 2);
+  });
+
+  // The dangerous one: no error, just a wrong number. `A2` is text, so the
+  // lookup column loses that row while the return column keeps all three —
+  // the match at index 1 then reads B2 instead of B3.
+  it("XLOOKUP stays row-aligned when the lookup column holds text", () => {
+    const mixed: (string | number)[][] = [
+      [1, 100],
+      ["x", 200],
+      [3, 300],
+    ];
+    assert.equal(evalInSheet(mixed, "=XLOOKUP(3, A1:A3, B1:B3)"), 300);
+  });
+
+  it("MATCH keeps its 1-based index when earlier rows hold text", () => {
+    const mixed: (string | number)[][] = [
+      ["x", 0],
+      [7, 0],
+      [9, 0],
+    ];
+    assert.equal(evalInSheet(mixed, "=MATCH(9, A1:A3, 0)"), 3);
+  });
+});


### PR DESCRIPTION
## Summary

`MATCH` と `XLOOKUP` が範囲を**数値専用リーダー**で読んでおり、テキストセルを黙って捨てて行がずれていました。**#2358 が SUMIF/AVERAGEIF について既に直した失敗モードと同一**で、この2つが取り残されていました（`calculator.ts` のコメント自身がその理由を説明しています）。

`#2736` の `noUncheckedIndexedAccess` スイープ中に発見。型の問題ではないため当時のPRでは触らず、単独で対応します。

## Items to Confirm / Review

**1. 4件中2件は、エラーを出さずに違う数値を返します。** 修正前の実測値（`actual` はテスト実行の出力）:

| 式 | 現状 | Excel |
|---|---|---|
| `MATCH("banana", A1:A3, 0)` | `#N/A` | `2` |
| `XLOOKUP("banana", A1:A3, B1:B3)` | `#N/A` | `2` |
| `XLOOKUP(3, A1:A3, B1:B3)`（A2 がテキスト） | **`200`** | `300` |
| `MATCH(9, A1:A3, 0)`（A1 がテキスト） | **`2`** | `3` |

上2件は `#N/A` なので間違いが見えます。**下2件は静かに誤答**します — 数式アプリで最悪の結果です。

- `MATCH` は**位置**を返すので、テキストセルが1つ落ちると以降の行番号が全部ずれる
- `XLOOKUP` はさらに悪く、lookup 範囲と return 範囲を**独立に**フィルタするため、片方だけ行が落ちて対応がずれ、別の行の値が返る

Registry に登録された `MATCH` の説明用サンプルが text 列を使っているので、**ドキュメント化された例自体が動きませんでした**。

**2. `rawRangeReader` はコピーせず共有化しました。** `statistical.ts` にローカル定義されていたものを `registry.ts`（`FunctionContext` とその optional な `getRangeValuesRaw` の定義元）に移して export。`lookup.ts` に2つ目の実装を作るのは避けました。数値リーダーへのフォールバックは維持しているので、`getRangeValuesRaw` を持たない古いホストは throw せず従来どおり動きます。

**3. これを pin するテストは1つもありませんでした。** 意図的な挙動ではなく、誰も見ていなかっただけです。上記4ケースをテスト化しました。修正前は4件とも fail、修正後は全 pass。

## 検証

```
spreadsheet 全体   951 tests / fail 0
yarn format 0 / lint 0 / typecheck 0 / build 0 / test 0  (11126 tests, fail 0)
```

Closes #2774

work in mulmoclaude3

## Summary by Sourcery

Align MATCH and XLOOKUP range reading with other spreadsheet functions to treat text cells correctly and preserve row positions.

Bug Fixes:
- Fix MATCH so text lookup keys in ranges are recognized instead of being silently dropped, returning the correct position.
- Fix XLOOKUP so lookup and return ranges remain row-aligned when they contain text, avoiding silent wrong results.

Enhancements:
- Centralize the raw range reader utility in the registry for reuse across functions instead of keeping a local implementation in statistical functions.

Tests:
- Add spreadsheet engine tests covering MATCH and XLOOKUP behavior over ranges containing text to pin the corrected semantics and prevent regressions.