### PR TITLE
fix(scripts): audit the launcher across the repo root, not just its own dir

### DIFF
--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -144,7 +144,8 @@ yarn audit:releases --code-only  # just the ones needing a decision
 git diff "@scope/name@$(npm view @scope/name version)" HEAD -- packages/<dir>
 
 # the launcher is the exception — its shipped source is not all under its own dir
-git diff "mulmoclaude@$(npm view mulmoclaude version)" HEAD -- packages/mulmoclaude server src
+git diff "mulmoclaude@$(npm view mulmoclaude version)" HEAD -- \
+  packages/mulmoclaude server src Dockerfile.sandbox sandbox-entrypoint.sh
 ```
 
 **The launcher is audited across the repo root too.** `packages/mulmoclaude/server/`

--- a/docs/package-releases.md
+++ b/docs/package-releases.md
@@ -142,14 +142,25 @@ yarn audit:releases --code-only  # just the ones needing a decision
 
 # or, for one package by hand
 git diff "@scope/name@$(npm view @scope/name version)" HEAD -- packages/<dir>
+
+# the launcher is the exception — its shipped source is not all under its own dir
+git diff "mulmoclaude@$(npm view mulmoclaude version)" HEAD -- packages/mulmoclaude server src
 ```
+
+**The launcher is audited across the repo root too.** `packages/mulmoclaude/server/`
+and `src/` are not in git — `prepack` copies them in from the repo root at pack time —
+so a diff scoped to `packages/mulmoclaude` sees none of the app code. The audit widens
+the launcher's pathspec to the roots `bin/prepare-dist.js` copies (`server`, `src`,
+`Dockerfile.sandbox`, `sandbox-entrypoint.sh`); every other workspace stays scoped to
+its own directory. Without this the launcher read `clean` while the change only it
+could ship sat undelivered (#2827).
 
 `state` is the useful column:
 
 | state | meaning |
 |---|---|
 | `clean` | nothing that feeds the tarball has changed, judged against **the package's own `files`** plus `src/` and `bin/` (which produce the shipped `dist/`) and README (npm ships it regardless). Tests and tsconfig land here only because no package here lists them in `files` — a package that starts shipping them is classified accordingly |
-| `code drift` | unreleased behaviour in something the package ships: `src/` or `bin/` (they become `dist/`), any root listed in its `files`, or README |
+| `code drift` | unreleased behaviour in something the package ships: `src/` or `bin/` (they become `dist/`), any root listed in its `files`, or README. For the launcher this also covers the repo-root `server/` and `src/` that `prepack` copies in |
 | `manifest drift` | a **published** `package.json` field moved — `dependencies`, `exports`, `files`, `bin`, `engines`, … A dependency-range sweep shows up here; it reaches users at this package's next release, so it is a decision, not an emergency |
 | `untagged` | published, but no tag, so drift **cannot be measured** — fix the tag first |
 | `unpublished` | never went to npm — decide whether it is meant to |

--- a/plans/fix-2827-audit-launcher-scope.md
+++ b/plans/fix-2827-audit-launcher-scope.md
@@ -33,7 +33,7 @@ const diff = run("git", ["diff", "--name-only", tag, "HEAD", "--", pkg.dir]);
 3. `isReleasePath()` を、パッケージ外のパスは **external roots に宣言されている場合
    だけ** 出荷対象と判定するよう明示化する。現状は「パッケージ外パスの相対化が
    素通りして `files` の root と偶然一致する」フォールスルーに依存していて脆い。
-4. `deps.mjs` に倣い、純粋ヘルパを export し CLI 実行を直接起動時のみに限定して
+4. `deps.mjs` に倣い、純粋ヘルパーを export し CLI 実行を直接起動時のみに限定して
    テスト可能にする。
 
 ルート `package.json` は tarball に入らない（skill §1）ため対象外のまま。

--- a/plans/fix-2827-audit-launcher-scope.md
+++ b/plans/fix-2827-audit-launcher-scope.md
@@ -1,0 +1,58 @@
+# fix(#2827): audit:releases がランチャーの app コード変更を検出できない
+
+## 現象
+
+`yarn audit:releases` は `mulmoclaude`（ランチャー）について、`server/` / `src/` の
+変更を code drift として報告しない。#2824 が `server/agent/stream.ts` 等を変更して
+マージされた直後も `manifest drift`（deps の差分のみ）としか出なかった。
+
+## 原因
+
+`scripts/packages/audit-releases.mjs:113` の drift 判定:
+
+```js
+const diff = run("git", ["diff", "--name-only", tag, "HEAD", "--", pkg.dir]);
+```
+
+`pkg.dir` はランチャーでは `packages/mulmoclaude`。ところがランチャーの `files` が
+指す `server/` `src/` は **git 管理下になく、`prepack`（`bin/prepare-dist.js`）が
+リポジトリルートからコピーして生成する**（`git ls-files packages/mulmoclaude/server`
+は空）。よって diff の対象範囲に、ランチャーが実際に出荷するソースが入っていない。
+
+`docs/package-releases.md` が明記するとおり app コードはランチャーでしか届かない
+のに、それを検出するための監査がその変更だけを見られない状態だった。
+
+## 方針
+
+「パッケージのディレクトリ外にある出荷ソース」という概念を明示的に持たせる。
+
+1. `EXTERNAL_SOURCE_ROOTS` を追加し、`prepare-dist.js` がルートからコピーする
+   `server` / `src` / `Dockerfile.sandbox` / `sandbox-entrypoint.sh` を宣言する。
+   該当するのはランチャーだけ。
+2. `git diff` の pathspec に `pkg.dir` + external roots を渡す。
+3. `isReleasePath()` を、パッケージ外のパスは **external roots に宣言されている場合
+   だけ** 出荷対象と判定するよう明示化する。現状は「パッケージ外パスの相対化が
+   素通りして `files` の root と偶然一致する」フォールスルーに依存していて脆い。
+4. `deps.mjs` に倣い、純粋ヘルパを export し CLI 実行を直接起動時のみに限定して
+   テスト可能にする。
+
+ルート `package.json` は tarball に入らない（skill §1）ため対象外のまま。
+ルート `src/` は vite で `dist/client` → `client/` にもなるので、`src` を見れば
+クライアント側も覆える。
+
+## テスト
+
+`test/scripts/packages/test_auditReleases.ts`（新規）:
+
+- ランチャーの diff pathspec に `server` / `src` が含まれる
+- ルートの `server/agent/stream.ts` がランチャーの出荷対象と判定される
+- 同じパスが**他のパッケージでは**出荷対象と判定されない（external roots は宣言制）
+- ルート `package.json` は出荷対象でない
+- 既存の判定（`src/` `bin/` `files` の root、README）が壊れていない
+
+修正前のコードで落ちることを変異テストで確認する。
+
+## ドキュメント
+
+`docs/package-releases.md` の「what is actually drifting?」節に、ランチャーだけは
+ルートの `server/` `src/` も監査対象であることを追記する。

--- a/scripts/packages/audit-releases.d.mts
+++ b/scripts/packages/audit-releases.d.mts
@@ -1,0 +1,31 @@
+// Type declarations for audit-releases.mjs. Kept as a sidecar so the script
+// itself stays plain JS (runnable with `node` on a fresh clone, no build step)
+// while tests still get a typed import surface — same arrangement as
+// scripts/mulmoclaude/deps.d.mts.
+
+/** A workspace manifest plus the directory it was read from. */
+export interface AuditedPackage {
+  /** Repo-relative package directory, e.g. `packages/plugins/chart-plugin`. */
+  dir: string;
+  name?: string;
+  version?: string;
+  files?: string[];
+}
+
+/** Sources that feed a package's tarball from outside its own directory, keyed by package name. */
+export const EXTERNAL_SOURCE_ROOTS: Record<string, string[]>;
+
+/** Repo-root-relative roots this package ships from outside `dir`. Empty for all but the launcher. */
+export function externalSourceRoots(pkg: AuditedPackage): string[];
+
+/** Pathspec `git diff` must cover to see everything this package ships. */
+export function diffPathspec(pkg: AuditedPackage): string[];
+
+/** `files` entries normalised to bare directory roots (globs, `./` and trailing slashes stripped). */
+export function shippedRoots(pkg: Pick<AuditedPackage, "files">): string[];
+
+/** Whether a repo-relative changed file ends up in this package's published tarball. */
+export function isReleasePath(pkg: AuditedPackage, file: string): boolean;
+
+/** CLI entry point. Returns 0 when every workspace could be checked, 1 otherwise. */
+export function main(argv?: string[]): number;

--- a/scripts/packages/audit-releases.mjs
+++ b/scripts/packages/audit-releases.mjs
@@ -144,9 +144,26 @@ const classify = (pkg, latest, tags) => {
 
 const NEEDS_DECISION = new Set(["code drift", "manifest drift", "untagged", "unpublished", "error"]);
 
-export function main(argv = process.argv) {
-  const codeOnly = argv.includes("--code-only");
+const auditWorkspace = (pkg, tags) => {
+  const latest = run("npm", ["view", pkg.name, "version", "--registry", "https://registry.npmjs.org/"]);
+  // `npm view` exits non-zero for a package that was never published; that is an
+  // answer, not a failure, so it is mapped back before classification.
+  const resolved = !latest.ok && /E?404|not found/i.test(`${latest.error ?? ""}${latest.raw ?? ""}`) ? { ok: true, out: "" } : latest;
+  return { name: pkg.name, local: pkg.version ?? "?", latest: resolved.out || "\u2014", ...classify(pkg, resolved, tags) };
+};
 
+const printTable = (rows) => {
+  if (rows.length === 0) return;
+  const width = Math.max(...rows.map((row) => row.name.length), 8);
+  console.log(`${"package".padEnd(width)}  ${"local".padEnd(8)} ${"npm".padEnd(8)} ${"state".padEnd(15)} detail`);
+  console.log("-".repeat(width + 46));
+  for (const row of rows) {
+    const bump = row.local !== row.latest && row.latest !== "\u2014" ? " <== version ahead of npm" : "";
+    console.log(`${row.name.padEnd(width)}  ${row.local.padEnd(8)} ${row.latest.padEnd(8)} ${row.state.padEnd(15)} ${row.detail}${bump}`);
+  }
+};
+
+export function main(argv = process.argv) {
   const tagList = run("git", ["tag", "--list"]);
   if (!tagList.ok) {
     // Without the tag list every published package would read as `untagged`, which is a
@@ -155,29 +172,12 @@ export function main(argv = process.argv) {
     return 1;
   }
   const tags = new Set(tagList.out.split("\n"));
-
-  const rows = findWorkspaces().map((pkg) => {
-    const latest = run("npm", ["view", pkg.name, "version", "--registry", "https://registry.npmjs.org/"]);
-    // `npm view` exits non-zero for a package that was never published; that is an
-    // answer, not a failure, so it is mapped back before classification.
-    const resolved = !latest.ok && /E?404|not found/i.test(`${latest.error ?? ""}${latest.raw ?? ""}`) ? { ok: true, out: "" } : latest;
-    return { name: pkg.name, local: pkg.version ?? "?", latest: resolved.out || "\u2014", ...classify(pkg, resolved, tags) };
-  });
-
+  const rows = findWorkspaces().map((pkg) => auditWorkspace(pkg, tags));
   const attention = rows.filter((row) => NEEDS_DECISION.has(row.state));
-  const shown = codeOnly ? attention : rows;
-  const width = Math.max(...shown.map((row) => row.name.length), 8, 0);
 
-  if (shown.length > 0) {
-    console.log(`${"package".padEnd(width)}  ${"local".padEnd(8)} ${"npm".padEnd(8)} ${"state".padEnd(15)} detail`);
-    console.log("-".repeat(width + 46));
-  }
-  for (const row of shown) {
-    const bump = row.local !== row.latest && row.latest !== "\u2014" ? " <== version ahead of npm" : "";
-    console.log(`${row.name.padEnd(width)}  ${row.local.padEnd(8)} ${row.latest.padEnd(8)} ${row.state.padEnd(15)} ${row.detail}${bump}`);
-  }
-
+  printTable(argv.includes("--code-only") ? attention : rows);
   console.log(`\n${rows.length} publishable workspaces \u00b7 ${attention.length} need a decision`);
+
   if (attention.some((row) => row.state === "error")) {
     console.error("audit incomplete: at least one workspace could not be checked");
     return 1;

--- a/scripts/packages/audit-releases.mjs
+++ b/scripts/packages/audit-releases.mjs
@@ -11,6 +11,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const WORKSPACE_ROOTS = ["packages", "packages/bridges", "packages/plugins", "packages/services"];
 const COMMAND_TIMEOUT_MS = 60_000;
@@ -40,7 +41,7 @@ const RELEASE_MANIFEST_KEYS = [
 // or anything else says so there. README is included by npm whether or not `files`
 // lists it, so an edit there changes the published artifact too.
 const BUILD_INPUT_DIRS = ["src", "bin"];
-const shippedRoots = (pkg) =>
+export const shippedRoots = (pkg) =>
   (Array.isArray(pkg.files) ? pkg.files : [])
     .map((entry) =>
       entry
@@ -50,14 +51,37 @@ const shippedRoots = (pkg) =>
     )
     .filter(Boolean);
 
-const isReleasePath = (pkg, file) => {
-  const relative = file.startsWith(`${pkg.dir}/`) ? file.slice(pkg.dir.length + 1) : file;
-  if (path.basename(relative).toLowerCase().startsWith("readme")) return true;
-  const under = (root) => relative === root || relative.startsWith(`${root}/`);
-  return BUILD_INPUT_DIRS.some(under) || shippedRoots(pkg).some(under);
+// Sources that feed a package's tarball from OUTSIDE its own directory, as
+// repo-root-relative paths. Declared per package rather than inferred: a diff
+// scoped to `pkg.dir` is right for every workspace but one.
+//
+// `mulmoclaude` is that one. Its `files` name `server/` and `src/`, but those
+// are not in git under `packages/mulmoclaude` — `prepack`
+// (`bin/prepare-dist.js`) copies them in from the repo root at pack time. App
+// code there reaches npm users ONLY through a launcher publish, so scoping the
+// diff to `pkg.dir` reported the launcher clean while the change that only it
+// could ship sat unshipped (#2827). The root `package.json` is deliberately
+// absent: it is not part of the tarball.
+export const EXTERNAL_SOURCE_ROOTS = {
+  mulmoclaude: ["server", "src", "Dockerfile.sandbox", "sandbox-entrypoint.sh"],
 };
 
-const codeOnly = process.argv.includes("--code-only");
+export const externalSourceRoots = (pkg) => EXTERNAL_SOURCE_ROOTS[pkg.name] ?? [];
+
+/** What `git diff` must cover to see everything this package ships. */
+export const diffPathspec = (pkg) => [pkg.dir, ...externalSourceRoots(pkg)];
+
+const isUnder = (root, target) => target === root || target.startsWith(`${root}/`);
+
+export const isReleasePath = (pkg, file) => {
+  // Outside the package dir, only a declared external root ships. Matching
+  // against `files` here instead would let any root-level path whose first
+  // segment happens to collide with a `files` entry read as shipped.
+  if (!file.startsWith(`${pkg.dir}/`)) return externalSourceRoots(pkg).some((root) => isUnder(root, file));
+  const relative = file.slice(pkg.dir.length + 1);
+  if (path.basename(relative).toLowerCase().startsWith("readme")) return true;
+  return BUILD_INPUT_DIRS.some((root) => isUnder(root, relative)) || shippedRoots(pkg).some((root) => isUnder(root, relative));
+};
 
 // Distinguishes "the command said nothing" from "the command failed". Conflating them
 // is how a registry blip would have been reported as `unpublished`, and a failed
@@ -80,19 +104,11 @@ const readManifest = (dir) => {
   return existsSync(manifest) ? { dir, ...JSON.parse(readFileSync(manifest, "utf8")) } : null;
 };
 
-const workspaces = WORKSPACE_ROOTS.filter((root) => existsSync(root))
-  .flatMap((root) => readdirSync(root).map((entry) => readManifest(path.join(root, entry))))
-  .filter((pkg) => pkg && !pkg.private && pkg.name)
-  .sort((left, right) => left.name.localeCompare(right.name));
-
-const tagList = run("git", ["tag", "--list"]);
-if (!tagList.ok) {
-  // Without the tag list every published package would read as `untagged`, which is a
-  // fabricated finding rather than a missing one (Codex, #2644).
-  console.error(`audit aborted: could not read git tags — ${tagList.error}`);
-  process.exit(1);
-}
-const tags = new Set(tagList.out.split("\n"));
+const findWorkspaces = () =>
+  WORKSPACE_ROOTS.filter((root) => existsSync(root))
+    .flatMap((root) => readdirSync(root).map((entry) => readManifest(path.join(root, entry))))
+    .filter((pkg) => pkg && !pkg.private && pkg.name)
+    .sort((left, right) => left.name.localeCompare(right.name));
 
 // A manifest diff only matters when a key a consumer sees actually moved.
 const manifestChangedKeys = (pkg, tag) => {
@@ -104,13 +120,13 @@ const manifestChangedKeys = (pkg, tag) => {
   return { unknown: false, keys };
 };
 
-const classify = (pkg, latest) => {
+const classify = (pkg, latest, tags) => {
   const tag = `${pkg.name}@${latest.out}`;
   if (!latest.ok) return { state: "error", detail: `npm lookup failed: ${latest.error}` };
   if (!latest.out) return { state: "unpublished", detail: "not on npm" };
   if (!tags.has(tag)) return { state: "untagged", detail: `no ${tag} tag — drift cannot be measured` };
 
-  const diff = run("git", ["diff", "--name-only", tag, "HEAD", "--", pkg.dir]);
+  const diff = run("git", ["diff", "--name-only", tag, "HEAD", "--", ...diffPathspec(pkg)]);
   if (!diff.ok) return { state: "error", detail: `git diff failed: ${diff.error}` };
   const changed = diff.out.split("\n").filter(Boolean);
   if (changed.length === 0) return { state: "clean", detail: "" };
@@ -123,34 +139,54 @@ const classify = (pkg, latest) => {
     if (unknown) return { state: "error", detail: "could not read the published package.json from the tag" };
     if (keys.length > 0) return { state: "manifest drift", detail: `published fields changed: ${keys.join(", ")}` };
   }
-  return { state: "clean", detail: `${changed.length} file(s) changed, none of which feed the tarball (per this package\u2019s own \`files\`)` };
+  return { state: "clean", detail: `${changed.length} file(s) changed, none of which feed the tarball` };
 };
 
 const NEEDS_DECISION = new Set(["code drift", "manifest drift", "untagged", "unpublished", "error"]);
 
-const rows = workspaces.map((pkg) => {
-  const latest = run("npm", ["view", pkg.name, "version", "--registry", "https://registry.npmjs.org/"]);
-  // `npm view` exits non-zero for a package that was never published; that is an
-  // answer, not a failure, so it is mapped back before classification.
-  const resolved = !latest.ok && /E?404|not found/i.test(`${latest.error ?? ""}${latest.raw ?? ""}`) ? { ok: true, out: "" } : latest;
-  return { name: pkg.name, local: pkg.version ?? "?", latest: resolved.out || "—", ...classify(pkg, resolved) };
-});
+export function main(argv = process.argv) {
+  const codeOnly = argv.includes("--code-only");
 
-const attention = rows.filter((row) => NEEDS_DECISION.has(row.state));
-const shown = codeOnly ? attention : rows;
-const width = Math.max(...shown.map((row) => row.name.length), 8, 0);
+  const tagList = run("git", ["tag", "--list"]);
+  if (!tagList.ok) {
+    // Without the tag list every published package would read as `untagged`, which is a
+    // fabricated finding rather than a missing one (Codex, #2644).
+    console.error(`audit aborted: could not read git tags \u2014 ${tagList.error}`);
+    return 1;
+  }
+  const tags = new Set(tagList.out.split("\n"));
 
-if (shown.length > 0) {
-  console.log(`${"package".padEnd(width)}  ${"local".padEnd(8)} ${"npm".padEnd(8)} ${"state".padEnd(15)} detail`);
-  console.log("-".repeat(width + 46));
+  const rows = findWorkspaces().map((pkg) => {
+    const latest = run("npm", ["view", pkg.name, "version", "--registry", "https://registry.npmjs.org/"]);
+    // `npm view` exits non-zero for a package that was never published; that is an
+    // answer, not a failure, so it is mapped back before classification.
+    const resolved = !latest.ok && /E?404|not found/i.test(`${latest.error ?? ""}${latest.raw ?? ""}`) ? { ok: true, out: "" } : latest;
+    return { name: pkg.name, local: pkg.version ?? "?", latest: resolved.out || "\u2014", ...classify(pkg, resolved, tags) };
+  });
+
+  const attention = rows.filter((row) => NEEDS_DECISION.has(row.state));
+  const shown = codeOnly ? attention : rows;
+  const width = Math.max(...shown.map((row) => row.name.length), 8, 0);
+
+  if (shown.length > 0) {
+    console.log(`${"package".padEnd(width)}  ${"local".padEnd(8)} ${"npm".padEnd(8)} ${"state".padEnd(15)} detail`);
+    console.log("-".repeat(width + 46));
+  }
+  for (const row of shown) {
+    const bump = row.local !== row.latest && row.latest !== "\u2014" ? " <== version ahead of npm" : "";
+    console.log(`${row.name.padEnd(width)}  ${row.local.padEnd(8)} ${row.latest.padEnd(8)} ${row.state.padEnd(15)} ${row.detail}${bump}`);
+  }
+
+  console.log(`\n${rows.length} publishable workspaces \u00b7 ${attention.length} need a decision`);
+  if (attention.some((row) => row.state === "error")) {
+    console.error("audit incomplete: at least one workspace could not be checked");
+    return 1;
+  }
+  return 0;
 }
-for (const row of shown) {
-  const bump = row.local !== row.latest && row.latest !== "—" ? " <== version ahead of npm" : "";
-  console.log(`${row.name.padEnd(width)}  ${row.local.padEnd(8)} ${row.latest.padEnd(8)} ${row.state.padEnd(15)} ${row.detail}${bump}`);
-}
 
-console.log(`\n${rows.length} publishable workspaces · ${attention.length} need a decision`);
-if (attention.some((row) => row.state === "error")) {
-  console.error("audit incomplete: at least one workspace could not be checked");
-  process.exitCode = 1;
+// Only run the CLI when this file is invoked directly, so tests can import the
+// helpers without triggering a full npm+git sweep.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.exitCode = main();
 }

--- a/test/scripts/packages/test_auditReleases.ts
+++ b/test/scripts/packages/test_auditReleases.ts
@@ -1,0 +1,106 @@
+// The launcher's release audit must see the app code only it can ship (#2827).
+//
+// Every workspace's shipped source sits under its own directory — except
+// `mulmoclaude`, whose `files` name `server/` and `src/` that `prepack` copies
+// in from the repo root. A diff scoped to `packages/mulmoclaude` therefore
+// reported the launcher clean while a `server/` change sat undelivered, which
+// is what happened right after #2824 merged.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { diffPathspec, externalSourceRoots, isReleasePath, shippedRoots } from "../../../scripts/packages/audit-releases.mjs";
+
+const launcher = {
+  dir: "packages/mulmoclaude",
+  name: "mulmoclaude",
+  files: ["bin/", "client/", "server/", "src/", "Dockerfile.sandbox", "sandbox-entrypoint.sh"],
+};
+
+const plugin = {
+  dir: "packages/plugins/chart-plugin",
+  name: "@mulmoclaude/chart-plugin",
+  files: ["dist"],
+};
+
+describe("externalSourceRoots", () => {
+  it("gives the launcher the repo-root dirs prepack copies in", () => {
+    assert.deepEqual(externalSourceRoots(launcher), ["server", "src", "Dockerfile.sandbox", "sandbox-entrypoint.sh"]);
+  });
+
+  it("gives every other workspace none", () => {
+    assert.deepEqual(externalSourceRoots(plugin), []);
+    assert.deepEqual(externalSourceRoots({ dir: "packages/core", name: "@mulmoclaude/core" }), []);
+  });
+});
+
+describe("diffPathspec", () => {
+  it("widens the launcher's diff beyond its own directory", () => {
+    const spec = diffPathspec(launcher);
+    assert.ok(spec.includes("packages/mulmoclaude"), "own dir still covered");
+    assert.ok(spec.includes("server"), "root server/ is what only the launcher ships");
+    assert.ok(spec.includes("src"), "root src/ feeds both src/ and the client bundle");
+  });
+
+  it("leaves other workspaces scoped to their own directory", () => {
+    assert.deepEqual(diffPathspec(plugin), ["packages/plugins/chart-plugin"]);
+  });
+});
+
+describe("isReleasePath — launcher", () => {
+  it("counts repo-root app code as shipped", () => {
+    assert.equal(isReleasePath(launcher, "server/agent/stream.ts"), true);
+    assert.equal(isReleasePath(launcher, "src/utils/session/sessionHelpers.ts"), true);
+    assert.equal(isReleasePath(launcher, "Dockerfile.sandbox"), true);
+    assert.equal(isReleasePath(launcher, "sandbox-entrypoint.sh"), true);
+  });
+
+  it("does NOT count the root package.json — it is not in the tarball", () => {
+    assert.equal(isReleasePath(launcher, "package.json"), false);
+  });
+
+  it("does NOT count other repo-root paths", () => {
+    assert.equal(isReleasePath(launcher, "docs/package-releases.md"), false);
+    assert.equal(isReleasePath(launcher, "test/agent/test_injectedText.ts"), false);
+    assert.equal(isReleasePath(launcher, "scripts/packages/audit-releases.mjs"), false);
+  });
+
+  it("still counts files inside its own directory", () => {
+    assert.equal(isReleasePath(launcher, "packages/mulmoclaude/bin/mulmoclaude.js"), true);
+    assert.equal(isReleasePath(launcher, "packages/mulmoclaude/README.md"), true);
+  });
+
+  // A root path must ship because the package DECLARED it, not because its
+  // first segment happens to collide with a `files` entry. Both packages below
+  // list `src`; only the launcher copies the repo's root `src/` into its tarball.
+  it("does not let another package's files entry claim a repo-root path", () => {
+    const libWithSrcInFiles = { dir: "packages/core", name: "@mulmoclaude/core", files: ["dist", "src"] };
+    assert.equal(isReleasePath(libWithSrcInFiles, "src/utils/session/sessionHelpers.ts"), false);
+    assert.equal(isReleasePath(libWithSrcInFiles, "server/agent/stream.ts"), false);
+  });
+});
+
+describe("isReleasePath — ordinary workspaces (unchanged behaviour)", () => {
+  it("counts build inputs and declared roots under the package dir", () => {
+    assert.equal(isReleasePath(plugin, "packages/plugins/chart-plugin/src/index.ts"), true);
+    assert.equal(isReleasePath(plugin, "packages/plugins/chart-plugin/dist/index.js"), true);
+  });
+
+  it("counts README, which npm ships regardless of `files`", () => {
+    assert.equal(isReleasePath(plugin, "packages/plugins/chart-plugin/README.md"), true);
+  });
+
+  it("skips files that do not feed the tarball", () => {
+    assert.equal(isReleasePath(plugin, "packages/plugins/chart-plugin/test/test_chart.ts"), false);
+    assert.equal(isReleasePath(plugin, "packages/plugins/chart-plugin/eslint.config.mjs"), false);
+  });
+});
+
+describe("shippedRoots", () => {
+  it("normalises trailing slashes, globs and ./ prefixes", () => {
+    assert.deepEqual(shippedRoots({ files: ["dist/", "./assets", "lib/**/*.js"] }), ["dist", "assets", "lib"]);
+  });
+
+  it("returns none when the package declares no files", () => {
+    assert.deepEqual(shippedRoots({}), []);
+  });
+});


### PR DESCRIPTION
## Summary

`yarn audit:releases` がランチャー（`mulmoclaude`）の app コード変更を検出できなかった問題（#2827）の修正です。

drift 判定は `git diff <tag> HEAD -- <pkg.dir>` で行っていました。他の全ワークスペースではこれで正しいのですが、ランチャーだけは違います。`files` が指す `server/` と `src/` は **git 管理下になく、`prepack`（`bin/prepare-dist.js`）がリポジトリルートからコピーして生成する**ため、`packages/mulmoclaude` に限定した diff からは app コードが1バイトも見えません。

結果として、**app コードを届けることが唯一の存在意義であるパッケージが、その app コードを一切見ずに監査されていました**。#2824 のマージ直後も `manifest drift` としか報告されませんでした。

## Items to Confirm / Review

1. **`EXTERNAL_SOURCE_ROOTS` をパッケージ名でハードコードした判断**
   `prepare-dist.js` のコピー処理をパースして導出することも考えましたが、脆いうえに読み手が追いにくいと判断し、宣言的なマップにしました。該当するのはランチャー1件のみです。`prepare-dist.js` のコピー元が変わったらここも変える必要があり、その旨をコメントに書いています。

2. **`isReleasePath` の挙動を「宣言制」に変えたこと（微妙な既存バグの修正を含む）**
   修正前は、パッケージ外のパスが相対化されずに素通りし、`files` の root と偶然一致すると出荷対象と判定されていました。今回ルートの `server/` を diff 対象に入れたことで、この経路が初めて実際に使われることになります。偶然の一致に依存させたくないので、**external roots に宣言されている場合だけ**通すよう明示化しました。テストで「`files` に `src` を持つ別パッケージがルートの `src/…` を横取りしないこと」を固定しています。

3. **ルート `package.json` を対象外にしたこと**
   tarball に入らないため（publish skill §1「the root `package.json` isn't shipped」）意図的に除外しています。root の deps 変更はランチャーの `package.json` 側に反映される必要があり、それは `launcherSync.mjs` の担当です。

4. **CLI をガードして export に切り出したこと**
   `scripts/mulmoclaude/deps.mjs` の既存パターン（helper を export ＋ 直接起動時のみ CLI 実行 ＋ サイドカー `.d.mts`）に合わせました。副作用なしで import できるので、テストが npm + git の全走査を起こしません。

## User Prompt

- #2827 も直してほしい

## 検証

イシューの実ケース（`mulmoclaude@1.11.0` 公開済み・#2824 マージ済み）を再現しました。

```text
修正後: pathspec = packages/mulmoclaude server src Dockerfile.sandbox sandbox-entrypoint.sh
        changed 6 / SHIPPED 5  → code drift
          server/agent/stream.ts
          server/api/routes/agent.ts
          server/plugins/markdown-builtin.ts
          src/assets/mulmo-icon.png
          src/utils/session/sessionHelpers.ts

修正前: pathspec = packages/mulmoclaude
        changed 1（package.json のみ）/ SHIPPED 0  → manifest drift ← バグ
```

- 新規テスト14件（`test/scripts/packages/test_auditReleases.ts`）
- `yarn audit:releases --code-only` が従来どおり最後まで走ることを確認
- `yarn format` / `lint`（0 errors）/ `typecheck` / `build` / `test` すべて green

## ドキュメント

`docs/package-releases.md` の「what is actually drifting?」節に、ランチャーだけルートの `server/` `src/` も監査対象であること、および手作業で調べる際の `git diff` 例を追記しました。`code drift` の説明にも1行足しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Broaden the release audit script to consider external source roots for the launcher, export its helpers behind a guarded CLI entrypoint, and document and test the new audit behaviour.

Enhancements:
- Audit the launcher package against repository-root sources it ships (server, src, sandbox assets) instead of only its own workspace directory.
- Introduce explicit configuration for external source roots and use it to determine diff pathspecs and release-path classification across workspaces.
- Refactor the audit script into exported helpers with a main() entrypoint so it can be safely imported without triggering a full npm/git sweep.
- Tweak clean-state messaging to no longer reference the package's own files list explicitly.

Documentation:
- Clarify in the package release docs that the launcher is audited against additional repo-root paths and update the definition of code drift accordingly.

Tests:
- Add tests covering external source roots, diff pathspecs, release-path classification, and shipped-roots normalisation for the audit script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release audits now detect changes to launcher source files located outside the package workspace.
  * Audits correctly distinguish shipped files, package-specific paths, and unrelated workspace changes.
  * Improved handling of package roots, README files, and audit failures.

* **Documentation**
  * Updated release-audit guidance with launcher-specific scope and commands.

* **Tests**
  * Added coverage for external source detection, diff scope, shipped paths, and workspace isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->