### PR TITLE
[do-not-merge] chore(perf): session-list instrumentation used to diagnose #2809

### DIFF
--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -40,7 +40,7 @@
         class="relative cursor-pointer rounded p-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         :class="rowClasses(session)"
         :data-testid="`session-item-${session.id}`"
-        @click="emit('loadSession', session.id)"
+        @click="onRowClick(session.id)"
         @keydown.enter.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
         @keydown.space.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
       >
@@ -114,7 +114,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount, onUpdated } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount, onUpdated, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
@@ -125,7 +125,7 @@ import { resolveSessionPrimaryText, sessionHasVisibleSummary } from "../utils/se
 import { formatDate } from "../utils/format/date";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 import FilterChip from "./FilterChip.vue";
-import { createPerfAccumulator, perfLogUntilPaint } from "../utils/devPerf";
+import { createPerfAccumulator, perfLogSinceClick, perfLogUntilPaint, perfMarkClick } from "../utils/devPerf";
 
 const { t } = useI18n();
 
@@ -174,6 +174,19 @@ const emit = defineEmits<{
 
 const root = ref<HTMLDivElement | null>(null);
 defineExpose({ root });
+
+// The row's selected border is the first feedback the click produces.
+// It cannot appear until loadSession has finished, so this measures the
+// "I clicked but nothing happened yet" window directly.
+function onRowClick(sessionId: string): void {
+  perfMarkClick();
+  emit("loadSession", sessionId);
+}
+
+watch(
+  () => props.currentSessionId,
+  () => perfLogSinceClick("click→row selected"),
+);
 
 // ── Filter ──────────────────────────────────────────────────
 

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -35,7 +35,7 @@
         :key="session.id"
         tabindex="0"
         role="button"
-        :aria-label="t('sessionHistoryPanel.openRowAria', { preview: primaryText(session) })"
+        :aria-label="rowAriaLabel(session)"
         :title="primaryText(session)"
         class="relative cursor-pointer rounded p-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
         :class="rowClasses(session)"
@@ -53,7 +53,7 @@
              previewClasses (bold text); bookmark state is signalled
              via the green role icon. -->
         <div class="absolute top-0 right-6 -translate-y-1/2 flex items-center gap-1 bg-white px-1 leading-none">
-          <span class="text-[10px] text-gray-400 pointer-events-none">{{ formatDate(session.updatedAt) }}</span>
+          <span class="text-[10px] text-gray-400 pointer-events-none">{{ rowTimestamp(session) }}</span>
           <button
             type="button"
             class="flex items-center justify-center px-0.5 border border-gray-300 rounded-md text-gray-400 hover:text-gray-700 hover:border-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-400"
@@ -114,7 +114,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount, onUpdated } from "vue";
 import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
@@ -125,8 +125,32 @@ import { resolveSessionPrimaryText, sessionHasVisibleSummary } from "../utils/se
 import { formatDate } from "../utils/format/date";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 import FilterChip from "./FilterChip.vue";
+import { createPerfAccumulator, perfLogUntilPaint } from "../utils/devPerf";
 
 const { t } = useI18n();
+
+// ── Investigation instrumentation (see src/utils/devPerf.ts) ────────
+// Off unless `localStorage["mulmoclaude:perf"] === "1"`. Splits the
+// panel's render cost into the three per-row calls the template makes,
+// so "the list is slow" resolves into which of them dominates.
+const setupStartedAt = performance.now();
+const timestampCost = createPerfAccumulator();
+const ariaCost = createPerfAccumulator();
+const primaryTextCost = createPerfAccumulator();
+
+function flushRowCosts(pass: string, rows: number): void {
+  timestampCost.flush(`${pass}: formatDate()`, { rows });
+  ariaCost.flush(`${pass}: t(openRowAria)`, { rows });
+  primaryTextCost.flush(`${pass}: primaryText()`, { rows });
+}
+
+function rowTimestamp(session: SessionSummary): string {
+  return timestampCost.add(() => formatDate(session.updatedAt));
+}
+
+function rowAriaLabel(session: SessionSummary): string {
+  return ariaCost.add(() => t("sessionHistoryPanel.openRowAria", { preview: primaryText(session) }));
+}
 
 // `unread` and `bookmarked` are mutually exclusive with origin pills —
 // selecting either shows every matching session regardless of origin,
