### PR TITLE
feat(chat): 入力中の下書きをセッションごとに保存し、リロードで消えないようにする (#2811)

### DIFF
--- a/e2e/tests/chatinput-draft-persist.spec.ts
+++ b/e2e/tests/chatinput-draft-persist.spec.ts
@@ -18,6 +18,16 @@ async function storedDrafts(page: Page): Promise<string> {
   return (await page.evaluate((key) => sessionStorage.getItem(key), DRAFTS_STORAGE_KEY)) ?? "";
 }
 
+// Which session an /api/agent POST addressed, or null when the body
+// isn't the shape we expect (so a malformed body fails the assertion
+// rather than throwing).
+function sentChatSessionId(body: string | undefined): string | null {
+  if (!body) return null;
+  const parsed: unknown = JSON.parse(body);
+  if (typeof parsed !== "object" || parsed === null || !("chatSessionId" in parsed)) return null;
+  return typeof parsed.chatSessionId === "string" ? parsed.chatSessionId : null;
+}
+
 test.beforeEach(async ({ page }) => {
   await mockAllApis(page);
 });
@@ -92,6 +102,45 @@ test.describe("chat input draft persistence", () => {
 
     await selectSessionTab(page, SESSION_A.id);
     await expect(page.getByTestId("chat-attachment-list")).toHaveCount(1);
+  });
+
+  // Attachment upload is a real round trip, so the displayed session can
+  // change before it resolves. The turn belongs to the session the user
+  // composed it in — both when the upload fails (the draft goes back
+  // there) and when it succeeds (the message is sent there).
+  test("a send whose upload outlives a session switch still lands in the origin session", async ({ page }) => {
+    let releaseUpload = (): void => undefined;
+    const uploadHeld = new Promise<void>((resolve) => {
+      releaseUpload = resolve;
+    });
+    const agentBodies: string[] = [];
+
+    await page.route(
+      (url) => url.pathname === "/api/attachments",
+      async (route) => {
+        await uploadHeld;
+        await route.fulfill({ json: { path: "/w/data/attachments/a.png", originalPath: "a.png", mimeType: "image/png" } });
+      },
+    );
+    await page.route(
+      (url) => url.pathname === "/api/agent",
+      (route) => {
+        if (route.request().method() !== "POST") return route.fallback();
+        agentBodies.push(route.request().postData() ?? "");
+        return route.fulfill({ status: 202, json: { chatSessionId: "mock-session" } });
+      },
+    );
+
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await page.getByTestId("file-input").setInputFiles([{ name: "a.png", mimeType: "image/png", buffer: Buffer.from("a") }]);
+    await fillChatInput(page, DRAFT_A);
+    await clickSend(page);
+
+    await selectSessionTab(page, SESSION_B.id);
+    releaseUpload();
+
+    await expect.poll(() => agentBodies.length).toBe(1);
+    expect(sentChatSessionId(agentBodies[0])).toBe(SESSION_A.id);
   });
 
   test("a sent message does not come back on the next load", async ({ page }) => {

--- a/e2e/tests/chatinput-draft-persist.spec.ts
+++ b/e2e/tests/chatinput-draft-persist.spec.ts
@@ -110,6 +110,31 @@ test.describe("chat input draft persistence", () => {
     await expect(chatInput(page)).toHaveValue("");
   });
 
+  // Landing on /chat without a session id in the URL, the composer is
+  // usable while the app is still deciding which session to resume. Text
+  // typed in that window has no session to belong to yet, and must not
+  // disappear when one arrives.
+  test("text typed before the session id arrives survives the hand-off", async ({ page }) => {
+    let releaseSessions = (): void => undefined;
+    const sessionsHeld = new Promise<void>((resolve) => (releaseSessions = resolve));
+    await page.route(
+      (url) => url.pathname === "/api/sessions",
+      async (route) => {
+        if (route.request().method() !== "GET") return route.fallback();
+        await sessionsHeld;
+        return route.fulfill({ json: { sessions: [], cursor: "v1:0", deletedIds: [] } });
+      },
+    );
+
+    await page.goto("/");
+    await expect(chatInput(page)).toBeVisible();
+    await fillChatInput(page, DRAFT_A);
+    releaseSessions();
+
+    await expect(page).toHaveURL(/\/chat\/.+/);
+    await expect(chatInput(page)).toHaveValue(DRAFT_A);
+  });
+
   // Switching away from a never-sent-to session evicts it: it has no
   // route and no history row left, so its draft must not sit in storage
   // forever — nothing can ever bring it back on screen.

--- a/e2e/tests/chatinput-draft-persist.spec.ts
+++ b/e2e/tests/chatinput-draft-persist.spec.ts
@@ -5,13 +5,18 @@
 // session's own draft, and anything that leaves the input empty (a
 // send) must leave nothing behind for the next load to resurrect.
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 import { SESSION_A, SESSION_B } from "../fixtures/sessions";
 import { chatInput, fillChatInput, clickSend, selectSessionTab, startNewSession } from "../fixtures/chat";
 
 const DRAFT_A = "draft for session A";
 const DRAFT_B = "draft for session B";
+const DRAFTS_STORAGE_KEY = "chat_drafts_by_session";
+
+async function storedDrafts(page: Page): Promise<string> {
+  return (await page.evaluate((key) => sessionStorage.getItem(key), DRAFTS_STORAGE_KEY)) ?? "";
+}
 
 test.beforeEach(async ({ page }) => {
   await mockAllApis(page);
@@ -60,6 +65,21 @@ test.describe("chat input draft persistence", () => {
     await startNewSession(page);
 
     await expect(chatInput(page)).toHaveValue("");
+  });
+
+  // Switching away from a never-sent-to session evicts it: it has no
+  // route and no history row left, so its draft must not sit in storage
+  // forever — nothing can ever bring it back on screen.
+  test("an evicted empty session leaves no orphan draft behind", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await startNewSession(page);
+    const [, emptySessionId] = new URL(page.url()).pathname.split("/chat/");
+    await fillChatInput(page, "written in a chat that never happened");
+    expect(await storedDrafts(page)).toContain(emptySessionId);
+
+    await selectSessionTab(page, SESSION_A.id);
+
+    expect(await storedDrafts(page)).not.toContain(emptySessionId);
   });
 
   test("attachments stay with their own session", async ({ page }) => {

--- a/e2e/tests/chatinput-draft-persist.spec.ts
+++ b/e2e/tests/chatinput-draft-persist.spec.ts
@@ -1,0 +1,97 @@
+// E2E for per-session chat input drafts (#2811).
+//
+// The draft lives in sessionStorage keyed by session id: a reload
+// restores what the user was typing, a session switch shows that
+// session's own draft, and anything that leaves the input empty (a
+// send) must leave nothing behind for the next load to resurrect.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+import { SESSION_A, SESSION_B } from "../fixtures/sessions";
+import { chatInput, fillChatInput, clickSend, selectSessionTab, startNewSession } from "../fixtures/chat";
+
+const DRAFT_A = "draft for session A";
+const DRAFT_B = "draft for session B";
+
+test.beforeEach(async ({ page }) => {
+  await mockAllApis(page);
+});
+
+test.describe("chat input draft persistence", () => {
+  test("restores the draft after a reload", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await fillChatInput(page, DRAFT_A);
+
+    await page.reload();
+
+    await expect(chatInput(page)).toHaveValue(DRAFT_A);
+  });
+
+  test("keeps each session's draft to itself", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await fillChatInput(page, DRAFT_A);
+
+    await page.goto(`/chat/${SESSION_B.id}`);
+    await expect(chatInput(page)).toHaveValue("");
+    await fillChatInput(page, DRAFT_B);
+
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await expect(chatInput(page)).toHaveValue(DRAFT_A);
+
+    await page.goto(`/chat/${SESSION_B.id}`);
+    await expect(chatInput(page)).toHaveValue(DRAFT_B);
+  });
+
+  test("switching sessions in-app swaps the draft instead of carrying it over", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await fillChatInput(page, DRAFT_A);
+
+    await selectSessionTab(page, SESSION_B.id);
+    await expect(chatInput(page)).toHaveValue("");
+
+    await selectSessionTab(page, SESSION_A.id);
+    await expect(chatInput(page)).toHaveValue(DRAFT_A);
+  });
+
+  test("a new session starts with an empty input", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await fillChatInput(page, DRAFT_A);
+
+    await startNewSession(page);
+
+    await expect(chatInput(page)).toHaveValue("");
+  });
+
+  test("attachments stay with their own session", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await page.getByTestId("file-input").setInputFiles([{ name: "a.png", mimeType: "image/png", buffer: Buffer.from("a") }]);
+    await expect(page.getByTestId("chat-attachment-list")).toHaveCount(1);
+
+    await selectSessionTab(page, SESSION_B.id);
+    await expect(page.getByTestId("chat-attachment-list")).toHaveCount(0);
+
+    await selectSessionTab(page, SESSION_A.id);
+    await expect(page.getByTestId("chat-attachment-list")).toHaveCount(1);
+  });
+
+  test("a sent message does not come back on the next load", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await fillChatInput(page, DRAFT_A);
+    await clickSend(page);
+    await expect(chatInput(page)).toHaveValue("");
+
+    await page.reload();
+
+    await expect(chatInput(page)).toHaveValue("");
+  });
+
+  test("clearing the input by hand leaves nothing stored", async ({ page }) => {
+    await page.goto(`/chat/${SESSION_A.id}`);
+    await fillChatInput(page, DRAFT_A);
+    await fillChatInput(page, "");
+
+    await page.reload();
+
+    await expect(chatInput(page)).toHaveValue("");
+  });
+});

--- a/e2e/tests/chatinput-draft-persist.spec.ts
+++ b/e2e/tests/chatinput-draft-persist.spec.ts
@@ -18,6 +18,39 @@ async function storedDrafts(page: Page): Promise<string> {
   return (await page.evaluate((key) => sessionStorage.getItem(key), DRAFTS_STORAGE_KEY)) ?? "";
 }
 
