### PR TITLE
fix: give the session-store tests a real JSONL sink, not "/dev/null" (#2779)

### DIFF
--- a/plans/fix-2779-windows-dev-null-test-path.md
+++ b/plans/fix-2779-windows-dev-null-test-path.md
@@ -1,0 +1,59 @@
+# fix #2779 — Windows CI: tests must not use `/dev/null` as a JSONL sink
+
+## Problem
+
+`lint_test (Windows)` is red on `main` (`4c5ab67`, run 30779639961), Node 22.x and 24.x, at
+`yarn run test:coverage`. Linux and macOS are green. 15 tests fail with:
+
+```
+Error: ENOENT: no such file or directory, open 'D:\dev\null'
+  errno: -4058, code: 'ENOENT', syscall: 'open', path: 'D:\\dev\\null'
+```
+
+## Root cause
+
+Two test files pass the POSIX null device as a session's results file:
+
+- `test/events/test_session_store.ts:290` — `sessionOpts({ resultsFilePath: "/dev/null" })`
+- `test/routes/test_sessionToolContext.ts:12` — `resultsFilePath: "/dev/null"`
+
+`pushToolResult` **awaits** `enqueueJsonlAppend` (the write is queued so a `tool_result` can't
+reach disk before its `tool_call`), so a rejected `fs.appendFile` fails the test rather than being
+swallowed the way `applyEventToSession`'s fire-and-forget append is.
+
+On Windows a leading-slash path is resolved against the current drive: `/dev/null` becomes
+`D:\dev\null`, and `D:\dev` does not exist, so the open fails. Reproduced the identical error
+locally by appending to a path whose parent is missing.
+
+Both files came from the #2754 / #2758 work and are the first tests in them that write.
+
+`test/events/test_session_store.ts:24` has the same latent trap in its shared `sessionOpts`
+default, `"/tmp/fake.jsonl"` → `D:\tmp\fake.jsonl`. It passes today only because its callers either
+never write or write through the error-swallowing path — a new test that awaits a write would turn
+it red.
+
+## Fix
+
+Follow the convention the rest of the suite already uses for tests that write a JSONL
+(`test/tool-trace/test_index.ts`, `test/events/test_persistToolCalls.ts`,
+`test/routes/test_wikiInternalSnapshotRoute.ts`): a real file under `mkdtemp(join(tmpdir(), …))`,
+removed in `after`.
+
+1. `test/events/test_session_store.ts`
+   - `before`/`after` hooks create and remove one temp dir for the file.
+   - `sessionOpts` defaults `resultsFilePath` to `<tmpdir>/results.jsonl`, replacing
+     `"/tmp/fake.jsonl"`.
+   - The `latestToolResult` block's `opts()` override disappears — `sessionOpts()` is now correct
+     for it, so the call sites use `sessionOpts()` directly.
+2. `test/routes/test_sessionToolContext.ts` — same temp-dir hooks; `session()` uses that path.
+
+No production change. `sessionJsonlAbsPath` already builds real paths with `node:path`, and the
+awaited write in `pushToolResult` is deliberate.
+
+## Verification
+
+- `yarn test` — the two affected files, then the whole suite.
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`.
+- `grep` for remaining `/dev/null` and `/tmp/` literals in `test/` used as a filesystem path.
+- Ground truth is the Windows job on the PR: macOS cannot prove the drive-relative resolution is
+  gone. Watch `lint_test (Windows)` on both Node versions before merging.

--- a/test/events/test_session_store.ts
+++ b/test/events/test_session_store.ts
@@ -1,5 +1,8 @@
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, before, beforeEach, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   __resetForTests,
   getSession,
@@ -18,10 +21,16 @@ import { EVENT_TYPES, GENERATION_KINDS, generationKey } from "../../src/types/ev
 
 const NOW = "2026-04-17T00:00:00.000Z";
 
+// A real file, not "/dev/null": `pushToolResult` awaits its append, and on
+// Windows a leading-slash path resolves against the current drive, so the
+// null device becomes `D:\dev\null` and the open fails (#2779).
+let resultsFilePath = "";
+let tmpRoot = "";
+
 function sessionOpts(overrides: Partial<Parameters<typeof getOrCreateSession>[1]> = {}) {
   return {
     roleId: "general",
-    resultsFilePath: "/tmp/fake.jsonl",
+    resultsFilePath,
     startedAt: NOW,
     updatedAt: NOW,
     ...overrides,
@@ -38,6 +47,15 @@ function stubPubSub() {
     },
   };
 }
+
+before(async () => {
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "session-store-"));
+  resultsFilePath = path.join(tmpRoot, "results.jsonl");
+});
+
+after(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
 
 beforeEach(() => {
   __resetForTests();
@@ -287,10 +305,8 @@ describe("pushSessionEvent — malformed payload fields", () => {
 // `pushToolResult` is the single writer of tool results, so the per-tool cache
 // hangs off it.
 describe("latestToolResult (#2754 the next call has to see the previous result)", () => {
-  const opts = () => sessionOpts({ resultsFilePath: "/dev/null" });
-
   it("remembers a result under its toolName", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: "made a map", data: { nodes: ["root"] } });
     const found = latestToolResult("s1", "createMindMap");
     assert.deepEqual(found?.data, { nodes: ["root"] });
@@ -298,14 +314,14 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   });
 
   it("replaces the previous result for the same tool", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: "v1", data: { v: 1 } });
     await pushToolResult("s1", { toolName: "createMindMap", message: "v2", data: { v: 2 } });
     assert.deepEqual(latestToolResult("s1", "createMindMap")?.data, { v: 2 });
   });
 
   it("keeps tools apart", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: "m", data: { a: 1 } });
     await pushToolResult("s1", { toolName: "putQuestions", message: "q", data: { b: 2 } });
     assert.deepEqual(latestToolResult("s1", "createMindMap")?.data, { a: 1 });
@@ -313,8 +329,8 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   });
 
   it("keeps sessions apart", async () => {
-    getOrCreateSession("s1", opts());
-    getOrCreateSession("s2", opts());
+    getOrCreateSession("s1", sessionOpts());
+    getOrCreateSession("s2", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: "m", data: { which: "s1" } });
     assert.deepEqual(latestToolResult("s1", "createMindMap")?.data, { which: "s1" });
     assert.equal(latestToolResult("s2", "createMindMap"), null);
@@ -324,7 +340,7 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   // cannot be looked up. Filing it under `undefined` would hand the wrong map
   // to the next edit.
   it("ignores a result whose toolName is missing or not a string", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     assert.equal((await pushToolResult("s1", { message: "m", data: { x: 1 } })).kind, "processed");
     assert.equal((await pushToolResult("s1", { toolName: 42, message: "m", data: { x: 2 } })).kind, "processed");
     assert.equal(latestToolResult("s1", "createMindMap"), null);
@@ -337,7 +353,7 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   // against a `Record`-backed cache. (Observed during Claude review; no bot
   // flagged it.)
   it("does not resolve a prototype key to something that is not a result", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: "m", data: {} });
     assert.equal(latestToolResult("s1", "constructor"), null);
     assert.equal(latestToolResult("s1", "toString"), null);
@@ -345,7 +361,7 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   });
 
   it("stores a prototype-named tool as an ordinary entry", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "__proto__", message: "m", data: { stored: true } });
     assert.deepEqual(latestToolResult("s1", "__proto__")?.data, { stored: true });
     // and it must not have leaked onto every other object
@@ -353,7 +369,7 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   });
 
   it("answers null for an unknown session or an untouched tool", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: "m", data: {} });
     assert.equal(latestToolResult("nope", "createMindMap"), null);
     assert.equal(latestToolResult("s1", "putQuestions"), null);
@@ -363,7 +379,7 @@ describe("latestToolResult (#2754 the next call has to see the previous result)"
   // there. Rebuilding rather than casting is what keeps a wrong-typed field
   // from being read back as if the interface guaranteed it.
   it("drops fields whose type does not match the interface, and still keeps data", async () => {
-    getOrCreateSession("s1", opts());
+    getOrCreateSession("s1", sessionOpts());
     await pushToolResult("s1", { toolName: "createMindMap", message: 42, title: {}, updating: "yes", data: { kept: true } });
     const found = latestToolResult("s1", "createMindMap");
     assert.equal(found?.message, "", "a non-string message becomes empty, not 42");

--- a/test/routes/test_sessionToolContext.ts
+++ b/test/routes/test_sessionToolContext.ts
@@ -1,19 +1,37 @@
 // `/api/mindmap` used to hand every call an empty context, so `add_node` had no
 // map to add to: in MulmoClaude a plugin's `execute()` never runs in the client,
 // and the create's result lived only in the session (#2754).
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, before, beforeEach, after, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { Request } from "express";
 import { sessionToolContext } from "../../server/api/routes/plugins.ts";
 import { __resetForTests, getOrCreateSession, initSessionStore, pushToolResult } from "../../server/events/session-store/index.ts";
 import { TOOL_NAMES } from "../../src/config/toolNames.ts";
 
 const NOW = "2026-08-03T00:00:00.000Z";
-const session = (sessionId: string) => getOrCreateSession(sessionId, { roleId: "general", resultsFilePath: "/dev/null", startedAt: NOW, updatedAt: NOW });
+
+// A real file, not "/dev/null": `pushToolResult` awaits its append, and on
+// Windows a leading-slash path resolves against the current drive, so the
+// null device becomes `D:\dev\null` and the open fails (#2779).
+let resultsFilePath = "";
+let tmpRoot = "";
+
+const session = (sessionId: string) => getOrCreateSession(sessionId, { roleId: "general", resultsFilePath, startedAt: NOW, updatedAt: NOW });
 
 // The MCP bridge appends `?session=<id>` to every request, which is how the id
 // reaches a plugin route at all.
 const reqWith = (query: Record<string, unknown>) => ({ query }) as unknown as Request<object, unknown, unknown>;
+
+before(async () => {
+  tmpRoot = await mkdtemp(path.join(tmpdir(), "session-tool-context-"));
+  resultsFilePath = path.join(tmpRoot, "results.jsonl");
+});
+after(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
 
 beforeEach(() => {
   __resetForTests();


### PR DESCRIPTION
## Summary

`lint_test (Windows)` is red on `main` (`4c5ab67`, [run 30779639961](https://github.com/receptron/mulmoclaude/actions/runs/30779639961)), Node 22.x and 24.x, at `yarn run test:coverage`. Linux and macOS are green. 15 tests fail with:

```
Error: ENOENT: no such file or directory, open 'D:\dev\null'
  errno: -4058, code: 'ENOENT', syscall: 'open', path: 'D:\\dev\\null'
```

Two test files passed the POSIX null device as a session's results file. On Windows a leading-slash path is drive-relative, so `/dev/null` resolves to `D:\dev\null`, whose parent does not exist. They now use a real temp file, matching the convention the rest of the suite already follows.

Test-only change; no production code touched.

## Items to Confirm / Review

- **The Windows job is the only real proof.** macOS cannot exercise the drive-relative resolution, so please check `lint_test (Windows)` on both 22.x and 24.x before merging. What I could verify locally is the mechanism itself: `path.win32.resolve("D:\\work", "/dev/null")` returns exactly the `D:\dev\null` from the CI error.
- **`sessionOpts`'s default changed too, not just the failing block.** `test/events/test_session_store.ts` defaulted `resultsFilePath` to `"/tmp/fake.jsonl"` → `D:\tmp\fake.jsonl`, the identical trap. It passes on Windows today only because its callers either never write or write through the error-swallowing path. I moved the default onto the temp file rather than fixing just the one block, so a future test that awaits a write cannot re-break Windows. That is slightly wider than the failure, and is the one judgement call here.
- **Other POSIX-only literals in `test/` were left alone on purpose.** `test/agent/test_agent_lifecycle_resilience.ts` (`/tmp/fake.jsonl`), `test/workspace/collections/test_io.ts` (`/dev/null/.claude/skills`) and a handful in `test/plugins/`, `test/logger/`, `test/workspace/` are either pure path-string computation or deliberately-nonexistent roots, and are green on Windows. Changing passing tests seemed like more risk than value — say the word if you would rather sweep them all.

## Root cause

`pushToolResult` **awaits** `enqueueJsonlAppend`:

```ts
await enqueueJsonlAppend(session, `${JSON.stringify({ source: "tool", type: EVENT_TYPES.toolResult, result })}\n`);
```

The append is chained onto the session's write queue so a `tool_result` cannot reach disk ahead of its `tool_call`. Because it is awaited, a rejected `fs.appendFile` propagates and fails the test — unlike the other call site (`server/events/session-store/index.ts:453`), which is fire-and-forget with a `.catch()`. That is exactly why these two files, and only these two, went red: they are the only tests that call `pushToolResult`.

Both files came from the #2754 / #2758 work (`7f33f2972`, `4d77a19f4`) and are the first tests in them that write anything.

## Changes

- `test/events/test_session_store.ts` — `before`/`after` create and remove one temp dir; `sessionOpts` defaults `resultsFilePath` to `<tmp>/results.jsonl`; the `latestToolResult` block's `opts()` override is gone (`sessionOpts()` is now correct for it).
- `test/routes/test_sessionToolContext.ts` — same hooks; `session()` uses that path.
- `plans/fix-2779-windows-dev-null-test-path.md` — the plan.

## Verification

- `npx tsx --test ./test/events/test_session_store.ts ./test/routes/test_sessionToolContext.ts` — 39/39 pass (all 15 previously-failing tests among them).
- Full root suite: **9049 pass, 0 fail, 7 skipped**.
- `yarn typecheck:test`, `eslint` and `prettier` clean on both files.
- Mechanism reproduced locally: appending to a path whose parent is missing yields the same `ENOENT`/`open`, and `path.win32.resolve` reproduces the exact `D:\dev\null` from the log.

## User Prompt

> fix https://github.com/receptron/mulmoclaude/actions/runs/30779639961/job/91581626612#step:15:13155

refs #2779

work in mulmoterminal6

## Summary by Sourcery

Update session-store related tests to use real temporary JSONL files instead of POSIX null-device paths so they run reliably on Windows.

Bug Fixes:
- Fix Windows test failures by replacing uses of '/dev/null' and other POSIX-only paths as session JSONL sinks with real temporary files in session-store tests.

Documentation:
- Add a plan document describing the Windows CI failure caused by using '/dev/null' in tests and the chosen fix.

Tests:
- Adjust session-store and session tool context tests to create and clean up temporary directories/files for JSONL output instead of writing to '/dev/null', and rely on shared helpers that default to these real paths.