### PR TITLE
[do-not-merge] chore(perf): instrumentation used to re-measure #2809 on the fixed code

### DIFF
--- a/src/components/SessionHistoryPanel.vue
+++ b/src/components/SessionHistoryPanel.vue
@@ -54,7 +54,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount, onBeforeUpdate, onUpdated, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import type { SessionSummary, SessionOrigin } from "../types/session";
@@ -63,8 +63,18 @@ import { HISTORY_FILTERS, HISTORY_FILTER_ORDER, type HistoryFilter } from "../co
 import { isLongRunningConversation } from "../utils/session/longRunning";
 import SessionHistoryRow from "./SessionHistoryRow.vue";
 import FilterChip from "./FilterChip.vue";
+import { flushRowPerf, perfLog, perfLogSinceClick, perfLogUntilPaint, perfMarkClick } from "../utils/devPerf";
 
 const { t } = useI18n();
+
+// ── Investigation instrumentation (see src/utils/devPerf.ts) ────────
+// Off unless `localStorage["mulmoclaude:perf"] === "1"`. #2810's version
+// of this measured the panel before the row split; the call sites here
+// measure the same click on the fixed code — how long until the row's
+// border appears, how long Vue spends patching the list, and how much
+// of the per-row work still runs.
+const setupStartedAt = performance.now();
+let updatePassStartedAt = 0;
 
 // `unread` and `bookmarked` are mutually exclusive with origin pills —
 // selecting either shows every matching session regardless of origin,
@@ -123,9 +133,17 @@ function countByOrigin(filterKey: HistoryFilter): number {
   return props.sessions.filter((session) => matchesFilter(session, filterKey)).length;
 }
 
+// The row's selected border is the first feedback the click produces,
+// so this pair brackets the "I clicked but nothing happened yet" window.
 function onSelect(sessionId: string): void {
+  perfMarkClick();
   emit("loadSession", sessionId);
 }
+
+watch(
+  () => props.currentSessionId,
+  () => perfLogSinceClick("click→row selected"),
+);
 
 // ── Row action menu ─────────────────────────────────────────
 //