+// Hold the attachment upload open so a test can act while a send is
+// mid-flight: `started` resolves when the request arrives, `release`
+// lets it complete.
+async function holdAttachmentUpload(page: Page): Promise<{ started: Promise<void>; release: () => void }> {
+  let release = (): void => undefined;
+  let markStarted = (): void => undefined;
+  const held = new Promise<void>((resolve) => (release = resolve));
+  const started = new Promise<void>((resolve) => (markStarted = resolve));
+  await page.route(
+    (url) => url.pathname === "/api/attachments",
+    async (route) => {
+      markStarted();
+      await held;
+      await route.fulfill({ json: { path: "/w/data/attachments/a.png", originalPath: "a.png", mimeType: "image/png" } });
+    },
+  );
+  return { started, release };
+}
+
+// Collect the raw body of every /api/agent POST the app dispatches.
+async function recordAgentPosts(page: Page): Promise<string[]> {
+  const bodies: string[] = [];
+  await page.route(
+    (url) => url.pathname === "/api/agent",
+    (route) => {
+      if (route.request().method() !== "POST") return route.fallback();
+      bodies.push(route.request().postData() ?? "");
+      return route.fulfill({ status: 202, json: { chatSessionId: "mock-session" } });
+    },
+  );
+  return bodies;
+}
+
 // Which session an /api/agent POST addressed, or null when the body
 // isn't the shape we expect (so a malformed body fails the assertion
 // rather than throwing).
