### PR TITLE
fix(e2e): cap local workers so they stop queueing on the one dev server

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,10 +1,27 @@
 import { defineConfig } from "@playwright/test";
 import { ONE_SECOND_MS } from "../server/utils/time.ts";
 
+// Every worker drives the SAME Vite dev server on 45173, so the server — not
+// the CPU — is the ceiling. Playwright's default (about half the cores) puts
+// ~10 browsers on it here, and past this cap they only queue: `page.goto`
+// waits on `load` long enough to blow the 30s test timeout, in a different
+// spec each run, always as a navigation timeout rather than a failed
+// assertion. Measured on one machine, one commit, 10 vs 4 workers:
+//
+//   loaded   10 → 2 failed, 286s      4 → 456 passed, 278s
+//   idle     10 →   0 failed, 245s    4 → 456 passed, 221s
+//
+// Fewer workers were never slower and never flakier, so the parallelism was
+// buying nothing. CI is left on the default: it splits the suite with
+// `--shard=N/2` across runners with far fewer cores, so its worker count is
+// already below this cap and it has never shown these timeouts.
+const LOCAL_MAX_WORKERS = 4;
+
 export default defineConfig({
   testDir: "./tests",
   timeout: 30 * ONE_SECOND_MS,
   retries: 0,
+  ...(process.env.CI ? {} : { workers: LOCAL_MAX_WORKERS }),
   // Pre-warm the Vite dev server before tests start so the first
   // navigation per spec doesn't pay Vite's on-demand module-compile cost
   // (which has been flaking `accounting-action-routing` and the


### PR DESCRIPTION
## Summary

`e2e/playwright.config.ts` が `workers` を指定しておらず、Playwright の既定（CPU の約半分 ≒ **10**）が使われていました。しかし全 worker が**ポート 45173 の単一 Vite dev server** を叩くので、**天井は CPU ではなく dev server** です。捌ける以上に増やしても並ぶだけで、`page.goto` が `load` を待つ間に30秒のテストタイムアウトを超えます。

ローカルのみ 4 に制限します。CI は既定のまま据え置きです。

## Items to Confirm / Review

**1. これがバグに見えなかった理由。** 落ちる spec が**毎回変わり**、どれも**単体では通る**ためです:

```
today-journal-button:67   collection-calendar:230   right-sidebar-toggle:48
accounting-flow:125       accounting-journal-detail-panel:225
```

いずれも `page.goto: Test timeout of 30000ms exceeded` — アサーション失敗ではなくナビゲーションのタイムアウトです。

**2. 実測（同一マシン・同一コミット）。**

| 条件 | workers | 結果 | 所要 |
|---|---|---|---|
| 高負荷（load ~19） | 10 | **2 failed** / 454 passed | 286s |
| 高負荷 | 4 | 456 passed | **278s** |
| 低負荷 | 10 | 456 passed | 245s |
| 低負荷 | 4 | 456 passed | **221s** |

**4 worker は全条件で 10 worker 以下の所要時間で、かつ落ちません** — 並列度を上げることに利益がありませんでした。**計測したのは 10 と 4 の2点のみ**で、その間の値は試していません。

**3. CI を据え置く理由。** CI は `--shard=N/2` で分割し、runner のコア数も少ないため既定 worker 数が元々このキャップ以下です。実際 CI でこのタイムアウトは一度も出ていません。

**4. 分岐が効くことを実測しました**（`process.env.CI` の判定を推測しない）:

```
local   workers = 4
CI=1    workers = (既定)
```

## 検証

キャップ有効でフルラン: **456 passed / 0 failed / 244s**。`format --check` / `lint` / `typecheck` すべて 0。

Closes #2794

work in mulmoclaude3

## Summary by Sourcery

Enhancements:
- Limit local Playwright workers to a maximum of 4 via configuration when not running in CI to reduce flakiness and stabilize runtimes for E2E tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Limited local end-to-end test execution to four parallel workers for more consistent performance.
  * Preserved the existing default worker behavior in continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->