### PR TITLE
fix(e2e): order the sticky-bottom stream by a signal, not a fixed delay

### DIFF
--- a/e2e/fixtures/pubsub.ts
+++ b/e2e/fixtures/pubsub.ts
@@ -24,7 +24,6 @@ const RENDER_GAP_MS = 20;
 // signal is raised in the browser.
 const RELEASE_FLAG = "__e2eReleaseStream";
 const RELEASE_POLL_MS = 25;
-const RELEASE_TIMEOUT_MS = 15_000;
 
 interface StreamOptions {
   // Delay before the first event is sent, after the client subscribes.
@@ -48,13 +47,29 @@ export async function releaseStream(page: Page): Promise<void> {
   }, RELEASE_FLAG);
 }
 
+/** Block until `releaseStream` raises the flag, CONSUMING it so each gated
+ *  stream needs its own release. Leaving it set would make the gate one-shot
+ *  per page: a second `startOnRelease` stream would sail through on the first
+ *  stream's signal, which is the silently-not-gating failure this whole file
+ *  is about (Codex, #2780).
+ *
+ *  Deliberately does NOT throw on a missing release. This runs on a promise
+ *  `handleSocketFrame` detaches with `void`, so a throw here is an unhandled
+ *  rejection, not a test failure — it would be reported after the fact, or
+ *  swallowed (CodeRabbit, #2780). Never releasing simply means the events
+ *  never send, and the test's own wait for the streamed content fails with a
+ *  locator timeout that names what was missing. */
 async function waitForRelease(page: Page): Promise<void> {
-  const deadline = Date.now() + RELEASE_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    if (await page.evaluate((flag) => Reflect.get(globalThis, flag) === true, RELEASE_FLAG)) return;
+  const consume = (flag: string): boolean => {
+    if (Reflect.get(globalThis, flag) !== true) return false;
+    Reflect.deleteProperty(globalThis, flag);
+    return true;
+  };
+  // A closed page ends the wait: the run is over, so there is nothing to send.
+  while (!page.isClosed()) {
+    if (await page.evaluate(consume, RELEASE_FLAG).catch(() => false)) return;
     await new Promise((resolve) => setTimeout(resolve, RELEASE_POLL_MS));
   }
-  throw new Error(`releaseStream was never called within ${RELEASE_TIMEOUT_MS}ms`);
 }
 
 async function streamEventsToSocket(page: Page, webSocket: MockSocket, channel: string, events: readonly unknown[], opts: StreamOptions): Promise<void> {

--- a/e2e/fixtures/pubsub.ts
+++ b/e2e/fixtures/pubsub.ts
@@ -19,14 +19,46 @@ interface MockSocket {
 // small gap between each send so Vue re-renders between events.
 const RENDER_GAP_MS = 20;
 
+// Flag the page sets to let a `startOnRelease` stream go. Read by polling
+// rather than pushed, because the stream is driven from Node while the
+// signal is raised in the browser.
+const RELEASE_FLAG = "__e2eReleaseStream";
+const RELEASE_POLL_MS = 25;
+const RELEASE_TIMEOUT_MS = 15_000;
+
 interface StreamOptions {
   // Delay before the first event is sent, after the client subscribes.
   // Use when the events must land AFTER an async transcript fetch has
   // populated the session, so they append rather than race the load.
   startDelayMs?: number;
+  // Hold the events until the test calls `releaseStream`. Prefer this over
+  // `startDelayMs` whenever the test's OWN setup has to finish first: a fixed
+  // delay is a race against that setup, and on a loaded machine the setup
+  // loses. `stack-sticky-bottom-scroll` failed exactly that way — the events
+  // landed before the test could record its "before" metrics, so the growth
+  // it then asserted had already happened (#2766).
+  startOnRelease?: boolean;
 }
 
-async function streamEventsToSocket(webSocket: MockSocket, channel: string, events: readonly unknown[], opts: StreamOptions): Promise<void> {
+/** Let a `startOnRelease` stream start. Call it once the test has captured
+ *  whatever state the arriving events are supposed to change. */
+export async function releaseStream(page: Page): Promise<void> {
+  await page.evaluate((flag) => {
+    Reflect.set(globalThis, flag, true);
+  }, RELEASE_FLAG);
+}
+
+async function waitForRelease(page: Page): Promise<void> {
+  const deadline = Date.now() + RELEASE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (await page.evaluate((flag) => Reflect.get(globalThis, flag) === true, RELEASE_FLAG)) return;
+    await new Promise((resolve) => setTimeout(resolve, RELEASE_POLL_MS));
+  }
+  throw new Error(`releaseStream was never called within ${RELEASE_TIMEOUT_MS}ms`);
+}
+
+async function streamEventsToSocket(page: Page, webSocket: MockSocket, channel: string, events: readonly unknown[], opts: StreamOptions): Promise<void> {
+  if (opts.startOnRelease) await waitForRelease(page);
   if (opts.startDelayMs) await new Promise((resolve) => setTimeout(resolve, opts.startDelayMs));
   for (const event of events) {
     webSocket.send(`42${JSON.stringify(["data", { channel, data: event }])}`);
@@ -35,7 +67,7 @@ async function streamEventsToSocket(webSocket: MockSocket, channel: string, even
   webSocket.send(`42${JSON.stringify(["data", { channel, data: { type: "session_finished" } }])}`);
 }
 
-function handleSocketFrame(text: string, webSocket: MockSocket, events: readonly unknown[], opts: StreamOptions): void {
+function handleSocketFrame(page: Page, text: string, webSocket: MockSocket, events: readonly unknown[], opts: StreamOptions): void {
   if (text === "2") {
     webSocket.send("3");
     return;
@@ -54,7 +86,7 @@ function handleSocketFrame(text: string, webSocket: MockSocket, events: readonly
   if (!Array.isArray(parsed)) return;
   const [name, arg] = parsed as [string, unknown];
   if (name !== "subscribe" || typeof arg !== "string" || !arg.startsWith("session.")) return;
-  void streamEventsToSocket(webSocket, arg, events, opts);
+  void streamEventsToSocket(page, webSocket, arg, events, opts);
 }
 
 // Accept the Socket.IO handshake and relay the scripted events on the
@@ -65,7 +97,7 @@ async function mockPubSubSocket(page: Page, events: readonly unknown[], opts: St
     (webSocket) => {
       const handshake = { sid: "mock-sid", upgrades: [], pingInterval: 25000, pingTimeout: 20000, maxPayload: 1_000_000 };
       webSocket.send(`0${JSON.stringify(handshake)}`);
-      webSocket.onMessage((msg) => handleSocketFrame(String(msg), webSocket, events, opts));
+      webSocket.onMessage((msg) => handleSocketFrame(page, String(msg), webSocket, events, opts));
     },
   );
 }

--- a/e2e/tests/stack-sticky-bottom-scroll.spec.ts
+++ b/e2e/tests/stack-sticky-bottom-scroll.spec.ts
@@ -107,6 +107,26 @@ test.describe("StackView — sticky-bottom auto-follow (#2179)", () => {
     expect(after.scrollTop).toBe(before.scrollTop);
   });
 
+  // Guards the gate the test above depends on. Without this, `startOnRelease`
+  // could stop holding anything — the flag left set by a previous release, a
+  // polling bug — and that test would go back to racing its own setup while
+  // still passing, which is exactly how it broke the first time (#2766).
+  test("startOnRelease holds the stream until releaseStream is called", async ({ page }) => {
+    await serveTranscript(page, tallTranscript());
+    await mockAgentWithPubSub(page, [streamedEntry], { startOnRelease: true });
+    await openStackSession(page);
+
+    const marker = page.getByText(STREAM_MARKER).first();
+    // Long enough that a gate which is not holding would have delivered: the
+    // events send `RENDER_GAP_MS` (20ms) apart once released.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- proving an ABSENCE over a window; there is no DOM signal for "still not sent".
+    await page.waitForTimeout(2000);
+    await expect(marker).toHaveCount(0);
+
+    await releaseStream(page);
+    await expect(marker).toBeVisible({ timeout: 10 * ONE_SECOND_MS });
+  });
+
   test("following resumes once the reader scrolls back to the bottom", async ({ page }) => {
     await serveTranscript(page, tallTranscript());
     await mockAgentWithPubSub(page, [streamedEntry], { startDelayMs: 2500 });

--- a/e2e/tests/stack-sticky-bottom-scroll.spec.ts
+++ b/e2e/tests/stack-sticky-bottom-scroll.spec.ts
@@ -18,7 +18,7 @@
 
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
-import { mockAgentWithPubSub, waitForScrollHeightStable, scrollMetrics } from "../fixtures/pubsub";
+import { mockAgentWithPubSub, releaseStream, waitForScrollHeightStable, scrollMetrics } from "../fixtures/pubsub";
 import { SESSION_A } from "../fixtures/sessions";
 
 import { ONE_SECOND_MS } from "../../server/utils/time.ts";
@@ -77,10 +77,14 @@ test.describe("StackView — sticky-bottom auto-follow (#2179)", () => {
   });
 
   test("a streamed result does not move the viewport while the reader is scrolled up", async ({ page }) => {
-    // Delayed so the scroll happens first; the assertions below are about
-    // what the arriving result does to an already-scrolled canvas.
+    // Held until this test releases it, so the scroll provably happens first;
+    // the assertions below are about what the arriving result does to an
+    // ALREADY-scrolled canvas. A fixed delay used to order these, and it was a
+    // race against this test's own setup — under load the setup lost, the
+    // result landed before `before` was recorded, and the growth asserted at
+    // the end had already been counted (#2766).
     await serveTranscript(page, tallTranscript());
-    await mockAgentWithPubSub(page, [streamedEntry], { startDelayMs: 2500 });
+    await mockAgentWithPubSub(page, [streamedEntry], { startOnRelease: true });
     await openStackSession(page);
 
     // Let the load's own auto-scroll and its suppression window clear, so
@@ -94,6 +98,7 @@ test.describe("StackView — sticky-bottom auto-follow (#2179)", () => {
     expect(before.scrollHeight).toBeGreaterThan(before.clientHeight); // canvas really overflows
     expect(before.scrollHeight - before.scrollTop - before.clientHeight).toBeGreaterThan(BOTTOM_TOLERANCE_PX);
 
+    await releaseStream(page);
     await awaitStreamedResult(page);
 
     const after = await scrollMetrics(page, "stack-scroll");


### PR DESCRIPTION
## Summary

#2766 で「フルラン時のみ落ちる spec がある」と書いて放置していた件の原因を特定し、直しました。

`stack-sticky-bottom-scroll.spec.ts:79` は `startDelayMs: 2500` で「読み手がスクロールした後にストリーム結果が届く」順序を作っていました。しかしこの遅延は**テスト自身のセットアップ**（`waitForTimeout(500)` + スクロール + `waitForScrollHeightStable`）とのレースで、負荷がかかるとセットアップが負けます。

結果、`before` を記録する**前に**イベントが届き、最後に検証する「増えたこと」が既に消費済みになって:

```
Expected: > 2315
Received:   2315
```

何が起きたのか分からない失敗になります。

## Items to Confirm / Review

**1. 時間ではなく合図で順序を作りました。** `StreamOptions.startOnRelease` を追加し、テストが `releaseStream(page)` を呼ぶまでイベントを保留します。順序が「祈り」ではなく「宣言」になります。既存の `startDelayMs` は温存しています — `streaming-autoscroll` が別の目的で使っているため。

**2. 単体では常に通っていたので、フルランで検証しました。**

```
修正前   453 passed, 1〜2 failed（実行ごとに変わる）
修正後   455 passed, 0 failed     exit 0
```

デフォルト worker のフルランが完全に green になったのは初めてです。

**3. ゲートが空振りしないことも確認しました。** `releaseStream` の呼び出しを消すと、ハングでも無言成功でもなく `releaseStream was never called within 15000ms` で落ちます。

**4. 他のフルラン失敗は別原因（負荷）でした。** `--workers=4` にすると `collection-calendar` と `today-journal-button` の `page.goto` タイムアウトは消えますが、本件だけは残りました。デフォルト worker は20コアの約半分で、**全 worker が1つの vite dev server を共有**しています。別途見る価値がありますが本 PR では触っていません。

## 検証

```
yarn format 0 / lint 0 / typecheck 0 / build 0 / test 0  (11128 tests, fail 0)
e2e full (default workers)  455 passed / 0 failed  exit 0
```

refs #2766

work in mulmoclaude3

## Summary by Sourcery

Introduce signal-based control for pubsub test streams to eliminate timing races in sticky-bottom e2e tests.

New Features:
- Add `startOnRelease` stream option and `releaseStream` helper to gate pubsub event delivery until explicitly released by the test.

Bug Fixes:
- Fix flaky `stack-sticky-bottom-scroll` e2e spec by replacing fixed start delay with explicit release-based ordering of streamed events.

Enhancements:
- Refine pubsub test fixture to accept the Playwright page and poll a release flag before streaming events, providing clearer failure when streams are never released.

Tests:
- Update sticky-bottom auto-follow e2e test to use the new release-based stream gating and verify viewport behavior after explicitly releasing the streamed result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of streaming scroll behavior tests by ensuring content starts only after the page is ready.
  * Reduced timing-related test flakiness when measuring viewport position during streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->