### PR TITLE
chore: sweep core ranges to ^2.0.1 and record both 2026-08-03 drift waves

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -81,7 +81,7 @@ A `Uint8Array` backed by a `SharedArrayBuffer` is not a `BodyInit`, and TypeScri
 
 #### Google Chat webhook verification asserted what it should have checked
 
-The relay's JWKS guard inspected only `kid` and `n` yet cast the result to a type declaring `kty`, `e` and `alg`; the OAuth response was asserted to be `{ access_token: string }`, so an error body produced `Bearer undefined` sent as a real credential. Both are parsed and verified now — this is the signature boundary for inbound Google Chat webhooks, so a claimed type and a checked one are not interchangeable here.
+The relay's JWKS guard inspected only `kid` and `n` yet cast the result to a type declaring `kty`, `e` and `alg`; the OAuth response was asserted to be `{ access_token: string }`, so an error body produced `Bearer undefined` sent as a real credential. Both are parsed and verified now — this is the signature boundary for inbound Google Chat webhooks, so a claimed type and a checked one are not interchangeable here. Reached users in **`@mulmobridge/relay@1.0.3`**, not in the 1.0.4 published beside this launcher.
 
 ### Internal
 
@@ -106,7 +106,15 @@ The bulk of this cycle was two codebase-wide ratchets, kept out of the highlight
 
 Ships `@mulmoclaude/core@1.14.1`, `@receptron/task-scheduler@1.0.3`, `@mulmoclaude/accounting-plugin@1.3.0`, `@mulmoclaude/core@1.14.0`, `@mulmoclaude/markdown-utils@1.3.3`, `@mulmoclaude/core@1.13.0` and `@mulmoclaude/core@1.12.0`, plus the range-only wave above (8 `@mulmobridge/*`, 8 `@mulmoclaude/*-plugin`) and the earlier `@mulmoclaude/accounting-plugin@1.2.0`, `@mulmoclaude/google-plugin@1.2.1`, `@mulmoclaude/spotify-plugin@1.0.3`.
 
-Also published with this launcher, all patch bumps closing the source drift each had accumulated since its last release: `@mulmoclaude/common@1.1.2`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/x-plugin@1.0.3`, `@mulmobridge/client@1.0.2`, `@mulmobridge/chat-service@1.0.3`, `@mulmobridge/mock-server@1.0.2`, `@mulmobridge/{bluesky,chatwork,irc,telegram,zulip}@1.0.2`, `@mulmobridge/{email,google-chat}@1.0.3`, `@mulmobridge/line@1.0.4` and `@mulmobridge/relay@1.0.4`.
+#### The two 2026-08-03 drift waves
+
+Both waves republish packages whose **source** had moved past their last tarball — `yarn audit:releases --code-only` calls this *code drift*, as against the manifest-only drift of the 2026-08-02 wave above. Almost all of it is the `as`-ban and `noUncheckedIndexedAccess` / `exactOptionalPropertyTypes` sweeps landing in package source; the two behaviour changes are named individually.
+
+**Wave 1 — 18 workspaces** (PR #2752). `@mulmobridge/discord@1.0.2`, `@mulmobridge/line-works@1.0.3`, `@mulmobridge/line@1.0.3`, `@mulmobridge/mattermost@1.0.2`, `@mulmobridge/nostr@1.0.2`, `@mulmobridge/slack@1.0.2`, `@mulmobridge/viber@1.0.3`, `@mulmobridge/whatsapp@1.0.3`, `@mulmobridge/chat-service@1.0.2`, `@mulmobridge/relay@1.0.3`, `@mulmoclaude/markdown-utils@1.3.4`, `@mulmoclaude/accounting-plugin@1.2.2`, `@mulmoclaude/collection-plugin@1.2.4`, `@mulmoclaude/form-plugin@1.0.3`, `@mulmoclaude/mulmoscript-plugin@1.1.4`, `@mulmoclaude/spotify-plugin@1.0.4`, `@mulmoclaude/x-plugin@1.0.2`, `@receptron/task-scheduler@1.0.2`. **`@mulmobridge/relay@1.0.3` is the one carrying a behaviour change**: the Google Chat webhook fix described under *Fixed* above reached users here, not in 1.0.4.
+
+**Wave 2 — 15 workspaces**, published alongside the launcher: `@mulmoclaude/common@1.1.2`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/x-plugin@1.0.3`, `@mulmobridge/client@1.0.2`, `@mulmobridge/chat-service@1.0.3`, `@mulmobridge/mock-server@1.0.2`, `@mulmobridge/{bluesky,chatwork,irc,telegram,zulip}@1.0.2`, `@mulmobridge/{email,google-chat}@1.0.3`, `@mulmobridge/line@1.0.4`, `@mulmobridge/relay@1.0.4`. Each is a strictness-sweep-only patch — `@mulmobridge/mock-server` (96 lines) and `@mulmobridge/telegram`'s router (65) are the largest, and no exported signature changed in any of them.
+
+Wave 1 was tagged but **its 18 GitHub releases were never created**, and it had no changelog entry at all until this section — which is how `relay@1.0.3`'s behaviour change came to be attributed to 1.0.4 on first writing. The releases are backfilled at the wave-1 tags.
 
 ## [1.9.0] - 2026-07-31
 

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.2",
-    "@mulmoclaude/core": "^2.0.0"
+    "@mulmoclaude/core": "^2.0.1"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^2.0.0"
+    "@mulmoclaude/core": "^2.0.1"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^2.0.0"
+    "@mulmoclaude/core": "^2.0.1"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^2.0.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.2",
-    "@mulmoclaude/core": "^2.0.0"
+    "@mulmoclaude/core": "^2.0.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.1.2",
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,20 +37,20 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.1.2",
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "@mulmoclaude/markdown-utils": "^1.3.5",
     "js-yaml": "^5.2.3",
     "marked": "^18.0.7",
     "mermaid": "^11.16.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^2.0.0",