@@ -109,35 +142,19 @@ test.describe("chat input draft persistence", () => {
   // composed it in — both when the upload fails (the draft goes back
   // there) and when it succeeds (the message is sent there).
   test("a send whose upload outlives a session switch still lands in the origin session", async ({ page }) => {
-    let releaseUpload = (): void => undefined;
-    const uploadHeld = new Promise<void>((resolve) => {
-      releaseUpload = resolve;
-    });
-    const agentBodies: string[] = [];
-
-    await page.route(
-      (url) => url.pathname === "/api/attachments",
-      async (route) => {
-        await uploadHeld;
-        await route.fulfill({ json: { path: "/w/data/attachments/a.png", originalPath: "a.png", mimeType: "image/png" } });
-      },
-    );
-    await page.route(
-      (url) => url.pathname === "/api/agent",
-      (route) => {
-        if (route.request().method() !== "POST") return route.fallback();
-        agentBodies.push(route.request().postData() ?? "");
-        return route.fulfill({ status: 202, json: { chatSessionId: "mock-session" } });
-      },
-    );
+    const upload = await holdAttachmentUpload(page);
+    const agentBodies = await recordAgentPosts(page);
 
     await page.goto(`/chat/${SESSION_A.id}`);
     await page.getByTestId("file-input").setInputFiles([{ name: "a.png", mimeType: "image/png", buffer: Buffer.from("a") }]);
     await fillChatInput(page, DRAFT_A);
     await clickSend(page);
 
+    // Switch only once the upload is provably in flight — otherwise the
+    // send could finish before the switch and the race goes untested.
+    await upload.started;
     await selectSessionTab(page, SESSION_B.id);
-    releaseUpload();
+    upload.release();
 
     await expect.poll(() => agentBodies.length).toBe(1);
     expect(sentChatSessionId(agentBodies[0])).toBe(SESSION_A.id);

--- a/plans/feat-2811-chat-draft-persist.md
+++ b/plans/feat-2811-chat-draft-persist.md
@@ -74,9 +74,20 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
 - `useSessionLifecycle`: `LifecycleDeps` に `dropSessionDraft` を追加し、`removeCurrentIfEmpty` が sessionMap から消したときに呼ぶ。
 - `useSessionSync`: `deletedIds` ループで `onSessionDeleted?.(deletedId)` を呼び、App.vue が `dropDraft` を繋ぐ。
 
+## レビュー指摘の反映
+
+| 指摘 | 対応 |
+|---|---|
+| `sendMessage` の差し戻しが **別セッションの下書きを壊す** — setter は「書いた瞬間の `currentSessionId`」に解決されるが、`resolveAttachments` は実 POST で待ちが長く、その間に切り替えられる | await の前に `originSessionId` を捕まえ、差し戻しとエラー表示をそれに固定。composable に `restoreDraft(sessionId, text, files)` を追加（表示中でないセッションに書き戻す唯一の口） |
+| `dropDraft` が変化なしでも毎回 `setItem` する（削除 broadcast の id ごと・セッション切替のたびに発火） | `commitDrafts` で「純粋関数が同じ参照を返した＝何も起きていない」を検出して書き込みをスキップ |
+| 共有の空配列定数 `NO_FILES` を getter が返しており、呼び出し側が in-place で触ると全セッションに波及 | 定数をやめ、空セッションには毎回新しい `[]` を返す |
+
+**未対応（本 PR のスコープ外・変更前からある別バグ）**: 成功経路の `sessionMap.get(currentSessionId.value)`（`App.vue`）も await 後に読むため、添付アップロード中にセッションを切り替えると **メッセージ自体が切替先のセッションに飛ぶ**。下書き機能とは独立した既存の不具合なので別 issue とする。
+
 ## テスト
 
 - `test/utils/chat/test_draftStore.ts`（node:test）: 保存 / 復元、空文字でキー削除、壊れた JSON、空 id を保存しない、LRU 上限、`omitSession` が添付マップでも動く。
+- `test/composables/test_useChatDrafts.ts`（node:test, sessionStorage スタブ）: セッション別の読み書き、前回ロードからの復元、添付は永続化しない、空セッションには毎回新しい配列、`restoreDraft` が表示中でなく **composeしたセッション** に戻す、`dropDraft` が両方を消す（破棄経路 5・6 の実装本体）、下書きが無いセッションの drop で書き込みが増えない、storage 不通でも入力を失わない。
 - `e2e/tests/chatinput-draft-persist.spec.ts`（mock）:
   1. 入力 → `page.reload()` → 値が復元される
   2. セッション A に入力 → B へ切替で空 → A に戻ると復元（URL 直叩き / タブ切替の両方）
@@ -84,6 +95,9 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
   4. 添付 chip も A → B で消え、A に戻ると復活
   5. 送信 → リロードしても空（送信済みの文字が復活しない）
   6. 手で全消し → リロードしても空
+  7. 空セッションが破棄されたら、その id の下書きが sessionStorage から消える（破棄経路 6 の配線）
+
+破棄経路 5（削除 broadcast）の配線だけは e2e 化していない — socket.io モックを丸ごと立てる必要があり、実装本体（`dropDraft`）は composable の unit で押さえているため。
 
 ## 検証
 

--- a/plans/feat-2811-chat-draft-persist.md
+++ b/plans/feat-2811-chat-draft-persist.md
@@ -1,0 +1,90 @@
+# feat(chat): 入力中の下書きをセッションごとに保存する (#2811)
+
+## 背景
+
+チャット入力欄の値は `src/App.vue` の `const userInput = ref("")` 1 本しかない。
+
+- **リロードで消える** — どこにも永続化していない。
+- **セッションをまたいで残る** — グローバル 1 本なので、A で書きかけて B に切り替えると B の入力欄に A の文字が出る。
+
+一方 buffered メッセージ（実行中に送った分の chip）は `bufferedMessagesBySession` として既にセッション別に持っている。下書きも同じ形に揃える。
+
+## 決定事項（ユーザ確認済み）
+
+| 論点 | 決定 | 理由 |
+|---|---|---|
+| 下書きの単位 | **セッションごと**（`sessionId` がキー） | 切替で他セッションの文字が残らない。buffered と同じ形 |
+| 保存先 | **sessionStorage** | リロード / タブ復元では残り、タブを閉じれば破棄。複数タブで下書きが混ざらない |
+| 添付（`pastedFiles`） | **セッションごと。ただしメモリのみ** | テキストだけ直すと「文字は消えたのに前のセッションの添付 chip だけ残る」ので同じ PR で揃える。data URL（1件最大 30MB）は sessionStorage の quota に載らないため永続化しない＝リロードで消えるのは従来どおり |
+
+## 消すタイミング（本 issue の肝）
+
+「不要なときに前の文字が残る」を避けるため、下書きが消える経路を全部潰す。
+
+| # | タイミング | 期待 | 実装位置 |
+|---|---|---|---|
+| 1 | 送信してエージェントに飛んだ | 下書き削除 | `sendMessage` の `userInput.value = ""`（setter が空文字でキーを消す） |
+| 2 | 実行中に送信 → chip に積まれた | 下書き削除 | 同上（buffered 分岐の `userInput.value = ""`） |
+| 3 | 添付の解決に失敗して差し戻し | 差し戻したテキストで復元 | 同上（`userInput.value = message`） |
+| 4 | 入力欄を手で全消し | キーごと削除（空文字を残さない） | `setDraft` が trim 後空ならキー削除 |
+| 5 | セッション削除（自タブ / 他タブの broadcast 経由） | そのセッションの下書き削除 | `useSessionSync` の `deletedIds` ループ |
+| 6 | 空セッションの破棄 | そのセッションの下書き削除 | `useSessionLifecycle.removeCurrentIfEmpty` |
+| 7 | 新規セッション（+） | 新しい id なので空 | 実装不要（キーが無い） |
+
+5 と 6 を落とすと、到達不能なセッションの下書きが sessionStorage に溜まり続ける（孤児）。
+
+## スコープ外
+
+- 添付の**永続化**: セッション別にはするが sessionStorage には載せない（リロードで消えるのは現状どおり）。
+- buffered メッセージの永続化: 現状どおりリロードで消える。必要なら別 issue。
+- `PageChatComposer`（wiki / files ページの下書き）: 別コンポーネントのローカル state。
+
+## 実装
+
+### 1. `src/utils/chat/draftStore.ts`（純粋関数）
+
+```ts
+export const CHAT_DRAFTS_STORAGE_KEY = "chat_drafts_by_session";
+export type DraftMap = Record<string, string>;
+
+parseStoredDrafts(raw: string | null): DraftMap   // 壊れた JSON / 非 string 値を捨てる
+serializeDrafts(drafts: DraftMap): string          // セッション id が空のエントリは永続化しない
+setDraft(drafts, sessionId, text): DraftMap        // trim 後空ならキー削除、上限超えは古い順に捨てる
+omitSession<T>(bySession, sessionId): Record<string, T>  // 下書きと添付の両方で使う破棄経路
+```
+
+- 上限 `MAX_DRAFT_SESSIONS`: 書き込みのたびに対象キーを末尾へ入れ直し、挿入順 = LRU として先頭から落とす。
+- 空セッション id（起動直後の `currentSessionId === ""`）はメモリ上では持つが**保存しない** — 保存すると次のロードで新規セッションに他人の文字が出る。
+
+### 2. `src/composables/useChatDrafts.ts`
+
+`currentSessionId` を見て読み書きする `WritableComputedRef` を返す。既存の `currentBufferedMessages` と同じ形なので、`App.vue` 側の呼び出し（`userInput.value = ...` / `pastedFiles.value = []`）は 1 行も変えずに済む。
+
+```ts
+const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
+```
+
+`dropDraft` はテキストと添付の両方を捨てる（破棄経路を 1 本にして「片方だけ消し忘れる」を作らない）。
+
+書き込みは同期的に sessionStorage へ（debounce しない — 打った直後の ⌘R で末尾を落とさないため。下書きは小さいので JSON.stringify のコストは無視できる）。`setItem` は quota 例外を握って握りつぶす（保存できなくても入力は続けられる）。
+
+### 3. 破棄フックの配線
+
+- `App.vue`: `userInput` を `useChatDrafts` 由来に差し替え、`dropDraft` を下の 2 経路に渡す。
+- `useSessionLifecycle`: `LifecycleDeps` に `dropSessionDraft` を追加し、`removeCurrentIfEmpty` が sessionMap から消したときに呼ぶ。
+- `useSessionSync`: `deletedIds` ループで `onSessionDeleted?.(deletedId)` を呼び、App.vue が `dropDraft` を繋ぐ。
+
+## テスト
+
+- `test/utils/chat/test_draftStore.ts`（node:test）: 保存 / 復元、空文字でキー削除、壊れた JSON、空 id を保存しない、LRU 上限、`omitSession` が添付マップでも動く。
+- `e2e/tests/chatinput-draft-persist.spec.ts`（mock）:
+  1. 入力 → `page.reload()` → 値が復元される
+  2. セッション A に入力 → B へ切替で空 → A に戻ると復元（URL 直叩き / タブ切替の両方）
+  3. 新規セッション（+）は空
+  4. 添付 chip も A → B で消え、A に戻ると復活
+  5. 送信 → リロードしても空（送信済みの文字が復活しない）
+  6. 手で全消し → リロードしても空
+
+## 検証
+
+`yarn format` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test` → `yarn test:e2e`

--- a/plans/feat-2811-chat-draft-persist.md
+++ b/plans/feat-2811-chat-draft-persist.md
@@ -82,6 +82,14 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
 | `dropDraft` が変化なしでも毎回 `setItem` する（削除 broadcast の id ごと・セッション切替のたびに発火） | `commitDrafts` で「純粋関数が同じ参照を返した＝何も起きていない」を検出して書き込みをスキップ |
 | 共有の空配列定数 `NO_FILES` を getter が返しており、呼び出し側が in-place で触ると全セッションに波及 | 定数をやめ、空セッションには毎回新しい `[]` を返す |
 
+**CI（webkit e2e）が拾った回帰 — セッション ID 確定前の入力**:
+
+`/chat/<id>` ではなく `/`（ID 無し）で開くと、`onMounted` は `refreshRoles()` → `/api/sessions` → `resumeOrCreateChatSession()` を **await** してからセッション ID を決める。その間すでに入力欄は操作できるため、**確定前に打った文字は空 ID のバケツに入り、確定と同時に画面から消える**（グローバル ref だった変更前は起こらなかった、この PR 固有の回帰）。ローカル chromium では窓が数十 ms で通ってしまい、CI の webkit で初めて落ちた。
+
+対処: 空 ID を `UNIDENTIFIED_SESSION` として明示し、**最初に実 ID が来たときだけ**その下書きを引き継ぐ（既存の下書きがあればその後ろに連結）。以降の「/chat を離れて戻る」では引き継がず、空 ID のエントリは常に破棄する — さもないと後から別セッションに他人の文字が出る。
+
+`/api/sessions` を握って ID 確定を遅らせる e2e で決定的に再現・検証した（修正前は入力値が `""` になる）。
+
 **CodeRabbit 指摘で追加対応**:
 
 | 指摘 | 対応 |

--- a/plans/feat-2811-chat-draft-persist.md
+++ b/plans/feat-2811-chat-draft-persist.md
@@ -82,7 +82,7 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
 | `dropDraft` が変化なしでも毎回 `setItem` する（削除 broadcast の id ごと・セッション切替のたびに発火） | `commitDrafts` で「純粋関数が同じ参照を返した＝何も起きていない」を検出して書き込みをスキップ |
 | 共有の空配列定数 `NO_FILES` を getter が返しており、呼び出し側が in-place で触ると全セッションに波及 | 定数をやめ、空セッションには毎回新しい `[]` を返す |
 
-**未対応（本 PR のスコープ外・変更前からある別バグ）**: 成功経路の `sessionMap.get(currentSessionId.value)`（`App.vue`）も await 後に読むため、添付アップロード中にセッションを切り替えると **メッセージ自体が切替先のセッションに飛ぶ**。下書き機能とは独立した既存の不具合なので別 issue とする。
+**Codex レビュー指摘で追加対応**: 成功経路の `sessionMap.get(currentSessionId.value)` も await 後に読むため、添付アップロード中にセッションを切り替えると **メッセージ自体が切替先のセッションに飛び、role もそちらのものになる**。当初は「変更前からある別バグなので別 issue」と判断したが、`originSessionId` が 3 行上にある状態で片方だけ直すのは一貫しないため同 PR で修正。`sessionRole` computed の中身を `roleOfSession(session)` に切り出し、送信は発信元セッションの role を使う。
 
 ## テスト
 
@@ -96,6 +96,7 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
   5. 送信 → リロードしても空（送信済みの文字が復活しない）
   6. 手で全消し → リロードしても空
   7. 空セッションが破棄されたら、その id の下書きが sessionStorage から消える（破棄経路 6 の配線）
+  8. アップロードを握ったままセッションを切り替えても、`/api/agent` の `chatSessionId` は発信元セッションのまま
 
 破棄経路 5（削除 broadcast）の配線だけは e2e 化していない — socket.io モックを丸ごと立てる必要があり、実装本体（`dropDraft`）は composable の unit で押さえているため。
 

--- a/plans/feat-2811-chat-draft-persist.md
+++ b/plans/feat-2811-chat-draft-persist.md
@@ -82,6 +82,17 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
 | `dropDraft` が変化なしでも毎回 `setItem` する（削除 broadcast の id ごと・セッション切替のたびに発火） | `commitDrafts` で「純粋関数が同じ参照を返した＝何も起きていない」を検出して書き込みをスキップ |
 | 共有の空配列定数 `NO_FILES` を getter が返しており、呼び出し側が in-place で触ると全セッションに波及 | 定数をやめ、空セッションには毎回新しい `[]` を返す |
 
+**CodeRabbit 指摘で追加対応**:
+
+| 指摘 | 対応 |
+|---|---|
+| 削除済みセッションに下書きを戻してしまう（アップロード中に削除されると、破棄フックが消した直後に孤児を作り直す） | 先に `sessionMap.get(originSessionId)` を引き、生きているときだけ戻す |
+| アップロード中にそのセッションで書き始めた文字を、差し戻しが上書きする | `restoreDraft` を上書きから **マージ** に変更（既存の `mergeBufferedIntoDraft` を再利用）。添付も新しくステージした分の前に連結 |
+| 添付だけ上限が無く、メモリが無制限に増える | LRU を `putSession<T>` として切り出し、テキストと添付に同じ 20 セッション上限を適用 |
+| e2e がアップロード開始を待っていないので、レースを検証しないまま通りうる | route ハンドラに「開始した」シグナルを足し、切替前に await。mock は `holdAttachmentUpload` / `recordAgentPosts` ヘルパへ抽出 |
+
+**見送り（理由付きで PR に返信）**: `useChatDrafts` / `sendMessage` / テストの `describe` が 20 行を超える、という 3 件。lint の閾値は 50 行で通っており、リポジトリ内の既存 composable / テストも同じ形。分割すると同じ 2 つの ref を各ヘルパへ引き回すだけで、可読性が上がらないと判断した。
+
 **Codex レビュー指摘で追加対応**: 成功経路の `sessionMap.get(currentSessionId.value)` も await 後に読むため、添付アップロード中にセッションを切り替えると **メッセージ自体が切替先のセッションに飛び、role もそちらのものになる**。当初は「変更前からある別バグなので別 issue」と判断したが、`originSessionId` が 3 行上にある状態で片方だけ直すのは一貫しないため同 PR で修正。`sessionRole` computed の中身を `roleOfSession(session)` に切り出し、送信は発信元セッションの role を使う。
 
 ## テスト

--- a/plans/feat-2811-chat-draft-persist.md
+++ b/plans/feat-2811-chat-draft-persist.md
@@ -86,7 +86,9 @@ const { userInput, pastedFiles, dropDraft } = useChatDrafts(currentSessionId);
 
 `/chat/<id>` ではなく `/`（ID 無し）で開くと、`onMounted` は `refreshRoles()` → `/api/sessions` → `resumeOrCreateChatSession()` を **await** してからセッション ID を決める。その間すでに入力欄は操作できるため、**確定前に打った文字は空 ID のバケツに入り、確定と同時に画面から消える**（グローバル ref だった変更前は起こらなかった、この PR 固有の回帰）。ローカル chromium では窓が数十 ms で通ってしまい、CI の webkit で初めて落ちた。
 
-対処: 空 ID を `UNIDENTIFIED_SESSION` として明示し、**最初に実 ID が来たときだけ**その下書きを引き継ぐ（既存の下書きがあればその後ろに連結）。以降の「/chat を離れて戻る」では引き継がず、空 ID のエントリは常に破棄する — さもないと後から別セッションに他人の文字が出る。
+対処: 空 ID を `UNIDENTIFIED_SESSION` として明示し、**最初に実 ID が来たときだけ**その下書きを引き継ぐ（既存の下書きがあればその後ろに連結）。以降の「/chat を離れて戻る」では引き継がず、空 ID の内容は常に破棄する — さもないと後から別セッションに他人の文字が出る。
+
+さらに Codex の指摘で、**pending は capped map の外**（`DraftState.pending`）に持つよう修正した。map に入れると 20 件 LRU の枠を 1 つ奪い、**満杯時に起動直後の 1 文字が既存セッションの下書きを追い出して、その消失をそのまま永続化**してしまう（`serializeDrafts` が空 ID を落とすのは保存の直前で、eviction はその前に済んでいる）。
 
 `/api/sessions` を握って ID 確定を遅らせる e2e で決定的に再現・検証した（修正前は入力値が `""` になる）。
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -531,21 +531,20 @@ const sessionRoleIcon = computed(() => {
   return roleIcon(roles.value, roleId);
 });
 
+// The role a given conversation runs under. `roles` always carries the
+// built-ins (merge keeps them), so its first entry is the effective
+// default; ROLES[0] only covers the type.
+function roleOfSession(session: ActiveSession | undefined): Role {
+  const match = session?.roleId ? roles.value.find((role) => role.id === session.roleId) : undefined;
+  return match ?? roles.value[0] ?? ROLES[0];
+}
+
 // Role of the conversation in progress. Drives the suggested-query
 // list, the right-sidebar role-prompt, and the MCP tool filter so
 // they all match the active session (not the role-selector
 // dropdown — which is owned by SessionHeaderControls and whose
 // selection only matters at "+" / role-change time).
-const sessionRole = computed<Role>(() => {
-  const sessionRoleId = activeSession.value?.roleId;
-  if (sessionRoleId) {
-    const match = roles.value.find((role) => role.id === sessionRoleId);
-    if (match) return match;
-  }
-  // `roles` always carries the built-ins (merge keeps them), so the first
-  // entry is the effective default; ROLES[0] only covers the type.
-  return roles.value[0] ?? ROLES[0];
-});
+const sessionRole = computed<Role>(() => roleOfSession(activeSession.value));
 
 // Translated suggested-query strings for the active session's role.
 // Falls back to the role's English source until /api/translation
@@ -1068,9 +1067,11 @@ async function sendMessage(text?: string) {
   pastedFiles.value = [];
 
   // Uploading the attachments is a real round trip, so the user can be
-  // looking at another session by the time it fails. Hand the message
-  // back to the session it was composed in — writing it to whatever is
-  // on screen would overwrite that session's own draft.
+  // looking at another session by the time it resolves. Everything past
+  // this point addresses the session the message was composed in: a
+  // failed send must not overwrite the displayed session's draft, and a
+  // successful one must not land in the conversation the user happens
+  // to be reading — under that session's role, at that.
   const originSessionId = currentSessionId.value;
   const resolved = await resolveAttachments(filesSnapshot);
   if (resolved !== null && "error" in resolved) {
@@ -1081,7 +1082,7 @@ async function sendMessage(text?: string) {
   }
   const attachments = resolved?.attachments;
 
-  const session = sessionMap.get(currentSessionId.value);
+  const session = sessionMap.get(originSessionId);
   if (!session) return;
 
   beginUserTurn(session, message, attachments);
@@ -1090,7 +1091,7 @@ async function sendMessage(text?: string) {
   const result = await postAgentRun(
     buildAgentRequestBody({
       message,
-      role: sessionRole.value,
+      role: roleOfSession(session),
       chatSessionId: session.id,
       attachments,
     }),

--- a/src/App.vue
+++ b/src/App.vue
@@ -398,6 +398,7 @@ import { useDebugBeat } from "./composables/useDebugBeat";
 import { useChatScroll } from "./composables/useChatScroll";
 import { useFileDropZone } from "./composables/useFileDropZone";
 import { useViewLayout } from "./composables/useViewLayout";
+import { useChatDrafts } from "./composables/useChatDrafts";
 import { useSessionSync } from "./composables/useSessionSync";
 import { useSessionLifecycle } from "./composables/useSessionLifecycle";
 import { useSessionDerived } from "./composables/useSessionDerived";
@@ -482,8 +483,13 @@ const { currentRoleId } = useCurrentRole(roles);
 // list and passes it down; the launcher stays presentational.
 const { shortcuts } = useShortcuts();
 
-const userInput = ref("");
-const pastedFiles = ref<PastedFile[]>([]);
+// Unsent composer state — draft text and staged attachments — keyed by
+// session (#2811). Reads/writes look like plain refs, but each session
+// keeps its own, and the text is mirrored into sessionStorage so a
+// reload restores what the user was typing. Every place that assigns
+// `userInput.value` therefore also updates storage — including the
+// clears in sendMessage.
+const { userInput, pastedFiles, dropDraft: dropSessionDraft } = useChatDrafts(currentSessionId);
 // Messages the user sends while a run is in flight queue here instead of
 // dispatching, keyed by the session they belong to so concurrent runs in
 // different sessions never mix. `currentBufferedMessages` is the displayed
@@ -662,6 +668,7 @@ const { removeCurrentIfEmpty, createNewSession, onRoleChange, loadSession, refre
   ensureSessionSubscription,
   focusChatInput,
   collapseChatSuggestions: () => chatInputRef.value?.collapseSuggestions(),
+  dropSessionDraft,
 });
 
 const { markSessionRead, refreshSessionStates } = useSessionSync({
@@ -674,6 +681,10 @@ const { markSessionRead, refreshSessionStates } = useSessionSync({
   // loadSession by spinning up a fresh session so the user lands on a
   // working /chat instead of a blank pane.
   onCurrentSessionDeleted: () => createNewSession(),
+  // Covers deletions from this tab too: the server broadcasts every
+  // hard delete on the sessions channel, so this is the one place a
+  // deleted session's draft has to be forgotten.
+  onSessionDeleted: dropSessionDraft,
 });
 
 // External URL changes (back/forward button, typed URL) → update ref.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1075,9 +1075,12 @@ async function sendMessage(text?: string) {
   const originSessionId = currentSessionId.value;
   const resolved = await resolveAttachments(filesSnapshot);
   if (resolved !== null && "error" in resolved) {
-    restoreDraft(originSessionId, message, filesSnapshot);
+    // Gone means deleted mid-upload: its draft was dropped with it, and
+    // handing one back would strand text nothing can ever display.
     const recoverySession = sessionMap.get(originSessionId);
-    if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
+    if (!recoverySession) return;
+    restoreDraft(originSessionId, message, filesSnapshot);
+    pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
     return;
   }
   const attachments = resolved?.attachments;

--- a/src/App.vue
+++ b/src/App.vue
@@ -489,7 +489,7 @@ const { shortcuts } = useShortcuts();
 // reload restores what the user was typing. Every place that assigns
 // `userInput.value` therefore also updates storage — including the
 // clears in sendMessage.
-const { userInput, pastedFiles, dropDraft: dropSessionDraft } = useChatDrafts(currentSessionId);
+const { userInput, pastedFiles, restoreDraft, dropDraft: dropSessionDraft } = useChatDrafts(currentSessionId);
 // Messages the user sends while a run is in flight queue here instead of
 // dispatching, keyed by the session they belong to so concurrent runs in
 // different sessions never mix. `currentBufferedMessages` is the displayed
@@ -1067,11 +1067,15 @@ async function sendMessage(text?: string) {
   const filesSnapshot = [...pastedFiles.value];
   pastedFiles.value = [];
 
+  // Uploading the attachments is a real round trip, so the user can be
+  // looking at another session by the time it fails. Hand the message
+  // back to the session it was composed in — writing it to whatever is
+  // on screen would overwrite that session's own draft.
+  const originSessionId = currentSessionId.value;
   const resolved = await resolveAttachments(filesSnapshot);
   if (resolved !== null && "error" in resolved) {
-    userInput.value = message;
-    pastedFiles.value = filesSnapshot;
-    const recoverySession = sessionMap.get(currentSessionId.value);
+    restoreDraft(originSessionId, message, filesSnapshot);
+    const recoverySession = sessionMap.get(originSessionId);
     if (recoverySession) pushErrorMessage(recoverySession, t("chatInput.attachImageFailed", { error: resolved.error }));
     return;
   }

--- a/src/composables/useChatDrafts.ts
+++ b/src/composables/useChatDrafts.ts
@@ -8,7 +8,7 @@
 // other. Attachments stay in memory only: they are data URLs (up to
 // 30 MB each) and would blow the storage quota.
 
-import { computed, ref, type Ref, type WritableComputedRef } from "vue";
+import { computed, ref, watch, type Ref, type WritableComputedRef } from "vue";
 import {
   CHAT_DRAFTS_STORAGE_KEY,
   getDraft,
@@ -21,6 +21,11 @@ import {
 } from "../utils/chat/draftStore";
 import { mergeBufferedIntoDraft } from "../utils/chat/buffer";
 import type { PastedFile } from "../types/pastedFile";
+
+// The composer is usable before the app has settled which session to
+// land on (/chat with no id in the URL awaits roles + the session list
+// first). Text typed then belongs to no session yet and parks here.
+const UNIDENTIFIED_SESSION = "";
 
 export interface UseChatDrafts {
   /** Draft text of the displayed session. Reads/writes look like a
@@ -40,7 +45,14 @@ export interface UseChatDrafts {
   dropDraft: (sessionId: string) => void;
 }
 
-export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
+interface DraftState {
+  drafts: Ref<DraftMap>;
+  attachments: Ref<Record<string, PastedFile[]>>;
+  commitDrafts: (next: DraftMap) => void;
+  setAttachments: (sessionId: string, files: PastedFile[]) => void;
+}
+
+function createDraftState(): DraftState {
   const drafts = ref<DraftMap>(parseStoredDrafts(readStoredDrafts()));
   const attachments = ref<Record<string, PastedFile[]>>({});
 
@@ -57,6 +69,44 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
     attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : putSession(attachments.value, sessionId, files);
   }
 
+  return { drafts, attachments, commitDrafts, setAttachments };
+}
+
+function filesOf(state: DraftState, sessionId: string): PastedFile[] {
+  return state.attachments.value[sessionId] ?? [];
+}
+
+// Hand what was typed before the id arrived to the session that
+// materialised, appended after anything that session already holds
+// (a draft restored from storage is older than what was just typed).
+function adoptPendingDraft(state: DraftState, sessionId: string): void {
+  const pendingText = getDraft(state.drafts.value, UNIDENTIFIED_SESSION);
+  const pendingFiles = filesOf(state, UNIDENTIFIED_SESSION);
+  if (pendingText === "" && pendingFiles.length === 0) return;
+  const merged = mergeBufferedIntoDraft([getDraft(state.drafts.value, sessionId)], pendingText);
+  state.commitDrafts(setDraft(state.drafts.value, sessionId, merged));
+  state.setAttachments(sessionId, [...filesOf(state, sessionId), ...pendingFiles]);
+}
+
+function dropPendingDraft(state: DraftState): void {
+  state.commitDrafts(omitSession(state.drafts.value, UNIDENTIFIED_SESSION));
+  state.attachments.value = omitSession(state.attachments.value, UNIDENTIFIED_SESSION);
+}
+
+export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
+  const state = createDraftState();
+  const { drafts, attachments, commitDrafts, setAttachments } = state;
+  // Only the very first session takes over the unidentified draft. Later
+  // returns to /chat must not resurrect a stray entry as someone else's.
+  let awaitingFirstSession = true;
+
+  watch(currentSessionId, (sessionId) => {
+    if (sessionId === UNIDENTIFIED_SESSION) return;
+    if (awaitingFirstSession) adoptPendingDraft(state, sessionId);
+    awaitingFirstSession = false;
+    dropPendingDraft(state);
+  });
+
   const userInput = computed<string>({
     get: () => getDraft(drafts.value, currentSessionId.value),
     set: (text) => commitDrafts(setDraft(drafts.value, currentSessionId.value, text)),
@@ -70,7 +120,7 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
   function restoreDraft(sessionId: string, text: string, files: PastedFile[]): void {
     const merged = mergeBufferedIntoDraft([text], getDraft(drafts.value, sessionId));
     commitDrafts(setDraft(drafts.value, sessionId, merged));
-    setAttachments(sessionId, [...files, ...(attachments.value[sessionId] ?? [])]);
+    setAttachments(sessionId, [...files, ...filesOf(state, sessionId)]);
   }
 
   function dropDraft(sessionId: string): void {

--- a/src/composables/useChatDrafts.ts
+++ b/src/composables/useChatDrafts.ts
@@ -1,0 +1,74 @@
+// What the user has composed but not sent, kept per session (#2811):
+// the input text plus its attachments. Both used to be single global
+// refs, so a session switch showed the previous session's text and
+// chips, and a reload threw the text away.
+//
+// The text is mirrored into sessionStorage — it survives a reload and a
+// tab restore, dies with the tab, and two tabs never overwrite each
+// other. Attachments stay in memory only: they are data URLs (up to
+// 30 MB each) and would blow the storage quota.
+
+import { computed, ref, type Ref, type WritableComputedRef } from "vue";
+import { CHAT_DRAFTS_STORAGE_KEY, getDraft, omitSession, parseStoredDrafts, serializeDrafts, setDraft, type DraftMap } from "../utils/chat/draftStore";
+import type { PastedFile } from "../types/pastedFile";
+
+const NO_FILES: PastedFile[] = [];
+
+export interface UseChatDrafts {
+  /** Draft text of the displayed session. Reads/writes look like a
+   *  plain `ref<string>` so callers stay unaware of the keying. */
+  userInput: WritableComputedRef<string>;
+  /** Attachments staged for the displayed session. */
+  pastedFiles: WritableComputedRef<PastedFile[]>;
+  /** Forget a session's draft and attachments — its session is gone
+   *  (deleted, or an empty one evicted), so both are unreachable. */
+  dropDraft: (sessionId: string) => void;
+}
+
+export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
+  const drafts = ref<DraftMap>(parseStoredDrafts(readStoredDrafts()));
+  const attachments = ref<Record<string, PastedFile[]>>({});
+
+  function commitDrafts(next: DraftMap): void {
+    drafts.value = next;
+    writeStoredDrafts(serializeDrafts(next));
+  }
+
+  const userInput = computed<string>({
+    get: () => getDraft(drafts.value, currentSessionId.value),
+    set: (text) => commitDrafts(setDraft(drafts.value, currentSessionId.value, text)),
+  });
+
+  const pastedFiles = computed<PastedFile[]>({
+    get: () => attachments.value[currentSessionId.value] ?? NO_FILES,
+    set: (files) => {
+      const sessionId = currentSessionId.value;
+      attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : { ...attachments.value, [sessionId]: files };
+    },
+  });
+
+  function dropDraft(sessionId: string): void {
+    commitDrafts(omitSession(drafts.value, sessionId));
+    attachments.value = omitSession(attachments.value, sessionId);
+  }
+
+  return { userInput, pastedFiles, dropDraft };
+}
+
+function readStoredDrafts(): string | null {
+  try {
+    return sessionStorage.getItem(CHAT_DRAFTS_STORAGE_KEY);
+  } catch {
+    // Storage can be unavailable (private mode / blocked cookies) —
+    // drafts then live in memory only, which still beats losing input.
+    return null;
+  }
+}
+
+function writeStoredDrafts(serialized: string): void {
+  try {
+    sessionStorage.setItem(CHAT_DRAFTS_STORAGE_KEY, serialized);
+  } catch {
+    // Quota or blocked storage: keep the in-memory draft, skip persisting.
+  }
+}

--- a/src/composables/useChatDrafts.ts
+++ b/src/composables/useChatDrafts.ts
@@ -12,14 +12,17 @@ import { computed, ref, type Ref, type WritableComputedRef } from "vue";
 import { CHAT_DRAFTS_STORAGE_KEY, getDraft, omitSession, parseStoredDrafts, serializeDrafts, setDraft, type DraftMap } from "../utils/chat/draftStore";
 import type { PastedFile } from "../types/pastedFile";
 
-const NO_FILES: PastedFile[] = [];
-
 export interface UseChatDrafts {
   /** Draft text of the displayed session. Reads/writes look like a
    *  plain `ref<string>` so callers stay unaware of the keying. */
   userInput: WritableComputedRef<string>;
   /** Attachments staged for the displayed session. */
   pastedFiles: WritableComputedRef<PastedFile[]>;
+  /** Put a composed message back under the session it was written in,
+   *  rather than the one on screen. A failed send resolves after a
+   *  network round trip, by which time the user may be looking at
+   *  another session — whose draft must not be overwritten. */
+  restoreDraft: (sessionId: string, text: string, files: PastedFile[]) => void;
   /** Forget a session's draft and attachments — its session is gone
    *  (deleted, or an empty one evicted), so both are unreachable. */
   dropDraft: (sessionId: string) => void;
@@ -29,9 +32,17 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
   const drafts = ref<DraftMap>(parseStoredDrafts(readStoredDrafts()));
   const attachments = ref<Record<string, PastedFile[]>>({});
 
+  // The pure helpers return the map unchanged when there was nothing to
+  // do, which is the signal to skip the write — session switches and
+  // delete broadcasts call through here constantly.
   function commitDrafts(next: DraftMap): void {
+    if (next === drafts.value) return;
     drafts.value = next;
     writeStoredDrafts(serializeDrafts(next));
+  }
+
+  function setAttachments(sessionId: string, files: PastedFile[]): void {
+    attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : { ...attachments.value, [sessionId]: files };
   }
 
   const userInput = computed<string>({
@@ -40,19 +51,21 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
   });
 
   const pastedFiles = computed<PastedFile[]>({
-    get: () => attachments.value[currentSessionId.value] ?? NO_FILES,
-    set: (files) => {
-      const sessionId = currentSessionId.value;
-      attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : { ...attachments.value, [sessionId]: files };
-    },
+    get: () => attachments.value[currentSessionId.value] ?? [],
+    set: (files) => setAttachments(currentSessionId.value, files),
   });
+
+  function restoreDraft(sessionId: string, text: string, files: PastedFile[]): void {
+    commitDrafts(setDraft(drafts.value, sessionId, text));
+    setAttachments(sessionId, files);
+  }
 
   function dropDraft(sessionId: string): void {
     commitDrafts(omitSession(drafts.value, sessionId));
     attachments.value = omitSession(attachments.value, sessionId);
   }
 
-  return { userInput, pastedFiles, dropDraft };
+  return { userInput, pastedFiles, restoreDraft, dropDraft };
 }
 
 function readStoredDrafts(): string | null {

--- a/src/composables/useChatDrafts.ts
+++ b/src/composables/useChatDrafts.ts
@@ -9,7 +9,17 @@
 // 30 MB each) and would blow the storage quota.
 
 import { computed, ref, type Ref, type WritableComputedRef } from "vue";
-import { CHAT_DRAFTS_STORAGE_KEY, getDraft, omitSession, parseStoredDrafts, serializeDrafts, setDraft, type DraftMap } from "../utils/chat/draftStore";
+import {
+  CHAT_DRAFTS_STORAGE_KEY,
+  getDraft,
+  omitSession,
+  parseStoredDrafts,
+  putSession,
+  serializeDrafts,
+  setDraft,
+  type DraftMap,
+} from "../utils/chat/draftStore";
+import { mergeBufferedIntoDraft } from "../utils/chat/buffer";
 import type { PastedFile } from "../types/pastedFile";
 
 export interface UseChatDrafts {
@@ -21,7 +31,9 @@ export interface UseChatDrafts {
   /** Put a composed message back under the session it was written in,
    *  rather than the one on screen. A failed send resolves after a
    *  network round trip, by which time the user may be looking at
-   *  another session — whose draft must not be overwritten. */
+   *  another session — whose draft must not be overwritten. Merges with
+   *  whatever that session holds now, since the user may have started a
+   *  new message there while the send was in flight. */
   restoreDraft: (sessionId: string, text: string, files: PastedFile[]) => void;
   /** Forget a session's draft and attachments — its session is gone
    *  (deleted, or an empty one evicted), so both are unreachable. */
@@ -42,7 +54,7 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
   }
 
   function setAttachments(sessionId: string, files: PastedFile[]): void {
-    attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : { ...attachments.value, [sessionId]: files };
+    attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : putSession(attachments.value, sessionId, files);
   }
 
   const userInput = computed<string>({
@@ -56,8 +68,9 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
   });
 
   function restoreDraft(sessionId: string, text: string, files: PastedFile[]): void {
-    commitDrafts(setDraft(drafts.value, sessionId, text));
-    setAttachments(sessionId, files);
+    const merged = mergeBufferedIntoDraft([text], getDraft(drafts.value, sessionId));
+    commitDrafts(setDraft(drafts.value, sessionId, merged));
+    setAttachments(sessionId, [...files, ...(attachments.value[sessionId] ?? [])]);
   }
 
   function dropDraft(sessionId: string): void {

--- a/src/composables/useChatDrafts.ts
+++ b/src/composables/useChatDrafts.ts
@@ -45,9 +45,18 @@ export interface UseChatDrafts {
   dropDraft: (sessionId: string) => void;
 }
 
+interface PendingDraft {
+  text: string;
+  files: PastedFile[];
+}
+
 interface DraftState {
   drafts: Ref<DraftMap>;
   attachments: Ref<Record<string, PastedFile[]>>;
+  // Held outside the capped maps: an unidentified draft that competed
+  // for one of their slots would evict a real session's draft — and
+  // persist that loss — for a single character typed during boot.
+  pending: Ref<PendingDraft>;
   commitDrafts: (next: DraftMap) => void;
   setAttachments: (sessionId: string, files: PastedFile[]) => void;
 }
@@ -55,6 +64,7 @@ interface DraftState {
 function createDraftState(): DraftState {
   const drafts = ref<DraftMap>(parseStoredDrafts(readStoredDrafts()));
   const attachments = ref<Record<string, PastedFile[]>>({});
+  const pending = ref<PendingDraft>({ text: "", files: [] });
 
   // The pure helpers return the map unchanged when there was nothing to
   // do, which is the signal to skip the write — session switches and
@@ -69,28 +79,50 @@ function createDraftState(): DraftState {
     attachments.value = files.length === 0 ? omitSession(attachments.value, sessionId) : putSession(attachments.value, sessionId, files);
   }
 
-  return { drafts, attachments, commitDrafts, setAttachments };
+  return { drafts, attachments, pending, commitDrafts, setAttachments };
 }
 
 function filesOf(state: DraftState, sessionId: string): PastedFile[] {
   return state.attachments.value[sessionId] ?? [];
 }
 
+function readText(state: DraftState, sessionId: string): string {
+  return sessionId === UNIDENTIFIED_SESSION ? state.pending.value.text : getDraft(state.drafts.value, sessionId);
+}
+
+function writeText(state: DraftState, sessionId: string, text: string): void {
+  if (sessionId === UNIDENTIFIED_SESSION) {
+    state.pending.value = { ...state.pending.value, text };
+    return;
+  }
+  state.commitDrafts(setDraft(state.drafts.value, sessionId, text));
+}
+
+function readFiles(state: DraftState, sessionId: string): PastedFile[] {
+  return sessionId === UNIDENTIFIED_SESSION ? state.pending.value.files : filesOf(state, sessionId);
+}
+
+function writeFiles(state: DraftState, sessionId: string, files: PastedFile[]): void {
+  if (sessionId === UNIDENTIFIED_SESSION) {
+    state.pending.value = { ...state.pending.value, files };
+    return;
+  }
+  state.setAttachments(sessionId, files);
+}
+
 // Hand what was typed before the id arrived to the session that
 // materialised, appended after anything that session already holds
 // (a draft restored from storage is older than what was just typed).
 function adoptPendingDraft(state: DraftState, sessionId: string): void {
-  const pendingText = getDraft(state.drafts.value, UNIDENTIFIED_SESSION);
-  const pendingFiles = filesOf(state, UNIDENTIFIED_SESSION);
-  if (pendingText === "" && pendingFiles.length === 0) return;
-  const merged = mergeBufferedIntoDraft([getDraft(state.drafts.value, sessionId)], pendingText);
+  const { text, files } = state.pending.value;
+  if (text === "" && files.length === 0) return;
+  const merged = mergeBufferedIntoDraft([getDraft(state.drafts.value, sessionId)], text);
   state.commitDrafts(setDraft(state.drafts.value, sessionId, merged));
-  state.setAttachments(sessionId, [...filesOf(state, sessionId), ...pendingFiles]);
+  state.setAttachments(sessionId, [...filesOf(state, sessionId), ...files]);
 }
 
 function dropPendingDraft(state: DraftState): void {
-  state.commitDrafts(omitSession(state.drafts.value, UNIDENTIFIED_SESSION));
-  state.attachments.value = omitSession(state.attachments.value, UNIDENTIFIED_SESSION);
+  state.pending.value = { text: "", files: [] };
 }
 
 export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
@@ -108,13 +140,13 @@ export function useChatDrafts(currentSessionId: Ref<string>): UseChatDrafts {
   });
 
   const userInput = computed<string>({
-    get: () => getDraft(drafts.value, currentSessionId.value),
-    set: (text) => commitDrafts(setDraft(drafts.value, currentSessionId.value, text)),
+    get: () => readText(state, currentSessionId.value),
+    set: (text) => writeText(state, currentSessionId.value, text),
   });
 
   const pastedFiles = computed<PastedFile[]>({
-    get: () => attachments.value[currentSessionId.value] ?? [],
-    set: (files) => setAttachments(currentSessionId.value, files),
+    get: () => readFiles(state, currentSessionId.value),
+    set: (files) => writeFiles(state, currentSessionId.value, files),
   });
 
   function restoreDraft(sessionId: string, text: string, files: PastedFile[]): void {

--- a/src/composables/useSessionLifecycle.ts
+++ b/src/composables/useSessionLifecycle.ts
@@ -37,6 +37,10 @@ interface LifecycleDeps {
   ensureSessionSubscription: (session: ActiveSession) => void;
   focusChatInput: () => void;
   collapseChatSuggestions: () => void;
+  /** Forget the chat draft of a session that is being thrown away.
+   *  An evicted empty session has no route and no history row left, so
+   *  its draft would otherwise sit in storage unreachable forever. */
+  dropSessionDraft: (sessionId: string) => void;
 }
 
 type LifecycleCtx = LifecycleDeps & {
@@ -68,6 +72,7 @@ function removeCurrentIfEmpty(ctx: LifecycleCtx): boolean {
   const session = ctx.sessionMap.get(sessionId);
   if (session && isSessionEmpty(session)) {
     ctx.sessionMap.delete(sessionId);
+    ctx.dropSessionDraft(sessionId);
     return true;
   }
   return false;

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -11,7 +11,7 @@ import { PUBSUB_CHANNELS, readSessionDeletedIds } from "../config/pubsubChannels
 import { apiPost } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
 
-export function useSessionSync(opts: {
+export interface SessionSyncOptions {
   sessionMap: Map<string, ActiveSession>;
   currentSessionId: Ref<string>;
   fetchSessions: () => Promise<SessionSummary[]>;
@@ -20,8 +20,14 @@ export function useSessionSync(opts: {
    *  recovery action — usually navigate to a fresh session so the
    *  blank chat view doesn't linger on a dead URL. */
   onCurrentSessionDeleted?: () => void;
-}) {
-  const { sessionMap, currentSessionId, fetchSessions, onCurrentSessionDeleted } = opts;
+  /** Called once per hard-deleted session (this tab's deletes included —
+   *  they come back through the same broadcast), so the host can drop
+   *  state it keeps outside sessionMap, e.g. the session's chat draft. */
+  onSessionDeleted?: (sessionId: string) => void;
+}
+
+export function useSessionSync(opts: SessionSyncOptions) {
+  const { sessionMap, currentSessionId, fetchSessions, onCurrentSessionDeleted, onSessionDeleted } = opts;
   const { subscribe } = usePubSub();
 
   // Monotonic sequence token — protects sessionMap from stale overwrites when
@@ -71,6 +77,7 @@ export function useSessionSync(opts: {
     let currentWasDeleted = false;
     for (const deletedId of deletedIds) {
       sessionMap.delete(deletedId);
+      onSessionDeleted?.(deletedId);
       if (deletedId === currentSessionId.value) currentWasDeleted = true;
     }
     if (currentWasDeleted) onCurrentSessionDeleted?.();

--- a/src/utils/chat/draftStore.ts
+++ b/src/utils/chat/draftStore.ts
@@ -1,0 +1,60 @@
+// Per-session chat input drafts (#2811). Pure helpers over the map the
+// composable keeps in sessionStorage, so the "when does a draft die"
+// rules are testable without a browser.
+
+export const CHAT_DRAFTS_STORAGE_KEY = "chat_drafts_by_session";
+
+export type DraftMap = Record<string, string>;
+
+// Cap on how many sessions keep a draft. Insertion order is the LRU
+// order (setDraft re-inserts the touched session last), so the oldest
+// entries fall off the front once the cap is hit.
+const MAX_DRAFT_SESSIONS = 20;
+
+export function parseStoredDrafts(raw: string | null): DraftMap {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isPlainObject(parsed)) return {};
+    return Object.fromEntries(Object.entries(parsed).filter(isDraftEntry));
+  } catch {
+    return {};
+  }
+}
+
+// Drafts under an empty session id are in-memory only: persisting them
+// would replay someone else's text into the next session that boots
+// before its id is known.
+export function serializeDrafts(drafts: DraftMap): string {
+  return JSON.stringify(Object.fromEntries(Object.entries(drafts).filter(([sessionId]) => sessionId !== "")));
+}
+
+export function getDraft(drafts: DraftMap, sessionId: string): string {
+  return drafts[sessionId] ?? "";
+}
+
+// Whitespace-only text drops the key so a stray space never counts as a
+// draft; the stored text itself is kept verbatim (a slash command like
+// `/skill ` needs its trailing space).
+export function setDraft(drafts: DraftMap, sessionId: string, text: string): DraftMap {
+  if (text.trim() === "") return omitSession(drafts, sessionId);
+  const withoutSession = omitSession(drafts, sessionId);
+  const entries = [...Object.entries(withoutSession), [sessionId, text] as const];
+  return Object.fromEntries(entries.slice(-MAX_DRAFT_SESSIONS));
+}
+
+// Also used for the memory-only attachment map, which is keyed the same
+// way — one drop path means one place to forget a dead session.
+export function omitSession<T>(bySession: Record<string, T>, sessionId: string): Record<string, T> {
+  if (!(sessionId in bySession)) return bySession;
+  return Object.fromEntries(Object.entries(bySession).filter(([storedId]) => storedId !== sessionId));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isDraftEntry(entry: [string, unknown]): entry is [string, string] {
+  const [sessionId, text] = entry;
+  return sessionId !== "" && typeof text === "string" && text.trim() !== "";
+}

--- a/src/utils/chat/draftStore.ts
+++ b/src/utils/chat/draftStore.ts
@@ -6,9 +6,10 @@ export const CHAT_DRAFTS_STORAGE_KEY = "chat_drafts_by_session";
 
 export type DraftMap = Record<string, string>;
 
-// Cap on how many sessions keep a draft. Insertion order is the LRU
-// order (setDraft re-inserts the touched session last), so the oldest
-// entries fall off the front once the cap is hit.
+// Cap on how many sessions keep unsent state — text and attachments
+// alike, so neither half can grow without bound. Insertion order is the
+// LRU order (putSession re-inserts the touched session last), so the
+// oldest entries fall off the front once the cap is hit.
 const MAX_DRAFT_SESSIONS = 20;
 
 export function parseStoredDrafts(raw: string | null): DraftMap {
@@ -37,9 +38,15 @@ export function getDraft(drafts: DraftMap, sessionId: string): string {
 // draft; the stored text itself is kept verbatim (a slash command like
 // `/skill ` needs its trailing space).
 export function setDraft(drafts: DraftMap, sessionId: string, text: string): DraftMap {
-  if (text.trim() === "") return omitSession(drafts, sessionId);
-  const withoutSession = omitSession(drafts, sessionId);
-  const entries = [...Object.entries(withoutSession), [sessionId, text] as const];
+  return text.trim() === "" ? omitSession(drafts, sessionId) : putSession(drafts, sessionId, text);
+}
+
+// Write one session's entry and re-insert it last, so insertion order
+// stays the LRU order and the cap drops whoever has been idle longest.
+// Shared by the draft text and the attachment lists — the two halves of
+// a composer are capped together or the uncapped one grows forever.
+export function putSession<T>(bySession: Record<string, T>, sessionId: string, value: T): Record<string, T> {
+  const entries: [string, T][] = [...Object.entries(omitSession(bySession, sessionId)), [sessionId, value]];
   return Object.fromEntries(entries.slice(-MAX_DRAFT_SESSIONS));
 }
 

--- a/test/composables/test_useChatDrafts.ts
+++ b/test/composables/test_useChatDrafts.ts
@@ -1,0 +1,165 @@
+// Per-session composer drafts (#2811). The rules that matter here are
+// the ones the pure store can't express: which session a read/write
+// lands in, that attachments never reach storage, and that the drop
+// path — the one every session eviction and delete broadcast calls —
+// clears both halves without rewriting storage when there was nothing
+// to clear.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ref } from "vue";
+import { useChatDrafts } from "../../src/composables/useChatDrafts.ts";
+import { CHAT_DRAFTS_STORAGE_KEY, parseStoredDrafts } from "../../src/utils/chat/draftStore.ts";
+import type { PastedFile } from "../../src/types/pastedFile.ts";
+
+const storage = new Map<string, string>();
+let writes = 0;
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+
+function installStubStorage(): void {
+  storage.clear();
+  writes = 0;
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        writes += 1;
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => storage.clear(),
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function restoreStorage(): void {
+  if (originalDescriptor) {
+    Object.defineProperty(globalThis, "sessionStorage", originalDescriptor);
+  } else {
+    delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+  }
+}
+
+function storedDrafts(): Record<string, string> {
+  return parseStoredDrafts(storage.get(CHAT_DRAFTS_STORAGE_KEY) ?? null);
+}
+
+function makeFile(name: string): PastedFile {
+  return { dataUrl: `data:image/png;base64,${name}`, name, mime: "image/png" };
+}
+
+describe("useChatDrafts", () => {
+  beforeEach(installStubStorage);
+  afterEach(restoreStorage);
+
+  it("shows each session its own draft as the displayed session changes", () => {
+    const sessionId = ref("a");
+    const { userInput } = useChatDrafts(sessionId);
+
+    userInput.value = "written in A";
+    sessionId.value = "b";
+    assert.equal(userInput.value, "");
+
+    userInput.value = "written in B";
+    sessionId.value = "a";
+    assert.equal(userInput.value, "written in A");
+  });
+
+  it("restores the drafts left in storage by a previous page load", () => {
+    storage.set(CHAT_DRAFTS_STORAGE_KEY, JSON.stringify({ a: "from last time" }));
+    const { userInput } = useChatDrafts(ref("a"));
+    assert.equal(userInput.value, "from last time");
+  });
+
+  it("keeps attachments per session but never writes them to storage", () => {
+    const sessionId = ref("a");
+    const { pastedFiles } = useChatDrafts(sessionId);
+
+    pastedFiles.value = [makeFile("a.png")];
+    sessionId.value = "b";
+    assert.deepEqual(pastedFiles.value, []);
+
+    sessionId.value = "a";
+    assert.equal(pastedFiles.value.length, 1);
+    assert.equal(storage.get(CHAT_DRAFTS_STORAGE_KEY), undefined);
+  });
+
+  it("hands a fresh array to each empty session, so a caller cannot poison the others", () => {
+    const sessionId = ref("a");
+    const { pastedFiles } = useChatDrafts(sessionId);
+
+    const first = pastedFiles.value;
+    first.push(makeFile("sneaky.png"));
+    sessionId.value = "b";
+
+    assert.deepEqual(pastedFiles.value, []);
+  });
+
+  it("restores a failed send into the session it was composed in, not the one on screen", () => {
+    const sessionId = ref("a");
+    const { userInput, pastedFiles, restoreDraft } = useChatDrafts(sessionId);
+
+    userInput.value = "";
+    sessionId.value = "b";
+    userInput.value = "B is writing this";
+
+    restoreDraft("a", "the message that failed to send", [makeFile("failed.png")]);
+
+    assert.equal(userInput.value, "B is writing this");
+    assert.deepEqual(pastedFiles.value, []);
+    sessionId.value = "a";
+    assert.equal(userInput.value, "the message that failed to send");
+    assert.equal(pastedFiles.value.length, 1);
+  });
+
+  it("drops both halves of a deleted session's draft and leaves the others alone", () => {
+    const sessionId = ref("a");
+    const { userInput, pastedFiles, dropDraft } = useChatDrafts(sessionId);
+
+    userInput.value = "draft A";
+    pastedFiles.value = [makeFile("a.png")];
+    sessionId.value = "b";
+    userInput.value = "draft B";
+
+    dropDraft("a");
+
+    assert.deepEqual(storedDrafts(), { b: "draft B" });
+    sessionId.value = "a";
+    assert.equal(userInput.value, "");
+    assert.deepEqual(pastedFiles.value, []);
+  });
+
+  it("does not rewrite storage when the dropped session had no draft", () => {
+    const { userInput, dropDraft } = useChatDrafts(ref("a"));
+    userInput.value = "draft A";
+    const writesAfterTyping = writes;
+
+    dropDraft("never-had-a-draft");
+
+    assert.equal(writes, writesAfterTyping);
+  });
+
+  it("survives storage being unavailable, keeping the draft in memory", () => {
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: {
+        getItem: () => {
+          throw new Error("blocked");
+        },
+        setItem: () => {
+          throw new Error("quota exceeded");
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const { userInput } = useChatDrafts(ref("a"));
+    userInput.value = "still typing";
+    assert.equal(userInput.value, "still typing");
+  });
+});

--- a/test/composables/test_useChatDrafts.ts
+++ b/test/composables/test_useChatDrafts.ts
@@ -140,6 +140,23 @@ describe("useChatDrafts", () => {
     assert.equal(userInput.value, "from last time\ntyped while booting");
   });
 
+  it("never costs a real session its draft — pre-session text is not in the capped map", async () => {
+    const seeded = Object.fromEntries(Array.from({ length: 20 }, (_, index) => [`s${index}`, `draft-${index}`]));
+    storage.set(CHAT_DRAFTS_STORAGE_KEY, JSON.stringify(seeded));
+    const sessionId = ref("");
+    const { userInput } = useChatDrafts(sessionId);
+    const writesBefore = writes;
+
+    userInput.value = "typed while booting";
+
+    assert.deepEqual(storedDrafts(), seeded);
+    assert.equal(writes, writesBefore);
+
+    sessionId.value = "s0";
+    await nextTick();
+    assert.equal(userInput.value, "draft-0\ntyped while booting");
+  });
+
   it("never hands a stray unidentified draft to a later session", async () => {
     const sessionId = ref("");
     const { userInput } = useChatDrafts(sessionId);

--- a/test/composables/test_useChatDrafts.ts
+++ b/test/composables/test_useChatDrafts.ts
@@ -117,6 +117,37 @@ describe("useChatDrafts", () => {
     assert.equal(pastedFiles.value.length, 1);
   });
 
+  it("merges a failed send with whatever the user typed there while it was in flight", () => {
+    const sessionId = ref("a");
+    const { userInput, pastedFiles, restoreDraft } = useChatDrafts(sessionId);
+
+    userInput.value = "started the next message";
+    pastedFiles.value = [makeFile("staged-since.png")];
+
+    restoreDraft("a", "the message that failed to send", [makeFile("failed.png")]);
+
+    assert.equal(userInput.value, "the message that failed to send\nstarted the next message");
+    assert.deepEqual(
+      pastedFiles.value.map((file) => file.name),
+      ["failed.png", "staged-since.png"],
+    );
+  });
+
+  it("caps staged attachments at the same session count as the text, so neither half grows forever", () => {
+    const sessionId = ref("s0");
+    const { pastedFiles } = useChatDrafts(sessionId);
+
+    Array.from({ length: 25 }, (_, index) => `s${index}`).forEach((staging) => {
+      sessionId.value = staging;
+      pastedFiles.value = [makeFile(`${staging}.png`)];
+    });
+
+    sessionId.value = "s0";
+    assert.deepEqual(pastedFiles.value, []);
+    sessionId.value = "s24";
+    assert.equal(pastedFiles.value.length, 1);
+  });
+
   it("drops both halves of a deleted session's draft and leaves the others alone", () => {
     const sessionId = ref("a");
     const { userInput, pastedFiles, dropDraft } = useChatDrafts(sessionId);

--- a/test/composables/test_useChatDrafts.ts
+++ b/test/composables/test_useChatDrafts.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 import { useChatDrafts } from "../../src/composables/useChatDrafts.ts";
 import { CHAT_DRAFTS_STORAGE_KEY, parseStoredDrafts } from "../../src/utils/chat/draftStore.ts";
 import type { PastedFile } from "../../src/types/pastedFile.ts";
@@ -115,6 +115,43 @@ describe("useChatDrafts", () => {
     sessionId.value = "a";
     assert.equal(userInput.value, "the message that failed to send");
     assert.equal(pastedFiles.value.length, 1);
+  });
+
+  it("hands text typed before the session id arrived to the session that materialises", async () => {
+    const sessionId = ref("");
+    const { userInput } = useChatDrafts(sessionId);
+
+    userInput.value = "typed while the app was still booting";
+    sessionId.value = "a";
+    await nextTick();
+
+    assert.equal(userInput.value, "typed while the app was still booting");
+  });
+
+  it("appends that text after the draft the session already had restored", async () => {
+    storage.set(CHAT_DRAFTS_STORAGE_KEY, JSON.stringify({ a: "from last time" }));
+    const sessionId = ref("");
+    const { userInput } = useChatDrafts(sessionId);
+
+    userInput.value = "typed while booting";
+    sessionId.value = "a";
+    await nextTick();
+
+    assert.equal(userInput.value, "from last time\ntyped while booting");
+  });
+
+  it("never hands a stray unidentified draft to a later session", async () => {
+    const sessionId = ref("");
+    const { userInput } = useChatDrafts(sessionId);
+    sessionId.value = "a";
+    await nextTick();
+
+    sessionId.value = "";
+    userInput.value = "written with no session in view";
+    sessionId.value = "b";
+    await nextTick();
+
+    assert.equal(userInput.value, "");
   });
 
   it("merges a failed send with whatever the user typed there while it was in flight", () => {

--- a/test/utils/chat/test_draftStore.ts
+++ b/test/utils/chat/test_draftStore.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getDraft, parseStoredDrafts, omitSession, serializeDrafts, setDraft, type DraftMap } from "../../../src/utils/chat/draftStore.js";
+
+describe("setDraft", () => {
+  it("stores the draft under its session id, leaving other sessions untouched", () => {
+    const drafts = setDraft({ b: "other" }, "a", "hello");
+    assert.deepEqual(drafts, { b: "other", a: "hello" });
+  });
+
+  it("keeps the text verbatim, including a trailing space (slash commands need it)", () => {
+    assert.equal(getDraft(setDraft({}, "a", "/skill "), "a"), "/skill ");
+  });
+
+  it("removes the key when the draft is cleared, so no empty entry lingers", () => {
+    assert.deepEqual(setDraft({ a: "hello", b: "other" }, "a", ""), { b: "other" });
+  });
+
+  it("removes the key for whitespace-only text", () => {
+    assert.deepEqual(setDraft({ a: "hello" }, "a", "  \n "), {});
+  });
+
+  it("does not mutate the map it is given", () => {
+    const before: DraftMap = { a: "hello" };
+    setDraft(before, "b", "new");
+    assert.deepEqual(before, { a: "hello" });
+  });
+
+  it("drops the least recently touched session once the cap is exceeded", () => {
+    const filled = Array.from({ length: 25 }, (_, i) => `s${i}`).reduce<DraftMap>((map, sessionId) => setDraft(map, sessionId, `draft-${sessionId}`), {});
+    assert.equal(Object.keys(filled).length, 20);
+    assert.equal(getDraft(filled, "s0"), "");
+    assert.equal(getDraft(filled, "s24"), "draft-s24");
+  });
+
+  it("refreshes a session's position when re-typed, so it survives the cap", () => {
+    const seeded = Array.from({ length: 20 }, (_, i) => `s${i}`).reduce<DraftMap>((map, sessionId) => setDraft(map, sessionId, `draft-${sessionId}`), {});
+    const touched = setDraft(seeded, "s0", "still writing");
+    const evicting = setDraft(touched, "new", "newest");
+    assert.equal(getDraft(evicting, "s0"), "still writing");
+    assert.equal(getDraft(evicting, "s1"), "");
+  });
+});
+
+describe("omitSession", () => {
+  it("forgets one session and keeps the rest", () => {
+    assert.deepEqual(omitSession({ a: "one", b: "two" }, "a"), { b: "two" });
+  });
+
+  it("is a no-op for an unknown session", () => {
+    assert.deepEqual(omitSession({ a: "one" }, "missing"), { a: "one" });
+  });
+
+  it("works on any per-session map, e.g. the attachment lists", () => {
+    assert.deepEqual(omitSession({ a: [{ name: "one.png" }], b: [{ name: "two.png" }] }, "a"), { b: [{ name: "two.png" }] });
+  });
+});
+
+describe("serializeDrafts / parseStoredDrafts", () => {
+  it("round-trips a map", () => {
+    const drafts = { a: "hello", b: "line1\nline2" };
+    assert.deepEqual(parseStoredDrafts(serializeDrafts(drafts)), drafts);
+  });
+
+  it("never persists the draft of an unidentified session", () => {
+    assert.deepEqual(parseStoredDrafts(serializeDrafts({ "": "off-chat text", a: "hello" })), { a: "hello" });
+  });
+
+  it("reads missing storage as no drafts", () => {
+    assert.deepEqual(parseStoredDrafts(null), {});
+    assert.deepEqual(parseStoredDrafts(""), {});
+  });
+
+  it("reads corrupted or foreign storage as no drafts", () => {
+    assert.deepEqual(parseStoredDrafts("{not json"), {});
+    assert.deepEqual(parseStoredDrafts('["a","b"]'), {});
+    assert.deepEqual(parseStoredDrafts("null"), {});
+  });
+
+  it("drops entries that are not usable drafts", () => {
+    assert.deepEqual(parseStoredDrafts('{"a":"hello","b":42,"c":null,"d":"   ","":"x"}'), { a: "hello" });
+  });
+});


### PR DESCRIPTION
## Summary

チャット入力欄の下書きを **セッションごと** に持つようにし、テキストは **sessionStorage** に保存してリロードで消えないようにした。添付（chip）も同じくセッション別にした。

変更前は `src/App.vue` の `userInput` / `pastedFiles` がグローバルな ref 1 本ずつで、

- リロードすると入力が全部消える
- セッション A で書きかけて B に切り替えると、B の入力欄に A の文字と添付 chip が残る

というふたつの問題があった。

| | 変更前 | 変更後 |
|---|---|---|
| リロード | テキストが消える | 表示中セッションの下書きが復元 |
| セッション切替 | 前のセッションの文字・添付が残る | そのセッション自身の下書きに入れ替わる |
| タブを閉じる / ブラウザ再起動 | — | 破棄（sessionStorage） |
| 複数タブ | — | 干渉しない（タブごとに独立） |
| 添付の永続化 | リロードで消える | 変わらず消える（data URL なので quota に載せない） |

## Items to Confirm / Review

人間に見てほしい点:

1. **消すタイミングを全部潰せているか**（本 PR の肝。ユーザからの明示的な要望）。下記の表の 6 経路を実装した。抜けがあれば「不要なときに前の文字が残る」になる。
2. **空セッションが破棄されたときに下書きも捨てる** 判断（`removeCurrentIfEmpty`）。新規チャットに書きかけたまま /files などへ移動すると、そのセッション自体が捨てられるためテキストも失われる。**変更前はグローバル ref だったので文字だけは残っていた**（ただし戻り先は別セッションだった）。捨てないと到達不能な孤児が storage に残るのでこうしたが、UX 判断としてレビューしてほしい。
3. **添付はメモリのみ・上限なし**。セッションを跨いで添付したまま送らないと、その分メモリに残る（従来は 1 セット分）。実運用で問題になりそうなら LRU 上限を足す。
4. **buffered メッセージ（実行中に送った chip）は永続化していない** — 従来どおりリロードで消える。必要なら別 issue。

## 消すタイミング

| # | タイミング | 挙動 | 実装位置 |
|---|---|---|---|
| 1 | 送信してエージェントに飛んだ | 下書き・添付とも削除 | `sendMessage`（既存の `userInput.value = ""` / `pastedFiles.value = []` が setter 経由でキーを消す） |
| 2 | 実行中に送信 → chip に積まれた | 下書き削除 | 同上（buffered 分岐） |
| 3 | 添付の解決に失敗して差し戻し | 差し戻したテキスト・添付で復元 | 同上 |
| 4 | 入力欄を手で全消し | キーごと削除（空文字を残さない） | `setDraft`（trim 後空ならキー削除） |
| 5 | セッション削除（自タブ / 他タブ経由の broadcast 含む） | そのセッションの下書き・添付を削除 | `useSessionSync` の `onSessionDeleted` |
| 6 | 空セッションの破棄 | 同上 | `useSessionLifecycle.removeCurrentIfEmpty` |

新規セッション（+）は新しい id なので、そもそもキーが無く空。

## 実装

- **`src/utils/chat/draftStore.ts`（新規・純粋関数）** — `parseStoredDrafts` / `serializeDrafts` / `setDraft` / `getDraft` / `omitSession`。
  - `serializeDrafts` は **セッション id が空のエントリを永続化しない**。/chat 以外では `currentSessionId` が `""` になるため、保存すると次のロードで新規セッションに他人の文字が出る。
  - `setDraft` は trim 後が空ならキーを削除し、上限 20 セッションを超えたら挿入順（= LRU）で古い方から落とす。
  - `omitSession<T>` は下書きと添付の両方で使う共通の破棄経路。
- **`src/composables/useChatDrafts.ts`（新規）** — `currentSessionId` をキーにした `WritableComputedRef`（`userInput` / `pastedFiles`）と `dropDraft` を返す。既存の `currentBufferedMessages` と同じ形なので、`App.vue` 側の呼び出しは 1 行も変えていない。
  - 書き込みは同期的に sessionStorage へ（debounce しない — 打った直後の ⌘R で末尾を落とさないため）。
  - `sessionStorage` の読み書きは try/catch（quota / プライベートモード）。保存できなくてもメモリ上の入力は生き続ける。
- **`useSessionSync`** に `onSessionDeleted` を追加。削除はサーバが sessions チャンネルに broadcast し、自タブの削除も同じ経路で戻ってくるので、ここが唯一の削除フック。
- **`useSessionLifecycle`** に `dropSessionDraft` を追加し、`removeCurrentIfEmpty` が sessionMap から消したときに呼ぶ。

## テスト

- `test/utils/chat/test_draftStore.ts`（node:test, 15 件）— 保存 / 復元、空文字・空白のみでキー削除、壊れた JSON・配列・非 string 値、空 id を保存しない、LRU 上限と再入力での延命、`omitSession` が添付マップでも動く。
- `e2e/tests/chatinput-draft-persist.spec.ts`（Playwright, 7 件）— リロード復元 / URL 直叩きでのセッション分離 / タブ切替でのセッション分離 / 新規セッションは空 / 添付 chip のセッション分離 / 送信後はリロードしても復活しない / 手で全消し後も復活しない。

ローカル検証: `yarn format` → `yarn lint`（変更ファイルはエラー 0）→ `yarn typecheck` → `yarn build` → `yarn test`（exit 0）→ `yarn test:e2e`（**463 passed**）。

## User Prompt

> chat の入力 form、画面がリフレッシュすると入力が消えてしまう。セッションごとに local session に保存するなどして消えないようにできる？ただし、消しべきときはきちんと消さないと不要なときに前の文字が残るから注意してね

確認して決めた事項:

- 下書きの単位: **セッションごとに分ける**（`sessionId` をキー）
- 保存先: **sessionStorage**（タブを閉じたら破棄・複数タブで混ざらない）
- 添付（`pastedFiles`）も同じセッション別の扱いに **この PR で一緒に直す**

Plan: [`plans/feat-2811-chat-draft-persist.md`](plans/feat-2811-chat-draft-persist.md)

Closes #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Persist unsent chat input drafts and attachments per session so they survive reloads, stay isolated between sessions, and are cleaned up when their session is removed.

New Features:
- Introduce a per-session chat draft store that mirrors text to sessionStorage and keeps attachments in memory, keyed by session id.
- Expose a useChatDrafts composable that presents session-scoped user input and attachments as simple refs for the chat composer.

Enhancements:
- Extend session lifecycle and sync hooks with callbacks to drop drafts when sessions are deleted or evicted, preventing unreachable storage entries.

Documentation:
- Add a feature plan document describing the design and behaviors of per-session chat input draft persistence.

Tests:
- Add unit tests covering draft storage parsing, serialization, eviction rules, and session-based omission logic.
- Add end-to-end tests verifying draft restoration on reload, session isolation for text and attachments, behavior for new sessions, and proper clearing after send or manual delete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat input drafts now persist separately for each chat session.
  * Draft text is restored after reloads and preserved when switching sessions.
  * New sessions start with empty drafts, while attachments remain session-isolated and memory-only.
  * Drafts are cleared after sending, manually clearing the input, or deleting a session.
  * Drafts remain associated with the originating session during attachment uploads.
  * Draft storage supports up to 20 recent sessions and handles unavailable or invalid storage safely.

* **Tests**
  * Added automated coverage for persistence, isolation, cleanup, storage recovery, uploads, and session limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->