@@ -209,7 +233,7 @@ function previewClasses(session: SessionSummary): string {
 // visible text, aria-label, and the hover title so all three stay in
 // lockstep.
 function primaryText(session: SessionSummary): string {
-  return resolveSessionPrimaryText(session) ?? t("sessionHistoryPanel.noMessages");
+  return primaryTextCost.add(() => resolveSessionPrimaryText(session) ?? t("sessionHistoryPanel.noMessages"));
 }
 
 // ── Row action menu ─────────────────────────────────────────
@@ -243,6 +267,17 @@ function onDelete(session: SessionSummary): void {
 
 onMounted(() => {
   document.addEventListener("click", closeMenu);
+  perfLogUntilPaint("history-panel setup→paint", setupStartedAt, {
+    rows: filteredSessions.value.length,
+    totalSessions: props.sessions.length,
+  });
+  flushRowCosts("mount", filteredSessions.value.length);
+});
+
+// Every re-render of the list (filter change, selection change, or a
+// sessions-channel refetch replacing the array) lands here.
+onUpdated(() => {
+  flushRowCosts("update", filteredSessions.value.length);
 });
 
 onBeforeUnmount(() => {

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -64,11 +64,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
 import { formatSmartTime } from "../utils/format/date";
+import { perfLogSinceClick } from "../utils/devPerf";
 import { isRecord } from "../utils/types";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
 import CopyChatButton from "./CopyChatButton.vue";
@@ -76,7 +77,7 @@ import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   // Already filtered to "what the user should see" by the parent's
   // `sidebarResults` computed (see useSessionDerived.ts) — keyboard
   // navigation, selection, and this render all consume the same
@@ -115,6 +116,15 @@ const emit = defineEmits<{
 
 const root = ref<HTMLDivElement | null>(null);
 defineExpose({ root });
+
+// Investigation instrumentation (src/utils/devPerf.ts). This pane is the
+// one that visibly swaps content on a session click, and each card can
+// mount a plugin preview component, so its cost scales with the result
+// count rather than with the session list.
+watch(
+  () => props.results,
+  (results) => perfLogSinceClick("click→middle pane painted", { results: results.length }),
+);
 </script>
 
 <style scoped>

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -6,6 +6,7 @@ import { PUBSUB_CHANNELS, readSessionDeletedIds } from "../config/pubsubChannels
 import type { SessionSummary } from "../types/session";
 import { apiDelete, apiGet, apiPost } from "../utils/api";
 import { applySessionDiff } from "../utils/session/mergeSessions";
+import { perfNote, perfTime, perfTimeAsync } from "../utils/devPerf";
 import { applyBookmarkFlag } from "./useSessionHistory.helpers";
 import { usePubSub } from "./usePubSub";
 
@@ -85,7 +86,12 @@ export function useSessionHistory(): UseSessionHistory {
   async function fetchSessions(): Promise<SessionSummary[]> {
     const query: Record<string, string> = {};
     if (cursor !== null) query.since = cursor;
-    const result = await apiGet<SessionsResponse>(API_ROUTES.sessions.list, query);
+    // Investigation instrumentation (src/utils/devPerf.ts): this call is
+    // the one every sessions-channel broadcast triggers, and its result
+    // replaces the array the 800-row list renders from.
+    const result = await perfTimeAsync(cursor === null ? "fetchSessions: GET /sessions (full)" : "fetchSessions: GET /sessions (diff)", () =>
+      apiGet<SessionsResponse>(API_ROUTES.sessions.list, query),
+    );
     if (!result.ok) {
       historyError.value = result.error;
       // Preserve sessions.value so callers keep showing the last-known-good list.
@@ -93,11 +99,18 @@ export function useSessionHistory(): UseSessionHistory {
     }
     historyError.value = null;
     const body = result.data;
-    if (cursor === null) {
-      sessions.value = body.sessions;
-    } else {
-      sessions.value = applySessionDiff(sessions.value, body.sessions, body.deletedIds);
-    }
+    perfTime(
+      "fetchSessions: merge into list",
+      () => {
+        if (cursor === null) {
+          sessions.value = body.sessions;
+        } else {
+          sessions.value = applySessionDiff(sessions.value, body.sessions, body.deletedIds);
+        }
+      },
+      { received: body.sessions.length },
+    );
+    perfNote("fetchSessions: list size after merge", { rows: sessions.value.length });
     ({ cursor } = body);
     return sessions.value;
   }

--- a/src/composables/useSessionLifecycle.ts
+++ b/src/composables/useSessionLifecycle.ts
@@ -15,6 +15,7 @@ import type { Role } from "../config/roles";
 import { PAGE_ROUTES } from "../router";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { perfLogUntilPaint, perfTime, perfTimeAsync } from "../utils/devPerf";
 import { createEmptySession } from "../utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries, shouldAdoptServerTranscript } from "../utils/session/sessionEntries";
 import {
@@ -108,23 +109,36 @@ function activateSession(ctx: LifecycleCtx, sessionId: string, replace: boolean)
 }
 
 async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> {
+  // Investigation instrumentation (src/utils/devPerf.ts): the click has
+  // no visible effect until this whole function completes, so each phase
+  // is timed separately and the paint is timed from the very start.
+  const clickedAt = performance.now();
   if (isSessionAlreadyDisplayed(sessionId, ctx.currentSessionId.value, ctx.sessionMap.has(sessionId))) return;
   const replaced = shouldReplaceHistory(removeCurrentIfEmpty(ctx), ctx.isChatPage.value);
   if (ctx.sessionMap.has(sessionId)) {
     activateSession(ctx, sessionId, replaced);
+    perfLogUntilPaint("loadSession cached→paint", clickedAt, { sessionId });
     return;
   }
-  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
+  const response = await perfTimeAsync("loadSession: GET /sessions/:id", () =>
+    apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId))),
+  );
   if (!response.ok) return;
-  const newSession = buildLoadedSession({
-    id: sessionId,
-    entries: response.data,
-    defaultRoleId: ctx.roles.value[0]?.id ?? "",
-    serverSummary: ctx.sessions.value.find((summary) => summary.id === sessionId),
-    nowIso: new Date().toISOString(),
-  });
+  const newSession = perfTime(
+    "loadSession: buildLoadedSession()",
+    () =>
+      buildLoadedSession({
+        id: sessionId,
+        entries: response.data,
+        defaultRoleId: ctx.roles.value[0]?.id ?? "",
+        serverSummary: ctx.sessions.value.find((summary) => summary.id === sessionId),
+        nowIso: new Date().toISOString(),
+      }),
+    { entries: response.data.length },
+  );
   ctx.sessionMap.set(sessionId, newSession);
   activateSession(ctx, sessionId, replaced);
+  perfLogUntilPaint("loadSession click→paint", clickedAt, { sessionId, entries: response.data.length });
 }
 
 // Re-fetch the transcript and patch entries missed via a dropped socket

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -10,6 +10,22 @@ import { usePubSub } from "./usePubSub";
 import { PUBSUB_CHANNELS, readSessionDeletedIds } from "../config/pubsubChannels";
 import { apiPost } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { createPerfCounter, perfTimeAsync } from "../utils/devPerf";
+
+// Investigation instrumentation (src/utils/devPerf.ts). Every hit here
+// is a server-side session state change (beginRun / endRun / markRead)
+// that makes THIS tab refetch the whole list and re-render it — the
+// re-renders that happen without the user touching anything.
+const sessionsChannelHits = createPerfCounter("sessions-channel broadcast");
+
+// Clicking an UNREAD row lands here, and the server answers this POST
+// with a sessions-channel broadcast — so it is what turns one click
+// into a second full-list refetch + re-render.
+function postMarkRead(sessionId: string) {
+  return perfTimeAsync("markSessionRead: POST mark-read", () =>
+    apiPost<{ ok: boolean }>(API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(sessionId))),
+  );
+}
 
 export function useSessionSync(opts: {
   sessionMap: Map<string, ActiveSession>;
@@ -56,7 +72,7 @@ export function useSessionSync(opts: {
   }
 
   async function markSessionRead(sessionId: string): Promise<void> {
-    const result = await apiPost<{ ok: boolean }>(API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(sessionId)));
+    const result = await postMarkRead(sessionId);
     if (!result.ok || result.data.ok === false) {
       await refreshSessionStates();
     }
@@ -74,6 +90,7 @@ export function useSessionSync(opts: {
       if (deletedId === currentSessionId.value) currentWasDeleted = true;
     }
     if (currentWasDeleted) onCurrentSessionDeleted?.();
+    sessionsChannelHits.hit({ deleted: deletedIds.length });
     void refreshSessionStates();
   });
   if (typeof unsub === "function") onScopeDispose(unsub);

--- a/src/utils/devPerf.ts
+++ b/src/utils/devPerf.ts
@@ -69,6 +69,27 @@ export function perfLogUntilPaint(label: string, startedAt: number, extra?: Reco
   });
 }
 
+// ── Click clock ─────────────────────────────────────────────────────
+// One click updates three things the reader notices at different
+// moments: the row's own selected border, the middle pane's transcript,
+// and the canvas. They live in different components, so the click time
+// is parked here and each of them reports its own distance from it.
+
+let lastClickAt = 0;
+
+/** Stamp the moment the user pressed a session row. */
+export function perfMarkClick(): void {
+  if (!perfEnabled) return;
+  lastClickAt = performance.now();
+}
+
+/** Report when this part of the UI actually finished painting, measured
+ *  from the click that caused it. No-op before the first click. */
+export function perfLogSinceClick(label: string, extra?: Record<string, unknown>): void {
+  if (!perfEnabled || lastClickAt === 0) return;
+  perfLogUntilPaint(label, lastClickAt, extra);
+}
+
 /** Sums many small calls (per-row work) across one render pass, so the
  *  cost of 800 individual `formatDate` / `t()` calls shows up as one
  *  line instead of 800. Call `add` around each unit, `flush` once the

--- a/src/utils/devPerf.ts
+++ b/src/utils/devPerf.ts
@@ -1,0 +1,117 @@
+// Investigation-only performance instrumentation for the session-list
+// slowness (left history panel). Everything here is inert unless the
+// reader opts in at runtime from the browser console:
+//
+//   localStorage.setItem("mulmoclaude:perf", "1"); location.reload();
+//
+// The flag is read once at module load, so a disabled session pays only
+// a boolean check per call site. Remove this module (and its call sites)
+// once the investigation lands a fix.
+
+const PERF_FLAG_KEY = "mulmoclaude:perf";
+const LOG_PREFIX = "[perf]";
+const MS_DECIMALS = 1;
+
+function readFlag(): boolean {
+  try {
+    return window.localStorage.getItem(PERF_FLAG_KEY) === "1";
+  } catch {
+    // Private-mode Safari throws on localStorage access — treat as off.
+    return false;
+  }
+}
+
+export const perfEnabled = readFlag();
+
+function format(elapsedMs: number): string {
+  return `${elapsedMs.toFixed(MS_DECIMALS)} ms`;
+}
+
+/** Log one timing. `extra` carries whatever context makes the number
+ *  interpretable (row counts, byte sizes, session ids). */
+export function perfLog(label: string, elapsedMs: number, extra?: Record<string, unknown>): void {
+  if (!perfEnabled) return;
+  console.log(`${LOG_PREFIX} ${label.padEnd(34)} ${format(elapsedMs).padStart(10)}`, extra ?? "");
+}
+
+/** Report context that is a count rather than a duration (list sizes,
+ *  entry counts) without pretending it took 0 ms. */
+export function perfNote(label: string, extra: Record<string, unknown>): void {
+  if (!perfEnabled) return;
+  console.log(`${LOG_PREFIX} ${label.padEnd(34)}`, extra);
+}
+
+/** Time an async block and log it. Returns whatever the block returns. */
+export async function perfTimeAsync<T>(label: string, run: () => Promise<T>, extra?: Record<string, unknown>): Promise<T> {
+  if (!perfEnabled) return run();
+  const started = performance.now();
+  const result = await run();
+  perfLog(label, performance.now() - started, extra);
+  return result;
+}
+
+/** Time a synchronous block and log it. */
+export function perfTime<T>(label: string, run: () => T, extra?: Record<string, unknown>): T {
+  if (!perfEnabled) return run();
+  const started = performance.now();
+  const result = run();
+  perfLog(label, performance.now() - started, extra);
+  return result;
+}
+
+/** Log the time from `startedAt` until the browser has actually painted.
+ *  Two rAFs: the first fires before paint, the second after it. This is
+ *  the number that matches "when did the user see it change". */
+export function perfLogUntilPaint(label: string, startedAt: number, extra?: Record<string, unknown>): void {
+  if (!perfEnabled) return;
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => perfLog(label, performance.now() - startedAt, extra));
+  });
+}
+
+/** Sums many small calls (per-row work) across one render pass, so the
+ *  cost of 800 individual `formatDate` / `t()` calls shows up as one
+ *  line instead of 800. Call `add` around each unit, `flush` once the
+ *  pass is over. */
+export interface PerfAccumulator {
+  add: <T>(run: () => T) => T;
+  flush: (label: string, extra?: Record<string, unknown>) => void;
+}
+
+export function createPerfAccumulator(): PerfAccumulator {
+  let totalMs = 0;
+  let calls = 0;
+
+  function add<T>(run: () => T): T {
+    if (!perfEnabled) return run();
+    const started = performance.now();
+    const result = run();
+    totalMs += performance.now() - started;
+    calls += 1;
+    return result;
+  }
+
+  function flush(label: string, extra?: Record<string, unknown>): void {
+    if (!perfEnabled || calls === 0) return;
+    perfLog(label, totalMs, { calls, ...extra });
+    totalMs = 0;
+    calls = 0;
+  }
+
+  return { add, flush };
+}
+
+/** Counts events (pub/sub-driven refetches) and reports the rate, so
+ *  background churn unrelated to a click is visible. */
+export function createPerfCounter(label: string) {
+  const startedAt = performance.now();
+  let count = 0;
+  return {
+    hit(extra?: Record<string, unknown>): void {
+      if (!perfEnabled) return;
+      count += 1;
+      const elapsedSec = (performance.now() - startedAt) / 1000;
+      console.log(`${LOG_PREFIX} ${label.padEnd(34)} #${count} @ ${elapsedSec.toFixed(1)}s`, extra ?? "");
+    },
+  };
+}


