### PR TITLE
fix(remote-host): presence の判定と give-up を壁時計から切り離す（走った beat で数える）

### DIFF
--- a/packages/core/src/remote-host/server/hostRunner.ts
+++ b/packages/core/src/remote-host/server/hostRunner.ts
@@ -38,6 +38,7 @@ import {
 } from "../index.js";
 import { stripUndefined, undefinedPaths, unexpectedPaths } from "./firestoreSafeResult.js";
 import { PRESENCE_STALE_BEATS, createPresenceBeat, type PresenceBeat } from "./presenceBeat.js";
+import { monotonicNowMs } from "./monotonicClock.js";
 
 // Exported so a host that judges presence freshness from the outside (a probe that
 // reads the doc back) measures against the same beat the runner writes on.
@@ -241,7 +242,8 @@ interface ListenerRun {
   retryTimer: ReturnType<typeof setTimeout> | null;
   attempt: number;
   // Start of the current outage, or null while healthy. `attempt` still drives the
-  // backoff ladder; only the give-up decision reads the clock.
+  // backoff ladder; only the give-up decision reads the clock — a MONOTONIC one, so
+  // a clock step cannot spend this window on its own.
   downSinceMs: number | null;
 }
 
@@ -250,6 +252,8 @@ interface ListenerRun {
 // orderBy("createdAt") because a Firestore orderBy silently EXCLUDES docs missing
 // the field, dropping every pre-offline-queue command.
 const dispatchAddedCommands = (ctx: RunnerContext, snapshot: QuerySnapshot): void => {
+  // Wall clock on purpose, unlike the outage timers below: this is compared with a
+  // command's `expiresAt`, which the phone stamped from its own clock.
   const now = Date.now();
   snapshot
     .docChanges()
@@ -281,7 +285,7 @@ function scheduleResubscribe(run: ListenerRun): void {
 function handleListenError(run: ListenerRun, error: FirestoreError): void {
   run.ctx.options.onEvent?.({ phase: "error", method: "listen", message: error.message });
   if (run.stopped) return;
-  const now = Date.now();
+  const now = monotonicNowMs();
   run.downSinceMs ??= now;
   if (classifyListenerError(error) === "fatal" || shouldGiveUpListening(run.downSinceMs, now)) {
     run.goOffline();
@@ -339,8 +343,8 @@ export const presenceStaleAfterMs = (options: HostRunnerOptions = {}): number =>
 
 // Advertise online/offline + the capability set (method names + protocol version)
 // on the same doc the remote already listens to for presence, and watch whether
-// those writes are landing — see presenceBeat.ts for why the sensor is the age of
-// the last acknowledgement rather than a count of failures.
+// those writes are landing — see presenceBeat.ts for why the sensor counts the
+// beats that ran rather than the time that passed.
 const buildPresenceBeat = (
   firestore: Firestore,
   channel: Channel,
@@ -354,10 +358,10 @@ const buildPresenceBeat = (
     write: (online) => setDoc(presence, { ...buildHostPresence(channel, handlers, online), updatedAt: serverTimestamp() }),
     onError: (message) => report(`presence write failed: ${message}`),
     onStale: (silentMs) => {
-      report(`no presence write acknowledged for ${Math.round(silentMs / 1_000)}s — the remote cannot see this host`);
+      report(`no presence write acknowledged across ${PRESENCE_STALE_BEATS} beats (${Math.round(silentMs / 1_000)}s) — the remote cannot see this host`);
       onStale();
     },
-    staleAfterMs: presenceStaleAfterMs(options),
+    staleAfterBeats: PRESENCE_STALE_BEATS,
   });
 };
 

--- a/packages/core/src/remote-host/server/monotonicClock.ts
+++ b/packages/core/src/remote-host/server/monotonicClock.ts
@@ -1,0 +1,14 @@
+// The clock the runner measures its OWN elapsed time with (#2845).
+//
+// `Date.now()` is the wall clock, and the wall clock moves for reasons that have
+// nothing to do with this process: an NTP step, a manual change, a VM syncing its
+// time after a suspend. A runner that measures "how long have we been failing"
+// against it reads those jumps as an outage — and one report arrived as
+// "no presence write acknowledged for 459s" from a host whose network was fine.
+//
+// Server-side only, which is where every caller lives.
+import { performance } from "node:perf_hooks";
+
+/** Milliseconds from an arbitrary origin, never moving backwards. Only differences
+ *  between two readings mean anything — never compare one to a wall-clock time. */
+export const monotonicNowMs = (): number => performance.now();

--- a/packages/core/src/remote-host/server/presenceBeat.ts
+++ b/packages/core/src/remote-host/server/presenceBeat.ts
@@ -14,8 +14,16 @@
 //
 // The write is injected so this file needs no Firestore: hostRunner binds it to
 // setDoc, tests bind it to a promise they control.
+//
+// Beats are COUNTED, not timed (#2845). Counting how much time passed answers a
+// different question than the one being asked: three beats' worth of wall clock
+// also elapses while the machine is asleep, while the event loop is blocked, and
+// when NTP steps the clock — in every one of those the beat never ran, so nothing
+// was ever attempted, let alone failed. Counting only the beats that RAN cannot
+// confuse the two, and needs no clock at all.
+import { monotonicNowMs } from "./monotonicClock.js";
 
-// Beats a write may go unacknowledged before the host stops claiming to be online.
+// Beats that may RUN unacknowledged before the host stops claiming to be online.
 // One missed beat is a blip; three means the phone has had nothing fresh to read
 // for as long as it takes to notice.
 export const PRESENCE_STALE_BEATS = 3;
@@ -23,11 +31,12 @@ export const PRESENCE_STALE_BEATS = 3;
 export interface PresenceBeatDeps {
   /** Announce online/offline. Resolves when the backend has the write. */
   write: (online: boolean) => Promise<void>;
-  /** No write has been acknowledged for `silentMs` — the phone cannot see this host. */
+  /** `staleAfterBeats` beats have run with nothing acknowledged — the phone cannot see
+   *  this host. `silentMs` is how long that took, for the report only. */
   onStale: (silentMs: number) => void;
   /** A write was refused (auth, rules, quota). Carries the reason, which used to be dropped. */
   onError: (message: string) => void;
-  staleAfterMs: number;
+  staleAfterBeats: number;
   now?: () => number;
 }
 
@@ -57,16 +66,18 @@ const notify = (report: () => void, onThrow?: (error: unknown) => void): void =>
 };
 
 export const createPresenceBeat = (deps: PresenceBeatDeps): PresenceBeat => {
-  const now = deps.now ?? Date.now;
+  const now = deps.now ?? monotonicNowMs;
   // Starts at "just acknowledged" so a host is given a full window to land its
   // first beat rather than being declared stale before it has written anything.
-  const state = { lastAckMs: now() };
+  // `lastAckMs` is carried for the report; `beatsSinceAck` is what decides.
+  const state = { lastAckMs: now(), beatsSinceAck: 0 };
 
   const announce = (online: boolean): void => {
     const fail = (error: unknown) => notify(() => deps.onError(errorText(error)));
     const ack = () =>
       notify(() => {
         state.lastAckMs = now();
+        state.beatsSinceAck = 0;
       });
     // A write can also fail SYNCHRONOUSLY — Firestore validates the payload before
     // it returns a promise (that is how one bad field throws before anything is
@@ -77,11 +88,11 @@ export const createPresenceBeat = (deps: PresenceBeatDeps): PresenceBeat => {
   };
 
   const beat = (): void => {
-    const silentMs = now() - state.lastAckMs;
+    state.beatsSinceAck += 1;
     // Deliberately no write here: another mutation would only queue up behind the
     // ones already stuck, and the answer for this beat is already known.
-    if (silentMs >= deps.staleAfterMs) {
-      notify(() => deps.onStale(silentMs));
+    if (state.beatsSinceAck >= deps.staleAfterBeats) {
+      notify(() => deps.onStale(now() - state.lastAckMs));
       return;
     }
     announce(true);

--- a/packages/core/src/remote-host/server/resilientRunner.ts
+++ b/packages/core/src/remote-host/server/resilientRunner.ts
@@ -9,13 +9,17 @@
 // parked blob — the only path that fixes an actually-dead credential.
 //
 // The give-up rule is TIME, not a count of relaunches, so a long outage does not
-// burn through a budget while nothing can possibly succeed.
+// burn through a budget while nothing can possibly succeed. Time this process was
+// not RUNNING is excluded from it, which is what `after` is for (#2845).
 //
 // It lives here rather than in each host because its correctness is a relation
 // between constants: SETTLE_MS must outlast `LISTEN_RETRY_WINDOW_MS`'s reporting
-// delay, and PROBE_INTERVAL_MS must sit above `presenceStaleAfterMs()`. While the
-// two hosts each kept a copy, raising LISTEN_RETRY_WINDOW_MS from ~31s to 5 minutes
-// silently disabled `giveUp` in the copy that had not been told (#2643).
+// delay, PROBE_INTERVAL_MS must sit above `presenceStaleAfterMs()`, and
+// RESUME_GAP_MS must sit above ordinary timer jitter yet below GIVE_UP_MS — above,
+// or every late timer restarts the budget and nothing ever escalates; below, or a
+// gap can still spend the whole budget undetected. While the two hosts each kept a
+// copy, raising LISTEN_RETRY_WINDOW_MS from ~31s to 5 minutes silently disabled
+// `giveUp` in the copy that had not been told (#2643).
 import type { RunnerHealth, RunnerHealthState } from "../health.js";
 import type { HostRunnerOptions } from "./hostRunner.js";
 import type { RemoteHostLogger } from "./lifecycle.js";
@@ -127,7 +131,9 @@ const after = (ctx: RunnerContext, delayMs: number, task: () => void): CancelTim
   return ctx.schedule(() => {
     const overshootMs = ctx.now() - dueMs;
     if (overshootMs > RESUME_GAP_MS) {
-      ctx.deps.log.warn(`host runner resumed after a ${Math.round(overshootMs / ONE_SECOND_MS)}s gap; the outage budget starts again`);
+      // Says only what is true in both cases: this fires while healthy too, where
+      // there is no outage for the budget to be "restarting".
+      ctx.deps.log.warn(`host runner resumed after a ${Math.round(overshootMs / ONE_SECOND_MS)}s gap; that time does not count as outage`);
       ctx.downSinceMs = null;
       ctx.attempt = 0;
     }

--- a/packages/core/src/remote-host/server/resilientRunner.ts
+++ b/packages/core/src/remote-host/server/resilientRunner.ts
@@ -20,6 +20,7 @@ import type { RunnerHealth, RunnerHealthState } from "../health.js";
 import type { HostRunnerOptions } from "./hostRunner.js";
 import type { RemoteHostLogger } from "./lifecycle.js";
 import type { Liveness } from "./presenceProbe.js";
+import { monotonicNowMs } from "./monotonicClock.js";
 
 const ONE_SECOND_MS = 1_000;
 const ONE_MINUTE_MS = 60 * ONE_SECOND_MS;
@@ -34,6 +35,10 @@ const GIVE_UP_MS = 5 * ONE_MINUTE_MS;
 // How often to ask whether the phone can still see us. Slower than the one-minute
 // heartbeat, because the question is "are the beats landing", not "did this one".
 const PROBE_INTERVAL_MS = 90 * ONE_SECOND_MS;
+// A task firing this much later than it asked for did not merely run late: the
+// process was not running at all (system sleep, a blocked event loop). Ordinary
+// load costs a timer milliseconds, not a minute.
+const RESUME_GAP_MS = ONE_MINUTE_MS;
 
 export const reconnectDelayMs = (attempt: number): number => Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** attempt);
 
@@ -54,13 +59,20 @@ export interface ResilientHostRunnerDeps {
   onHealth?: (health: RunnerHealth) => void;
   log: Pick<RemoteHostLogger, "info" | "warn">;
   schedule?: (task: () => void, delayMs: number) => CancelTimer;
+  /** Measures how long things have taken. MONOTONIC by default — never render one
+   *  of its readings, and never compare it with a wall-clock time. */
   now?: () => number;
+  /** Wall-clock epoch ms, and used for `RunnerHealth.changedAt` alone, which the UI
+   *  renders as a time. Separate from `now` on purpose: an epoch that quietly became
+   *  "ms since this process started" reads as 1970 in the UI. */
+  wallNow?: () => number;
 }
 
 interface RunnerContext {
   deps: ResilientHostRunnerDeps;
   schedule: (task: () => void, delayMs: number) => CancelTimer;
   now: () => number;
+  wallNow: () => number;
   stopUnderlying: (() => void) | null;
   cancelTimer: CancelTimer | null;
   attempt: number;
@@ -86,7 +98,7 @@ const scheduleWithTimeout = (task: () => void, delayMs: number): CancelTimer => 
 const setState = (ctx: RunnerContext, next: RunnerHealthState): void => {
   ctx.state = next;
   try {
-    ctx.deps.onHealth?.({ state: next, lastError: ctx.lastError, changedAt: ctx.now() });
+    ctx.deps.onHealth?.({ state: next, lastError: ctx.lastError, changedAt: ctx.wallNow() });
   } catch (error) {
     ctx.deps.log.warn(`host runner health observer threw: ${errorText(error)}`);
   }
@@ -102,12 +114,33 @@ const clearProbe = (ctx: RunnerContext): void => {
   ctx.cancelProbe = null;
 };
 
+// Schedule, and notice when the process was not running for part of the wait.
+//
+// Time this host spent frozen is not time the channel spent failing, but the outage
+// budget cannot tell them apart on its own: a gap longer than GIVE_UP_MS spends the
+// whole budget while nothing was ever attempted, and the ring then escalates to the
+// client without one try against the network as it now stands (#2845). So a gap
+// restarts the budget and the backoff ladder, and the task runs as the first attempt
+// after it.
+const after = (ctx: RunnerContext, delayMs: number, task: () => void): CancelTimer => {
+  const dueMs = ctx.now() + delayMs;
+  return ctx.schedule(() => {
+    const overshootMs = ctx.now() - dueMs;
+    if (overshootMs > RESUME_GAP_MS) {
+      ctx.deps.log.warn(`host runner resumed after a ${Math.round(overshootMs / ONE_SECOND_MS)}s gap; the outage budget starts again`);
+      ctx.downSinceMs = null;
+      ctx.attempt = 0;
+    }
+    task();
+  }, delayMs);
+};
+
 // Only worth asking while we believe we are up: during a reconnect the answer is
 // already known, and the recovery it would trigger is the one already running.
 function scheduleProbe(ctx: RunnerContext): void {
   if (ctx.stopped || !ctx.deps.checkAlive) return;
   clearProbe(ctx);
-  ctx.cancelProbe = ctx.schedule(() => void runProbe(ctx), PROBE_INTERVAL_MS);
+  ctx.cancelProbe = after(ctx, PROBE_INTERVAL_MS, () => void runProbe(ctx));
 }
 
 // `alive: null` (no probe wired, or nothing judgeable yet) is not an answer — the
@@ -203,7 +236,7 @@ function scheduleRelaunch(ctx: RunnerContext): void {
   // Re-announcing on every relaunch would restamp `changedAt`, and a UI reading it
   // as "down since" would reset to zero each cycle of the outage it is reporting.
   if (ctx.state !== "reconnecting") setState(ctx, "reconnecting");
-  ctx.cancelTimer = ctx.schedule(() => launch(ctx), delayMs);
+  ctx.cancelTimer = after(ctx, delayMs, () => launch(ctx));
 }
 
 function onUnderlyingClosed(ctx: RunnerContext): void {
@@ -247,14 +280,15 @@ function launch(ctx: RunnerContext): void {
     onUnderlyingClosed(ctx);
     return;
   }
-  ctx.cancelTimer = ctx.schedule(() => void settle(ctx), SETTLE_MS);
+  ctx.cancelTimer = after(ctx, SETTLE_MS, () => void settle(ctx));
 }
 
 export function startResilientHostRunner(deps: ResilientHostRunnerDeps): () => void {
   const ctx: RunnerContext = {
     deps,
     schedule: deps.schedule ?? scheduleWithTimeout,
-    now: deps.now ?? Date.now,
+    now: deps.now ?? monotonicNowMs,
+    wallNow: deps.wallNow ?? Date.now,
     stopUnderlying: null,
     cancelTimer: null,
     attempt: 0,

--- a/packages/core/test/remote-host/test_presenceBeat.ts
+++ b/packages/core/test/remote-host/test_presenceBeat.ts
@@ -14,7 +14,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { createPresenceBeat, type PresenceBeatDeps } from "../../src/remote-host/server/presenceBeat.js";
+import { createPresenceBeat, type PresenceBeat, type PresenceBeatDeps } from "../../src/remote-host/server/presenceBeat.js";
 
 const STALE_AFTER_BEATS = 3;
 const HEARTBEAT_MS = 60_000;
@@ -30,38 +30,54 @@ interface WriteRecord {
   reject: (reason: unknown) => void;
 }
 
+interface FakeClock {
+  nowMs: number;
+}
+
+// A write that settles only when the test says so — which is the point: Firestore
+// holds an undeliverable mutation rather than failing it.
+const pendingWrite =
+  (writes: WriteRecord[]) =>
+  (online: boolean): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+      writes.push({ online, resolve: () => resolve(), reject });
+    });
+
+// A missing write means the beat never attempted one — fail there, not on `.reject` of undefined.
+const writeAtOf =
+  (writes: WriteRecord[]) =>
+  (index: number): WriteRecord => {
+    const write = writes[index];
+    assert.ok(write, `expected a write at index ${index}, got ${writes.length}`);
+    return write;
+  };
+
+// The timer firing on schedule: one beat per heartbeat, the clock moving with it.
+const beatTimesOf =
+  (clock: FakeClock, beat: PresenceBeat) =>
+  (count: number): void => {
+    Array.from({ length: count }).forEach(() => {
+      clock.nowMs += HEARTBEAT_MS;
+      beat.beat();
+    });
+  };
+
 // A beat whose writes stay pending until the test decides their fate, plus the
 // clock it reads. `writes` is every write attempted, newest last.
 const makeBeat = (overrides: Partial<PresenceBeatDeps> = {}) => {
-  const clock = { nowMs: 1_000_000 };
+  const clock: FakeClock = { nowMs: 1_000_000 };
   const writes: WriteRecord[] = [];
   const stale: number[] = [];
   const errors: string[] = [];
   const beat = createPresenceBeat({
-    write: (online) =>
-      new Promise<void>((resolve, reject) => {
-        writes.push({ online, resolve: () => resolve(), reject });
-      }),
+    write: pendingWrite(writes),
     onStale: (silentMs) => stale.push(silentMs),
     onError: (message) => errors.push(message),
     staleAfterBeats: STALE_AFTER_BEATS,
     now: () => clock.nowMs,
     ...overrides,
   });
-  // A missing write means the beat never attempted one — fail there, not on `.reject` of undefined.
-  const writeAt = (index: number): WriteRecord => {
-    const write = writes[index];
-    assert.ok(write, `expected a write at index ${index}, got ${writes.length}`);
-    return write;
-  };
-  // The timer firing on schedule: one beat per heartbeat, the clock moving with it.
-  const beatTimes = (count: number): void => {
-    Array.from({ length: count }).forEach(() => {
-      clock.nowMs += HEARTBEAT_MS;
-      beat.beat();
-    });
-  };
-  return { beat, beatTimes, clock, writes, writeAt, stale, errors };
+  return { beat, beatTimes: beatTimesOf(clock, beat), clock, writes, writeAt: writeAtOf(writes), stale, errors };
 };
 
 describe("createPresenceBeat", () => {

--- a/packages/core/test/remote-host/test_presenceBeat.ts
+++ b/packages/core/test/remote-host/test_presenceBeat.ts
@@ -3,9 +3,11 @@
 //   - a write that NEVER settles goes stale — the case a rejection counter misses,
 //     because Firestore queues an undeliverable write instead of rejecting it
 //   - a rejected write is reported with its reason AND does not count as an ack
-//   - an acknowledgement resets the age, so a recovered channel is not declared dead
+//   - an acknowledgement resets the count, so a recovered channel is not declared dead
 //   - once stale, the beat reports instead of queueing yet another write
-//   - boundary: exactly `staleAfterMs` of silence is already stale
+//   - boundary: exactly `staleAfterBeats` beats is already stale
+//   - regression (#2845): wall-clock time alone never makes it stale, however much
+//     of it passes, because beats that never RAN are not beats that failed
 //
 // The Firestore write is injected, so these run with a fake clock and promises the
 // test controls — no Firebase, no waiting out a three-minute window.
@@ -14,7 +16,8 @@ import assert from "node:assert/strict";
 
 import { createPresenceBeat, type PresenceBeatDeps } from "../../src/remote-host/server/presenceBeat.js";
 
-const STALE_AFTER_MS = 180_000;
+const STALE_AFTER_BEATS = 3;
+const HEARTBEAT_MS = 60_000;
 
 // Let the injected write's `.then` handlers run: the ack lands in a microtask.
 const settle = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
@@ -41,7 +44,7 @@ const makeBeat = (overrides: Partial<PresenceBeatDeps> = {}) => {
       }),
     onStale: (silentMs) => stale.push(silentMs),
     onError: (message) => errors.push(message),
-    staleAfterMs: STALE_AFTER_MS,
+    staleAfterBeats: STALE_AFTER_BEATS,
     now: () => clock.nowMs,
     ...overrides,
   });
@@ -51,14 +54,20 @@ const makeBeat = (overrides: Partial<PresenceBeatDeps> = {}) => {
     assert.ok(write, `expected a write at index ${index}, got ${writes.length}`);
     return write;
   };
-  return { beat, clock, writes, writeAt, stale, errors };
+  // The timer firing on schedule: one beat per heartbeat, the clock moving with it.
+  const beatTimes = (count: number): void => {
+    Array.from({ length: count }).forEach(() => {
+      clock.nowMs += HEARTBEAT_MS;
+      beat.beat();
+    });
+  };
+  return { beat, beatTimes, clock, writes, writeAt, stale, errors };
 };
 
 describe("createPresenceBeat", () => {
-  it("announces while the last acknowledgement is fresh", async () => {
-    const { beat, clock, writes, stale } = makeBeat();
-    clock.nowMs += STALE_AFTER_MS - 1;
-    beat.beat();
+  it("announces while the last acknowledgement is fresh", () => {
+    const { beatTimes, writes, stale } = makeBeat();
+    beatTimes(1);
     assert.deepEqual(
       writes.map((write) => write.online),
       [true],
@@ -67,7 +76,7 @@ describe("createPresenceBeat", () => {
   });
 
   it("goes stale on a write that never settles — the offline case, which never rejects", async () => {
-    const { beat, clock, writes, stale } = makeBeat();
+    const { beat, beatTimes, writes, stale } = makeBeat();
     beat.announce(true);
     await settle();
     // The write is still pending: Firestore holds an undeliverable mutation rather
@@ -75,9 +84,14 @@ describe("createPresenceBeat", () => {
     assert.equal(writes.length, 1);
     assert.deepEqual(stale, []);
 
-    clock.nowMs += STALE_AFTER_MS;
-    beat.beat();
-    assert.deepEqual(stale, [STALE_AFTER_MS]);
+    beatTimes(STALE_AFTER_BEATS);
+    assert.equal(stale.length, 1);
+  });
+
+  it("reports how long the silence lasted, for the log line", () => {
+    const { beatTimes, stale } = makeBeat();
+    beatTimes(STALE_AFTER_BEATS);
+    assert.deepEqual(stale, [STALE_AFTER_BEATS * HEARTBEAT_MS]);
   });
 
   it("reports a rejected write with its reason", async () => {
@@ -89,49 +103,44 @@ describe("createPresenceBeat", () => {
   });
 
   it("a rejected write does not count as an acknowledgement", async () => {
-    const { beat, clock, writeAt, stale } = makeBeat();
+    const { beat, beatTimes, writeAt, stale } = makeBeat();
     beat.announce(true);
     writeAt(0).reject(new Error("unavailable"));
     await settle();
 
-    clock.nowMs += STALE_AFTER_MS;
-    beat.beat();
-    assert.deepEqual(stale, [STALE_AFTER_MS]);
+    beatTimes(STALE_AFTER_BEATS);
+    assert.equal(stale.length, 1);
   });
 
-  it("an acknowledgement resets the age, so a recovered channel stays online", async () => {
-    const { beat, clock, writes, writeAt, stale } = makeBeat();
-    beat.announce(true);
-    clock.nowMs += STALE_AFTER_MS - 1;
+  it("an acknowledgement resets the count, so a recovered channel stays online", async () => {
+    const { beatTimes, writes, writeAt, stale } = makeBeat();
+    beatTimes(STALE_AFTER_BEATS - 1); // one beat short of stale
+    assert.deepEqual(stale, []);
+
     writeAt(0).resolve();
     await settle();
 
-    // Another full window minus a tick since that ack: still fresh.
-    clock.nowMs += STALE_AFTER_MS - 1;
-    beat.beat();
+    // A full window minus one beat since that ack: still fresh.
+    beatTimes(STALE_AFTER_BEATS - 1);
     assert.deepEqual(stale, []);
-    assert.equal(writes.length, 2);
+    assert.equal(writes.length, 2 * (STALE_AFTER_BEATS - 1));
   });
 
-  it("stops writing once stale — another mutation would only queue behind the stuck ones", async () => {
-    const { beat, clock, writes, stale } = makeBeat();
-    beat.announce(true);
-    clock.nowMs += STALE_AFTER_MS;
-    beat.beat();
-    beat.beat();
-    assert.equal(writes.length, 1);
+  it("stops writing once stale — another mutation would only queue behind the stuck ones", () => {
+    const { beatTimes, writes, stale } = makeBeat();
+    beatTimes(STALE_AFTER_BEATS + 1);
+    // The beats before the threshold wrote; the two at and past it did not.
+    assert.equal(writes.length, STALE_AFTER_BEATS - 1);
     assert.equal(stale.length, 2);
   });
 
-  it("treats exactly staleAfterMs of silence as stale (boundary)", async () => {
-    const { beat, clock, stale } = makeBeat();
-    clock.nowMs += STALE_AFTER_MS - 1;
-    beat.beat();
+  it("treats exactly staleAfterBeats beats as stale (boundary)", () => {
+    const { beatTimes, stale } = makeBeat();
+    beatTimes(STALE_AFTER_BEATS - 1);
     assert.deepEqual(stale, []);
 
-    clock.nowMs += 1;
-    beat.beat();
-    assert.deepEqual(stale, [STALE_AFTER_MS]);
+    beatTimes(1);
+    assert.equal(stale.length, 1);
   });
 
   it("reports a non-Error rejection as text rather than dropping it", async () => {
@@ -140,6 +149,33 @@ describe("createPresenceBeat", () => {
     writeAt(0).reject("just a string");
     await settle();
     assert.deepEqual(errors, ["just a string"]);
+  });
+});
+
+// #2845. A host reported "no presence write acknowledged for 459s" with a working
+// network: 459 is not a number the old sensor could reach while its 60s timer was
+// firing (three beats put it at 180s and it never got further), so the beats had
+// not run at all — the machine had been asleep, or the clock had stepped. Measuring
+// elapsed time cannot tell "nothing was attempted" from "everything failed";
+// counting the beats that ran can only ever mean the latter.
+describe("createPresenceBeat — time that passes without beats is not an outage", () => {
+  it("stays online across an hour of wall clock in which no beat ran", async () => {
+    const { beat, beatTimes, clock, writes, stale } = makeBeat();
+    beat.announce(true);
+    await settle();
+
+    clock.nowMs += 60 * 60_000; // asleep, stalled, or the clock stepped
+
+    beatTimes(1);
+    assert.deepEqual(stale, [], "a gap in the beats is not evidence that any write failed");
+    assert.equal(writes.length, 2, "the beat after the gap writes, rather than declaring the host dead");
+  });
+
+  it("still goes stale after the gap if the channel really is down", () => {
+    const { beatTimes, clock, stale } = makeBeat();
+    clock.nowMs += 60 * 60_000;
+    beatTimes(STALE_AFTER_BEATS);
+    assert.equal(stale.length, 1);
   });
 });
 
@@ -153,16 +189,17 @@ describe("createPresenceBeat — a broken observer must not take the host down",
   };
 
   it("survives an onStale that throws, and keeps beating afterwards", async () => {
-    const { beat, clock, writes } = makeBeat({ onStale: boom });
-    clock.nowMs += STALE_AFTER_MS;
+    const { beat, beatTimes, writes } = makeBeat({ onStale: boom });
+    beatTimes(STALE_AFTER_BEATS);
     assert.doesNotThrow(() => beat.beat());
 
     // A later ack clears the staleness, and the next beat writes again.
     beat.announce(true);
     writes.at(-1)?.resolve();
     await settle();
-    beat.beat();
-    assert.equal(writes.length, 2); // the announce above, then this beat
+    const writesBefore = writes.length;
+    beatTimes(1);
+    assert.equal(writes.length, writesBefore + 1);
   });
 
   it("survives an onError that throws (an unhandled rejection would end the process)", async () => {
@@ -181,7 +218,7 @@ describe("createPresenceBeat — a broken observer must not take the host down",
       },
       onStale: () => undefined,
       onError: (message) => errors.push(message),
-      staleAfterMs: STALE_AFTER_MS,
+      staleAfterBeats: STALE_AFTER_BEATS,
     });
     assert.doesNotThrow(() => beat.beat());
     assert.deepEqual(errors, ["firestore is gone"]);

--- a/packages/core/test/remote-host/test_resilientRunner.ts
+++ b/packages/core/test/remote-host/test_resilientRunner.ts
@@ -49,16 +49,23 @@ const fakeClock = () => {
       };
     },
     pendingCount: () => pending.size,
+    // Time passing with the process NOT running — a system sleep, a blocked event
+    // loop. Due timers stay pending and fire, late, on the next advance. `advance`
+    // cannot express this: it runs every task at the exact moment it came due.
+    sleep: (deltaMs: number) => {
+      state.nowMs += deltaMs;
+    },
     advance: (deltaMs: number) => {
       const targetMs = state.nowMs + deltaMs;
       for (;;) {
         const due = nextDue(targetMs);
         if (!due) break;
         pending.delete(due[0]);
-        state.nowMs = due[1].atMs;
+        // Never backwards: after a `sleep` the due time is already in the past.
+        state.nowMs = Math.max(state.nowMs, due[1].atMs);
         due[1].task();
       }
-      state.nowMs = targetMs;
+      state.nowMs = Math.max(state.nowMs, targetMs);
     },
   };
 };
@@ -81,19 +88,26 @@ const fakeRunner = () => {
   };
 };
 
+// How far the fake wall clock sits from the fake elapsed clock. Offset on purpose:
+// `changedAt` is an epoch the UI renders as a time, and a test in which both clocks
+// read the same number could not tell one being used for the other (#2845).
+const EPOCH_OFFSET_MS = 1_700_000_000_000;
+
 const setup = (overrides: Partial<ResilientHostRunnerDeps> = {}) => {
   const clock = fakeClock();
   const runner = fakeRunner();
   const logs = { info: [] as string[], warn: [] as string[] };
+  const wallNow = () => clock.now() + EPOCH_OFFSET_MS;
   const stop = startResilientHostRunner({
     start: runner.start,
     options: {},
     log: { info: (msg) => logs.info.push(msg), warn: (msg) => logs.warn.push(msg) },
     schedule: clock.schedule,
     now: clock.now,
+    wallNow,
     ...overrides,
   });
-  return { clock, runner, logs, stop };
+  return { clock, runner, logs, stop, wallNow };
 };
 
 // An outage nothing recovers from: every relaunch is killed before it can settle,
@@ -473,20 +487,25 @@ describe("startResilientHostRunner — health reporting", () => {
   });
 
   it("carries the channel error, and drops it again on recovery", async () => {
-    const { clock, runner, health } = withHealth();
+    const { clock, runner, health, wallNow } = withHealth();
     runner.started[0]?.onEvent?.({ phase: "error", method: "listen", message: "unavailable" });
     runner.die();
     assert.equal(health.at(-1)?.lastError, "listen: unavailable");
 
     await advanceAsync(clock, 1_000 + SETTLE_MS);
-    assert.deepEqual(health.at(-1), { state: "online", lastError: null, changedAt: clock.now() });
+    assert.deepEqual(health.at(-1), { state: "online", lastError: null, changedAt: wallNow() });
   });
 
-  it("stamps each change with the clock it was given", () => {
-    const { clock, runner, health } = withHealth();
+  // `changedAt` is documented as "ms epoch of the last state change, so the UI can
+  // say how long it has been down". The clock the runner measures outages with is
+  // monotonic and counts from process start, so stamping this from it would render
+  // as 1970 (#2845).
+  it("stamps each change with the wall clock, not the elapsed-time clock", () => {
+    const { clock, runner, health, wallNow } = withHealth();
     clock.advance(5_000);
     runner.die();
-    assert.equal(health.at(-1)?.changedAt, clock.now());
+    assert.equal(health.at(-1)?.changedAt, wallNow());
+    assert.notEqual(health.at(-1)?.changedAt, clock.now());
   });
 
   // A host with no health UI passes no callback; nothing here may depend on one.
@@ -517,5 +536,59 @@ describe("startResilientHostRunner — health reporting", () => {
       logs.warn.some((msg) => msg.includes("health observer threw: observer blew up")),
       logs.warn.join(" | "),
     );
+  });
+});
+
+// #2845. The give-up rule is TIME, and time is exactly what a frozen process keeps
+// spending: a host reported "no presence write acknowledged for 459s" — a number
+// its 60s beat could not reach while running — and by the time anything ran again
+// the five-minute budget was gone, so the ring escalated to the client without one
+// attempt against the network as it then stood. A gap in which nothing ran is not
+// an outage the channel is responsible for.
+describe("startResilientHostRunner — a gap in which nothing ran does not spend the budget", () => {
+  const GAP_MS = GIVE_UP_MS + 60_000;
+
+  it("does not give up when an overdue relaunch fires after a gap longer than the whole budget", async () => {
+    const closures = { count: 0 };
+    const { clock, runner, logs } = setup({
+      options: {
+        onClosed: () => {
+          closures.count += 1;
+        },
+      },
+    });
+    runner.die(); // the outage starts; a relaunch is queued one second out
+    clock.sleep(GAP_MS); // asleep / stalled: the wall clock moves, nothing runs
+    await advanceAsync(clock, 0); // and now the overdue relaunch fires
+
+    assert.equal(closures.count, 0, "gave up without one attempt against the network as it now stands");
+    assert.equal(runner.started.length, 2, "the overdue relaunch still runs");
+    assert.ok(
+      logs.warn.some((msg) => msg.includes("resumed after a")),
+      logs.warn.join(" | "),
+    );
+  });
+
+  it("still gives up if the channel keeps failing after the gap", async () => {
+    const closures = { count: 0 };
+    const { clock, runner } = setup({
+      options: {
+        onClosed: () => {
+          closures.count += 1;
+        },
+      },
+    });
+    runner.die();
+    clock.sleep(GAP_MS);
+    await advanceAsync(clock, 0);
+
+    keepFailing(clock, runner, 11); // 363s of real, attempted failure > the 5-minute window
+    assert.equal(closures.count, 1);
+  });
+
+  it("leaves the budget alone when a task merely fires on time", () => {
+    const { clock, runner, logs } = setup({ options: { onClosed: () => undefined } });
+    keepFailing(clock, runner, 11);
+    assert.ok(!logs.warn.some((msg) => msg.includes("resumed after a")), "ordinary backoff must not read as a gap");
   });
 });

--- a/packages/core/test/remote-host/test_resilientRunner.ts
+++ b/packages/core/test/remote-host/test_resilientRunner.ts
@@ -31,13 +31,27 @@ interface PendingTask {
   task: () => void;
 }
 
+const nextDue = (pending: Map<number, PendingTask>, targetMs: number): [number, PendingTask] | undefined =>
+  [...pending.entries()].filter(([, timer]) => timer.atMs <= targetMs).sort(([, left], [, right]) => left.atMs - right.atMs)[0];
+
+// Run everything due by `targetMs`, oldest first, then land the clock there.
+// Never backwards: after a `sleep` the due time is already in the past.
+const runDue = (pending: Map<number, PendingTask>, state: { nowMs: number }, targetMs: number): void => {
+  for (;;) {
+    const due = nextDue(pending, targetMs);
+    if (!due) break;
+    pending.delete(due[0]);
+    state.nowMs = Math.max(state.nowMs, due[1].atMs);
+    due[1].task();
+  }
+  state.nowMs = Math.max(state.nowMs, targetMs);
+};
+
 // A controllable clock: the windows here are minutes long, so tests drive time
 // rather than wait for it.
 const fakeClock = () => {
   const state = { nowMs: 1_000_000, nextKey: 1 };
   const pending = new Map<number, PendingTask>();
-  const nextDue = (targetMs: number): [number, PendingTask] | undefined =>
-    [...pending.entries()].filter(([, timer]) => timer.atMs <= targetMs).sort(([, left], [, right]) => left.atMs - right.atMs)[0];
   return {
     now: () => state.nowMs,
     schedule: (task: () => void, delayMs: number) => {
@@ -55,18 +69,7 @@ const fakeClock = () => {
     sleep: (deltaMs: number) => {
       state.nowMs += deltaMs;
     },
-    advance: (deltaMs: number) => {
-      const targetMs = state.nowMs + deltaMs;
-      for (;;) {
-        const due = nextDue(targetMs);
-        if (!due) break;
-        pending.delete(due[0]);
-        // Never backwards: after a `sleep` the due time is already in the past.
-        state.nowMs = Math.max(state.nowMs, due[1].atMs);
-        due[1].task();
-      }
-      state.nowMs = Math.max(state.nowMs, targetMs);
-    },
+    advance: (deltaMs: number) => runDue(pending, state, state.nowMs + deltaMs),
   };
 };
 

--- a/plans/fix-2845-presence-wall-clock.md
+++ b/plans/fix-2845-presence-wall-clock.md
@@ -1,0 +1,87 @@
+# fix(remote-host): presence の staleness と give-up を壁時計から切り離す
+
+issue: #2845
+
+## 何が壊れているか
+
+ユーザー報告:
+
+```
+Remote host disconnected
+Your phone can no longer reach this Mac. Last error: presence: no presence write acknowledged for 459s — the remote cannot see this host.
+```
+
+459 という数字がバグの証拠になっている。heartbeat は 60 秒、stale 判定は 3 beats = 180 秒
+(`presenceBeat.ts` の `silentMs >= staleAfterMs`)。beat が正常に発火していれば silentMs は
+60 → 120 → 180 と進むので、**真のオフラインでは必ず 180 秒で報告される**。何時間切れていても 180 秒。
+
+459 秒が出るには、その1つ前の beat が 180 秒未満の時点を通っている必要がある。つまり
+**約 280 秒以上、60 秒タイマーが1度も発火していない**。これは「通信が切れた」記録ではなく
+「壁時計だけ進んで beat が動いていない」記録である。
+
+そうなる原因は3つあり、現状のコードはどれも区別できない:
+
+- システムスリープ（MacBook の蓋閉じ。プロセスが凍り、壁時計だけ進む）
+- 時計のジャンプ（NTP のステップ補正、手動変更、VM / デュアルブートの時刻同期）
+- イベントループの長時間ブロック
+
+そして壊れ方は2段階ある:
+
+1. **誤検知** — `presenceBeat` は経過時間だけで判定するので、「beat が実行されて失敗した」と
+   「beat がそもそも実行されていない」を区別できない
+2. **無試行 give-up** — `resilientRunner` の `onUnderlyingClosed` は
+   `ctx.now() - ctx.downSinceMs >= GIVE_UP_MS`（壁時計・5分）で諦める。空白が5分を超えていると、
+   **ネットワークが正常に戻った状態で1回も再接続を試さないまま** `giveUp` → `onClosed` →
+   ホストは `offline`、ユーザーには手動再接続の通知が出る
+
+## 直し方
+
+### 1. presenceBeat: 経過時間ではなく「実際に走った beat の数」で判定する
+
+`PRESENCE_STALE_BEATS = 3` は元々「3 beats」と言っている。それを時間に換算していたことが誤検知の
+原因なので、換算をやめて beat を数える。
+
+- `staleAfterMs` → `staleAfterBeats`
+- ack が来たら 0 に戻す（今の `lastAckMs` リセットと同じ位置）
+- `beat()` は「走った」ことを1つ数え、閾値に達したら stale
+
+これで**時計を一切読まずに**判定できる。スリープ・時計ジャンプ・ストールのいずれでも beat は走って
+いないので数は増えず、誤検知が原理的に起きない。真のオフラインでは今までどおり3回目の beat（180秒）で
+stale になる。
+
+`lastAckMs` は**報告用にのみ**残す（メッセージに載せる経過秒数）。判定には使わない。
+
+`presenceStaleAfterMs()` の export はそのまま。あれは presence doc を**外から**読む probe が使う
+サーバ時刻ベースの鮮度判定で、こちらの問題とは別のもの。
+
+### 2. resilientRunner: プロセスが動いていなかった時間を outage 予算から外す
+
+give-up は仕様どおり時間で測る（relaunch の回数ではない）。ただし「動いていなかった時間」は
+チャネルが失敗していた時間ではないので、予算から外す。
+
+- スケジュールしたタスクが**要求した遅延より大きく遅れて発火**したら、それはプロセスが動いていな
+  かった証拠。`downSinceMs` を null に戻し（予算を測り直す）、backoff の段も 0 に戻す
+- 閾値 `RESUME_GAP_MS` は 1 分。通常の負荷でタイマーが1分遅れることはない
+- `now` の既定を単調時計にする。時計が**後ろに**飛ぶと `now() - downSinceMs` が負になり
+  永久に諦めなくなるため、既定を `Date.now` のままにはしない
+
+### 3. hostRunner: リスナ側の outage 時計も単調時計に
+
+`handleListenError` の `downSinceMs` / `shouldGiveUpListening` も同じ壁時計依存。単調時計に替える。
+
+`dispatchAddedCommands` の `Date.now()` は**そのまま**。あれはコマンドの `expiresAt`（サーバ時刻）
+との比較なので、壁時計でなければならない。
+
+## テスト
+
+`now` と `schedule` はすべて注入可能なので、実時間を待たずに書ける。
+
+- presenceBeat: 3 beats 走れば stale / 時計だけ飛んでも beat が走っていなければ stale にならない /
+  ack で数が戻る / 境界（ちょうど 3 beats）
+- resilientRunner: 予算超えの空白のあとにタスクが発火したら give up せず再試行する /
+  通常の遅延では予算が測り直されない
+
+## 影響しないもの
+
+presence doc は `serverTimestamp()` で書かれるので、**スマホ側の「このホストが見えているか」の判定は
+変わらない**。ホストが自分自身を誤診する部分だけの修正。

--- a/plans/fix-2845-presence-wall-clock.md
+++ b/plans/fix-2845-presence-wall-clock.md
@@ -6,7 +6,7 @@ issue: #2845
 
 ユーザー報告:
 
-```
+```text
 Remote host disconnected
 Your phone can no longer reach this Mac. Last error: presence: no presence write acknowledged for 459s — the remote cannot see this host.
 ```


### PR DESCRIPTION
## Summary

remote-host が「スマホから見えているか」を自分で判定する部分と、外側リングの give-up 予算が、
どちらも**壁時計**で測っていた。プロセスが動いていなかった時間（スリープ / 時計ジャンプ /
イベントループ停止）も「チャネルが失敗していた時間」として数えてしまうため、

1. 通信が正常でも「切断」と誤検知し、
2. さらに空白が5分を超えていると、**復帰後に1回も再接続を試さないまま諦めて**、
   ユーザーに手動再接続を要求する

という2段階の壊れ方をしていた。判定を「実際に走った beat の数」に変え、空白を検出して outage
予算から外し、経過時間の計測を単調時計に移した。

Closes #2845

## Items to Confirm / Review

人間に見てほしい点:

1. **`staleAfterMs` → `staleAfterBeats` は core の内部 API 変更**。`createPresenceBeat` の
   呼び出し元は `hostRunner` だけで、published な `presenceStaleAfterMs()` / `createPresenceProbe`
   の signature は変えていない（MulmoTerminal 側の変更は不要）。この読みで合っているか。
2. **エラーメッセージの文言を変えた**: `no presence write acknowledged for 180s` →
   `no presence write acknowledged across 3 beats (180s)`。MulmoTerminal の通知に
   `Last error:` としてそのまま出る。beats を出すのは、次に同じ報告が来たときに
   「時計が飛んだ」と「本当に落ちている」を1行で切り分けられるようにするため。
3. **`RESUME_GAP_MS = 1分` という閾値**。「通常の負荷でタイマーが1分遅れることはない」という
   前提を置いている。もっと保守的にすべきか。
4. **`changedAt` のために時計を2本に分けた**（`now` = 単調 / `wallNow` = epoch）。
   実装中にここを踏みかけた（下記「途中で潰した回帰」）ので、分離の仕方が妥当か見てほしい。
5. **引き金は未確定**。報告環境でスリープ・時計・ストールのどれだったかは特定できていない。
   3つとも同じ壁時計依存に帰着するので修正内容は変わらないが、「これで本当に消えるか」の
   最終確認は報告者の再発有無を待つことになる。

## User Prompt

（複数ターンにわたるやり取りを、意図を落とさずまとめたもの）

- firebase のログインで、こういう報告が来た。心当たりある？
  ```
  Remote host disconnected
  Your phone can no longer reach this Mac. Last error: presence: no presence write
  acknowledged for 459s — the remote cannot see this host. Reconnect from the Remote
  host menu in the toolbar.
  ```
- これが発生する根本理由は分かる？ バグ？ オフライン？ 何？
- Mac の時計がおかしいときとか？
- （調査対象について）このマシンではない。ユーザーからの報告。
- issue を立てて。ユーザーに聞くので症状もまとめて。
- （issue のコメントへの返信について）書く必要ある？ 原因は分からないの？ こっちで何かできる？
- では、できる対策を入れよう。
- PR を作って、レビューまで。

## なぜ 459 がバグの証拠なのか

- heartbeat 60秒、stale 判定は 3 beats = 180秒（`silentMs >= staleAfterMs`）
- beat が正常に発火していれば silentMs は 60 → 120 → 180 と進むので、**真のオフラインでは
  必ず 180秒で報告される**。何時間切れていても 180秒
- 459秒が出るには、その1つ前の beat が 180秒未満の時点を通っている必要がある。つまり
  **約 280秒（4.7分）以上、60秒タイマーが1度も発火していない**

これは「通信が切れた」記録ではなく「壁時計だけ進んで beat が動いていない」記録だった。

## 変更点

### 1. `presenceBeat`: 経過時間ではなく「走った beat の数」で判定

`staleAfterMs` → `staleAfterBeats`。ack で 0 に戻す。**判定に時計を使わない**ので、beat が
走っていない限りカウントは増えず、スリープ・時計ジャンプ・ストールで誤検知しない。真のオフラインは
従来どおり3回目の beat（180秒）で stale。`lastAckMs` はログに載せる経過秒数のためだけに残した。

### 2. `resilientRunner`: 動いていなかった時間を outage 予算から外す

スケジュールしたタスクが要求より `RESUME_GAP_MS`（1分）以上遅れて発火したら、それはプロセスが
動いていなかった証拠として `downSinceMs` と backoff 段をリセットし、そのタスク自体が「空白明けの
最初の1回」になる。give-up は仕様どおり時間で測る（relaunch の回数ではない）ままにしてある。

### 3. 経過時間の計測を単調時計へ

`resilientRunner` の `now` と `hostRunner.handleListenError` の outage 時計を
`performance.now()` ベースに。時計が**後ろ**に飛ぶと `now() - downSinceMs` が負になり永久に
諦めなくなるため、既定を `Date.now` のままにはできない。

`dispatchAddedCommands` の `Date.now()` は**そのまま**残した。あれはコマンドの `expiresAt`
（スマホが自分の時計で押した値）との比較なので、壁時計でなければ正しくない。理由をコメントにした。

## 途中で潰した回帰

`now` の既定を単調時計にした時点で、`RunnerHealth.changedAt` が巻き添えになっていた。あれは
型定義で **"ms epoch of the last state change, so the UI can say how long it has been down"**
と約束している公開フィールドで、単調時計はプロセス起動からの経過ミリ秒なので、UI に 1970年と
出る。`wallNow` を別依存に分離し、テストでは2つの fake 時計をわざとオフセットさせて
「epoch 側から来ていること」を固定した。

## テスト

新規は #2845 の再現を直接固定するもの:

- 1時間の壁時計が流れても、beat が走っていなければ stale にしない
- その空白のあとも本当に失敗し続ければ、ちゃんと stale になる
- 予算より長い空白のあとに遅れて発火したタスクで give up しない（＋ログに `resumed after a` が出る）
- 空白のあとも失敗し続ければ、ちゃんと give up する
- 通常の backoff を空白と誤認しない
- `changedAt` は wall clock から来ていて、経過時間クロックからではない

fake clock に `sleep()`（時間だけ進めてタイマーを発火させない）を足した。既存の `advance()` は
各タスクをちょうど due の瞬間に実行するので、スリープを表現できなかった。

検証結果:

| | 結果 |
|---|---|
| `yarn test`（core） | 753 / 753 pass |
| `yarn typecheck`（core） | pass |
| eslint（変更ファイル） | 0 errors / 0 warnings |
| `yarn build`（core） | pass |
| `yarn typecheck:server`（再ビルドした core に対して） | pass |

## 影響しないもの

presence doc は `serverTimestamp()` で書かれるので、**スマホ側の「このホストが見えているか」の
判定は変わらない**。ホストが自分自身を誤診する部分だけの修正。

## Follow-up

マージ後に core を publish → MulmoTerminal 側で依存バージョンを上げる（#2633 → #2640 と同じ流れ）。

## Summary by Sourcery

Decouple remote-host presence detection and outage give-up logic from wall-clock time to avoid false disconnects after sleeps or clock jumps.

Bug Fixes:
- Change presence staleness detection to count heartbeat beats rather than elapsed wall-clock time, preventing false offline reports when the process is paused.
- Reset outage and backoff budgets after long gaps where scheduled tasks fire late, so time spent while the process is frozen does not cause immediate give-up.
- Use a monotonic clock for outage timing and listen error give-up decisions, while keeping wall-clock time for user-facing timestamps and command expiry comparisons.

Enhancements:
- Refine presence stale error messaging to include both beat count and elapsed seconds for easier diagnosis of clock-related issues.
- Introduce a shared monotonic clock utility and separate wall-clock dependency for runner health reporting.
- Extend remote-host tests with scenarios covering clock jumps, process sleeps, and health timestamp behavior to lock in the new semantics.
- Add an internal design document explaining the wall-clock related presence and give-up issues and the chosen fixes.

Documentation:
- Add a planning document describing the presence and give-up wall-clock bug, its root cause, and the rationale behind the fix.

Tests:
- Expand presence beat tests to cover beat-count-based staleness, reporting of silence duration, and behavior when time advances without beats running.
- Extend resilient runner tests to simulate process sleep gaps, ensure outage budgets are not consumed during such gaps, and verify health change timestamps use the wall clock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presence status accuracy by basing staleness on acknowledged heartbeat activity rather than wall-clock time.
  * Prevented false outage reports after system pauses or clock adjustments.
  * Improved reconnection behavior after long process suspensions, allowing retries to resume correctly.
  * Preserved accurate server-time handling for command expiration and health timestamps.
  * Stopped additional presence writes after staleness is detected.
* **Documentation**
  * Added a design plan documenting timing and presence reliability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->