### PR TITLE
chore: move the codex review to the latest CLI (0.147.0) and model (gpt-5.6-terra)

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -10,18 +10,18 @@
 #     produces one review against the latest commit, not N reviews
 #   - `~/.npm` is cached, so `npm install -g @openai/codex` reuses
 #     the prior tarball + skips the network on warm runs
-#   - Azure deployment SKU caps TPM (5000 currently); throttling
+#   - Azure deployment SKU caps TPM (10000 currently); throttling
 #     happens at the model layer, not the workflow layer
 #
 # Auth: Azure OpenAI via the OpenAI-compatible `/openai/v1` endpoint.
-# Codex CLI 0.125.0 does NOT honour `OPENAI_BASE_URL` directly —
+# Codex CLI does NOT honour `OPENAI_BASE_URL` directly —
 # the iter-1 attempt 401'd against `api.openai.com` because the env
 # var was silently ignored. Workflow now writes an explicit
 # `~/.codex/config.toml` with `[model_providers.azure]` before the
 # `codex exec` invocation. Required secrets:
 #   - AZURE_OPENAI_API_KEY        (the Azure key)
 #   - AZURE_OPENAI_BASE_URL       (e.g. https://<resource>.openai.azure.com — no path)
-#   - AZURE_OPENAI_DEPLOYMENT     (optional; defaults to gpt-5.4-mini)
+#   - AZURE_OPENAI_DEPLOYMENT     (optional; defaults to codex-review-terra)
 #   - AZURE_OPENAI_API_VERSION    (optional; defaults to `preview`)
 #
 # `workflow_dispatch` is also kept for manual re-runs (e.g.
@@ -62,7 +62,7 @@ permissions:
 # upgrades are explicit. Bump together with cache-version when
 # moving to a new Codex release.
 env:
-  CODEX_VERSION: "0.125.0"
+  CODEX_VERSION: "0.147.0"
 
 concurrency:
   group: codex-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}
@@ -122,12 +122,17 @@ jobs:
           # Deployment name on the Azure resource (the LLM model
           # alias the workspace administrator created). Codex passes
           # this through as `model = ...` in the request body.
-          # Default `gpt-5.3-codex` is the codex-optimized GPT-5.3
-          # variant (deployed on `mulmo-sweden` 2026-04-30) — the
-          # MSFT-documented choice for Codex CLI agentic-coding
-          # workloads. Older `gpt-4o` still works as a fallback if
-          # the codex variant isn't deployed; override via secret.
-          AZURE_MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT || 'gpt-5.3-codex' }}
+          # `codex-review-terra` runs gpt-5.6-terra (deployed on
+          # `mulmo-sweden` 2026-08-07) under a name the CLI does NOT
+          # recognise, and that mismatch is deliberate: for a model it
+          # has metadata for, Codex nests the whole tool list under a
+          # `functions` namespace carrying an empty description, and
+          # Azure's Responses validator rejects that outright —
+          # `400 empty_string` on `input[0].tools[0].description`.
+          # An unknown name falls back to the flat tool list Azure
+          # accepts. Deploying gpt-5.6-terra under its own name breaks
+          # every review until upstream stops sending that payload.
+          AZURE_MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT || 'codex-review-terra' }}
         run: |
           mkdir -p "$HOME/.codex"
           # Strip trailing slash so concatenation never doubles up.
@@ -137,7 +142,7 @@ jobs:
           # so no accidental command substitution. envsubst then fills
           # ONLY the three whitelisted vars — anything else, including
           # a literal `$x` in TOML, is left untouched.
-          # Codex CLI 0.125.0 only supports the "responses" wire (Chat
+          # Codex CLI only supports the "responses" wire (Chat
           # Completions was removed); on Azure that needs
           # api-version >= 2025-03-01-preview on a deployment exposing
           # the Responses surface (recent gpt-4o / gpt-4.1 / gpt-5).


### PR DESCRIPTION
## Summary

CI の codex auto-review を **最新の CLI + 最新のモデル** に載せ替える。receptron/mulmoterminal#1526 と同一の変更。