### PR DESCRIPTION
## Summary

#2809 の調査に使った計測コード。セッション履歴パネルの描画とセッション読み込み経路に、`localStorage["mulmoclaude:perf"] === "1"` のときだけ動くタイマーを入れる。

- 計測対象は「クリックしてから見えるまで」を構成する4経路 — 行の選択枠が付くまで、中央ペインが切り替わるまで、一覧の再取得、`sessions` チャンネルのブロードキャスト回数
- 行ごとに走る処理（日時整形・i18n 補間・プレビュー解決）は1行ずつではなく描画パス単位で合算して出力する。800行ぶんのログで埋もれないため
- フラグ未設定時は各呼び出し点が真偽値の判定1回だけを払う

**このままマージする想定ではありません。** #2809 の修正 PR に取り込んで修正前後の数字を示したうえで削除するか、記録として close するかを決めるための draft です。

## Items to Confirm / Review

- 計測点の置き場所が妥当か（`SessionHistoryPanel.vue` / `SessionSidebar.vue` / `useSessionLifecycle.ts` / `useSessionHistory.ts` / `useSessionSync.ts`）
- opt-in の方式。`localStorage` フラグをモジュール読み込み時に1回だけ読む形にしている。環境変数やビルドフラグの方が良ければ差し替えたい
- `devPerf.ts` の共有クリック時刻（モジュールスコープの `lastClickAt`）。複数コンポーネントが同じクリックからの距離を報告するための仕組みで、副作用として最後のクリックだけが基準になる
- `useSessionSync.ts` で `markSessionRead` の中身を `postMarkRead` に切り出している。計測を挟むと関数が `max-lines-per-function` を超えたための分割で、挙動は変えていない

