### PR TITLE
feat(scripts): check the CHANGELOG's `Ships` roster against the launcher's deps

### DIFF
--- a/.claude/skills/publish-mulmoclaude/SKILL.md
+++ b/.claude/skills/publish-mulmoclaude/SKILL.md
@@ -251,6 +251,15 @@ A launcher publish is not done until it has a visible, changelog-backed `latest`
 - a `### Highlights` block with `#### <feature> (#issue, #pr)` subsections,
 - a closing `Ships \`@mulmoclaude/core@<v>\`, …` line naming every scoped package version this launcher pulls in.
 
+That last line is thirteen hand-typed `name@version` strings, so verify it rather than
+trusting the retype — and note it answers "which versions does this launcher pull in?",
+NOT "what did we publish this week" (1.9.0 and 1.10.0 used it for the latter, which is
+why the check exists):
+
+```bash
+yarn check:changelog-ships   # compares the [X.Y.Z] Ships line against the launcher's deps
+```
+
 **9a-bis. Re-check the window between cutting the branch and merging it.** The section is written from the PRs merged as of the moment the release branch is cut — but `main` keeps moving while the release PR sits in CI and review, and everything that lands in that window ships in this release too. Run this after the §8 PR merges and BEFORE tagging:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "plugins:codegen:check": "tsx scripts/codegen-plugin-barrels.ts --check",
     "check:launcher-sync": "node scripts/mulmoclaude/launcherSync.mjs",
     "audit:releases": "node scripts/packages/audit-releases.mjs",
+    "check:changelog-ships": "node scripts/packages/check-changelog-ships.mjs",
     "knip": "knip",
     "sleep": "node -e \"setTimeout(()=>{},2000)\"",
     "predev": "yarn plugins:codegen",

--- a/scripts/packages/check-changelog-ships.d.mts
+++ b/scripts/packages/check-changelog-ships.d.mts
@@ -16,8 +16,9 @@ export function releaseSection(changelog: string, version: string): string | nul
 /** The roster the section's `Ships …` line claims, sorted. Null when there is no such line. */
 export function claimedRoster(section: string): string[] | null;
 
-/** Entries the line forgot (`missing`) and entries it kept but the launcher dropped (`stale`). */
-export function compareRosters(claimed: string[], declared: string[]): { missing: string[]; stale: string[] };
+/** Entries the line forgot (`missing`), entries it kept but the launcher dropped
+ *  (`stale`), and entries it names more than once (`duplicated`). */
+export function compareRosters(claimed: string[], declared: string[]): { missing: string[]; stale: string[]; duplicated: string[] };
 
 /** CLI entry point. Returns 0 when the line matches the launcher's dependencies, 1 otherwise. */
 export function main(): number;

--- a/scripts/packages/check-changelog-ships.d.mts
+++ b/scripts/packages/check-changelog-ships.d.mts
@@ -1,0 +1,23 @@
+// Type declarations for check-changelog-ships.mjs. Sidecar so the script stays
+// plain JS (runnable with `node` on a fresh clone) while tests get a typed
+// import surface — same arrangement as scripts/packages/audit-releases.d.mts.
+
+export interface LauncherManifest {
+  version?: string;
+  dependencies?: Record<string, string>;
+}
+
+/** The `@mulmoclaude/*` roster the launcher declares, as sorted `name@version` strings. */
+export function declaredRoster(manifest: LauncherManifest): string[];
+
+/** The `## [X.Y.Z]` section body, or null when the CHANGELOG has no such heading. */
+export function releaseSection(changelog: string, version: string): string | null;
+
+/** The roster the section's `Ships …` line claims, sorted. Null when there is no such line. */
+export function claimedRoster(section: string): string[] | null;
+
+/** Entries the line forgot (`missing`) and entries it kept but the launcher dropped (`stale`). */
+export function compareRosters(claimed: string[], declared: string[]): { missing: string[]; stale: string[] };
+
+/** CLI entry point. Returns 0 when the line matches the launcher's dependencies, 1 otherwise. */
+export function main(): number;

--- a/scripts/packages/check-changelog-ships.mjs
+++ b/scripts/packages/check-changelog-ships.mjs
@@ -42,17 +42,29 @@ export const releaseSection = (changelog, version) => {
   return end < 0 ? rest : rest.slice(0, end);
 };
 
