### PR TITLE
chore(mulmoclaude): launcher 1.11.0 — per-session chat drafts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,50 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-05
+
+**The composer stops losing your work — drafts now survive a reload and stay with the session you wrote them in.**
+
+### Highlights
+
+#### Per-session chat drafts that survive a reload (#2811, #2814)
+
+Text in the chat input was a single global value held nowhere but memory. Reloading the page threw it away, and switching sessions carried the previous session's text — and its attachment chips — into the next one.
+
+Drafts are now keyed by session and mirrored into `sessionStorage`: a reload restores what you were typing, closing the tab discards it, and two tabs never overwrite each other. Attachments are keyed the same way but stay in memory, since they are data URLs that would blow the storage quota.
+
+The harder half was deciding when a draft must die, so old text never reappears where it doesn't belong. It is dropped on send, on clearing the input, when the session is deleted (including from another tab, via the sessions broadcast), and when an empty never-sent-to session is evicted. Two failure modes found during review are covered too: a send that fails after its attachment upload now hands the message back to the session it was composed in — merged with anything typed there meanwhile, rather than overwriting it — and a send whose upload outlives a session switch still lands in the origin session, under that session's role, instead of the one now on screen.
+
+Text typed before the app has resolved which session to open (arriving on `/chat` without an id in the URL) is held aside and handed to the first session that materialises, appended after any draft that session restored.
+
+#### Split source editor beside the document on wide panes (#2812)
+
+The markdown source editor takes the free horizontal space on wide viewports instead of stacking below, so the source and the rendered document are visible at once.
+
+#### Reload button on document and HTML views (#2816)
+
+An icon-only reload control on the present views, for re-reading a file that changed underneath the canvas.
+
+#### Session history stops re-rendering every row (#2809, #2813)
+
+Selecting a session re-rendered the entire history list, delaying all feedback by 100-300 ms. Only the rows whose selection actually changed re-render now, and the clicked row highlights immediately rather than after the transcript round trip.
+
+### Also in this release
+
+- `sonarjs/void-use` promoted from warning to error (#2800, #2801).
+- The three open jscpd duplicate-code clones collapsed to single sources (#2807, #2808).
+- CI: e2e worker cap (#2794, #2795), install-deps hang (#2805, #2806), concurrency groups (#2791, #2792), test tempdir leak (#2789, #2797).
+
+Ships `@mulmoclaude/core@2.0.2`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.0.0`, `@mulmoclaude/chart-plugin@2.0.0`, `@mulmoclaude/collection-plugin@2.0.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.0.0`, `@mulmoclaude/html-plugin@2.1.0`, `@mulmoclaude/markdown-plugin@2.2.0`, `@mulmoclaude/mulmoscript-plugin@2.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
+### Packages published alongside
+
+- `@mulmoclaude/common@1.2.0` — adds `splitJwtSegments`, the shared JWT-segment parser the relay and Google Chat bridges had each open-coded.
+- `@mulmobridge/webhook-runtime@1.1.0` — adds `registerMetaWebhook`, shared by the Messenger and WhatsApp bridges.
+- `@mulmoclaude/core@2.0.2` — jscpd dedup in `skillDescription` (no behaviour change).
+- `@mulmobridge/relay@1.0.5`, `@mulmobridge/google-chat@1.0.4` — adopt `splitJwtSegments`. The relay's `tsconfig` also gained an explicit `rootDir`, which TypeScript 6 requires alongside `outDir` (TS5011) and without which its build — and therefore `prepack` — failed.
+- `@mulmobridge/messenger@1.0.3`, `@mulmobridge/whatsapp@1.0.4` — adopt `registerMetaWebhook`.
+
 ## [1.10.0] - 2026-08-03
 
 **The first launcher release since 1.9.0 — it carries 38 merged PRs of app code that no package publish could deliver.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`mulmoclaude@1.11.0` を npm に publish 済み。そのバージョン識別子（launcher + root の `package.json`）と CHANGELOG をここで取り込みます。

今回の目玉は #2814（入力中の下書きをセッションごとに保存し、リロードで消えないようにする）。`server/` と `src/` は launcher の tarball でしか npm ユーザーに届かないため、この publish が無いと #2814 は npm 経由では使えません。

## Items to Confirm / Review

1. **CHANGELOG の内容** — 1.10.0 以降にマージされた PR（#2812 / #2813 / #2814 / #2816 と、内部変更の #2801 / #2807 / CI 群）を拾っています。抜けがないか。
2. **Ships 行のバージョン** — launcher の `dependencies` の宣言レンジと npm の最新を突き合わせて記載しました（markdown-plugin 2.2.0 / html-plugin 2.1.0 / markdown-utils 1.3.5 など、この作業中に他の PR で上がったものを含む）。
3. **publish が PR より先** — `/publish-mulmoclaude` の手順どおり（§6 publish → §8 PR）。tarball スモークをローカルで通してから publish しています。

## 事前検証

| チェック | 結果 |
|---|---|
| `scripts/mulmoclaude/deps.mjs` | OK — 不足依存なし |
| `scripts/mulmoclaude/drift.mjs` | OK — workspace drift なし |
| launcher の全内部依存が npm に存在するか | ⚠ 0 件（全て解決） |
| `yarn build` | 成功 |
| `scripts/mulmoclaude/tarball.mjs` | OK — HTTP 200 / runtime plugins=5 |
| `npx --registry=https://registry.npmjs.org/ mulmoclaude@1.11.0 --version` | `mulmoclaude 1.11.0` |

## 併せて publish 済みのパッケージ（ボトムアップ順）

未公開の export を参照していた不整合をここで解消しています。

| # | パッケージ | 版 | 理由 |
|---|---|---|---|
| 1 | `@mulmoclaude/common` | 1.2.0 | `splitJwtSegments` を新規 export |
| 2 | `@mulmobridge/webhook-runtime` | 1.1.0 | `registerMetaWebhook` を新規 export |
| 3 | `@mulmoclaude/core` | 2.0.2 | #2807 の重複コード整理（挙動変化なし） |
| 4 | `@mulmobridge/relay` | 1.0.5 | 1 を利用。`tsconfig` に `rootDir` を追加（TS6 の TS5011 で build が落ちていた） |
| 5 | `@mulmobridge/google-chat` | 1.0.4 | 1 を利用 |
| 6 | `@mulmobridge/messenger` | 1.0.3 | 2 を利用 |
| 7 | `@mulmobridge/whatsapp` | 1.0.4 | 2 を利用 |

宣言レンジだけが drift している 24 本（bridges 16 + plugins 8）は、コード差分が無いため今回は見送りました。

また、tag が無かった `mulmoclaude@1.10.0` と `@mulmoclaude/markdown-plugin@2.1.0` を該当コミットに遡って作成しています（drift 検出が機能するように）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Release mulmoclaude launcher 1.11.0 with per-session, reload-persistent chat drafts and associated app changes.

New Features:
- Preserve chat input drafts per session across reloads while isolating them between sessions.
- Show markdown source editor side-by-side with the rendered document on wide viewports.
- Add reload control to document and HTML views for refreshing changed files without leaving the view.

Enhancements:
- Reduce unnecessary re-renders in the session history list to improve responsiveness when changing sessions.
- Promote `sonarjs/void-use` from warning to error and deduplicate jscpd-reported clones in core logic.

Build:
- Bump monorepo and mulmoclaude package versions to 1.11.0 and document shipped plugin versions and related package publishes.

CI:
- Tighten various CI behaviours including e2e worker limits, dependency install robustness, concurrency grouping, and test tempdir handling.

Documentation:
- Add detailed 1.11.0 changelog entry describing new draft handling, editor layout, reload control, performance improvements, and published packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat drafts are preserved during the current session.
  - Source editing is available in a wider workspace.
  - Document and HTML views include reload controls.

- **Improvements**
  - Session history now renders more efficiently.
  - Maintenance and CI updates improve overall reliability.

- **Release**
  - Released version 1.11.0, including shared authentication parsing and webhook registration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->