@@ -158,6 +176,24 @@ function onDelete(session: SessionSummary): void {
 
 onMounted(() => {
   document.addEventListener("click", closeMenu);
+  perfLogUntilPaint("history-panel setup→paint", setupStartedAt, {
+    rows: filteredSessions.value.length,
+    totalSessions: props.sessions.length,
+  });
+  flushRowPerf("mount", filteredSessions.value.length);
+});
+
+// Every re-render of the list (filter change, selection change, or a
+// sessions-channel refetch replacing the array) lands here. The span
+// between the two hooks is the vnode diff + child patch of the whole
+// list — the ~110 ms line in #2809's Safari table.
+onBeforeUpdate(() => {
+  updatePassStartedAt = performance.now();
+});
+
+onUpdated(() => {
+  perfLog("list patch (vnode diff)", performance.now() - updatePassStartedAt, { rows: filteredSessions.value.length });
+  flushRowPerf("update", filteredSessions.value.length);
 });
 
 onBeforeUnmount(() => {

--- a/src/components/SessionHistoryRow.vue
+++ b/src/components/SessionHistoryRow.vue
@@ -91,15 +91,23 @@
 //     makes the props compare fail, so every row re-renders again)
 //   - every derived string is a `computed`, so date formatting and
 //     i18n interpolation survive a re-render instead of re-running
-import { computed } from "vue";
+import { computed, onUpdated } from "vue";
 import { useI18n } from "vue-i18n";
 import type { Role } from "../config/roles";
 import type { SessionSummary } from "../types/session";
 import { resolveSessionPrimaryText, sessionHasVisibleSummary } from "../utils/session/sessionPreview";
 import { formatDate } from "../utils/format/date";
+import { rowPerf } from "../utils/devPerf";
 import SessionRoleIcon from "./SessionRoleIcon.vue";
 
 const { t } = useI18n();
+
+// ── Investigation instrumentation (see src/utils/devPerf.ts) ────────
+// Off unless `localStorage["mulmoclaude:perf"] === "1"`. Counts this
+// instance into the pass the panel flushes, so a click reports how many
+// of the N rows Vue actually re-rendered and how much of the per-row
+// string work re-ran inside them.
+onUpdated(() => rowPerf.renders.bump());
 
 const props = defineProps<{
   session: SessionSummary;
@@ -119,11 +127,11 @@ const emit = defineEmits<{
 // title so all three stay in lockstep. `null` from the resolver means
 // "nothing to show" — the localised placeholder is applied here rather
 // than in the pure helper.
-const primaryText = computed(() => resolveSessionPrimaryText(props.session) ?? t("sessionHistoryPanel.noMessages"));
+const primaryText = computed(() => rowPerf.primaryText.add(() => resolveSessionPrimaryText(props.session) ?? t("sessionHistoryPanel.noMessages")));
 
-const rowAria = computed(() => t("sessionHistoryPanel.openRowAria", { preview: primaryText.value }));
+const rowAria = computed(() => rowPerf.aria.add(() => t("sessionHistoryPanel.openRowAria", { preview: primaryText.value })));
 
-const formattedDate = computed(() => formatDate(props.session.updatedAt));
+const formattedDate = computed(() => rowPerf.timestamp.add(() => formatDate(props.session.updatedAt)));
 
 const hasVisibleSummary = computed(() => sessionHasVisibleSummary(props.session));
 

--- a/src/components/SessionSidebar.vue
+++ b/src/components/SessionSidebar.vue
@@ -64,11 +64,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { ToolResultComplete } from "gui-chat-protocol/vue";
 import { getPlugin } from "../tools";
 import { formatSmartTime } from "../utils/format/date";
+import { perfLogSinceClick } from "../utils/devPerf";
 import { isRecord } from "../utils/types";
 import CanvasViewToggle from "./CanvasViewToggle.vue";
 import CopyChatButton from "./CopyChatButton.vue";
@@ -76,7 +77,7 @@ import type { LayoutMode } from "../utils/canvas/layoutMode";
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   // Already filtered to "what the user should see" by the parent's
   // `sidebarResults` computed (see useSessionDerived.ts) — keyboard
   // navigation, selection, and this render all consume the same
@@ -115,6 +116,15 @@ const emit = defineEmits<{
 
 const root = ref<HTMLDivElement | null>(null);
 defineExpose({ root });
+
+// Investigation instrumentation (src/utils/devPerf.ts). This pane is the
+// one that visibly swaps content on a session click, and each card can
+// mount a plugin preview component, so its cost scales with the result
+// count rather than with the session list.
+watch(
+  () => props.results,
+  (results) => perfLogSinceClick("click→middle pane painted", { results: results.length }),
+);
 </script>
 
 <style scoped>

--- a/src/composables/useSessionHistory.ts
+++ b/src/composables/useSessionHistory.ts
@@ -6,6 +6,7 @@ import { PUBSUB_CHANNELS, readSessionDeletedIds } from "../config/pubsubChannels
 import type { SessionSummary } from "../types/session";
 import { apiDelete, apiGet, apiPost } from "../utils/api";
 import { applySessionDiff } from "../utils/session/mergeSessions";
+import { perfNote, perfTime, perfTimeAsync } from "../utils/devPerf";
 import { applyBookmarkFlag } from "./useSessionHistory.helpers";
 import { usePubSub } from "./usePubSub";
 
@@ -85,7 +86,12 @@ export function useSessionHistory(): UseSessionHistory {
   async function fetchSessions(): Promise<SessionSummary[]> {
     const query: Record<string, string> = {};
     if (cursor !== null) query.since = cursor;
-    const result = await apiGet<SessionsResponse>(API_ROUTES.sessions.list, query);
+    // Investigation instrumentation (src/utils/devPerf.ts): this call is
+    // the one every sessions-channel broadcast triggers, and its result
+    // replaces the array the 800-row list renders from.
+    const result = await perfTimeAsync(cursor === null ? "fetchSessions: GET /sessions (full)" : "fetchSessions: GET /sessions (diff)", () =>
+      apiGet<SessionsResponse>(API_ROUTES.sessions.list, query),
+    );
     if (!result.ok) {
       historyError.value = result.error;
       // Preserve sessions.value so callers keep showing the last-known-good list.
@@ -93,11 +99,18 @@ export function useSessionHistory(): UseSessionHistory {
     }
     historyError.value = null;
     const body = result.data;
-    if (cursor === null) {
-      sessions.value = body.sessions;
-    } else {
-      sessions.value = applySessionDiff(sessions.value, body.sessions, body.deletedIds);
-    }
+    perfTime(
+      "fetchSessions: merge into list",
+      () => {
+        if (cursor === null) {
+          sessions.value = body.sessions;
+        } else {
+          sessions.value = applySessionDiff(sessions.value, body.sessions, body.deletedIds);
+        }
+      },
+      { received: body.sessions.length },
+    );
+    perfNote("fetchSessions: list size after merge", { rows: sessions.value.length });
     ({ cursor } = body);
     return sessions.value;
   }

--- a/src/composables/useSessionLifecycle.ts
+++ b/src/composables/useSessionLifecycle.ts
@@ -15,6 +15,7 @@ import type { Role } from "../config/roles";
 import { PAGE_ROUTES } from "../router";
 import { apiGet } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { perfLogSinceClick, perfTime, perfTimeAsync } from "../utils/devPerf";
 import { createEmptySession } from "../utils/session/sessionFactory";
 import { buildLoadedSession, parseSessionEntries, shouldAdoptServerTranscript } from "../utils/session/sessionEntries";
 import {
@@ -120,16 +121,27 @@ function activateSession(ctx: LifecycleCtx, sessionId: string, replace: boolean)
   ctx.currentSessionId.value = sessionId;
 }
 
+// Investigation instrumentation (src/utils/devPerf.ts): the two phases
+// the click used to wait on before anything moved on screen. Since
+// #2813 the row highlights before this runs, so these numbers now say
+// how long the CONTENT lags the highlight rather than the whole click.
 async function fetchLoadedSession(ctx: LifecycleCtx, sessionId: string): Promise<ActiveSession | null> {
-  const response = await apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId)));
+  const response = await perfTimeAsync("loadSession: GET /sessions/:id", () =>
+    apiGet<SessionEntry[]>(API_ROUTES.sessions.detail.replace(":id", encodeURIComponent(sessionId))),
+  );
   if (!response.ok) return null;
-  return buildLoadedSession({
-    id: sessionId,
-    entries: response.data,
-    defaultRoleId: ctx.roles.value[0]?.id ?? "",
-    serverSummary: ctx.sessions.value.find((summary) => summary.id === sessionId),
-    nowIso: new Date().toISOString(),
-  });
+  return perfTime(
+    "loadSession: buildLoadedSession()",
+    () =>
+      buildLoadedSession({
+        id: sessionId,
+        entries: response.data,
+        defaultRoleId: ctx.roles.value[0]?.id ?? "",
+        serverSummary: ctx.sessions.value.find((summary) => summary.id === sessionId),
+        nowIso: new Date().toISOString(),
+      }),
+    { entries: response.data.length },
+  );
 }
 
 async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> {
@@ -138,6 +150,7 @@ async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> 
   const replaced = shouldReplaceHistory(removeCurrentIfEmpty(ctx), ctx.isChatPage.value);
   if (ctx.sessionMap.has(sessionId)) {
     activateSession(ctx, sessionId, replaced);
+    perfLogSinceClick("loadSession cached→paint", { sessionId });
     return;
   }
   // Highlight the row on the click instead of a round trip later (#2809).
@@ -155,6 +168,7 @@ async function loadSession(ctx: LifecycleCtx, sessionId: string): Promise<void> 
   // and their next click on this session then costs no round trip.
   ctx.sessionMap.set(sessionId, newSession);
   if (stillAwaited) activateSession(ctx, sessionId, replaced);
+  perfLogSinceClick("loadSession fetched→paint", { sessionId, stillAwaited });
 }
 
 // Re-fetch the transcript and patch entries missed via a dropped socket

--- a/src/composables/useSessionSync.ts
+++ b/src/composables/useSessionSync.ts
@@ -10,6 +10,22 @@ import { usePubSub } from "./usePubSub";
 import { PUBSUB_CHANNELS, readSessionDeletedIds } from "../config/pubsubChannels";
 import { apiPost } from "../utils/api";
 import { API_ROUTES } from "../config/apiRoutes";
+import { createPerfCounter, perfTimeAsync } from "../utils/devPerf";
+
+// Investigation instrumentation (src/utils/devPerf.ts). Every hit here
+// is a server-side session state change (beginRun / endRun / markRead)
+// that makes THIS tab refetch the whole list and re-render it — the
+// re-renders that happen without the user touching anything.
+const sessionsChannelHits = createPerfCounter("sessions-channel broadcast");
+
+// Clicking an UNREAD row lands here, and the server answers this POST
+// with a sessions-channel broadcast — so it is what turns one click
+// into a second full-list refetch + re-render.
+function postMarkRead(sessionId: string) {
+  return perfTimeAsync("markSessionRead: POST mark-read", () =>
+    apiPost<{ ok: boolean }>(API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(sessionId))),
+  );
+}
 
 export interface SessionSyncOptions {
   sessionMap: Map<string, ActiveSession>;
@@ -62,7 +78,7 @@ export function useSessionSync(opts: SessionSyncOptions) {
   }
 
   async function markSessionRead(sessionId: string): Promise<void> {
-    const result = await apiPost<{ ok: boolean }>(API_ROUTES.sessions.markRead.replace(":id", encodeURIComponent(sessionId)));
+    const result = await postMarkRead(sessionId);
     if (!result.ok || result.data.ok === false) {
       await refreshSessionStates();
     }
@@ -81,6 +97,7 @@ export function useSessionSync(opts: SessionSyncOptions) {
       if (deletedId === currentSessionId.value) currentWasDeleted = true;
     }
     if (currentWasDeleted) onCurrentSessionDeleted?.();
+    sessionsChannelHits.hit({ deleted: deletedIds.length });
     void refreshSessionStates();
   });
   if (typeof unsub === "function") onScopeDispose(unsub);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import router from "./router/index";
 import { installGuards } from "./router/guards";
 import i18n from "./lib/vue-i18n";
 import { setAuthToken } from "./utils/api";
+import { perfEnabled } from "./utils/devPerf";
 import { readAuthTokenFromMeta } from "./utils/dom/authTokenMeta";
 import { loadRuntimePlugins } from "./tools/runtimeLoader";
 import { startDevPluginReloadListener } from "./composables/useDevPluginReload";
@@ -120,6 +121,11 @@ setupMarked();
 installGuards(router);
 
 const app = createApp(App);
+// Investigation instrumentation (src/utils/devPerf.ts): makes Vue emit a
+// `performance.measure` per component init / render / patch, which
+// devPerf's observer aggregates into a per-click breakdown. Only on
+// when `localStorage["mulmoclaude:perf"] === "1"`.
+app.config.performance = perfEnabled;
 app.use(router);
 app.use(i18n);
 app.mount("#app");

--- a/src/utils/devPerf.ts
+++ b/src/utils/devPerf.ts
@@ -1,0 +1,201 @@
+// Investigation-only performance instrumentation for the session-list
+// slowness (left history panel). Everything here is inert unless the
+// reader opts in at runtime from the browser console:
+//
+//   localStorage.setItem("mulmoclaude:perf", "1"); location.reload();
+//
+// The flag is read once at module load, so a disabled session pays only
+// a boolean check per call site. Remove this module (and its call sites)
+// once the investigation lands a fix.
+//
+// Re-applied on top of the #2809 fix (#2813) to re-measure the same
+// paths. Ported from #2810 with two changes the fix made necessary:
+//   - accumulators flush even at zero calls, because "0 formatDate calls
+//     per click" is now the result being looked for, not an absence
+//   - a tally for how many rows actually re-render per click, which is
+//     what the row-component split was supposed to change
+
+const PERF_FLAG_KEY = "mulmoclaude:perf";
+const LOG_PREFIX = "[perf]";
+const MS_DECIMALS = 1;
+const LABEL_WIDTH = 34;
+const VALUE_WIDTH = 10;
+const MS_PER_SECOND = 1000;
+
+function readFlag(): boolean {
+  try {
+    return window.localStorage.getItem(PERF_FLAG_KEY) === "1";
+  } catch {
+    // Private-mode Safari throws on localStorage access — treat as off.
+    return false;
+  }
+}
+
+export const perfEnabled = readFlag();
+
+function format(elapsedMs: number): string {
+  return `${elapsedMs.toFixed(MS_DECIMALS)} ms`;
+}
+
+/** Log one timing. `extra` carries whatever context makes the number
+ *  interpretable (row counts, byte sizes, session ids). */
+export function perfLog(label: string, elapsedMs: number, extra?: Record<string, unknown>): void {
+  if (!perfEnabled) return;
+  console.log(`${LOG_PREFIX} ${label.padEnd(LABEL_WIDTH)} ${format(elapsedMs).padStart(VALUE_WIDTH)}`, extra ?? "");
+}
+
+/** Report context that is a count rather than a duration (list sizes,
+ *  entry counts) without pretending it took 0 ms. */
+export function perfNote(label: string, extra: Record<string, unknown>): void {
+  if (!perfEnabled) return;
+  console.log(`${LOG_PREFIX} ${label.padEnd(LABEL_WIDTH)}`, extra);
+}
+
+/** Time an async block and log it. Returns whatever the block returns. */
+export async function perfTimeAsync<T>(label: string, run: () => Promise<T>, extra?: Record<string, unknown>): Promise<T> {
+  if (!perfEnabled) return run();
+  const started = performance.now();
+  const result = await run();
+  perfLog(label, performance.now() - started, extra);
+  return result;
+}
+
+/** Time a synchronous block and log it. */
+export function perfTime<T>(label: string, run: () => T, extra?: Record<string, unknown>): T {
+  if (!perfEnabled) return run();
+  const started = performance.now();
+  const result = run();
+  perfLog(label, performance.now() - started, extra);
+  return result;
+}
+
+/** Log the time from `startedAt` until the browser has actually painted.
+ *  Two rAFs: the first fires before paint, the second after it. This is
+ *  the number that matches "when did the user see it change". */
+export function perfLogUntilPaint(label: string, startedAt: number, extra?: Record<string, unknown>): void {
+  if (!perfEnabled) return;
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => perfLog(label, performance.now() - startedAt, extra));
+  });
+}
+
+// ── Click clock ─────────────────────────────────────────────────────
+// One click updates three things the reader notices at different
+// moments: the row's own selected border, the middle pane's transcript,
+// and the canvas. They live in different components, so the click time
+// is parked here and each of them reports its own distance from it.
+
+let lastClickAt = 0;
+
+/** Stamp the moment the user pressed a session row. */
+export function perfMarkClick(): void {
+  if (!perfEnabled) return;
+  lastClickAt = performance.now();
+}
+
+/** The click currently being measured, for callers that need to time a
+ *  synchronous span rather than a paint (0 before the first click). */
+export function perfClickAt(): number {
+  return lastClickAt;
+}
+
+/** Report when this part of the UI actually finished painting, measured
+ *  from the click that caused it. No-op before the first click. */
+export function perfLogSinceClick(label: string, extra?: Record<string, unknown>): void {
+  if (!perfEnabled || lastClickAt === 0) return;
+  perfLogUntilPaint(label, lastClickAt, extra);
+}
+
+/** Sums many small calls (per-row work) across one render pass, so the
+ *  cost of 800 individual `formatDate` / `t()` calls shows up as one
+ *  line instead of 800. Call `add` around each unit, `flush` once the
+ *  pass is over. */
+export interface PerfAccumulator {
+  add: <T>(run: () => T) => T;
+  flush: (label: string, extra?: Record<string, unknown>) => void;
+}
+
+export function createPerfAccumulator(): PerfAccumulator {
+  let totalMs = 0;
+  let calls = 0;
+
+  function add<T>(run: () => T): T {
+    if (!perfEnabled) return run();
+    const started = performance.now();
+    const result = run();
+    totalMs += performance.now() - started;
+    calls += 1;
+    return result;
+  }
+
+  // Logs even when `calls` is 0 — after #2813 the per-row work sits
+  // behind `computed`, so "this pass re-ran it 0 times" is the finding.
+  function flush(label: string, extra?: Record<string, unknown>): void {
+    if (!perfEnabled) return;
+    perfLog(label, totalMs, { calls, ...extra });
+    totalMs = 0;
+    calls = 0;
+  }
+
+  return { add, flush };
+}
+
+/** Counts occurrences within one render pass (how many row components
+ *  actually re-rendered) and reports them the same way as the
+ *  accumulators, so a click's whole cost reads as one block. */
+export interface PerfTally {
+  bump: () => void;
+  flush: (label: string, extra?: Record<string, unknown>) => void;
+}
+
+export function createPerfTally(): PerfTally {
+  let count = 0;
+  return {
+    bump(): void {
+      if (!perfEnabled) return;
+      count += 1;
+    },
+    flush(label: string, extra?: Record<string, unknown>): void {
+      if (!perfEnabled) return;
+      perfNote(label, { count, ...extra });
+      count = 0;
+    },
+  };
+}
+
+// ── Session-row render pass ─────────────────────────────────────────
+// The per-row work now lives in SessionHistoryRow.vue (one component
+// instance per row) while the pass that contains it is owned by
+// SessionHistoryPanel.vue, so the accumulators are shared here rather
+// than held by either component.
+
+export const rowPerf = {
+  renders: createPerfTally(),
+  timestamp: createPerfAccumulator(),
+  aria: createPerfAccumulator(),
+  primaryText: createPerfAccumulator(),
+};
+
+/** Report one render pass of the list: how many row components actually
+ *  re-rendered, and what the per-row string work cost inside them. */
+export function flushRowPerf(pass: string, rows: number): void {
+  rowPerf.renders.flush(`${pass}: rows re-rendered`, { rows });
+  rowPerf.timestamp.flush(`${pass}: formatDate()`);
+  rowPerf.aria.flush(`${pass}: t(openRowAria)`);
+  rowPerf.primaryText.flush(`${pass}: primaryText()`);
+}
+
+/** Counts events (pub/sub-driven refetches) and reports the rate, so
+ *  background churn unrelated to a click is visible. */
+export function createPerfCounter(label: string) {
+  const startedAt = performance.now();
+  let count = 0;
+  return {
+    hit(extra?: Record<string, unknown>): void {
+      if (!perfEnabled) return;
+      count += 1;
+      const elapsedSec = (performance.now() - startedAt) / MS_PER_SECOND;
+      console.log(`${LOG_PREFIX} ${label.padEnd(LABEL_WIDTH)} #${count} @ ${elapsedSec.toFixed(1)}s`, extra ?? "");
+    },
+  };
+}

--- a/src/utils/devPerf.ts
+++ b/src/utils/devPerf.ts
@@ -79,6 +79,58 @@ export function perfLogUntilPaint(label: string, startedAt: number, extra?: Reco
   });
 }
 
