### PR TITLE
fix(lint): promote sonarjs/void-use to error (#2800)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -655,7 +655,9 @@ export default [
       // `off` at the bottom of this file for why the flag invalidates it.
       "sonarjs/no-try-promise": "error",
       "sonarjs/post-message": "error",
-      // Same treatment, measured in #2800: zero findings over the same scope.
+      // Same treatment, measured in #2800: zero findings over `src server test
+      // e2e e2e-live packages scripts batch config` — the paths `yarn lint`
+      // passes, so a wider scope than the six above.
       // It does NOT collide with `no-floating-promises` above, despite both
       // ruling on `void expr` — S3735 returns early on a promise operand, so the
       // `void somePromise()` that rule asks for is never reported. Checked by

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -655,6 +655,13 @@ export default [
       // `off` at the bottom of this file for why the flag invalidates it.
       "sonarjs/no-try-promise": "error",
       "sonarjs/post-message": "error",
+      // Same treatment, measured in #2800: zero findings over the same scope.
+      // It does NOT collide with `no-floating-promises` above, despite both
+      // ruling on `void expr` — S3735 returns early on a promise operand, so the
+      // `void somePromise()` that rule asks for is never reported. Checked by
+      // forcing this rule on a probe: `void syncFn()` reported, `void asyncFn()`
+      // not. `src/composables/useContentDisplay.ts` relies on that.
+      "sonarjs/void-use": "error",
 
       // Three of those woken rules are off entirely rather than warned. Each
       // was checked against all of its findings in this repo, and none of them

--- a/plans/fix-2800-void-use-error.md
+++ b/plans/fix-2800-void-use-error.md
@@ -42,11 +42,13 @@ issue は sonarjs の実装(promise を除外する分岐)を引用している�
 ```ts
 const syncFn = (): number => 1;
 const asyncFn = async (): Promise<number> => 1;
-void syncFn();    // ← line 4
-void asyncFn();   // ← line 5
+export const probe = () => {
+  void syncFn(); // line 4
+  void asyncFn(); // line 5
+};
 ```
 
-```
+```text
 line 4 sev=2 :: Remove this use of the "void" operator.
 void-use findings in probe: 1
 ```

--- a/plans/fix-2800-void-use-error.md
+++ b/plans/fix-2800-void-use-error.md
@@ -1,0 +1,71 @@
+# fix #2800 — `sonarjs/void-use` を error に昇格する
+
+## やること
+
+`sonarjs/void-use` は型情報つきルールなので `sonarTypeAwareRulesAsWarn` の一括降格に入り、
+実効 `warn`(`[1]`)になっている。**findings は 0 件**なので、移行作業なしで `error` に昇格できる。
+#2743(枯れた13ルールを error に昇格)と同じパターン。
+
+## 実測して確かめたこと
+
+issue の主張をそのまま信じず、3 点とも実測した。
+
+### 1. 現在の実効値は warn
+
+```console
+$ npx eslint --print-config server/index.ts | jq '.rules["sonarjs/void-use"]'
+[1]
+```
+
+プラグインの metadata 側も確認: `requiresTypeChecking: true` かつ recommended は `"error"`。
+つまり `sonarTypeAwareRulesAsWarn` の条件(型情報つき かつ recommended で有効)に合致して降格されている。
+
+### 2. findings は 0 件(キャッシュなしで全ファイル)
+
+`yarn lint` は `--cache` 付きなので、キャッシュが結果を隠しうる。キャッシュを使わず全スコープで測った:
+
+```console
+$ npx eslint src server test e2e e2e-live packages scripts batch config --format json
+files linted: 2433
+sonarjs/void-use findings: 0
+```
+
+同時に測った他の warn ルールには backlog が残っている(`no-unsafe-assignment` 19、
+`function-return-type` 12、`super-linear-regex` 5 など)ので、「0 件」は
+「lint が走っていない」ではなく **void-use だけが本当に枯れている**ことを示す。
+
+### 3. `no-floating-promises` とは衝突しない — 引用ではなく実験で確認
+
+issue は sonarjs の実装(promise を除外する分岐)を引用しているが、**引用は証拠にならない**ので、
+ルールを `error` に強制して probe ファイルを流した:
+
+```ts
+const syncFn = (): number => 1;
+const asyncFn = async (): Promise<number> => 1;
+void syncFn();    // ← line 4
+void asyncFn();   // ← line 5
+```
+
+```
+line 4 sev=2 :: Remove this use of the "void" operator.
+void-use findings in probe: 1
+```
+
+**非 promise の `void` だけが報告され、promise の `void` は報告されない。**
+これで「0 件なのはルールが死んでいるから」という可能性も同時に潰せている(negative control)。
+
+リポジトリ内の実例でも裏が取れる: `src/composables/useContentDisplay.ts:68` の
+`void loadCspExtra()` は `async function loadCspExtra(): Promise<void>` を呼ぶ
+fire-and-forget だが、void-use は報告していない。
+
+## 実装
+
+`sonarTypeAwareRulesAsWarn` の展開より **後ろ**に明示キーを置けば上書きされるので、
+一括降格の仕組み自体には手を入れない(issue のチェックリスト2番目の答え)。
+#2743 で昇格した13ルールと同じ置き方。
+
+## 検証
+
+- `--print-config` の実効値が `[1]` → `[2]` になること
+- `yarn lint` が緑のままであること(0 件なので新規エラーは出ないはず)
+- `yarn format` / `yarn typecheck` / `yarn build` / `yarn test`


### PR DESCRIPTION
## Summary

`sonarjs/void-use` を **`warn` → `error`** に昇格しました(#2800)。

型情報つきルールなので `sonarTypeAwareRulesAsWarn` の一括降格に入って実効 `warn`(`[1]`)になっていましたが、
**findings は 0 件**なので移行作業なしで昇格できます。#2743(枯れた13ルールを error に昇格)と同じパターンです。

`sonarTypeAwareRulesAsWarn` の展開より**後ろ**に明示キーを置けば上書きされるため、
**一括降格の仕組み自体には手を入れていません**(issue のチェックリスト2番目の答え)。

## Items to Confirm / Review

- **`no-floating-promises` と衝突しない根拠を、引用ではなく実験で取りました**。
  issue は sonarjs の実装(promise を除外する分岐)を引用していますが、引用はコードが今そう動く証拠にならないので、
  ルールを `error` に強制した probe を流して確認しています(下記)。この検証方法でよいか。
- **0 件の測定はキャッシュを外して行いました**。`yarn lint` は `--cache` 付きなので、
  キャッシュ済みの結果が findings を隠しうるためです。
- **`src/composables/useContentDisplay.ts:68` の `void loadCspExtra()` が実地の裏付け**になっています
  (`async function loadCspExtra(): Promise<void>` の fire-and-forget)。ここが将来 error になると困るので、
  設定コメントにもこのファイル名を残しました。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2800 対応して

## 実測(issue の主張を3点とも検証)

### 1. 現在の実効値は warn

```console
$ npx eslint --print-config server/index.ts | jq '.rules["sonarjs/void-use"]'
[1]
```

プラグイン側の metadata も確認: `requiresTypeChecking: true` / recommended は `"error"`。
`sonarTypeAwareRulesAsWarn` の条件(型情報つき かつ recommended で有効)に合致して降格されていました。

### 2. findings 0 件(キャッシュなし・全スコープ)

```console
$ npx eslint src server test e2e e2e-live packages scripts batch config --format json
files linted: 2433
sonarjs/void-use findings: 0
```

同じ実行で他の warn ルールは backlog を報告しています
(`no-unsafe-assignment` 19 / `sonarjs/function-return-type` 12 / `super-linear-regex` 5 / `reduce-initial-value` 2 / `regex-complexity` 1)。
つまり「0 件」は **lint が走っていないからではなく、void-use だけが本当に枯れている**ことを意味します。

### 3. `no-floating-promises` と衝突しない — negative control つき

ルールを `error` に強制して probe を流しました:

```ts
const syncFn = (): number => 1;
const asyncFn = async (): Promise<number> => 1;
void syncFn();    // line 4
void asyncFn();   // line 5
```

```
line 4 sev=2 :: Remove this use of the "void" operator.
void-use findings in probe: 1
```

**非 promise の `void` だけが報告され、promise の `void` は報告されない。**
これで「0 件なのはルールが死んでいるだけ」という可能性も同時に潰しています。

## 検証

| 項目 | 結果 |
|---|---|
| 実効 severity | `[1]` → **`[2]`** |
| `yarn lint` | **0 errors**(warning 43件は既存) |
| ゲートが効くか | 新規の非 promise `void` を置くと **error + exit 1**、消すと再び 0 errors |
| `yarn typecheck` / `yarn build` | 通過 |
| `yarn test` | **11148 pass / 0 fail** |
| #2789 の一時ディレクトリ修正 | 残骸 **0** のまま(退行なし) |

Closes #2800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude2

## Summary by Sourcery

Enhancements:
- Document and justify the severity change for `sonarjs/void-use`, including measurements, conflict checks, and implementation approach in a dedicated plan file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Code Quality**
  * Strengthened linting to flag unintended ignored promise results as errors.
  * Confirmed the rule has no current findings and does not conflict with existing promise-handling checks.

* **Documentation**
  * Added a maintenance plan covering validation through linting, formatting, type checks, builds, and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->