### PR TITLE
chore(release): @mulmoclaude/core@3.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Package releases
+
+#### `@mulmoclaude/core` 3.0.0 → 3.0.1 — remote host stops mistaking its own downtime for a dead channel (#2845, #2846)
+
+The remote host judged "can my phone still reach this Mac?" by wall clock, so any stretch where the
+process was not running — sleep, a clock jump, a stalled event loop — was counted as time the channel
+had been failing. A user saw `no presence write acknowledged for 459s`, which a genuine outage cannot
+produce: with a 60s heartbeat and a 3-beat threshold, a real disconnect always reports at 180s. 459s
+means the 60s timer did not fire for roughly five minutes.
+
+It failed twice over: the false "disconnected" report, and then the outer ring — whose give-up budget
+was also wall-clock — spending its whole 5-minute allowance on the gap and giving up **without
+attempting a single reconnect**, leaving the user to reconnect by hand.
+
+- Presence now counts **beats that actually ran** (`staleAfterBeats`) instead of elapsed milliseconds,
+  so a beat that never fired cannot age the channel. A real outage still reports on the third beat.
+- The resilient runner treats a task firing more than `RESUME_GAP_MS` (1 min) late as evidence the
+  process was not running: it resets the outage window and backoff, and that task becomes the first
+  attempt after the gap. Give-up remains measured in time, as specified.
+- Elapsed-time measurement moved to a monotonic clock, with the wall clock kept separately for
+  `changedAt` timestamps.
+- The error string now reads `no presence write acknowledged across 3 beats (180s)` — surfaced in
+  MulmoTerminal as `Last error:` — so a future report distinguishes "the clock jumped" from "the host
+  is genuinely down" on one line.
+
+`staleAfterMs` → `staleAfterBeats` is internal to core; the published `presenceStaleAfterMs()` and
+`createPresenceProbe` signatures are unchanged, so downstream hosts need no change. Every consumer's
+declared range was swept to `^3.0.1`; a caret floats across a patch, so no plugin or launcher
+republish is required to deliver it.
+
+Ships `@mulmoclaude/accounting-plugin@2.1.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.0.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@3.0.1`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.1.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ## [1.13.0] - 2026-08-09
 
 **A package-line release: it carries the 3.x core and plugins to npm. No app behaviour changes.**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.0.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.1.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.0.0"
+    "@mulmoclaude/core": "^3.0.1"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^3.0.0"
+    "@mulmoclaude/core": "^3.0.1"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^3.0.0"
+    "@mulmoclaude/core": "^3.0.1"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^2.0.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.0.0"
+    "@mulmoclaude/core": "^3.0.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,20 +37,20 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "@mulmoclaude/markdown-utils": "^1.3.5",
     "js-yaml": "^5.2.3",
     "marked": "^18.0.7",
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^3.0.0",
+    "@mulmoclaude/core": "^3.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.0.0"
+    "@mulmoclaude/core": "^3.0.1"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",


### PR DESCRIPTION
## Summary

Publishes `@mulmoclaude/core` **3.0.0 → 3.0.1** — a patch release whose only payload is the
remote-host presence fix merged in #2846. No source changed in this PR; it is a version bump,
a range sweep, and a changelog entry.

`yarn audit:releases --code-only` reported `@mulmoclaude/core` as **code drift** — 4 shipped
files changed since the `@mulmoclaude/core@3.0.0` tag — so the fix is in the tree but not on npm.

**What the released fix does** (from #2846): the remote host judged "can my phone still reach
this Mac?" by wall clock, so time the process was NOT running (sleep, clock jump, stalled event
loop) counted as time the channel had been failing. A user saw `no presence write acknowledged
for 459s`, which a genuine outage cannot produce — with a 60s heartbeat and a 3-beat threshold a
real disconnect always reports at 180s. It then failed a second time: the outer ring's give-up
budget was also wall-clock, so it spent the whole allowance on the gap and gave up **without one
reconnect attempt**. Presence now counts beats that actually ran, the runner discounts gaps from
its outage window, and elapsed time moved to a monotonic clock.

## Items to Confirm / Review

1. **Patch, not minor.** #2846 changed `staleAfterMs` → `staleAfterBeats` on `createPresenceBeat`,
   which is core-internal (`hostRunner` is the only caller). The published `presenceStaleAfterMs()`
   and `createPresenceProbe` signatures are unchanged, so no downstream host breaks. Confirm that
   reading — if `createPresenceBeat` counts as public surface, this should be 3.1.0.
2. **No plugin or launcher republish.** All 8 consumers declared `^3.0.0`, and a caret DOES float
   across a patch within the same major — unlike the 3.0.0 release, which crossed a major and so
   required republishing all 7 plugins. npm users of `mulmoclaude@1.13.0` pick up core 3.0.1 on a
   fresh install with nothing else published. The swept ranges reach npm at each consumer's own
   next release, per the CLAUDE.md internal-range rule.
3. **The launcher's own `version` is deliberately untouched** (still 1.13.0), per the
   `chore(release)` rule in CLAUDE.md — only its dep range moved.
4. **The `Ships` line moved to `[Unreleased]`.** Because the launcher's `@mulmoclaude/core` range
   changed while the launcher stays at 1.13.0, `check-changelog-ships.mjs` would otherwise fall
   back to `## [1.13.0]` and demand rewriting a published release's historical roster. Giving
   `[Unreleased]` its own `Ships` line is the documented way out (see the script's header comment).

## Changes

| file(s) | change |
|---|---|
| `packages/core/package.json` | `3.0.0` → `3.0.1` |
| launcher + 7 plugins (8 files, 13 sites) | `"@mulmoclaude/core": "^3.0.0"` → `"^3.0.1"`, in `dependencies`, `devDependencies` and `peerDependencies` alike |
| `docs/CHANGELOG.md` | `[Unreleased]` entry for the core patch, ending in the updated `Ships` roster |

## Verification

Run locally on this branch:

- `node scripts/packages/check-changelog-ships.mjs` → OK, `[Unreleased]` lists all 13 deps
- `node scripts/mulmoclaude/launcherSync.mjs` → OK, root ↔ launcher in sync, no peer-dep violations
- `yarn format` (no changes), `yarn lint` (0 errors, 43 pre-existing warnings)
- `yarn build`, `yarn typecheck` — pass
- `yarn test` — **11303 pass / 0 fail**, exit 0 (root suite + every workspace, incl. core's 753)

## After merge

Tag `@mulmoclaude/core@3.0.1` on the merge commit → `npm publish` from `packages/core` →
GitHub release with `--latest=false` (this repo ships app releases under `v*`).

refs #2845

work in mulmoclaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release @mulmoclaude/core 3.0.1 and align dependent packages and changelog with the new patch version.

Enhancements:
- Update all launcher and plugin dependency/peer/dev ranges to consume @mulmoclaude/core 3.0.1 instead of 3.0.0.

Build:
- Bump @mulmoclaude/core package version from 3.0.0 to 3.0.1.

Documentation:
- Add an Unreleased changelog entry describing the core presence/remote host reliability fix delivered in 3.0.1 and update the Ships roster accordingly.