### PR TITLE
chore(release): bump @mulmoclaude/core to 2.0.1 for the shipped assets change

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.0.0",
     "@mulmoclaude/collection-plugin": "^2.0.0",
     "@mulmoclaude/common": "^1.1.1",
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.0.0",
     "@mulmoclaude/html-plugin": "^2.0.0",


### PR DESCRIPTION
## Summary

`packages/core` は **2.0.0**（npm の最新と同一）を名乗りながら、公開済み 2.0.0 に**無い32行**を抱えていました。

```
git diff '@mulmoclaude/core@2.0.0' origin/main -- packages/core/
 packages/core/assets/helps/error-recovery.md | 32 ++++++++++++++++++++++
```

core は `files: ["dist", "assets"]` でこのディレクトリを同梱するため、**この内容は npm 利用者に一切届きません**。しかも version が npm の最新と一致しているので、後から見た人には「公開済み」に読めます。

## Items to Confirm / Review

**1. 経緯。** #2782 はこのファイルの変更に対する `1.14.1 → 1.14.2` の patch bump を含んでいました。その後 main が gui-chat-protocol 移行（#2783）でワークスペースを 2.0.0 に再採番し、`package.json` で両者が衝突。**main の 2.0.0 をそのまま採る形で解決されたため、bump だけが落ちて asset の変更が残りました**。`@mulmoclaude/core@2.0.0` はその28分前に publish 済みだったので、#2782 がマージされた瞬間にタグとソースが乖離しました。

私自身のマージを再確認したレビューエージェントが発見したもので、私は見落としていました。

**2. 監査結果が「嘘」から「正直」に変わります。**

```
修正前  2.0.0  2.0.0  code drift                          ← 公開済みと同じ版を名乗りつつ中身が違う
修正後  2.0.1  2.0.0  code drift <== version ahead of npm  ← publish が必要、と明示
```

**3. 動かしたのは core の `version` と launcher の DEP レンジだけ**です（`chore(release)` の規約どおり）。launcher 自身の `version` は 1.9.0 のまま。他の consumer は `^2.0.0` のままで、caret が 2.0.1 に自動追従します。

**4. publish はまだ必要です。** この PR はツリーが嘘をつくのを止めるだけで、実際の公開は行っていません。

## 検証

```
check:launcher-sync 0 / build:packages 0 / format --check 0 / lint 0 / typecheck 0 / build 0
yarn test  11148 tests / fail 0
```

work in mulmoclaude3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core package to version 2.0.1.
  * Updated the related package to use the latest compatible core version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->