### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.12.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-07
+
+**Bridges stop pasting the whole SKILL.md into their replies — the bot answers your question instead of reciting its instructions.**
+
+### Highlights
+
+#### SKILL.md bodies no longer reach bridge replies (#2821, #2824)
+
+Asking a Skill-invoking role anything over Discord — or Telegram, Slack, or any of the other 22 bridges — got you the entire SKILL.md back, several thousand characters of it, before the actual answer. The answer then arrived twice. The web canvas showed the same session correctly, so only the bridges were visibly broken.
+
+The cause was one discarded fact. Claude CLI delivers the SKILL.md body as a `user`-role message — context it injected into the conversation, not something the assistant said — but the stream parser mapped every text block to the same event regardless of which role produced it. The server therefore could not tell injected context from the assistant's own prose, published it immediately, and only re-classified it as a skill entry at the next flush. The canvas could undo that by replacing the card it had just drawn; a bridge, which accumulates text events as they arrive, could not.
+
+The role is now preserved. Injected text becomes an internal event that is never published, and turns into the skill entry on arrival instead of after the fact. Bridges need no change and no reinstall — the fix reaches them through this launcher. The duplicated answer is gone too, since the reply no longer shares a flush with the body.
+
+Measured against real captured CLI streams rather than assumption, and those streams ship as test fixtures: if a future CLI version moves the body back onto an assistant block, the suite fails rather than the bridges.
+
+#### Bookmark rail in the presentDocument source editor (#2819)
+
+The markdown source editor gained a bookmark rail for navigating long documents.
+
+### Also in this release
+
+- `repo.json` and a square mascot icon for the repository (#2818).
+- `@mulmoclaude/core` dependency ranges swept to `^2.1.0` across six plugins, which the core 2.1.0 publish had missed (#2825).
+- Retroactive release tags for `@mulmoclaude/core@2.1.0` and `@mulmoclaude/markdown-plugin@2.3.0`, both published without one. Their npm tarballs were byte-compared against this tree before tagging, so neither needed republishing.
+
+Ships `@mulmoclaude/core@2.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.0.0`, `@mulmoclaude/chart-plugin@2.0.0`, `@mulmoclaude/collection-plugin@2.0.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.0.0`, `@mulmoclaude/html-plugin@2.1.0`, `@mulmoclaude/markdown-plugin@2.3.0`, `@mulmoclaude/mulmoscript-plugin@2.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ## [1.11.0] - 2026-08-05
 
 **The composer stops losing your work — drafts now survive a reload and stay with the session you wrote them in.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`mulmoclaude@1.12.0` を npm に公開しました。この PR はそのバージョン識別と CHANGELOG をツリーに反映するものです（**公開は実施済み**）。

app コード（`server/` / `src/`）はランチャーの tarball でしか npm ユーザーに届かないため、1.11.0 以降にマージされた以下3件はこの公開まで未配信でした。

| 内容 | PR |
|---|---|
| SKILL.md 本文がブリッジ返信に混入する不具合の修正 | #2824（issue #2821） |
| markdown ソースエディタのブックマークレール | #2819 |
| repo.json + 正方形マスコットアイコン | #2818 |

feature が2件含まれるため **minor**（1.11.0 → 1.12.0）です。

## Items to Confirm / Review

1. **公開が先、PR が後という順序**
   `/publish-mulmoclaude` の手順どおり（§6 publish → §8 commit + PR）ですが、npm には既に 1.12.0 があります。この PR がマージされるまで、`main` の root `package.json` は 1.11.0 のままです。

2. **`lint_test (Windows)` の扱い**
   `main` の Windows CI が完走（success）するまで待ってから publish しています。ただし #2824 のマージ時は GitHub 側の事象で `pull_request` ワークフローが約20時間発火しておらず、当時は手動 dispatch で Windows CI を通していました。現在は復旧し、`main` で全 CI が green です。

3. **CHANGELOG の記述粒度**
   #2821 の項目は「なぜブリッジだけ壊れて Web UI は正しく見えたのか」を説明する構成にしています。長すぎる場合は削ってください。

## User Prompt

- #2821 の修正を含め、publish が必要なものを判断して公開してほしい
- ランチャー以外の publish は不要か？ 関連パッケージのバージョンはきちんと上がっているか確認してほしい
- （確認結果を受けて）range 掃き替え → ランチャー publish の順で進めてほしい

## 公開前の検証

| 項目 | 結果 |
|---|---|
| `MulmoClaude publish smoke` on `main` | ✅ success（スキルの go/no-go） |
| `Node.js CI` on `main` | ✅ success |
| `lint_test (Windows)` on `main` | ✅ success |
| `secret-scan` / `duplication-scan` on `main` | ✅ success |
| `node scripts/mulmoclaude/smoke.mjs`（ローカル、1.12.0） | ✅ deps / drift / **tarball から起動して HTTP 200** |
| `launcherSync.mjs` | ✅ OK |
| ランチャーの内部依存17件が npm で解決するか | ✅ 全件一致 |
| 公開後のクリーンインストール | ✅ `mulmoclaude 1.12.0` |

## 公開したもの

`mulmoclaude@1.12.0` のみです。監査の結果、他のパッケージは公開不要でした。

- `yarn audit:releases --code-only` に **code drift は0件**
- `untagged` だった `@mulmoclaude/core@2.1.0` と `@mulmoclaude/markdown-plugin@2.3.0` は、**npm の tarball を取得して local build の `dist/` とバイト比較し完全一致**を確認。よって再公開不要。タグは #2825 で遡及作成済み

## 関連

- 監査ツールがランチャーの app コード変更を検出できない構造的な問題 → #2827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Bump the monorepo and mulmoclaude launcher to version 1.12.0 and document the included changes.

New Features:
- Add a bookmark rail to the markdown source editor for easier navigation of long documents.

Bug Fixes:
- Fix bridge replies incorrectly including the full SKILL.md body and duplicating answers by preserving injected context roles in the stream processing.

Enhancements:
- Document repo metadata and mascot icon additions, dependency range sweeps to @mulmoclaude/core@2.1.0, and retroactive release tagging for previously untagged packages in the 1.12.0 changelog entry.

Build:
- Update root and mulmoclaude package versions from 1.11.0 to 1.12.0 to match the published launcher release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bookmark rail to the source editor for faster navigation.
  * Added repository metadata and icon support.
* **Bug Fixes**
  * Bridge replies no longer expose injected `SKILL.md` content.
* **Documentation**
  * Added release notes for version 1.12.0, including included packages and package tag updates.
* **Release**
  * Published version 1.12.0 across the main package and its companion package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->