## User Prompt

- MulmoClaude の左ペイン（セッション一覧）をクリックしたときの反応が遅い。Safari だからか？
- 過去に描画が多いと遅くなるバグがあったはずで、それと同等か
- issue を起票するだけの情報が揃っているか。揃っていないなら調査してほしい
- 対策を3本の issue に分けるのは避けたい
- `yarn dev` で調査するので、調査用のコードを入れてほしい
- Safari の方がやや遅いと思う。クリックしてからフォーカスが当たるまでラグがあるし、中央ペインの表示が変わるのも遅い

## 計測結果

#2809 に記載。要点は、クリックのたびに全808行が再描画され、その間フィードバックが一切ないこと。行の選択枠・中央ペイン・全体描画はすべて同じフレームで一斉に出る。

## Summary by Sourcery

Add optional performance instrumentation around session loading and history rendering to investigate session list slowness.

Enhancements:
- Instrument SessionHistoryPanel row rendering with per-row accumulators and click-to-paint timing logs gated by a localStorage flag.
- Instrument session loading lifecycle to time network fetch, session building, and click-to-paint latency.
- Instrument session history fetching and merging to measure list refetch and merge costs and resulting list sizes.
- Instrument session sync pub/sub handling and mark-read requests to count broadcasts and time server-triggered refetches.
- Instrument SessionSidebar result updates to measure click-to-middle-pane paint timing.

Chores:
- Introduce a dev-only perf utilities module providing timing, paint, accumulator, and counter helpers, all disabled by default unless explicitly opted in.