+// ── Component breakdown ─────────────────────────────────────────────
+// `app.config.performance = true` (src/main.ts) makes Vue emit a
+// `performance.measure` per component init / render / patch. Collecting
+// them per click answers "which component owns the frame the click waits
+// for" without hand-instrumenting each pane. Vue's measures NEST (a
+// parent's patch contains its children's), so the durations overlap —
+// read the ranking, not the sum.
+
+interface MeasureRecord {
+  name: string;
+  startTime: number;
+  duration: number;
+}
+
+const MEASURE_MIN_MS = 1;
+const MEASURE_TOP_N = 12;
+const MEASURE_BUFFER_MAX = 4000;
+const NAME_WIDTH = 40;
+
+const measures: MeasureRecord[] = [];
+
+if (perfEnabled && typeof PerformanceObserver !== "undefined") {
+  const observer = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      measures.push({ name: entry.name, startTime: entry.startTime, duration: entry.duration });
+    }
+    if (measures.length > MEASURE_BUFFER_MAX) measures.splice(0, measures.length - MEASURE_BUFFER_MAX);
+  });
+  observer.observe({ entryTypes: ["measure"] });
+}
+
+let dumpedClickAt = 0;
+
+function dumpMeasuresSinceClick(clickAt: number): void {
+  if (dumpedClickAt === clickAt) return;
+  dumpedClickAt = clickAt;
+  const totals = new Map<string, { ms: number; calls: number }>();
+  for (const record of measures.filter((entry) => entry.startTime >= clickAt)) {
+    const acc = totals.get(record.name) ?? { ms: 0, calls: 0 };
+    totals.set(record.name, { ms: acc.ms + record.duration, calls: acc.calls + 1 });
+  }
+  const ranked = [...totals.entries()]
+    .map(([name, acc]) => ({ name, ...acc }))
+    .filter((row) => row.ms >= MEASURE_MIN_MS)
+    .sort((left, right) => right.ms - left.ms)
+    .slice(0, MEASURE_TOP_N);
+  console.log(`${LOG_PREFIX} ── component breakdown for this click (${totals.size} distinct, nested: durations overlap)`);
+  for (const row of ranked) {
+    console.log(`${LOG_PREFIX}   ${row.name.padEnd(NAME_WIDTH)} ${row.ms.toFixed(MS_DECIMALS).padStart(VALUE_WIDTH)} ms  x${row.calls}`);
+  }
+}
+
 // ── Click clock ─────────────────────────────────────────────────────
 // One click updates three things the reader notices at different
 // moments: the row's own selected border, the middle pane's transcript,
