### PR TITLE
fix(lint): `as` キャスト禁止を error に昇格して #2692 を閉じる

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -261,10 +261,12 @@ export default [
       // accumulated ~190 casts in production code (#2692). `never` is the
       // setting that matches the written rule.
       //
-      // Staged at `warn` while the backlog drains file by file; it graduates
-      // to `error` once production code is clean. Tests keep the permissive
-      // setting via the test override below.
-      "@typescript-eslint/consistent-type-assertions": ["warn", { assertionStyle: "never" }],
+      // `error` since the backlog drained: a new cast now fails CI, which is
+      // the whole point — the rule existed in prose for months and the count
+      // only ever went up. Tests keep the permissive setting via the test
+      // override below; the eight irreducible production casts are listed,
+      // one reason each, in the allowlist block at the end of this file.
+      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
       "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/prefer-enum-initializers": "error",
       "import/first": "error",
@@ -463,10 +465,10 @@ export default [
       // was therefore invisible to `consistent-type-assertions` — 18 of them
       // across host and plugin components (#2692). `vue/no-restricted-syntax`
       // is the one rule that does walk that AST, so the same ban is spelled
-      // here as a selector. `warn` matches the script-side severity; both
-      // graduate together.
+      // here as a selector. `error` matches the script-side severity; both
+      // graduated together once the template backlog reached zero.
       "vue/no-restricted-syntax": [
-        "warn",
+        "error",
         {
           selector: "TSAsExpression",
           message: "Do not use any type assertions — narrow in <script> and pass the result to the template.",
@@ -693,32 +695,43 @@ export default [
       "sonarjs/different-types-comparison": "off",
     },
   },
-  // Per-package ratchet for the `as`-cast ban (#2692). The rule is `warn`
-  // repo-wide while the backlog drains; these packages are already at ZERO,
-  // so a new cast in them is a regression rather than a known debt — and the
-  // only thing that stops the drained set from refilling behind the drain.
+  // The eight production casts the `as`-cast ban (#2692) could not remove.
+  // Each is here because the assertion is the LEAST bad option at that site,
+  // not because nobody got to it — the reasoning also sits at the call site.
   //
-  // Verified at zero when added; `packages/relay`'s last one went in the same
-  // PR. Extend this list as a directory reaches zero, and delete the block
-  // once the repo-wide setting itself graduates to `error`.
+  // Listed in config rather than as inline `eslint-disable` comments, per the
+  // issue: an allowlist is greppable, reviewable in one place, and cannot be
+  // added to without touching this file. **Its cost is granularity** — the
+  // rule is off for the whole FILE, so a NINTH cast added to one of these
+  // would not be flagged. Keep the entries pointed at small files, and drop
+  // an entry the moment its cast goes.
   {
     files: [
-      "packages/chat-service/**/*.ts",
-      "packages/client/**/*.ts",
-      "packages/common/**/*.ts",
-      "packages/create-mulmoclaude-plugin/**/*.ts",
-      "packages/mock-server/**/*.ts",
-      "packages/protocol/**/*.ts",
-      "packages/relay/**/*.ts",
-      "packages/scheduler/**/*.ts",
-      "packages/web-push/**/*.ts",
-      "packages/webhook-runtime/**/*.ts",
+      // Widens `Jsonify<T>` to the channel's `JsonObject` at the ONE place
+      // that reasoning is allowed to live; eight handlers used to re-argue it.
+      "packages/core/src/remote-host/index.ts",
+      // `doc.data() as Command`: narrowing it means narrowing the published
+      // `onExpire` signature MulmoTerminal also implements.
+      "packages/core/src/remote-host/server/hostRunner.ts",
+      // Persisted books are deliberately looser than their types (legacy
+      // `fiscalYearEnd: "Q1"`); a predicate would lock users out of them.
+      "packages/plugins/accounting-plugin/src/server/io.ts",
+      // `loadSchedulerItems` / `loadUserTasks` rewrite the file they read, so
+      // dropping unrecognised entries here would delete the user's data.
+      "server/utils/files/json.ts",
+      // `E` is the caller's generic — nothing inside can check it.
+      "src/plugins/api.ts",
+      // The single claimed step of the aggregator pipeline; the claim itself
+      // is checked against every live aggregator by test_meta_aggregation.ts.
+      "src/plugins/metas.ts",
+      // Proving `ToolDefinition.parameters` means shipping a JSON-Schema
+      // validator to the browser for a field nothing on this path reads.
+      "src/tools/runtimeLoader.ts",
+      // `T` belongs to the plugin; validating the payload is its job.
+      "src/utils/plugin/runtime.ts",
     ],
-    // Tests keep the permissive setting the test override below grants them;
-    // this block covers source only, so it must not reach `**/test/**`.
-    ignores: ["packages/*/test/**", "packages/*/**/*.test.ts"],
     rules: {
-      "@typescript-eslint/consistent-type-assertions": ["error", { assertionStyle: "never" }],
+      "@typescript-eslint/consistent-type-assertions": "off",
     },
   },
   // Build + release scripts. `yarn lint` never reached them, so 21 files that

--- a/plans/fix-2692-assertions-to-error.md
+++ b/plans/fix-2692-assertions-to-error.md
@@ -12,7 +12,7 @@
 | `consistent-type-assertions` が `error` | **未** — 主ブロックは `warn`、drain 済み 10 パッケージだけ `error` |
 | テストの扱いを決めて設定に書く | 済 — `test/**` 等は `assertionStyle: "as"` に緩和、理由付き |
 | 残る例外が設定ファイルに理由付きで | **未** — 理由は書かれているが**インラインコメント**であって設定側の allowlist ではない |
-| インライン `eslint-disable` が 0 件 | 済 — 0 件 |
+| インライン `eslint-disable` が 0 件 | 済 — **`consistent-type-assertions` / #2692 の例外に対して** 0 件。リポジトリ全体では他ルール向けのインライン disable が 200 件超あり（`no-explicit-any` 106、`detect-unsafe-regex` 18 など）、それらは #2692 の対象外 |
 
 残っている `as` は **8 箇所**（187 → 8、96% 削減）。すべて既に `Cast kept (#2692)` と理由が
 コメントされた「不可避」判定済みで、潰す対象は残っていない。

--- a/plans/fix-2692-assertions-to-error.md
+++ b/plans/fix-2692-assertions-to-error.md
@@ -1,0 +1,53 @@
+# fix(lint): `as` キャスト禁止を `error` に昇格して #2692 を閉じる
+
+## 背景
+
+#2692 は「CLAUDE.md が `as` を禁止しているのに ESLint が止めておらず、本体に 187 箇所ある」という issue。
+`consistent-type-assertions` を `assertionStyle: "never"` で入れ、**`warn` のまま**段階的に潰してきた。
+
+現状（実測）:
+
+| 完了条件 | 状態 |
+|---|---|
+| `consistent-type-assertions` が `error` | **未** — 主ブロックは `warn`、drain 済み 10 パッケージだけ `error` |
+| テストの扱いを決めて設定に書く | 済 — `test/**` 等は `assertionStyle: "as"` に緩和、理由付き |
+| 残る例外が設定ファイルに理由付きで | **未** — 理由は書かれているが**インラインコメント**であって設定側の allowlist ではない |
+| インライン `eslint-disable` が 0 件 | 済 — 0 件 |
+
+残っている `as` は **8 箇所**（187 → 8、96% 削減）。すべて既に `Cast kept (#2692)` と理由が
+コメントされた「不可避」判定済みで、潰す対象は残っていない。
+
+## やること
+
+1. 主ブロックを `warn` → **`error`**
+2. Vue テンプレート側（`vue/no-restricted-syntax` の `TSAsExpression` セレクタ）も `warn` → **`error`**
+3. **per-package の ratchet ブロックを削除** — 主ブロックが `error` になれば役目が終わるため
+   （ブロック自身のコメントにも「repo-wide が graduate したら消す」と書いてある）
+4. 残る 8 ファイルを **`eslint.config.mjs` の allowlist** に移し、1 エントリ 1 理由を書く
+
+## 8 箇所とその理由
+
+| ファイル | 理由 |
+|---|---|
+| `packages/core/src/remote-host/index.ts` | `Jsonify<T>` → `JsonObject` の唯一の広げ場所（8 ハンドラが各自で再論していたのを集約済み） |
+| `packages/core/src/remote-host/server/hostRunner.ts` | `doc.data() as Command`。外すには公開済み `onExpire` の型を狭める＝破壊的変更 |
+| `packages/plugins/accounting-plugin/src/server/io.ts` | 永続化された book は型より緩い（legacy `fiscalYearEnd: "Q1"`）。述語にすると既存 book が開けなくなる |
+| `server/utils/files/json.ts` | 読んだファイルを同じ経路が書き戻すので、未知エントリを落とすとユーザーのデータが消える |
+| `src/plugins/api.ts` | `E` は呼び出し側のジェネリック |
+| `src/plugins/metas.ts` | アグリゲータで唯一「主張」する箇所。主張自体は `test_meta_aggregation.ts` が全 aggregator に対して検証 |
+| `src/tools/runtimeLoader.ts` | `ToolDefinition.parameters` を証明するにはブラウザに JSON-Schema validator を積む必要がある |
+| `src/utils/plugin/runtime.ts` | `T` はプラグインのもの。ペイロード検証はプラグインの責務 |
+
+### allowlist の代償を明記する
+
+ファイル単位で `off` にするので、**そのファイルに 9 個目の `as` が足されても検出されない**。
+issue が「インライン `eslint-disable` を使わずに設定へ」と指定しているのでこの形にするが、
+粒度が落ちることは設定コメントに書き、エントリは小さいファイルに限る。
+
+## 検証
+
+- `yarn lint` が **0 errors**
+- **ゲートが実際に落ちることを壊して確認する**（設定を変えただけで「効いている」と主張しない）:
+  - 通常のソースに `v as string` を足す → `error` が出ることを確認して戻す
+  - Vue テンプレートに `($event.target as HTMLInputElement)` を足す → `error` が出ることを確認して戻す
+- `yarn format` / `typecheck` / `build` / `test`


### PR DESCRIPTION
## Summary

#2692 の最後の一歩です。issue の主張は「**規約に書いただけで機械が止めていないので、書くたびに増える**」でした。187 箇所を潰しきったので、**止める側**を入れて閉じます。

現状を実測したところ、完了条件 4 つのうち 2 つが未達でした:

| 完了条件 | before | after |
|---|---|---|
| `consistent-type-assertions` が `error` | ❌ `warn`（drain 済み 10 パッケージのみ `error`） | ✅ **`error`** |
| テストの扱いを決めて設定に書かれている | ✅ 済 | ✅ 済 |
| 残る例外が設定ファイルに理由付きで | ❌ 理由は**インラインコメント**にしか無い | ✅ **allowlist に 1 エントリ 1 理由** |
| インライン `eslint-disable` が 0 件 | ✅ 0 件<sup>※</sup> | ✅ 0 件<sup>※</sup> |

<sup>※</sup> **`consistent-type-assertions` / #2692 の例外に対して** 0 件です。リポジトリ全体では他ルール向けのインライン disable が 200 件超あり（`no-explicit-any` 106、`detect-unsafe-regex` 18 など）、それらは #2692 の対象外です（CodeRabbit 指摘で限定しました）。

残っていた `as` は **8 箇所（187 → 8、96% 削減）**。すべて既に `Cast kept (#2692)` と理由が書かれた「不可避」判定済みで、潰す対象は残っていませんでした。

## Items to Confirm / Review

1. **allowlist はファイル単位で `off` にします。** issue が「インライン `eslint-disable` を使わずに `eslint.config.mjs` の allowlist へ（1エントリ1理由）」と指定しているのでこの形にしましたが、**代償として、そのファイルに 9 個目の `as` が足されても検出されません**。設定コメントにその限界を明記し、エントリは小さいファイルに限っています。ESLint には inline comment 以外の行単位設定が無いので、この粒度が issue の指定と両立する上限です。
2. **per-package の ratchet ブロックを削除しました。** 主ブロックが `error` になれば役目が終わるためで、ブロック自身のコメントにも「repo-wide が graduate したら消す」と書いてありました。
3. **Vue テンプレート側も同時に `error` に上げました。** `consistent-type-assertions` はテンプレート AST を歩かないので、`vue/no-restricted-syntax` のセレクタが対になっています。「both graduate together」と設定コメントが約束していたとおりです。

## allowlist の 8 エントリ

| ファイル | 理由 |
|---|---|
| `packages/core/src/remote-host/index.ts` | `Jsonify<T>` → `JsonObject` を広げる唯一の場所（8 ハンドラが各自で再論していたのを集約済み） |
| `packages/core/src/remote-host/server/hostRunner.ts` | `doc.data() as Command`。外すには公開済み `onExpire` の型を狭める＝MulmoTerminal も実装する契約の破壊的変更 |
| `packages/plugins/accounting-plugin/src/server/io.ts` | 永続化された book は型より緩い（legacy `fiscalYearEnd: "Q1"`）。述語にすると既存 book が開けなくなる |
| `server/utils/files/json.ts` | 読んだファイルを同じ経路が書き戻すので、未知エントリを落とすとユーザーのデータが消える |
| `src/plugins/api.ts` | `E` は呼び出し側のジェネリック |
| `src/plugins/metas.ts` | アグリゲータで唯一「主張」する箇所。主張自体は `test_meta_aggregation.ts` が全 aggregator に対して検証している |
| `src/tools/runtimeLoader.ts` | `ToolDefinition.parameters` を証明するにはブラウザに JSON-Schema validator を積む必要がある |
| `src/utils/plugin/runtime.ts` | `T` はプラグインのもの。ペイロード検証はプラグインの責務 |

## 検証 — **ゲートが実際に落ちることを壊して確認しました**

設定を変えて lint が緑なだけでは「効いている」証拠になりません。両方の経路を実際に壊しました。

**通常のソース**（`server/utils/time.ts` に一時的に追加）:
```
58:48  error  Do not use any type assertions  @typescript-eslint/consistent-type-assertions
✖ 2 problems (2 errors, 0 warnings)
```

**Vue テンプレート**（`src/components/ChatInput.vue` に一時的に追加）:
```
2:26  error  Do not use any type assertions — narrow in <script> and pass the result to the template  vue/no-restricted-syntax
```

どちらも確認後に戻してあり、この PR には含まれていません。

適用順（flat config は last-match-wins）も確認済みです: allowlist が最後のマッチで、テスト override（`test/**` / `e2e/**` / `e2e-live/**` / `packages/**/test/**`）とは 1 ファイルも重なりません。

### ゲート

`yarn format` / `yarn lint`（**0 errors**）/ `yarn typecheck`（exit 0）/ `yarn build`（exit 0、hook バンドル差分なし）/ `yarn test` **11121 passed / 0 failed**。

## User Prompt

> 2692っておわっている？
>
> （残 8 箇所と error 昇格が残っている旨を報告し、「やりますか？」に対して）はい

Closes #2692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude2

## Summary by Sourcery

Elevate the TypeScript `as`-cast ban from a gradual warning-based rollout to a strict error gate and formally close out the remaining work tracked in #2692.

Enhancements:
- Change `@typescript-eslint/consistent-type-assertions` and the paired Vue `vue/no-restricted-syntax` selector from `warn` to `error` for production code, keeping tests permissive.
- Replace the previous per-package ratchet with a centralized allowlist of eight irreducible production casts, each documented with its rationale in lint config.
- Add an engineering plan document capturing the background, remaining exceptions, and verification steps for promoting the assertion rule to error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Strengthened linting rules to treat TypeScript and Vue template type assertions as errors, helping prevent unsafe type usage from reaching production.
  - Documented and limited existing exceptions to a small, explicitly reviewed allowlist.
- **Documentation**
  - Added a plan describing validation steps, exception handling, and the approach for eliminating remaining assertion violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
