### PR TITLE
chore: sweep @mulmoclaude/core ranges to ^2.1.0 + retroactive release tags

### DIFF
--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^2.0.2"
+    "@mulmoclaude/core": "^2.1.0"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^2.0.2"
+    "@mulmoclaude/core": "^2.1.0"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^2.0.2",
+    "@mulmoclaude/core": "^2.1.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^2.0.2",
+    "@mulmoclaude/core": "^2.1.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^2.0.2"
+    "@mulmoclaude/core": "^2.1.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^2.0.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^2.0.2"
+    "@mulmoclaude/core": "^2.1.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^2.0.2",
+    "@mulmoclaude/core": "^2.1.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^2.0.2",
+    "@mulmoclaude/core": "^2.1.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^2.0.2"
+    "@mulmoclaude/core": "^2.1.0"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",


### PR DESCRIPTION
## Summary

`#2824` のあと「何を publish すべきか」を監査した際に見つけたリリース衛生の修正です。**npm publish は伴いません**（ツリーとタグの整合のみ）。

1. **`@mulmoclaude/core` の range 掃き替え** — core は npm で 2.1.0 なのに、6プラグイン・9箇所の宣言が `^2.0.2` のままでした
2. **欠落していたリリースタグ2件を遡及作成** — `@mulmoclaude/core@2.1.0` / `@mulmoclaude/markdown-plugin@2.3.0`（タグ + GH release、push 済み）

## Items to Confirm / Review

1. **タグの対象コミットを `81320eff4`（publish 時点の main）にした判断**
   CLAUDE.md は「version を上げたコミットに best effort で」と言っていますが、markdown-plugin は version bump 後にさらにソース変更（`2c1febce4` 等）があり、npm への publish（22:13:52Z）はその後でした。bump コミットに打つと**実際に出荷された内容と食い違うタグ**になるため、publish 時点の main を対象にしています。両パッケージとも `81320eff4` と `HEAD` で該当ディレクトリの内容は同一です。

2. **「republish 不要」の根拠**
   推測ではなく、**npm から tarball を実際に取得して local build の `dist/` とバイト比較**し、両方とも完全一致を確認しています。よって core / markdown-plugin の再公開は不要です。

3. **今回の range ドリフトの実害は小さいこと**
   core は 2.x なので `^2.0.2` は既に 2.1.0 に解決されており、機能的な withholding は起きていません（CLAUDE.md が警告する `0.x` のケースとは異なります）。それでもルール上、consumer が次に publish される前にツリーが正しい必要があるため直しています。

## User Prompt

- #2821 の修正を含め、publish が必要なものを判断して公開してほしい
- ランチャー以外の publish は不要か？ 関連パッケージのバージョンはきちんと上がっているか確認してほしい
- （確認結果を受けて）range 掃き替え → ランチャー publish の順で進めてほしい

## 経緯

`yarn audit:releases --code-only` に加えて、全54マニフェストの内部 dep range を npm の最新と突き合わせるスクリプトを回したところ、以下が判明しました。

```text
accounting-plugin   [dependencies]           ^2.0.2
chart-plugin        [dependencies]           ^2.0.2
collection-plugin   [devDeps, peerDeps]      ^2.0.2
google-plugin       [dependencies]           ^2.0.2
html-plugin         [deps, devDeps, peerDeps] ^2.0.2
mulmoscript-plugin  [dependencies]           ^2.0.2
```

core 2.1.0 を publish した際（#2819）に consumer の掃き替えが漏れたものです。`launcherSync.mjs` はランチャーしか見ないため検出されませんでした（ランチャー自身の range は正しい状態でした）。

## 検証

- 掃き替え後、同じ監査スクリプトで **全ワークスペースの内部 range が npm 最新と一致**することを確認
- `yarn install` で **lockfile に差分が出ない**ことを確認（内部パッケージは workspace リンク）
- `node scripts/mulmoclaude/launcherSync.mjs` → OK
- `yarn format` / `lint`（0 errors）/ `typecheck` / `build` / `test`（exit 0）
- タグ追加後に `yarn audit:releases --code-only` を再実行し、`untagged` 2件が解消（34 → 32 件）

## 別途報告：`audit-releases.mjs` の構造的な盲点

このツールは `git diff <tag> HEAD -- <pkg.dir>` で drift を判定しますが、**ランチャーの `server/` / `src/` はリポジトリルートにあり `prepack`（`bin/prepare-dist.js`）でコピーされる**ため、この diff から見えません。

つまり **app コードが変わっても `mulmoclaude` は code drift として報告されません**。実際 #2824 のマージ後も `manifest drift` としか出ませんでした。ランチャーだけは `server/` `src/` も diff 対象に含める必要があります。本 PR のスコープ外なので別イシューにします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core platform version used by the accounting, chart, collection, Google, HTML, and MulmoScript plugins.
  * Ensures these plugins remain compatible with the latest core release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->