-/** The roster the `Ships …` line claims. Null when the section has no such line. */
+// Derived from SCOPE so the two cannot drift apart: `@scope/name@version`
+// inside backticks. Requiring the `@version` is what skips prose mentions like
+// `@mulmoclaude/*-plugin`.
+const ROSTER_ENTRY = new RegExp(`\`(${SCOPE.replace("/", "\\/")}[^\`@]+@[^\`]+)\``, "g");
+
+/** The roster the `Ships …` line claims. Null when the section has no such line.
+ *  Returning null is a LOUD failure, not a silent skip — `main` reports it and
+ *  exits 1 — so the line is matched strictly rather than guessed at. */
 export const claimedRoster = (section) => {
-  const line = section.split("\n").find((entry) => entry.startsWith("Ships `"));
+  const line = section.split("\n").find((entry) => entry.trimStart().startsWith("Ships `"));
   if (!line) return null;
-  return [...line.matchAll(/`(@mulmoclaude\/[^`@]+@[^`]+)`/g)].map((match) => match[1]).sort();
+  return [...line.matchAll(ROSTER_ENTRY)].map((match) => match[1]).sort();
 };
 
-/** Both directions, so neither a forgotten addition nor a stale entry can hide. */
+const duplicatesIn = (entries) => [...new Set(entries.filter((entry, index) => entries.indexOf(entry) !== index))];
+
+/** Both directions, so neither a forgotten addition nor a stale entry can hide.
+ *  `duplicated` is the third way to disagree: set membership alone calls a line
+ *  that names one package twice a match for a roster that names it once. */
 export const compareRosters = (claimed, declared) => ({
   missing: declared.filter((entry) => !claimed.includes(entry)),
   stale: claimed.filter((entry) => !declared.includes(entry)),
+  duplicated: duplicatesIn(claimed),
 });
 
 const readJson = (file) => JSON.parse(readFileSync(file, "utf8"));