| | before | after |
|---|---|---|
| Codex CLI | `0.125.0` | `0.147.0`（npm latest） |
| Azure deployment | `gpt-5.3-codex` | `codex-review-terra` = **gpt-5.6-terra**（2026-07-09 GA） |

`gpt-5.3-codex` は Codex 上ではすでに deprecated 扱い。gpt-5.6 系（sol / terra / luna）が現行ラインナップで、balanced の **terra** を選択。

Azure 側の作業は実施済み（3 リポジトリ共有の `mulmo-sweden` リソース）:
- `codex-review-terra` → `gpt-5.6-terra` (2026-07-09) を GlobalStandard / 10,000 TPM で deploy
- 旧 `gpt-5.3-codex` deployment はロールバック用にそのまま残置
- `AZURE_OPENAI_DEPLOYMENT` secret はこのリポジトリでも未設定なので、workflow のデフォルト値変更だけで切り替わる

## Items to Confirm / Review

1. **deployment 名がモデル名を名乗っていないのは意図的** — Codex CLI 0.147.0 は「自分がメタデータを
   持っているモデル名」のときだけ、tools を `input[0]` の `functions` namespace 形式で送る。その
   namespace の `description` が空文字で、Azure の Responses バリデータがこれを拒否する:
   ```
   400 Invalid 'input[0].tools[0].description': empty string.
       Expected a string with minimum length 1 (code: empty_string)
   ```
   つまり `gpt-5.6-terra` という名前で deploy すると **レビューが 100% 失敗する**。CLI が知らない名前
   （= `codex-review-terra`）にすると従来どおりフラットな tools 配列になり Azure が受理する。実行される
   モデルは Azure 側のマッピングどおり gpt-5.6-terra 本体。workflow のコメントにも理由を残してある。

2. **メタデータ fallback の警告が出る** — `Model metadata for 'codex-review-terra' not found` が毎回
   ログに出るが、**現状の `gpt-5.3-codex` でも同じ**（CLI は 5.3-codex も知らない）ので新たな劣化ではない。

3. **TPM を 5,000 → 10,000 に増やした**（terra の GlobalStandard quota 上限いっぱい）。従量課金なので
   待機コストは増えない。

## 動作確認

**CI 実機で検証済み** — receptron/mulmoterminal#1526 の codex-review ジョブが同一設定で success:

```
OpenAI Codex v0.147.0
model: codex-review-terra
→ CODEX VERDICT: LGTM を PR に投稿
```

加えてローカルで Azure 実機に対し、CI と同一の `~/.codex/config.toml`（`wire_api = "responses"`,
`api-version=preview`）でツール実行込みの動作も確認済み。

比較のため取得した実リクエストの tools 形状:

| model | tools の形 | Azure |
|---|---|---|
| `gpt-5.6-terra`（CLI が認識） | `input[0].tools[0]` = namespace `functions`, `description: ""` | **400** |
| `gpt-5.3-codex` / `codex-review-terra`（未認識） | top-level `tools[]` にフラットな function 10 個 | OK |

## User Prompt

> ci で使っている codex の review って model は最新？
>
> cli で azure 使えるからそれ含め動作させて確認して。で、変更できるんだったら変更、修正して。mulmoclaude と mulmoserver も同様に。
>
> codex は最新にしてよ。それが目的。それが出来ないなら変更不要。
>
> 良さそうなのでマージして他にも展開しよう

## Summary by Sourcery

Update the Codex review CI workflow to use the latest Codex CLI and a new Azure deployment alias for the current review model.

Build:
- Increase documented Azure TPM cap from 5,000 to 10,000 in workflow comments.
- Change the default Azure deployment name used by the workflow to the new codex-review-terra alias for the review model.
- Bump the Codex CLI version used in CI from 0.125.0 to 0.147.0 and refresh related configuration comments.

CI:
- Adjust Codex CLI configuration notes in the workflow to reflect current behavior around OPENAI_BASE_URL handling and supported wire protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Azure deployment guidance with the latest TPM limit and Codex CLI version.
  * Changed the default deployment to `codex-review-terra`.
  * Clarified Azure model compatibility with tool payloads.
  * Updated Responses API compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->