+    "@mulmoclaude/core": "^2.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.65.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.1.2",
-    "@mulmoclaude/core": "^2.0.0"
+    "@mulmoclaude/core": "^2.0.1"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",


### PR DESCRIPTION
## Summary

Two release-hygiene gaps found while auditing what `mulmoclaude@1.10.0` actually shipped.

1. **Seven plugins still declared `@mulmoclaude/core: ^2.0.0`** across 12 `dependencies` / `devDependencies` / `peerDependencies` entries, while npm's latest is **2.0.1**. Swept to `^2.0.1`.
2. **PR #2752's 18-workspace wave had no changelog entry at all** — and that omission is what made the Google Chat webhook fix read as shipping in `@mulmobridge/relay@1.0.4`, when it actually reached users in **1.0.3**. Both 2026-08-03 waves are now recorded per package, and the `Fixed` entry names the version that carries the fix.

## Items to Confirm / Review

- **No republish is forced by this PR.** `^2.0.0` already floats to 2.0.1 (caret on a `2.x` range), so nothing an installer resolves changes today. What moves is the declared **floor**, which is what stops a consumer pinning an older core from assembling a combination the plugin's code does not support. Per the repo rule a range update reaches users through that consumer's own next release, so the requirement is that it be in the tree before each is published next — not that all seven ship now.
- **The `relay@1.0.3` correction is the part worth checking.** Verified by diffing the package against its own tag: `packages/relay/src/webhooks/google-chat.ts` does **not** appear in `@mulmobridge/relay@1.0.3..HEAD`, and #2715 merged 2026-08-02 while the 1.0.3 tag sits on the 2026-08-03 release merge. So 1.0.4 carries only the strictness sweep.
- **Scope of the backfill.** 186 of 370 package tags have no GitHub release, most of them historical `0.1.x`. This PR does not attempt that backlog — only PR #2752's 18 releases are being created, since that wave shipped today and is part of the 1.10.0 cycle.

## How the drift was found

Not by reading manifests — by resolving every internal dep name against the public registry and comparing each declared range to `^<npm latest>`, across all 53 workspaces plus the root:

```
✓ 全ワークスペースの内部依存レンジが npm latest と一致
```

An earlier run of this same check reported a false pass: a leftover `cd` from the publish step meant the relative path never resolved and the loop iterated zero times while still printing its success line. Rerun with absolute paths, it read 53 workspaces and found the 12 stale entries.

## Verification

| gate | result |
|---|---|
| `yarn format` | 0 |
| `yarn lint` | 0 |
| `yarn typecheck` | 0 |
| `yarn build` | 0 |
| `yarn test` | 0 — **11148 pass / 0 fail** |
| `scripts/mulmoclaude/launcherSync.mjs` | 0 |

`yarn install` left `yarn.lock` unchanged, as expected for workspace-internal ranges.

## User Prompt

> PRつくって。
>
> バージョンも直してね
>
> それぞれのreleaseとかchangelogだしてる？

work in mulmoclaude

## Summary by Sourcery

Update plugin core dependency ranges and backfill release documentation for August 3, 2026 drift waves.

Bug Fixes:
- Correct the documented release version carrying the Google Chat webhook fix for @mulmobridge/relay.

Enhancements:
- Raise @mulmoclaude/core dependency, devDependency, and peerDependency ranges to ^2.0.1 across affected plugins.
- Document the two 2026-08-03 code-drift release waves and explicitly attribute behaviour changes and strictness-only patches in the changelog.

Documentation:
- Expand changelog with detailed entries for the August 3, 2026 drift waves and clarify the version containing the Google Chat webhook fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with the release version for the Google Chat webhook verification fix.
  - Added details about recent publication waves, relay behavior improvements, strictness updates, missing releases, and backfilled tags.

- **Maintenance**
  - Updated plugin packages for compatibility with the latest core release, improving consistency across accounting, chart, collection, Google, HTML, Markdown, and MulmoScript integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->