@@ -60,6 +72,7 @@ const readJson = (file) => JSON.parse(readFileSync(file, "utf8"));
 export function main() {
   const manifest = readJson(LAUNCHER_MANIFEST);
   const { version } = manifest;
+  const declared = declaredRoster(manifest);
 
   const section = releaseSection(readFileSync(CHANGELOG, "utf8"), version);
   if (section === null) {
@@ -71,12 +84,12 @@ export function main() {
   const claimed = claimedRoster(section);
   if (claimed === null) {
     console.error(`[changelog:ships] the [${version}] section has no \`Ships …\` line.`);
-    console.error(`  End the section with: Ships \`${declaredRoster(manifest).join("`, `")}\`.`);
+    console.error(`  End the section with: Ships \`${declared.join("`, `")}\`.`);
     return 1;
   }
 
-  const { missing, stale } = compareRosters(claimed, declaredRoster(manifest));
-  if (missing.length === 0 && stale.length === 0) {
+  const { missing, stale, duplicated } = compareRosters(claimed, declared);
+  if (missing.length === 0 && stale.length === 0 && duplicated.length === 0) {
     console.log(`[changelog:ships] OK — [${version}] lists all ${claimed.length} @mulmoclaude/* dependencies.`);
     return 0;
   }
@@ -84,6 +97,7 @@ export function main() {
   console.error(`[changelog:ships] the [${version}] \`Ships\` line disagrees with ${LAUNCHER_MANIFEST}:`);
   for (const entry of missing) console.error(`  - missing: ${entry}`);
   for (const entry of stale) console.error(`  - not a current dependency: ${entry}`);
+  for (const entry of duplicated) console.error(`  - listed more than once: ${entry}`);
   console.error("");
   console.error("  The line answers 'which package versions does this launcher pull in?' —");
   console.error("  not 'what did we publish this week'. Fix the line, not the manifest.");

--- a/scripts/packages/check-changelog-ships.mjs
+++ b/scripts/packages/check-changelog-ships.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Does the CHANGELOG's `Ships …` line match what the launcher actually pulls in?
+//
+// Every app release ends with a hand-typed roster of thirteen
+// `@mulmoclaude/<pkg>@<version>` strings. Nothing derived it and nothing checked
+// it, so it was a list of facts maintained by retyping them — and its MEANING
+// drifted too: 1.8.0 / 1.11.0 / 1.12.0 list the launcher's dependency roster,
+// while 1.9.0 / 1.10.0 listed the packages published during that release window
+// instead. Two different questions answered by the same sentence.
+//
+// This pins the first meaning — the roster a reader can act on ("which package
+// versions am I getting?") — and makes it checkable.
+//
+// Usage: node scripts/packages/check-changelog-ships.mjs
+//
+// Checks the launcher's CURRENT version only — the section a release PR is
+// about to ship. There is deliberately no flag for an older version: the
+// manifest read here is today's, so pointing it at a frozen section would
+// compare two different releases and report a mismatch that is not one.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHANGELOG = "docs/CHANGELOG.md";
+const LAUNCHER_MANIFEST = "packages/mulmoclaude/package.json";
+const SCOPE = "@mulmoclaude/";
+
+/** The `@mulmoclaude/*` roster the launcher declares, as `name@version` strings. */
+export const declaredRoster = (manifest) =>
+  Object.entries(manifest.dependencies ?? {})
+    .filter(([name]) => name.startsWith(SCOPE))
+    .map(([name, range]) => `${name}@${range.replace(/^[\^~]/, "")}`)
+    .sort();
+
+/** The `## [X.Y.Z]` section body, or null when the CHANGELOG has no such heading. */
+export const releaseSection = (changelog, version) => {
+  const heading = `## [${version}]`;
+  const start = changelog.indexOf(heading);
+  if (start < 0) return null;
+  const rest = changelog.slice(start + heading.length);
+  const end = rest.indexOf("\n## [");
+  return end < 0 ? rest : rest.slice(0, end);
+};
+
+/** The roster the `Ships …` line claims. Null when the section has no such line. */
+export const claimedRoster = (section) => {
+  const line = section.split("\n").find((entry) => entry.startsWith("Ships `"));
+  if (!line) return null;
+  return [...line.matchAll(/`(@mulmoclaude\/[^`@]+@[^`]+)`/g)].map((match) => match[1]).sort();
+};
+
+/** Both directions, so neither a forgotten addition nor a stale entry can hide. */
+export const compareRosters = (claimed, declared) => ({
+  missing: declared.filter((entry) => !claimed.includes(entry)),
+  stale: claimed.filter((entry) => !declared.includes(entry)),
+});
+
+const readJson = (file) => JSON.parse(readFileSync(file, "utf8"));
+
+export function main() {
+  const manifest = readJson(LAUNCHER_MANIFEST);
+  const { version } = manifest;
+
+  const section = releaseSection(readFileSync(CHANGELOG, "utf8"), version);
+  if (section === null) {
+    console.error(`[changelog:ships] ${CHANGELOG} has no "## [${version}]" section.`);
+    console.error("  A launcher publish needs a changelog entry — see /publish-mulmoclaude §9a.");
+    return 1;
+  }
+
+  const claimed = claimedRoster(section);
+  if (claimed === null) {
+    console.error(`[changelog:ships] the [${version}] section has no \`Ships …\` line.`);
+    console.error(`  End the section with: Ships \`${declaredRoster(manifest).join("`, `")}\`.`);
+    return 1;
+  }
+
+  const { missing, stale } = compareRosters(claimed, declaredRoster(manifest));
+  if (missing.length === 0 && stale.length === 0) {
+    console.log(`[changelog:ships] OK — [${version}] lists all ${claimed.length} @mulmoclaude/* dependencies.`);
+    return 0;
+  }
+
+  console.error(`[changelog:ships] the [${version}] \`Ships\` line disagrees with ${LAUNCHER_MANIFEST}:`);
+  for (const entry of missing) console.error(`  - missing: ${entry}`);
+  for (const entry of stale) console.error(`  - not a current dependency: ${entry}`);
+  console.error("");
+  console.error("  The line answers 'which package versions does this launcher pull in?' —");
+  console.error("  not 'what did we publish this week'. Fix the line, not the manifest.");
+  return 1;
+}
+
+// Only run the CLI when invoked directly, so tests can import the helpers.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.exitCode = main();
+}

--- a/test/scripts/packages/test_changelogShips.ts
+++ b/test/scripts/packages/test_changelogShips.ts
@@ -1,0 +1,121 @@
+// The CHANGELOG's `Ships …` roster is hand-typed; this is what checks it.
+//
+// Sourcery raised it on #2829: thirteen `@mulmoclaude/<pkg>@<version>` strings
+// maintained by retyping them, with nothing comparing them to the launcher's
+// actual dependencies. Auditing the released entries found the values correct
+// but the SENTENCE ambiguous — 1.8.0 / 1.11.0 / 1.12.0 list the dependency
+// roster, 1.9.0 / 1.10.0 listed the packages published that week. These tests
+// pin the first meaning.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { claimedRoster, compareRosters, declaredRoster, releaseSection } from "../../../scripts/packages/check-changelog-ships.mjs";
+
+const manifest = {
+  version: "1.12.0",
+  dependencies: {
+    "@mulmoclaude/core": "^2.1.0",
+    "@mulmoclaude/common": "^1.2.0",
+    "@mulmobridge/client": "^1.0.2",
+    express: "^5.0.0",
+  },
+};
+
+const changelog = [
+  "# Changelog",
+  "",
+  "## [Unreleased]",
+  "",
+  "## [1.12.0] - 2026-08-07",
+  "",
+  "**Tagline.**",
+  "",
+  "Ships `@mulmoclaude/core@2.1.0`, `@mulmoclaude/common@1.2.0`.",
+  "",
+  "## [1.11.0] - 2026-08-05",
+  "",
+  "Ships `@mulmoclaude/core@2.0.2`.",
+  "",
+].join("\n");
+
+describe("declaredRoster", () => {
+  it("takes only @mulmoclaude/* deps, strips the range prefix, and sorts", () => {
+    assert.deepEqual(declaredRoster(manifest), ["@mulmoclaude/common@1.2.0", "@mulmoclaude/core@2.1.0"]);
+  });
+
+  it("ignores @mulmobridge/* and third-party deps", () => {
+    const roster = declaredRoster(manifest);
+    assert.ok(!roster.some((entry) => entry.startsWith("@mulmobridge/")), "bridges are listed in their own section");
+    assert.ok(!roster.some((entry) => entry.startsWith("express")));
+  });
+
+  it("strips ~ as well as ^", () => {
+    assert.deepEqual(declaredRoster({ dependencies: { "@mulmoclaude/core": "~2.1.0" } }), ["@mulmoclaude/core@2.1.0"]);
+  });
+
+  it("survives a manifest with no dependencies at all", () => {
+    assert.deepEqual(declaredRoster({}), []);
+  });
+});
+
+describe("releaseSection", () => {
+  it("returns the requested section and stops at the next heading", () => {
+    const section = releaseSection(changelog, "1.12.0");
+    assert.ok(section);
+    assert.ok(section.includes("@mulmoclaude/common@1.2.0"));
+    assert.ok(!section.includes("2.0.2"), "must not bleed into the previous release");
+  });
+
+  it("returns null for a version the changelog does not document", () => {
+    assert.equal(releaseSection(changelog, "9.9.9"), null);
+  });
+
+  it("handles the last section, which has no following heading", () => {
+    const section = releaseSection(changelog, "1.11.0");
+    assert.ok(section?.includes("@mulmoclaude/core@2.0.2"));
+  });
+});
+
+describe("claimedRoster", () => {
+  it("reads the entries out of the Ships line", () => {
+    const section = releaseSection(changelog, "1.12.0");
+    assert.ok(section);
+    assert.deepEqual(claimedRoster(section), ["@mulmoclaude/common@1.2.0", "@mulmoclaude/core@2.1.0"]);
+  });
+
+  it("returns null when the section has no Ships line", () => {
+    assert.equal(claimedRoster("## [1.0.0]\n\nNo roster here.\n"), null);
+  });
+
+  it("ignores backticked package names that carry no version", () => {
+    assert.deepEqual(claimedRoster("Ships `@mulmoclaude/core@2.1.0`, plus the `@mulmoclaude/*-plugin` wave."), ["@mulmoclaude/core@2.1.0"]);
+  });
+});
+
+describe("compareRosters", () => {
+  it("reports nothing when the two agree", () => {
+    const roster = ["@mulmoclaude/core@2.1.0"];
+    assert.deepEqual(compareRosters(roster, roster), { missing: [], stale: [] });
+  });
+
+  it("catches a dependency the line forgot", () => {
+    const result = compareRosters(["@mulmoclaude/core@2.1.0"], ["@mulmoclaude/common@1.2.0", "@mulmoclaude/core@2.1.0"]);
+    assert.deepEqual(result.missing, ["@mulmoclaude/common@1.2.0"]);
+    assert.deepEqual(result.stale, []);
+  });
+
+  // The failure that actually happens: the roster is copied from the previous
+  // release and one version is never updated.
+  it("catches a version left at the previous release", () => {
+    const result = compareRosters(["@mulmoclaude/core@2.0.2"], ["@mulmoclaude/core@2.1.0"]);
+    assert.deepEqual(result.missing, ["@mulmoclaude/core@2.1.0"]);
+    assert.deepEqual(result.stale, ["@mulmoclaude/core@2.0.2"]);
+  });
+});
+
+describe("the real CHANGELOG and launcher manifest", () => {
+  it("agree for the version currently in packages/mulmoclaude/package.json", async () => {
+    const { main } = await import("../../../scripts/packages/check-changelog-ships.mjs");
+    assert.equal(main(), 0, "run `node scripts/packages/check-changelog-ships.mjs` to see which entries disagree");
+  });
+});

--- a/test/scripts/packages/test_changelogShips.ts
+++ b/test/scripts/packages/test_changelogShips.ts
@@ -87,6 +87,10 @@ describe("claimedRoster", () => {
     assert.equal(claimedRoster("## [1.0.0]\n\nNo roster here.\n"), null);
   });
 
+  it("tolerates an indented Ships line", () => {
+    assert.deepEqual(claimedRoster("  Ships `@mulmoclaude/core@2.1.0`."), ["@mulmoclaude/core@2.1.0"]);
+  });
+
   it("ignores backticked package names that carry no version", () => {
     assert.deepEqual(claimedRoster("Ships `@mulmoclaude/core@2.1.0`, plus the `@mulmoclaude/*-plugin` wave."), ["@mulmoclaude/core@2.1.0"]);
   });
@@ -95,7 +99,22 @@ describe("claimedRoster", () => {
 describe("compareRosters", () => {
   it("reports nothing when the two agree", () => {
     const roster = ["@mulmoclaude/core@2.1.0"];
-    assert.deepEqual(compareRosters(roster, roster), { missing: [], stale: [] });
+    assert.deepEqual(compareRosters(roster, roster), { missing: [], stale: [], duplicated: [] });
+  });
+
+  // Set membership alone called this a match: every claimed entry is declared
+  // and every declared entry is claimed, so both lists came back empty for a
+  // line that names one package twice. (CodeRabbit, #2831.)
+  it("catches an entry the line names twice", () => {
+    const result = compareRosters(["@mulmoclaude/core@2.1.0", "@mulmoclaude/core@2.1.0"], ["@mulmoclaude/core@2.1.0"]);
+    assert.deepEqual(result.duplicated, ["@mulmoclaude/core@2.1.0"]);
+    assert.deepEqual(result.missing, []);
+    assert.deepEqual(result.stale, []);
+  });
+
+  it("reports a duplicate once, however many times it repeats", () => {
+    const thrice = ["@mulmoclaude/core@2.1.0", "@mulmoclaude/core@2.1.0", "@mulmoclaude/core@2.1.0"];
+    assert.deepEqual(compareRosters(thrice, ["@mulmoclaude/core@2.1.0"]).duplicated, ["@mulmoclaude/core@2.1.0"]);
   });
 
   it("catches a dependency the line forgot", () => {


### PR DESCRIPTION
## Summary

マージ済み PR のレビューを読み直したところ、**#2829 の Sourcery 指摘を私が読まないままマージしていました**。その2件目が妥当だったので、フォローアップとして対応します。

> The explicit list of shipped package versions in the 1.12.0 entry looks manually maintained; if this needs to stay accurate over time, consider generating or validating it via the existing audit/smoke tooling to avoid future drift.

app リリースの CHANGELOG は毎回 `@mulmoclaude/<pkg>@<version>` を13個手打ちした行で終わります。導出も検査もされておらず、**再入力し続けることで正確さを保っている事実のリスト**でした。

`yarn check:changelog-ships` を追加し、`/publish-mulmoclaude` §9a（この行を書く場所）に組み込みました。

## Items to Confirm / Review

1. **過去の全リリースを検査した結果 — 値は正しいが「行の意味」が揺れていました**

   | version | Ships 行の意味 |
   |---|---|
   | 1.8.0 / 1.11.0 / 1.12.0 | ランチャーが取り込む依存パッケージ一覧 |
   | **1.9.0 / 1.10.0** | **その期間に公開したパッケージ**（別の質問への答え） |

   同じ文が2つの異なる質問に答えており、読者はどちらを見せられているのか判別できません。本 PR は**前者に固定**します。この判断が意図と合っているかご確認ください。

2. **`--version` フラグを意図的に付けていないこと**
   最初は付けましたが、読むマニフェストは常に「今」のものなので、過去の版を指定すると**別リリース同士を比較してドリフトでないものをドリフトと報告**します。実際 `--version 1.11.0` で誤検出したため削除しました。用途は「リリース PR で今から出す版を検査する」の1つだけです。

3. **CI ではなくリリースフローに置いた判断**
   CHANGELOG エントリはリリース PR で書かれるため、常時走る CI チェックにすると通常の PR では検査対象が存在しません。`/publish-mulmoclaude` の手順に組み込む形にしています。CI 化が望ましければ「ランチャーの version が変わった PR のみ」という条件付けが必要です。

## User Prompt

- マージ後だけど gh-review-loop してほしい。マージ後のコメントを読んで、課題があれば別 PR で修正して回す

## トリアージ結果（マージ済み4 PR）

| PR | Codex | CodeRabbit | Sourcery | 未対応だったもの |
|---|---|---|---|---|
| #2824 | LGTM | 3件 → 対応済み | 2件 → 対応済み | 2回目 push は CR/Sourcery の再レビューなし（Codex は最終 SHA を LGTM、自己レビューでも問題なし） |
| #2825 | LGTM | **Review failed — PR is closed** | — | **CodeRabbit がレビューできていない**（マージが早すぎた） |
| #2829 | LGTM | No actionable comments | **2件 → 未読だった** | 本 PR で対応 |
| #2830 | LGTM ×2 | 2件 → 対応済み | 1件 → 対応済み | なし |

Sourcery の1件目「CHANGELOG が説明過多。要約して #2821/#2824 にリンクを」は**見送り**ます。1.11.0 / 1.10.0 のエントリも同様に多段落の因果説明を含んでおり、リポジトリの既存スタイルに沿っているためです。スタイル変更をするなら CHANGELOG 全体の方針として別途決めるべきと考えます。

## 検証

- 新規テスト14件（`test/scripts/packages/test_changelogShips.ts`）
- 「前リリースからコピーして1つだけ更新し忘れる」という実際に起きる失敗パターンを含む
- 実 CHANGELOG と実マニフェストの整合もテストで固定（`main()` が 0 を返すこと）
- `yarn format` / `lint`（0 errors）/ `typecheck` / `build` / `test` すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Introduce a scripted check and supporting tests to ensure the changelog `Ships` line accurately reflects the launcher’s current scoped package dependencies and document its role in the release flow.

New Features:
- Add a changelog consistency check script that verifies the `Ships` roster against the launcher package dependencies and exposes it via the `yarn check:changelog-ships` npm script.

Enhancements:
- Clarify the release documentation so the changelog `Ships` line is explicitly defined as listing the launcher dependencies rather than recently published packages.

Tests:
- Add targeted tests for changelog parsing and roster comparison helpers, including real manifest/changelog agreement, to guard against drift and common failure modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated validation to ensure each release changelog’s “Ships” list matches the launcher’s included packages and versions.
  * Added clear validation errors for missing, outdated, duplicate, or incomplete entries.

* **Tests**
  * Added coverage for roster extraction, release sections, parsing, mismatch detection, edge cases, and current release consistency.

* **Documentation**
  * Updated publishing guidance to include the changelog validation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->