### PR TITLE
fix(session-history): re-render only the rows whose selection changed (#2809)

### DIFF
--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -121,6 +121,9 @@ test.describe("session selection feedback", () => {
 
     await page.goto("/chat");
     await page.getByTestId("session-history-toggle-off").click();
+    // SESSION_B is the newer fixture, so boot resumes into B and A
+    // starts unselected — asserted rather than assumed, since the
+    // whole test hinges on A not already carrying the border.
     const row = page.getByTestId(`session-item-${SESSION_A.id}`);
     await expect(row).toBeVisible();
     await expect(row).not.toHaveClass(/border-blue-500/);

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -11,7 +11,7 @@
 
 import { test, expect, type Route } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
-import { SESSION_A, SESSION_B } from "../fixtures/sessions";
+import { SESSION_A, SESSION_B, makeSessionEntries } from "../fixtures/sessions";
 
 function urlEndsWith(suffix: string): (url: URL) => boolean {
   return (url) => url.pathname === suffix;
@@ -91,6 +91,47 @@ test.describe("session-history side panel", () => {
     await expect(page.getByTestId("session-filter-scheduler")).toBeVisible();
     await expect(page.getByTestId("session-filter-skill")).toBeVisible();
     await expect(page.getByTestId("session-filter-bridge")).toBeVisible();
+  });
+});
+
+test.describe("session selection feedback", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+  });
+
+  test("the clicked row highlights before its transcript arrives", async ({ page }) => {
+    // Regression guard for #2809: loadSession used to write
+    // currentSessionId only after `GET /api/sessions/:id` resolved, so
+    // the selection border waited on the round trip. Hold the response
+    // open and assert the border is already there.
+    let releaseTranscript = (): void => {};
+    const transcriptGate = new Promise<void>((resolve) => {
+      releaseTranscript = resolve;
+    });
+
+    // Registered after mockAllApis, so Playwright checks it first.
+    await page.route(
+      (url) => url.pathname === `/api/sessions/${SESSION_A.id}`,
+      async (route: Route) => {
+        if (route.request().method() !== "GET") return route.fallback();
+        await transcriptGate;
+        return route.fulfill({ json: makeSessionEntries(SESSION_A.id) });
+      },
+    );
+
+    await page.goto("/chat");
+    await page.getByTestId("session-history-toggle-off").click();
+    const row = page.getByTestId(`session-item-${SESSION_A.id}`);
+    await expect(row).toBeVisible();
+    await expect(row).not.toHaveClass(/border-blue-500/);
+
+    await row.click();
+
+    // Still gated — nothing has come back from the server yet.
+    await expect(row).toHaveClass(/border-blue-500/);
+
+    releaseTranscript();
+    await expect(page).toHaveURL(new RegExp(`/chat/${SESSION_A.id}`));
   });
 });
 

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -9,7 +9,7 @@
 // is gone — the filter bar is now panel-local state, and tests that
 // asserted URL shape have been retired in favor of DOM assertions.
 
-import { test, expect, type Route } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 import { SESSION_A, SESSION_B, makeSessionEntries } from "../fixtures/sessions";
 
@@ -94,6 +94,26 @@ test.describe("session-history side panel", () => {
   });
 });
 