@@ -91,6 +143,7 @@ let lastClickAt = 0;
 export function perfMarkClick(): void {
   if (!perfEnabled) return;
   lastClickAt = performance.now();
+  measures.length = 0;
 }
 
 /** The click currently being measured, for callers that need to time a
@@ -103,7 +156,15 @@ export function perfClickAt(): number {
  *  from the click that caused it. No-op before the first click. */
 export function perfLogSinceClick(label: string, extra?: Record<string, unknown>): void {
   if (!perfEnabled || lastClickAt === 0) return;
-  perfLogUntilPaint(label, lastClickAt, extra);
+  const clickAt = lastClickAt;
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      perfLog(label, performance.now() - clickAt, extra);
+      // Several call sites report the same click; only the first one to
+      // paint prints the breakdown.
+      dumpMeasuresSinceClick(clickAt);
+    });
+  });
 }
 
 /** Sums many small calls (per-row work) across one render pass, so the


### PR DESCRIPTION
## Summary

#2809 の修正（#2813）が実機で効いているかを確認するために使った計測コード。#2810 と同じく `localStorage["mulmoclaude:perf"] === "1"` のときだけ動く opt-in で、修正後の構造に合わせて置き直したもの。**マージしない前提**で、記録として残すために PR にして即 close する。

#2810 からの変更点は 3 つ。

- 行ごとの日時整形・i18n 補間・プレビュー解決は `SessionHistoryRow.vue` の `computed` に移ったので、計測を子側に置き、描画パス単位で合算して親が出力する。呼び出し 0 回でもログを出す（0 であること自体が確認したい結果のため）
- 1 クリックで実際に再描画された行数を数える tally を追加。案 2（行の子コンポーネント化）が効いているかの直接の証拠になる
- Vue 自身の component 計測（`app.config.performance`）を同じフラグ連動で有効にし、1 クリックぶんの `performance.measure` を `PerformanceObserver` で集計してコンポーネント名別に出力する。残り時間の帰属をコンポーネント名で特定するため

## Items to Confirm / Review

マージしないので指摘は不要。同じ計測をやり直す人向けのメモとして。

- 計測点: `SessionHistoryPanel.vue` / `SessionHistoryRow.vue` / `SessionSidebar.vue` / `useSessionLifecycle.ts` / `useSessionHistory.ts` / `useSessionSync.ts` / `main.ts`
- Vue の component 計測は入れ子（親の patch が子の時間を含む）なので、合計ではなく順位で読む
- `click→row selected` は requestAnimationFrame 2 段で「ペイントされるまで」を測っている。#2813 の PR 本文にある Chromium の数字は MutationObserver で「DOM が変わるまで」なので、物差しが違う

## 計測結果

#2809 のコメントに記載。要点は次のとおり（Safari 26.5 / macOS 26.5.1、セッション 827 件、手動クリック 22 回）。

- click→選択枠がペイントされるまで: 中央値 64.5 ms（43〜96 ms）
- 選択のパスは毎回「再描画された行 2 行」「`formatDate` 0 回」「`t()` 0 回」
- 64.5 ms のうち Vue の処理は 18 ms 程度。残る約 45 ms は Vue の外（Safari のスタイル計算・レイアウト・ペイント、rAF 待ち）
- 一覧をフィルタで 18 行に絞っても click→ペイントは下がらない

## User Prompt

- #2809 が解決したようなので計測したい
- issue に前使った計測コードの PR（すぐ close したもの）がある。それを使い、変更後のコードだけを Safari で測る
- たまにちょっと遅い気がする
- （フィルタで一覧を 18 行に絞った状態で再計測）
- 最後のクリックが若干遅いかな、という程度
- 報告は「速くなった（実測値あり）→ お礼 → 若干遅い部分はあるが体感には影響なし → 備忘録として共有し、今後体感に影響が出たらここから調査」という流れで書く
- 今回の計測コードも PR を作ってすぐ close しておきたい

work in mulmoclaude-code

## Summary by Sourcery

Add opt-in performance instrumentation around session history interactions to re-measure click-to-paint behavior after the session-list fix.

Enhancements:
- Introduce a shared devPerf utility module providing timing helpers, per-pass accumulators, and event counters gated by a localStorage flag.
- Wire performance logging into session history panel, row, sidebar, lifecycle, history, and sync flows to capture click-to-paint timings, list patch costs, and background refetch activity.
- Enable Vue's built-in component performance measurements when the perf flag is set to produce per-click component breakdowns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in development performance monitoring for session history, session loading, synchronization, and list rendering.
  * Added browser-console timing details for clicks, API requests, updates, rendering, and background refresh activity.
  * Added safe handling when performance monitoring cannot access local browser storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->