### PR TITLE
fix: address coderabbitai review comments on the codex review workflow

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -21,8 +21,11 @@
 # `codex exec` invocation. Required secrets:
 #   - AZURE_OPENAI_API_KEY        (the Azure key)
 #   - AZURE_OPENAI_BASE_URL       (e.g. https://<resource>.openai.azure.com — no path)
-#   - AZURE_OPENAI_DEPLOYMENT     (optional; defaults to codex-review-terra)
-#   - AZURE_OPENAI_API_VERSION    (optional; defaults to `preview`)
+# Optional overrides:
+#   - AZURE_OPENAI_DEPLOYMENT     (defaults to codex-review-terra; whatever it names
+#                                  must stay a deployment the CLI does not recognise
+#                                  as a model — see the AZURE_MODEL comment below)
+#   - AZURE_OPENAI_API_VERSION    (defaults to `preview`)
 #
 # `workflow_dispatch` is also kept for manual re-runs (e.g.
 # requesting a re-review after argument changes, or running on a
@@ -143,9 +146,10 @@ jobs:
           # ONLY the three whitelisted vars — anything else, including
           # a literal `$x` in TOML, is left untouched.
           # Codex CLI only supports the "responses" wire (Chat
-          # Completions was removed); on Azure that needs
-          # api-version >= 2025-03-01-preview on a deployment exposing
+          # Completions was removed), so the deployment has to expose
           # the Responses surface (recent gpt-4o / gpt-4.1 / gpt-5).
+          # The api-version that reaches it is the one above, not a
+          # dated preview.
           export AZURE_MODEL BASE_URL AZURE_API_VERSION
           # envsubst's SHELL-FORMAT arg MUST stay single-quoted: it is
           # the literal allowlist of names to replace, not a shell

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -148,8 +148,8 @@ jobs:
           # Codex CLI only supports the "responses" wire (Chat
           # Completions was removed), so the deployment has to expose
           # the Responses surface (recent gpt-4o / gpt-4.1 / gpt-5).
-          # The api-version that reaches it is the one above, not a
-          # dated preview.
+          # It is reached with whatever AZURE_API_VERSION resolved to
+          # above — `preview` unless a resource pins a dated one.
           export AZURE_MODEL BASE_URL AZURE_API_VERSION
           # envsubst's SHELL-FORMAT arg MUST stay single-quoted: it is
           # the literal allowlist of names to replace, not a shell


### PR DESCRIPTION
## Summary

直前の「codex review を最新 CLI + 最新モデルへ」PR に対して CodeRabbit が出した指摘のうち、妥当だった 3 件をまとめて反映する。コメントのみの変更で、実行される設定値は一切変えていない。

1. **必須 secret と任意 override の混在を解消** — `AZURE_OPENAI_DEPLOYMENT` / `AZURE_OPENAI_API_VERSION` は `(optional; ...)` と書きつつ `Required secrets:` の下にぶら下がっていた。`Optional overrides:` として分離。
2. **override 時の制約を明記** — `AZURE_OPENAI_DEPLOYMENT` で上書きする場合も、**CLI がモデルとして認識しない deployment 名**でなければならない（認識される名前だと namespace 形式の tools payload が復活し、Azure が `400 empty_string` で全レビューを落とす）。この制約は `AZURE_MODEL` 側のコメントにしか無かった。
3. **矛盾していた api-version の記述を削除** — 「on Azure that needs api-version >= 2025-03-01-preview」と書いてあったが、その少し上のブロックは「**dated preview は `mulmo-sweden` で 400 になる。`preview` という magic value を使う**」と正反対のことを記録していた。実際のデフォルトは `preview`。dated 版の要求を消し、上のブロックを参照する形に。

## Items to Confirm / Review

- **コメントのみ**。`CODEX_VERSION` も `AZURE_MODEL` も既定値のまま。YAML パースは 3 リポとも確認済み。
- CodeRabbit は上記とは別に「codex の provider 設定 `namespace_tools` で tool 形状を切り替えれば alias 回避は不要」という趣旨の web 検索結果も提示していたが、**採用していない**。pin している 0.147.0 のバイナリを実際に調べたところ、provider の設定キーは `wire_api` / `query_params` / `request_max_retries` / `stream_max_retries` / `stream_idle_timeout_ms` / `websocket_connect_timeout_ms` / `requires_openai_auth` / `supports_websockets` / `supports_standalone_web_search` のみで、**`namespace_tools` は存在しない**。upstream の未リリース分と思われる。将来 CLI を上げる際に再確認する価値はある。
- CodeRabbit は 2 番目の指摘を Major としていたが、**現時点の実害はない**（ドキュメントしているロールバック先 `gpt-5.3-codex` も CLI 非認識名で、実機で動作確認済み）。将来の踏み間違いを防ぐコメントとして採用した。

## User Prompt

> gh-review-loop

（直前の 3 リポジトリ向け codex review 更新 PR に対する bot レビューのトリアージ）

---

## Summary by Sourcery

Clarify configuration semantics and constraints for the codex review GitHub workflow without changing any executed settings.

Documentation:
- Document AZURE_OPENAI_DEPLOYMENT and AZURE_OPENAI_API_VERSION as optional overrides separate from required secrets.
- Clarify that AZURE_OPENAI_DEPLOYMENT must refer to a deployment not recognized as a model by the Codex CLI and that the effective api-version is the workflow default rather than a dated preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Azure OpenAI configuration requirements for custom or unrecognized model names.
  * Updated API-version guidance to reflect use of the Responses API with the configured preview version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->