+// Hold `GET /api/sessions/<sessionId>` open until the returned release()
+// is called, so a test can inspect the UI while the transcript is still
+// in flight. Register after mockAllApis — Playwright checks routes in
+// reverse registration order.
+async function gateTranscript(page: Page, sessionId: string): Promise<() => void> {
+  let release = (): void => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await page.route(
+    (url) => url.pathname === `/api/sessions/${sessionId}`,
+    async (route: Route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      await gate;
+      return route.fulfill({ json: makeSessionEntries(sessionId) });
+    },
+  );
+  return release;
+}
+
 test.describe("session selection feedback", () => {
   test.beforeEach(async ({ page }) => {
     await mockAllApis(page);
@@ -102,22 +122,8 @@ test.describe("session selection feedback", () => {
   test("the clicked row highlights before its transcript arrives", async ({ page }) => {
     // Regression guard for #2809: loadSession used to write
     // currentSessionId only after `GET /api/sessions/:id` resolved, so
-    // the selection border waited on the round trip. Hold the response
-    // open and assert the border is already there.
-    let releaseTranscript = (): void => {};
-    const transcriptGate = new Promise<void>((resolve) => {
-      releaseTranscript = resolve;
-    });
-
-    // Registered after mockAllApis, so Playwright checks it first.
-    await page.route(
-      (url) => url.pathname === `/api/sessions/${SESSION_A.id}`,
-      async (route: Route) => {
-        if (route.request().method() !== "GET") return route.fallback();
-        await transcriptGate;
-        return route.fulfill({ json: makeSessionEntries(SESSION_A.id) });
-      },
-    );
+    // the selection border waited on the round trip.
+    const releaseTranscript = await gateTranscript(page, SESSION_A.id);
 
     await page.goto("/chat");
     await page.getByTestId("session-history-toggle-off").click();
@@ -135,6 +141,36 @@ test.describe("session selection feedback", () => {
 
     releaseTranscript();
     await expect(page).toHaveURL(new RegExp(`/chat/${SESSION_A.id}`));
+  });
+
+  test("a slow transcript landing after a newer click does not steal the view", async ({ page }) => {
+    // Optimistic selection makes the out-of-order case reachable by
+    // impatient clicking: A (slow) then B (already in memory, instant).
+    // When A finally arrives it must be cached, not activated.
+    const releaseSlowA = await gateTranscript(page, SESSION_A.id);
+
+    await page.goto("/chat");
+    await page.getByTestId("session-history-toggle-off").click();
+    const rowA = page.getByTestId(`session-item-${SESSION_A.id}`);
+    const rowB = page.getByTestId(`session-item-${SESSION_B.id}`);
+    await expect(rowA).toBeVisible();
+
+    await rowA.click();
+    await expect(rowA).toHaveClass(/border-blue-500/);
+    await rowB.click();
+    await expect(rowB).toHaveClass(/border-blue-500/);
+
+    const slowResponse = page.waitForResponse((response) => response.url().endsWith(`/api/sessions/${SESSION_A.id}`));
+    releaseSlowA();
+    await slowResponse;
+
+    // Negative assertion: the absence of a navigation has no signal to
+    // synchronise on, so give the handler a beat to run.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- see above
+    await page.waitForTimeout(300);
+    await expect(page).toHaveURL(new RegExp(SESSION_B.id));
+    await expect(rowB).toHaveClass(/border-blue-500/);
+    await expect(rowA).not.toHaveClass(/border-blue-500/);
   });
 });
 

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -174,6 +174,46 @@ test.describe("session selection feedback", () => {
   });
 });
 
+test.describe("session selection failure handling", () => {
+  test("a transcript that fails to load leaves the row unread and the selection where it was", async ({ page }) => {
+    // The optimistic selection reaches the unread watcher before the
+    // load resolves. A transcript that 500s while its meta sidecar is
+    // healthy would let mark-read succeed, dropping the badge for a
+    // session that never opened.
+    const unreadA = { ...SESSION_A, hasUnread: true };
+    await mockAllApis(page, { sessions: [unreadA, SESSION_B] });
+    let markReadCalls = 0;
+    await page.route(
+      (url) => url.pathname.startsWith(`/api/sessions/${SESSION_A.id}`),
+      (route: Route) => {
+        if (route.request().method() === "POST") {
+          markReadCalls++;
+          return route.fulfill({ json: { ok: true } });
+        }
+        return route.fulfill({ status: 500, json: { error: "unreadable transcript" } });
+      },
+    );
+
+    await page.goto("/chat");
+    await page.getByTestId("session-history-toggle-off").click();
+    const rowA = page.getByTestId(`session-item-${SESSION_A.id}`);
+    await expect(rowA).toBeVisible();
+    // Unread rows render bold via previewClasses.
+    await expect(rowA.locator("p")).toHaveClass(/font-bold/);
+
+    await rowA.click();
+
+    // Negative assertions: neither the badge dropping nor a navigation
+    // has a signal to synchronise on, so give the failure path a beat.
+    // eslint-disable-next-line sonarjs/no-fixed-wait-in-tests -- see above
+    await page.waitForTimeout(500);
+    await expect(rowA.locator("p")).toHaveClass(/font-bold/);
+    await expect(rowA).not.toHaveClass(/border-blue-500/);
+    await expect(page).toHaveURL(new RegExp(SESSION_B.id));
+    expect(markReadCalls).toBe(0);
+  });
+});
+
 test.describe("session-history filter pills", () => {
   test.beforeEach(async ({ page }) => {
     await mockAllApis(page);

--- a/plans/fix-2809-session-row-rerender.md
+++ b/plans/fix-2809-session-row-rerender.md
@@ -93,11 +93,45 @@ Playwright（Chromium、同一マシン・同一 fixture）で **クリック �
 案3 の効果は別に確認する（下記 e2e）。上表の経路はどちらの版でも `currentSessionId` を
 同期的に書くので、この数字には案3 は含まれていない。
 
+## レビューで判明した追加修正（PR #2813）
+
+案3（選択を fetch より先に進める）は、**「選択 ID が URL より先に動く」という新しい状態**を生む。
+これが既存コードの 3 箇所の前提を崩していて、いずれもレビュー中に判明した。
+
+1. **stale な成功レスポンスで activate しない**（CodeRabbit）
+   A（遅い）→ B の順にクリックし、後から A が返ると `activateSession(A)` で A に飛ばされる。
+   レース自体は PR 以前からあるが、失敗パスにだけ同趣旨のガードを入れて成功パスを無防備に
+   残すのは一貫しないため、両分岐で同じ述語（`isAwaitedSession`）を使う。
+   ユーザーが移動済みでも **transcript は sessionMap に残す** — 中身は正しいので次回の往復が消える。
+
+2. **`activateSession` が選択 ID を書き戻さない**（この PR が入れたバグ。1 の e2e を書いていて発覚）
+   `activateSession` は URL が既に対象を指すとき `navigateToSession` をスキップする（#762: 再 push で
+   query string が落ちるため）。**そのスキップは `currentSessionId` の書き込みも巻き添えにしていた**。
+   選択 ID が常に URL と一緒に動いていた頃は無害。A（遅い）→ B（URL が指しているセッション）と
+   クリックすると、選択枠が A に貼り付いたままになる。当該分岐でも ID を書くようにした。
+
+3. **失敗した読み込みでセッションが既読になる**（Codex。当初「稀」として見送ったが撤回）
+   `currentSessionId` が先に進むと App.vue の既読 watcher が発火する。transcript が 500 で
+   meta サイドカーが健全なら mark-read は成功し、**「新着あり」の信号が復元不能に失われる**。
+   既読クリアの起点を `activeSession`（= `sessionMap` に載って初めて定義される）に変更。
+   購読管理は引き続き `currentSessionId` の watcher に残す（クリック時点で走るのが正しい）。
+
+教訓: 「選択を楽観的に先行させる」変更は、**選択 ID と URL の同期を暗黙の前提にしていた
+コードすべて**を洗い出す必要がある。build も既存テストも通ったまま壊れる。
+
 ## 検証
 
 - `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`
 - e2e: 既存の `history-panel` / `a11y-clickable-rows` / `router-navigation` /
   `session-history-side-panel` が testid 据え置きでそのまま通ること。
-- 追加 e2e: `/api/sessions/:id` を遅延させ、**レスポンスが返る前に**行へ選択枠
-  (`border-blue-500`) が付くことを確認する（案3 の回帰ガード）。
-- 追加単体テスト: `shouldRestorePreviousSelection` の 2 分岐。
+- 追加 e2e（`history-panel.spec.ts`）:
+  - `/api/sessions/:id` を保留し、**レスポンスが返る前に**行へ選択枠 (`border-blue-500`) が付く
+  - A（遅い）→ B の順にクリックし、後から A が返っても **B から引き剥がされない**
+  - transcript が 500 のとき、行が**未読の太字のまま**・選択枠が付かない・URL が動かない・
+    `mark-read` が 0 回
+- 追加単体テスト: `isAwaitedSession` の 3 分岐。
+- 追加ガード（`test/components/test_session_history_row_wiring.ts`）: 案1・案2 は**振る舞いを
+  変えないので既存テストが全部緑のまま壊せる**。親がハンドラを裸の識別子で渡すこと、行の
+  文字列生成が computed であることをソース parse で固定する。Vue コンポーネントの unit test
+  基盤が無いリポなので、既存の `test_stackview_googlemap_wiring.ts` と同じ方式。
+- **各テストが修正を外すと落ちることを個別に確認済み**（回帰ガードとして機能することの実証）。

--- a/plans/fix-2809-session-row-rerender.md
+++ b/plans/fix-2809-session-row-rerender.md
@@ -1,0 +1,103 @@
+# セッション選択のたびに全行が再描画される (#2809)
+
+## 背景
+
+セッション履歴パネル（左カラム）で行をクリックしてから画面が変わるまで、セッション数が
+多い環境で 100〜300 ms かかり、その間フィードバックが一切ない。
+
+#2809 の計測（セッション 808 件、Safari、典型値 約 170 ms）:
+
+| 内訳 | 時間 |
+| --- | --- |
+| `GET /api/sessions/:id` | 7〜13 ms |
+| セッション構築 | 0〜1 ms |
+| `formatDate()` × 808 行 | 41〜50 ms |
+| `t()` × 808 行 | 6〜8 ms |
+| プレビュー解決 × 2424 回 | 1〜4 ms |
+| Vue のパッチ + レイアウト/ペイント | 約 110 ms |
+
+サーバ側は律速ではない。実際に見た目が変わるのは 2 行（選択が外れる行と付く行）だけで、
+残りは同じ内容を作り直している。
+
+## この PR でやること
+
+#2809 の「考えられるアプローチ」1〜3 を 1 PR で入れる。4（仮想化）は入れない。
+
+### 1. 行を子コンポーネントへ切り出す（案2、効果の主体）
+
+`SessionHistoryPanel.vue` の `v-for` の中身を `SessionHistoryRow.vue` に移す。
+親が再描画されても、Vue は props が `===` で変わっていない子の更新をスキップするため、
+選択変更で実際に再描画されるのは `selected` が反転した 2 行だけになる。
+
+props が安定していることが前提なので、次を守る:
+
+- `session` — `mergedSessions` は live セッションだけ `buildLiveSummary` で新しい
+  オブジェクトを作り、server-only 行は `sessions.value` の参照をそのまま流す
+  （`mergeSessionLists`）。よって大半の行は参照が変わらない。
+- `roles` — `App.vue` の `ref` をそのまま渡す。
+- ハンドラ — v-for のループ変数を閉じ込めたインライン矢印関数を渡すと毎回新しい関数参照に
+  なり、props 比較が必ず不一致になって子がスキップされない。**`@select="onRowSelect"` の
+  ようにメソッド参照だけを渡し、対象は emit のペイロードで返す**。
+
+### 2. 行ごとの日時整形・i18n 補間を computed にする（案1）
+
+`formatDate()` / `t()` / プレビュー解決を子の `computed` にする。computed は依存
+（`session.updatedAt` など）が変わらない限り再評価されないので、`selected` が変わって
+子が再描画されても文字列整形は走らない。全行ぶんの `toLocale*`（Safari 41〜50 ms）が
+クリック経路から消える。
+
+### 3. クリック直後に選択状態を反映する（案3）
+
+`useSessionLifecycle.ts` の `loadSession` は `await apiGet(...)` の後まで
+`currentSessionId` を書かないため、選択枠がサーバ往復ぶん遅れる。fetch の**前**に
+`currentSessionId` を進める。
+
+URL は従来どおり成功後の `activateSession` で確定させる（router を先に動かさない）ので、
+失敗時のロールバックは ref の巻き戻しだけで済む。
+
+**失敗時の扱い**（#2809 で「決める必要がある」とされていた点）:
+
+- 取得に失敗したら `currentSessionId` を直前の値へ戻す。
+- ただし**戻すのは、失敗した ID がまだ選択中のときだけ**。行 A（遅い）→ 行 B（速い、成功）
+  と続けてクリックし、その後 A が失敗した場合に B から引き剥がしてはいけない。
+  この判定は `shouldRestorePreviousSelection()` として `utils/session/sessionLifecycle.ts`
+  （純粋ルール置き場）に置き、単体テストで固定する。
+- 呼び出し側の既存フォールバック（route watcher の `createNewSession()`、
+  `resumeOrCreateChatSession` の `if (!sessionMap.has(topId)) createNewSession()`）は
+  そのまま残る。`loadSession` の契約（失敗時は sessionMap に入らないまま返る）は変えない。
+
+## 変更しないもの
+
+- `data-testid`（`session-item-<id>` / `session-row-menu-<id>` / `session-row-menu-popover-<id>` /
+  `session-row-bookmark-<id>` / `session-row-delete-<id>`）は据え置き。既存 e2e がそのまま通る。
+- 行の a11y 契約（`role="button"` / `tabindex="0"` / `aria-label` / `.self` 付き Enter・Space /
+  `event.repeat` 無視）は #684 のまま子へ移送する。
+- ポップオーバーの排他制御（`openMenuId` と document クリックリスナ）と削除確認ダイアログは
+  親に残す。子は「開いているか」を bool で受け取るだけ。
+
+## 実測（修正前 / 修正後）
+
+Playwright（Chromium、同一マシン・同一 fixture）で **クリック → 行に選択枠が付くまで** を
+`MutationObserver` で計測。両方のセッションを先に `sessionMap` へ載せてから測るので、
+ネットワークは経路に入らず、**一覧の再描画コストだけ**を見ている。12 サンプルの中央値:
+
+| セッション数 | 修正前 | 修正後 |
+| --- | --- | --- |
+| 200 | 17.6 ms | 3.2 ms |
+| 800 | 62.5 ms | 5.0 ms |
+
+修正前は行数に比例して伸びる（4 倍で 3.6 倍）。修正後はほぼ横ばい（1.6 倍）で、
+再描画が O(行数) でなくなったことが確認できる。Chromium での数字なので、#2809 の
+「Safari の Vue パッチは Chrome の約 3.7 倍」を踏まえると Safari の改善幅はこれより大きい。
+
+案3 の効果は別に確認する（下記 e2e）。上表の経路はどちらの版でも `currentSessionId` を
+同期的に書くので、この数字には案3 は含まれていない。
+
+## 検証
+
+- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`
+- e2e: 既存の `history-panel` / `a11y-clickable-rows` / `router-navigation` /
+  `session-history-side-panel` が testid 据え置きでそのまま通ること。
+- 追加 e2e: `/api/sessions/:id` を遅延させ、**レスポンスが返る前に**行へ選択枠
+  (`border-blue-500`) が付くことを確認する（案3 の回帰ガード）。
+- 追加単体テスト: `shouldRestorePreviousSelection` の 2 分岐。

--- a/src/App.vue
+++ b/src/App.vue
@@ -864,16 +864,25 @@ watch(currentSessionId, (sessionId) => {
     }
   }
   previousSessionId = sessionId;
+});
 
-  // Clear unread in both sessionMap and sessions list (for badge count),
+// Clearing unread keys off the transcript arriving, not off the click.
+// currentSessionId now moves ahead of the fetch (#2809), so a session
+// whose load then fails would otherwise lose its unread badge without
+// ever having been read — and a transcript that 500s while its meta
+// sidecar is healthy leaves the server happy to accept the mark-read.
+// activeSession only becomes defined once the session is in sessionMap,
+// which covers both switching to an already-loaded session and a
+// just-completed load.
+watch(activeSession, (session) => {
+  if (!session) return;
+  // Clear in both sessionMap and the sessions list (for badge count),
   // then tell the server so other tabs see it too.
-  const summary = sessions.value.find((entry) => entry.id === sessionId);
-  const wasUnread = (session && session.hasUnread) || (summary && summary.hasUnread);
-  if (wasUnread) {
-    if (session) session.hasUnread = false;
-    if (summary) summary.hasUnread = false;
-    markSessionRead(sessionId);
-  }
+  const summary = sessions.value.find((entry) => entry.id === session.id);
+  if (!(session.hasUnread || summary?.hasUnread)) return;
+  session.hasUnread = false;
+  if (summary) summary.hasUnread = false;
+  markSessionRead(session.id);
 });
 
 const { handleCanvasKeydown, handleKeyNavigation } = useKeyNavigation({

--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -30,85 +30,25 @@
       <p v-if="filteredSessions.length === 0" class="text-xs text-gray-400 p-2">
         {{ activeFilter === HISTORY_FILTERS.all ? t("sessionHistoryPanel.noSessions") : t("sessionHistoryPanel.noMatching") }}
       </p>
-      <div
+      <!-- Handlers are passed as method references on purpose: an
+           inline arrow closing over `session` would be a fresh
+           function on every render of this list, so every row's props
+           compare would fail and the whole list would re-render on
+           each selection change — the cost SessionHistoryRow exists to
+           avoid. The row hands its own session back through the emit
+           payload instead. -->
+      <SessionHistoryRow
         v-for="session in filteredSessions"
         :key="session.id"
-        tabindex="0"
-        role="button"
-        :aria-label="t('sessionHistoryPanel.openRowAria', { preview: primaryText(session) })"
-        :title="primaryText(session)"
-        class="relative cursor-pointer rounded p-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
-        :class="rowClasses(session)"
-        :data-testid="`session-item-${session.id}`"
-        @click="emit('loadSession', session.id)"
-        @keydown.enter.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
-        @keydown.space.prevent.self="(e) => !e.repeat && emit('loadSession', session.id)"
-      >
-        <!-- Timestamp pill straddling the top border, mirroring the
-             SessionSidebar card design. The kebab "..." button sits
-             next to it on the same border line — clicking opens a
-             popover with delete + bookmark actions. The running
-             indicator still renders inline in the meta line below
-             (it's a status, not a time); unread is signalled through
-             previewClasses (bold text); bookmark state is signalled
-             via the green role icon. -->
-        <div class="absolute top-0 right-6 -translate-y-1/2 flex items-center gap-1 bg-white px-1 leading-none">
-          <span class="text-[10px] text-gray-400 pointer-events-none">{{ formatDate(session.updatedAt) }}</span>
-          <button
-            type="button"
-            class="flex items-center justify-center px-0.5 border border-gray-300 rounded-md text-gray-400 hover:text-gray-700 hover:border-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-400"
-            :aria-label="t('sessionHistoryPanel.rowMenuAria')"
-            :data-testid="`session-row-menu-${session.id}`"
-            @click.stop="toggleMenu(session.id)"
-            @keydown.enter.stop
-            @keydown.space.stop
-          >
-            <span class="material-icons !text-[14px] leading-none" aria-hidden="true">more_horiz</span>
-          </button>
-        </div>
-        <div
-          v-if="openMenuId === session.id"
-          class="absolute top-2 right-2 z-10 min-w-[140px] rounded border border-gray-200 bg-white shadow-md py-1 text-xs"
-          role="menu"
-          :data-testid="`session-row-menu-popover-${session.id}`"
-          @click.stop
-        >
-          <button
-            type="button"
-            role="menuitem"
-            class="block w-full text-left px-3 py-1.5 hover:bg-gray-100"
-            :data-testid="`session-row-bookmark-${session.id}`"
-            @click.stop="onToggleBookmark(session)"
-          >
-            {{ session.isBookmarked ? t("sessionHistoryPanel.unbookmark") : t("sessionHistoryPanel.bookmark") }}
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            class="block w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50"
-            :data-testid="`session-row-delete-${session.id}`"
-            @click.stop="onDelete(session)"
-          >
-            {{ t("sessionHistoryPanel.delete") }}
-          </button>
-        </div>
-        <!-- Primary line prefers the AI-generated summary (chat indexer,
-             #123) when present — it's typically more informative than
-             the first user message. Fall back to the first user message,
-             then to a "no messages" placeholder. `line-clamp-2` lets a
-             summary wrap so more of it is readable at a glance; the raw
-             first-message fallback stays on a single line via `truncate`
-             so short prompts don't disturb row heights. -->
-        <div class="flex items-start gap-1.5">
-          <SessionRoleIcon :session="session" :roles="roles" size="sm" class="flex-shrink-0 mt-0.5" />
-          <p class="flex-1 min-w-0" :class="[previewClasses(session), sessionHasVisibleSummary(session) ? 'line-clamp-2' : 'truncate']">
-            {{ primaryText(session) }}
-          </p>
-          <span v-if="isSessionRunning(session)" class="flex-shrink-0 flex items-center mt-0.5" :aria-label="t('sessionHistoryPanel.running')">
-            <span class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
-          </span>
-        </div>
-      </div>
+        :session="session"
+        :roles="roles"
+        :selected="session.id === currentSessionId"
+        :menu-open="openMenuId === session.id"
+        @select="onSelect"
+        @toggle-menu="toggleMenu"
+        @toggle-bookmark="onToggleBookmark"
+        @delete-session="onDelete"
+      />
     </div>
   </div>
 </template>
@@ -121,9 +61,7 @@ import type { SessionSummary, SessionOrigin } from "../types/session";
 import { SESSION_ORIGINS } from "../types/session";
 import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, type HistoryFilter } from "../config/historyFilters";
 import { isLongRunningConversation } from "../utils/session/longRunning";
-import { resolveSessionPrimaryText, sessionHasVisibleSummary } from "../utils/session/sessionPreview";
-import { formatDate } from "../utils/format/date";
-import SessionRoleIcon from "./SessionRoleIcon.vue";
+import SessionHistoryRow from "./SessionHistoryRow.vue";
 import FilterChip from "./FilterChip.vue";
 
 const { t } = useI18n();
@@ -185,31 +123,8 @@ function countByOrigin(filterKey: HistoryFilter): number {
   return props.sessions.filter((session) => matchesFilter(session, filterKey)).length;
 }
 
-function isSessionRunning(session: SessionSummary): boolean {
-  return session.isRunning ?? false;
-}
-
-function isSessionUnread(session: SessionSummary): boolean {
-  return session.hasUnread ?? false;
-}
-
-function rowClasses(session: SessionSummary): string {
-  if (session.id === props.currentSessionId) return "border-2 border-blue-500 hover:bg-gray-50";
-  return "border border-gray-200 hover:bg-gray-50";
-}
-
-function previewClasses(session: SessionSummary): string {
-  if (isSessionUnread(session)) return "text-gray-900 font-bold";
-  return "text-gray-700";
-}
-
-// Primary line resolution: prefer the AI summary (trim + whitespace
-// guarded so a summarizer returning "   " doesn't blank the row) →
-// first user message → localised placeholder. Same call is used for
-// visible text, aria-label, and the hover title so all three stay in
-// lockstep.
-function primaryText(session: SessionSummary): string {
-  return resolveSessionPrimaryText(session) ?? t("sessionHistoryPanel.noMessages");
+function onSelect(sessionId: string): void {
+  emit("loadSession", sessionId);
 }
 
 // ── Row action menu ─────────────────────────────────────────

--- a/src/components/SessionHistoryRow.vue
+++ b/src/components/SessionHistoryRow.vue
@@ -1,0 +1,140 @@
+<template>
+  <div
+    tabindex="0"
+    role="button"
+    :aria-label="rowAria"
+    :title="primaryText"
+    class="relative cursor-pointer rounded p-2 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+    :class="rowClasses"
+    :data-testid="`session-item-${session.id}`"
+    @click="emit('select', session.id)"
+    @keydown.enter.prevent.self="onActivateKey"
+    @keydown.space.prevent.self="onActivateKey"
+  >
+    <!-- Timestamp pill straddling the top border, mirroring the
+         SessionSidebar card design. The kebab "..." button sits
+         next to it on the same border line — clicking opens a
+         popover with delete + bookmark actions. The running
+         indicator still renders inline in the meta line below
+         (it's a status, not a time); unread is signalled through
+         previewClasses (bold text); bookmark state is signalled
+         via the green role icon. -->
+    <div class="absolute top-0 right-6 -translate-y-1/2 flex items-center gap-1 bg-white px-1 leading-none">
+      <span class="text-[10px] text-gray-400 pointer-events-none">{{ formattedDate }}</span>
+      <button
+        type="button"
+        class="flex items-center justify-center px-0.5 border border-gray-300 rounded-md text-gray-400 hover:text-gray-700 hover:border-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-400"
+        :aria-label="t('sessionHistoryPanel.rowMenuAria')"
+        :data-testid="`session-row-menu-${session.id}`"
+        @click.stop="emit('toggleMenu', session.id)"
+        @keydown.enter.stop
+        @keydown.space.stop
+      >
+        <span class="material-icons !text-[14px] leading-none" aria-hidden="true">more_horiz</span>
+      </button>
+    </div>
+    <div
+      v-if="menuOpen"
+      class="absolute top-2 right-2 z-10 min-w-[140px] rounded border border-gray-200 bg-white shadow-md py-1 text-xs"
+      role="menu"
+      :data-testid="`session-row-menu-popover-${session.id}`"
+      @click.stop
+    >
+      <button
+        type="button"
+        role="menuitem"
+        class="block w-full text-left px-3 py-1.5 hover:bg-gray-100"
+        :data-testid="`session-row-bookmark-${session.id}`"
+        @click.stop="emit('toggleBookmark', session)"
+      >
+        {{ session.isBookmarked ? t("sessionHistoryPanel.unbookmark") : t("sessionHistoryPanel.bookmark") }}
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        class="block w-full text-left px-3 py-1.5 text-red-600 hover:bg-red-50"
+        :data-testid="`session-row-delete-${session.id}`"
+        @click.stop="emit('deleteSession', session)"
+      >
+        {{ t("sessionHistoryPanel.delete") }}
+      </button>
+    </div>
+    <!-- Primary line prefers the AI-generated summary (chat indexer,
+         #123) when present — it's typically more informative than
+         the first user message. Fall back to the first user message,
+         then to a "no messages" placeholder. `line-clamp-2` lets a
+         summary wrap so more of it is readable at a glance; the raw
+         first-message fallback stays on a single line via `truncate`
+         so short prompts don't disturb row heights. -->
+    <div class="flex items-start gap-1.5">
+      <SessionRoleIcon :session="session" :roles="roles" size="sm" class="flex-shrink-0 mt-0.5" />
+      <p class="flex-1 min-w-0" :class="[previewClasses, hasVisibleSummary ? 'line-clamp-2' : 'truncate']">
+        {{ primaryText }}
+      </p>
+      <span v-if="session.isRunning" class="flex-shrink-0 flex items-center mt-0.5" :aria-label="t('sessionHistoryPanel.running')">
+        <span class="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// One row of the session-history list, split out of
+// SessionHistoryPanel so that selecting a session re-renders only the
+// two rows whose `selected` flipped. Measured at 800 sessions, the
+// wholesale re-render cost 100-300 ms of unresponsive UI per click.
+//
+// Two things keep the skip working, and both are easy to undo by
+// accident:
+//   - the parent must pass method references, never inline arrows
+//     closing over the v-for variable (a fresh function each render
+//     makes the props compare fail, so every row re-renders again)
+//   - every derived string is a `computed`, so date formatting and
+//     i18n interpolation survive a re-render instead of re-running
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+import type { Role } from "../config/roles";
+import type { SessionSummary } from "../types/session";
+import { resolveSessionPrimaryText, sessionHasVisibleSummary } from "../utils/session/sessionPreview";
+import { formatDate } from "../utils/format/date";
+import SessionRoleIcon from "./SessionRoleIcon.vue";
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  session: SessionSummary;
+  roles: Role[];
+  selected: boolean;
+  menuOpen: boolean;
+}>();
+
+const emit = defineEmits<{
+  select: [id: string];
+  toggleMenu: [id: string];
+  toggleBookmark: [session: SessionSummary];
+  deleteSession: [session: SessionSummary];
+}>();
+
+// Same call feeds the visible text, the aria-label, and the hover
+// title so all three stay in lockstep. `null` from the resolver means
+// "nothing to show" — the localised placeholder is applied here rather
+// than in the pure helper.
+const primaryText = computed(() => resolveSessionPrimaryText(props.session) ?? t("sessionHistoryPanel.noMessages"));
+
+const rowAria = computed(() => t("sessionHistoryPanel.openRowAria", { preview: primaryText.value }));
+
+const formattedDate = computed(() => formatDate(props.session.updatedAt));
+
+const hasVisibleSummary = computed(() => sessionHasVisibleSummary(props.session));
+
+const rowClasses = computed(() => (props.selected ? "border-2 border-blue-500 hover:bg-gray-50" : "border border-gray-200 hover:bg-gray-50"));
+
+const previewClasses = computed(() => (props.session.hasUnread ? "text-gray-900 font-bold" : "text-gray-700"));
+
+// Held Enter / Space on a native <button> activates once per physical
+// press, not per OS auto-repeat tick (#684).
+function onActivateKey(event: KeyboardEvent): void {
+  if (event.repeat) return;
+  emit("select", props.session.id);
+}
+</script>

--- a/src/composables/useSessionLifecycle.ts
+++ b/src/composables/useSessionLifecycle.ts
@@ -24,7 +24,7 @@ import {
   isSessionAlreadyDisplayed,
   isOnTargetSessionRoute,
   resolveResumeAction,
-  shouldRestorePreviousSelection,
+  isAwaitedSession,
 } from "../utils/session/sessionLifecycle";
 
 interface LifecycleDeps {
@@ -105,7 +105,14 @@ function activateSession(ctx: LifecycleCtx, sessionId: string, replace: boolean)
   // #762) because navigateToSession builds the location with params only.
   if (!isOnTargetSessionRoute(routeSessionId, sessionId, ctx.route.name === PAGE_ROUTES.chat)) {
     navigateToSession(ctx, sessionId, replace);
+    return;
   }
+  // Taking that shortcut skips the one thing navigateToSession also does.
+  // The selection can sit ahead of the URL now that loadSession moves it
+  // before the fetch, so returning to the session the URL already names
+  // has to write the id back by hand — otherwise the selection stays
+  // stuck on the abandoned in-flight one.
+  ctx.currentSessionId.value = sessionId;
 }
 
 async function fetchLoadedSession(ctx: LifecycleCtx, sessionId: string): Promise<ActiveSession | null> {
@@ -134,12 +141,15 @@ async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> 
   // second navigation.
   ctx.currentSessionId.value = sessionId;
   const newSession = await fetchLoadedSession(ctx, sessionId);
+  const stillAwaited = isAwaitedSession(ctx.currentSessionId.value, sessionId);
   if (newSession === null) {
-    if (shouldRestorePreviousSelection(ctx.currentSessionId.value, sessionId)) ctx.currentSessionId.value = previousSessionId;
+    if (stillAwaited) ctx.currentSessionId.value = previousSessionId;
     return;
   }
+  // Keep the transcript even when the user has moved on — it is valid,
+  // and their next click on this session then costs no round trip.
   ctx.sessionMap.set(sessionId, newSession);
-  activateSession(ctx, sessionId, replaced);
+  if (stillAwaited) activateSession(ctx, sessionId, replaced);
 }
 
 // Re-fetch the transcript and patch entries missed via a dropped socket

--- a/src/composables/useSessionLifecycle.ts
+++ b/src/composables/useSessionLifecycle.ts
@@ -24,6 +24,7 @@ import {
   isSessionAlreadyDisplayed,
   isOnTargetSessionRoute,
   resolveResumeAction,
+  shouldRestorePreviousSelection,
 } from "../utils/session/sessionLifecycle";
 
 interface LifecycleDeps {
@@ -107,22 +108,36 @@ function activateSession(ctx: LifecycleCtx, sessionId: string, replace: boolean)
   }
 }
 
-async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> {
-  if (isSessionAlreadyDisplayed(sessionId, ctx.currentSessionId.value, ctx.sessionMap.has(sessionId))) return;
-  const replaced = shouldReplaceHistory(removeCurrentIfEmpty(ctx), ctx.isChatPage.value);
-  if (ctx.sessionMap.has(sessionId)) {
-    activateSession(ctx, sessionId, replaced);
-    return;
-  }
+async function fetchLoadedSession(ctx: LifecycleCtx, sessionId: string): Promise<ActiveSession | null> {
   const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
-  if (!response.ok) return;
-  const newSession = buildLoadedSession({
+  if (!response.ok) return null;
+  return buildLoadedSession({
     id: sessionId,
     entries: response.data,
     defaultRoleId: ctx.roles.value[0]?.id ?? "",
     serverSummary: ctx.sessions.value.find((summary) => summary.id === sessionId),
     nowIso: new Date().toISOString(),
   });
+}
+
+async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> {
+  if (isSessionAlreadyDisplayed(sessionId, ctx.currentSessionId.value, ctx.sessionMap.has(sessionId))) return;
+  const previousSessionId = ctx.currentSessionId.value;
+  const replaced = shouldReplaceHistory(removeCurrentIfEmpty(ctx), ctx.isChatPage.value);
+  if (ctx.sessionMap.has(sessionId)) {
+    activateSession(ctx, sessionId, replaced);
+    return;
+  }
+  // Highlight the row on the click instead of a round trip later (#2809).
+  // The URL still settles in activateSession once the transcript is in
+  // the map, so undoing a failed load is a ref assignment and never a
+  // second navigation.
+  ctx.currentSessionId.value = sessionId;
+  const newSession = await fetchLoadedSession(ctx, sessionId);
+  if (newSession === null) {
+    if (shouldRestorePreviousSelection(ctx.currentSessionId.value, sessionId)) ctx.currentSessionId.value = previousSessionId;
+    return;
+  }
   ctx.sessionMap.set(sessionId, newSession);
   activateSession(ctx, sessionId, replaced);
 }

--- a/src/utils/session/sessionLifecycle.ts
+++ b/src/utils/session/sessionLifecycle.ts
@@ -36,6 +36,16 @@ export function isSessionAlreadyDisplayed(sessionId: string, currentSessionId: s
   return sessionId === currentSessionId && sessionInMemory;
 }
 
+// loadSession moves the selection before the transcript arrives, so the
+// history row highlights on the click rather than a round trip later.
+// When the fetch then fails the selection has to go back — but only
+// while the attempted session is still the selected one. Clicking a slow
+// row and then a fast one that succeeds must not be undone when the
+// slow row's response finally errors.
+export function shouldRestorePreviousSelection(currentSessionId: string, attemptedSessionId: string): boolean {
+  return currentSessionId === attemptedSessionId;
+}
+
 // activateSession skips a redundant navigate when the URL already points
 // at the target session. Re-pushing the same path strips query strings
 // (e.g. the `?result=<uuid>` notification permalink, #762), so the guard

--- a/src/utils/session/sessionLifecycle.ts
+++ b/src/utils/session/sessionLifecycle.ts
@@ -38,12 +38,13 @@ export function isSessionAlreadyDisplayed(sessionId: string, currentSessionId: s
 
 // loadSession moves the selection before the transcript arrives, so the
 // history row highlights on the click rather than a round trip later.
-// When the fetch then fails the selection has to go back — but only
-// while the attempted session is still the selected one. Clicking a slow
-// row and then a fast one that succeeds must not be undone when the
-// slow row's response finally errors.
-export function shouldRestorePreviousSelection(currentSessionId: string, attemptedSessionId: string): boolean {
-  return currentSessionId === attemptedSessionId;
+// Both endings of that fetch have to ask whether the user is still
+// waiting on THIS session: a stale failure must not roll the selection
+// back off a newer one, and a stale success must not navigate back to a
+// session the user already left. Clicking a slow row and then a fast one
+// produces both cases.
+export function isAwaitedSession(currentSessionId: string, requestedSessionId: string): boolean {
+  return currentSessionId === requestedSessionId;
 }
 
 // activateSession skips a redundant navigate when the URL already points

--- a/test/components/test_session_history_row_wiring.ts
+++ b/test/components/test_session_history_row_wiring.ts
@@ -35,10 +35,14 @@ test("SessionHistoryPanel binds SessionHistoryRow handlers as method references"
   const handlers = [...sessionHistoryRowTag().matchAll(/@[\w-]+="([^"]*)"/g)].map((match) => match[1] ?? "");
   assert.ok(handlers.length > 0, "expected at least one @event binding on <SessionHistoryRow>");
   handlers.forEach((handler) => {
-    assert.doesNotMatch(
+    // A bare identifier is the only form Vue passes through as-is. Both
+    // `(id) => onSelect(id)` and `onSelect($event)` compile to a fresh
+    // closure per render, so matching on `=>` alone would let the second
+    // one through.
+    assert.match(
       handler,
-      /=>/,
-      `@-binding "${handler}" is an inline arrow. Pass a method reference and return the session through the emit payload — see the comment above <SessionHistoryRow>.`,
+      /^[A-Za-z_$][\w$]*$/,
+      `@-binding "${handler}" must be a bare method reference — anything Vue has to wrap is a new function on every render. Return the session through the emit payload instead; see the comment above <SessionHistoryRow>.`,
     );
   });
 });

--- a/test/components/test_session_history_row_wiring.ts
+++ b/test/components/test_session_history_row_wiring.ts
@@ -1,0 +1,56 @@
+// Regression guard for the re-render fix in #2809: SessionHistoryPanel
+// must hand SessionHistoryRow *method references*, never inline arrows
+// closing over the `v-for` variable. An arrow is a fresh function on
+// every render of the list, so every row's props compare fails and Vue
+// re-renders all of them — which is the entire cost the child component
+// was extracted to avoid. Reverting to a closure looks harmless in
+// review and leaves every behavioural test green, so the invariant is
+// pinned here instead.
+//
+// The repo has no Vue component unit-test infrastructure (e2e/ covers
+// that surface), so this parses the source the same way
+// test_stackview_googlemap_wiring.ts does.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+
+function readSource(rel: string): string {
+  return readFileSync(path.join(REPO_ROOT, rel), "utf-8");
+}
+
+function sessionHistoryRowTag(): string {
+  const src = readSource("src/components/SessionHistoryPanel.vue");
+  const tag = /<SessionHistoryRow[\s\S]*?\/>/.exec(src)?.[0];
+  assert.ok(tag, "SessionHistoryPanel must render the list through <SessionHistoryRow ... />");
+  return tag;
+}
+
+test("SessionHistoryPanel binds SessionHistoryRow handlers as method references", () => {
+  const handlers = [...sessionHistoryRowTag().matchAll(/@[\w-]+="([^"]*)"/g)].map((match) => match[1] ?? "");
+  assert.ok(handlers.length > 0, "expected at least one @event binding on <SessionHistoryRow>");
+  handlers.forEach((handler) => {
+    assert.doesNotMatch(
+      handler,
+      /=>/,
+      `@-binding "${handler}" is an inline arrow. Pass a method reference and return the session through the emit payload — see the comment above <SessionHistoryRow>.`,
+    );
+  });
+});
+
+test("SessionHistoryRow derives its per-row strings as computeds", () => {
+  // formatDate() and t() ran once per row on every list render before
+  // #2809. As computeds they survive a re-render of the row; calling
+  // them straight from the template would put them back in the click path.
+  const src = readSource("src/components/SessionHistoryRow.vue");
+  const template = /<template>([\s\S]*?)<\/template>/.exec(src)?.[1];
+  assert.ok(template, "SessionHistoryRow must have a <template> block");
+  assert.doesNotMatch(template, /formatDate\(/, "call formatDate() in a computed, not from the template");
+  assert.match(src, /const formattedDate = computed\(/, "SessionHistoryRow must expose the row timestamp as a computed");
+  assert.match(src, /const primaryText = computed\(/, "SessionHistoryRow must expose the primary line as a computed");
+});

--- a/test/utils/session/test_sessionLifecycle.ts
+++ b/test/utils/session/test_sessionLifecycle.ts
@@ -7,6 +7,7 @@ import {
   isSessionAlreadyDisplayed,
   isOnTargetSessionRoute,
   resolveResumeAction,
+  shouldRestorePreviousSelection,
 } from "../../../src/utils/session/sessionLifecycle.ts";
 
 describe("resolveNewSessionRoleId", () => {
@@ -106,6 +107,23 @@ describe("isOnTargetSessionRoute", () => {
 
   it("is false when the route has no session id", () => {
     assert.equal(isOnTargetSessionRoute("", "s1", true), false);
+  });
+});
+
+describe("shouldRestorePreviousSelection", () => {
+  it("restores when the failed load is still the selected session", () => {
+    assert.equal(shouldRestorePreviousSelection("s1", "s1"), true);
+  });
+
+  it("leaves the selection alone when a later click already moved on", () => {
+    // Click s1 (slow) → click s2 (fast, succeeds) → s1 errors. Rolling
+    // back here would yank the user off the session they are reading.
+    assert.equal(shouldRestorePreviousSelection("s2", "s1"), false);
+  });
+
+  it("leaves the selection alone when the user left /chat mid-flight", () => {
+    // currentSessionId is "" off /chat.
+    assert.equal(shouldRestorePreviousSelection("", "s1"), false);
   });
 });
 

--- a/test/utils/session/test_sessionLifecycle.ts
+++ b/test/utils/session/test_sessionLifecycle.ts
@@ -7,7 +7,7 @@ import {
   isSessionAlreadyDisplayed,
   isOnTargetSessionRoute,
   resolveResumeAction,
-  shouldRestorePreviousSelection,
+  isAwaitedSession,
 } from "../../../src/utils/session/sessionLifecycle.ts";
 
 describe("resolveNewSessionRoleId", () => {
@@ -110,20 +110,22 @@ describe("isOnTargetSessionRoute", () => {
   });
 });
 
-describe("shouldRestorePreviousSelection", () => {
-  it("restores when the failed load is still the selected session", () => {
-    assert.equal(shouldRestorePreviousSelection("s1", "s1"), true);
+describe("isAwaitedSession", () => {
+  it("is true while the in-flight load is still the selected session", () => {
+    assert.equal(isAwaitedSession("s1", "s1"), true);
   });
 
-  it("leaves the selection alone when a later click already moved on", () => {
-    // Click s1 (slow) → click s2 (fast, succeeds) → s1 errors. Rolling
-    // back here would yank the user off the session they are reading.
-    assert.equal(shouldRestorePreviousSelection("s2", "s1"), false);
+  it("is false once a later click has moved the selection on", () => {
+    // Click s1 (slow) → click s2 (fast, succeeds) → s1 finally lands.
+    // Acting on s1 now would yank the user off the session they are
+    // reading, whether s1 succeeded (navigate back) or failed (roll the
+    // selection back to whatever preceded s1).
+    assert.equal(isAwaitedSession("s2", "s1"), false);
   });
 
-  it("leaves the selection alone when the user left /chat mid-flight", () => {
+  it("is false when the user left /chat mid-flight", () => {
     // currentSessionId is "" off /chat.
-    assert.equal(shouldRestorePreviousSelection("", "s1"), false);
+    assert.equal(isAwaitedSession("", "s1"), false);
   });
 });
 


### PR DESCRIPTION
## Summary

セッション履歴パネルで行をクリックしてから画面が変わるまでの 100〜300 ms の無反応を解消する。#2809 の「考えられるアプローチ」1〜3 を 1 PR で入れる（4 の仮想化は入れない）。

1. **行を子コンポーネントへ** — `SessionHistoryRow.vue` を新設。props が `===` で変わらない行は Vue が更新をスキップするため、選択変更で再描画されるのは `selected` が反転した 2 行だけになる。
2. **行ごとの整形を computed に** — `formatDate()` / `t()` / プレビュー解決を子の `computed` へ。依存が変わらない限り再評価されないので、全行ぶんの `toLocale*`・i18n 補間がクリック経路から消える。
3. **クリック直後に選択を反映** — `loadSession` が `await apiGet(...)` の**前**に `currentSessionId` を進める。

### 実測（Chromium、同一マシン・同一 fixture）

**クリック → 行に選択枠が付くまで**を `MutationObserver` で計測。両セッションを先に `sessionMap` へ載せてから測るので、**ネットワークは経路に入らず一覧の再描画コストだけ**を見ている。12 サンプルの中央値:

| セッション数 | 修正前 | 修正後 |
| --- | --- | --- |
| 200 | 17.6 ms | 3.2 ms |
| 800 | 62.5 ms | 5.0 ms |

修正前は行数に比例して伸びる（4 倍で 3.6 倍）。修正後はほぼ横ばい（1.6 倍）で、再描画が O(行数) でなくなった。Chromium の数字なので、#2809 の「Safari の Vue パッチは Chrome の約 3.7 倍」を踏まえると Safari の改善幅はこれより大きい。計測は使い捨ての Playwright spec で行い、コミットには含めていない。

## Items to Confirm / Review

### 1. 案3 が生んだ「選択 ID が URL より先に動く」状態 — ここが一番のレビュー対象

案3 は、既存コードが暗黙に前提にしていた「`currentSessionId` と URL は一緒に動く」を崩す。**レビュー中に、この前提に依存していた箇所が 3 つ見つかった**（詳細は `plans/fix-2809-session-row-rerender.md`）:

| # | 内容 | 出どころ |
| --- | --- | --- |
| 1 | stale な成功レスポンスで `activateSession` してしまう（A 遅い → B → A 到着で A に飛ぶ）。レース自体は PR 以前から存在 | CodeRabbit |
| 2 | `activateSession` が URL 一致時に `navigateToSession` をスキップする際、**`currentSessionId` の書き込みまで巻き添えでスキップ**していた。**この PR が入れたバグ** | 上の e2e を書いていて発覚 |
| 3 | 読み込みに失敗したセッションが既読になる（transcript 500 + meta 健全 → mark-read 成功 → 「新着あり」が復元不能に消える） | Codex |

**同種の前提がまだ他に残っていないか**が、人間に一番見てほしい点です。build も既存テストも通ったまま壊れる類のもの。

### 2. fetch 中の中央ペイン

`currentSessionId` が先に進むので、`sessionMap` に載るまでの数〜十数 ms は `activeSession` が undefined になり中央ペインが空になる。遅い回線ではこれが「読み込み中」として見える時間になる。許容範囲か。

### 3. ハンドラをメソッド参照で渡している点

`SessionHistoryPanel.vue` の `@select="onSelect"` 等。v-for のループ変数を閉じ込めたインライン矢印関数（や `onSelect($event)`）に戻すと、毎回新しい関数参照になって props 比較が必ず不一致になり、**この PR の効果が丸ごと消える**。テンプレートのコメント＋ソース parse のテストで固定してあります。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2809 を対応してほしい
- 対応範囲は #2809 の「考えられるアプローチ」の 1+2+3（仮想化は入れない）
- （その後）`/gh-review-loop` で bot レビューを triage

## 変更しないもの

- `data-testid`（`session-item-<id>` / `session-row-menu-<id>` / `session-row-menu-popover-<id>` / `session-row-bookmark-<id>` / `session-row-delete-<id>`）は据え置き。既存 e2e がそのまま通る。
- 行の a11y 契約（`role="button"` / `tabindex="0"` / `aria-label` / `.self` 付き Enter・Space / `event.repeat` 無視、#684）は子へそのまま移送。
- ポップオーバーの排他制御（`openMenuId` + document クリックリスナ）と削除確認ダイアログは親に残す。

## テスト

追加した e2e（`history-panel.spec.ts`）:

- レスポンスを保留したまま、**返る前に**行へ選択枠が付く（案3 の回帰ガード）
- A（遅い）→ B の順にクリックし、後から A が返っても **B から引き剥がされない**
- transcript が 500 のとき、行が**未読の太字のまま**・選択枠が付かない・URL が動かない・`mark-read` が 0 回

その他:

- 単体テスト `isAwaitedSession` の 3 分岐
- `test/components/test_session_history_row_wiring.ts` — 案1・案2 は**振る舞いを変えないので既存テストが全部緑のまま壊せる**ため、ハンドラが裸の識別子であること・行の文字列生成が computed であることをソース parse で固定（Vue コンポーネントの unit test 基盤が無いリポなので、既存の `test_stackview_googlemap_wiring.ts` と同じ方式）

**追加したテストは、対応する修正を外すと個別に落ちることを確認済み**です（回帰ガードとして機能することの実証）。

`yarn lint` / `typecheck` / `build` / `test` / `test:e2e`（459 件）すべて green。

## レビュー経緯

`/gh-review-loop` で 4 イテレーション。Codex は最終的に `CODEX VERDICT: LGTM`、CodeRabbit は指摘 3 件すべて対応済み、Sourcery は weekly rate limit で本体レビューなし。各 iteration の対応内容は PR コメントに記載。

Refs #2809

work in mulmoclaude5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
