### PR TITLE
feat(accounting): make the accounting engine safely multi-root

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Package releases
 
+#### Accounting can follow a project root, the way collections already do
+
+`@mulmoclaude/accounting-plugin@2.2.0`. The engine was root-parameterised down in the io and
+service layers but bound to one workspace at the top: every dispatch action resolved the
+ambient root, and everything keyed by `bookId` alone would collide the moment two project
+directories each held a book of that name. MulmoClaude wires none of the new options and its
+requests, channel names and card envelopes are byte-identical to before.
+
+- `AccountingServerDeps.workspaceRoot` widens to `string | null`. `null` is explicit-root
+  mode: `defaultWorkspaceRoot()` throws rather than guessing, because with N roots a
+  forgotten option is not a crash but a silent write to the wrong project.
+- `createAccountingRouter({ resolveWorkspaceRoot })` resolves a root per request, threaded
+  through all 15 dispatch actions. The resolver is host-owned; the package never reads a root
+  or project id off a request body, and `manageAccounting`'s tool schema has no project
+  parameter (now pinned by a test), so the model cannot pick a project.
+- `bookChannel(bookId, scope?)` / `booksChannel(scope?)`, fed by the new
+  `channelScopeForRoot` dep, namespace the pub/sub names by the host's OPAQUE project id —
+  an id, never a path, because these names reach the browser.
+- The snapshot rebuild queue is keyed by `(root, bookId)`. Previously one project's write
+  cancelled another's in-flight rebuild and `awaitRebuildIdle` returned early.
+- An `openBook` result carries that scope, so a mounted card fetches its own project rather
+  than whatever the host has selected when it renders; the Vue surface takes a `projectScope`
+  seam that rides requests and channel subscriptions.
+- The `listAccountingBooks` remote-host handler resolves a scope from its params, defaulting
+  to the host root, so a phone-side project picker is an added parameter and not a protocol
+  change.
+
 #### Multi-root, finished: identity, the authoring docs, and per-root operation
 
 `@mulmoclaude/core@3.1.0`. A collection's identity is `(root, slug)`, but everything that
@@ -54,7 +81,7 @@ Roots are canonicalised (`path.resolve`) wherever one becomes an identity — a 
 change payload, a bell id — so `/work/proj` and `/work/proj/` are one project rather than two.
 Symlinks are deliberately not resolved; see `canonicalRoot`.
 
-Ships `@mulmoclaude/core@3.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.1.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.0.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.1.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.0.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.1.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 #### `@mulmoclaude/core` 3.0.0 → 3.0.1 — remote host stops mistaking its own downtime for a dead channel (#2845, #2846)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,9 +30,10 @@ requests, channel names and card envelopes are byte-identical to before.
   an id, never a path, because these names reach the browser.
 - The snapshot rebuild queue is keyed by `(root, bookId)`. Previously one project's write
   cancelled another's in-flight rebuild and `awaitRebuildIdle` returned early.
-- An `openBook` result carries that scope, so a mounted card fetches its own project rather
-  than whatever the host has selected when it renders; the Vue surface takes a `projectScope`
-  seam that rides requests and channel subscriptions.
+- An `openBook` result carries that scope and the mounted View PINS itself to it at mount —
+  every request and both channel subscriptions in the card's subtree go to the project the
+  card was opened for, not to whatever the host has selected later. The Vue surface also
+  takes a `projectScope` seam for surfaces the host scopes itself.
 - The `listAccountingBooks` remote-host handler resolves a scope from its params, defaulting
   to the host root, so a phone-side project picker is an added parameter and not a protocol
   change.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,10 +30,13 @@ requests, channel names and card envelopes are byte-identical to before.
   an id, never a path, because these names reach the browser.
 - The snapshot rebuild queue is keyed by `(root, bookId)`. Previously one project's write
   cancelled another's in-flight rebuild and `awaitRebuildIdle` returned early.
-- An `openBook` result carries that scope and the mounted View PINS itself to it at mount —
+- An `openBook` result carries that scope — explicitly `null` for a scoped host's default
+  root, since an absent field means "resolve the host's active project" — and the mounted
+  View binds itself to it:
   every request and both channel subscriptions in the card's subtree go to the project the
-  card was opened for, not to whatever the host has selected later. The Vue surface also
-  takes a `projectScope` seam for surfaces the host scopes itself.
+  card was opened for, not to whatever the host has selected later, and they re-bind if the
+  surface is retargeted at another card. The Vue surface also takes a `projectScope` seam for
+  surfaces the host scopes itself.
 - The `listAccountingBooks` remote-host handler resolves a scope from its params, defaulting
   to the host root, so a phone-side project picker is an added parameter and not a protocol
   change.

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -35,7 +35,7 @@
     "@mulmocast/types": "^2.9.0",
     "@mulmochat-plugin/quiz": "^2.0.0",
     "@mulmochat-plugin/ui-image": "^0.4.1",
-    "@mulmoclaude/accounting-plugin": "^2.1.0",
+    "@mulmoclaude/accounting-plugin": "^2.2.0",
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.0.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/plugins/accounting-plugin/README.md
+++ b/packages/plugins/accounting-plugin/README.md
@@ -4,6 +4,42 @@ Double-entry accounting plugin for MulmoClaude and MulmoTerminal. Three surfaces
 
 A plugin for [MulmoClaude](https://github.com/receptron/mulmoclaude) and [MulmoTerminal](https://github.com/receptron/mulmoterminal) — loaded by the host, not run standalone.
 
+## Host wiring
+
+A single-workspace host (MulmoClaude) wires three calls once at boot:
+
+```ts
+configureAccountingServer({ workspaceRoot, logger });
+initAccountingEventPublisher(pubsub);
+app.use(createAccountingRouter());
+```
+
+A host that serves one root per project directory (MulmoTerminal) wires the same three
+differently:
+
+```ts
+configureAccountingServer({
+  workspaceRoot: null,                    // explicit-root mode: a forgotten root throws
+  logger,
+  channelScopeForRoot: (root) => projectIdForRoot(root), // opaque id, or null for the default root
+});
+app.use(createAccountingRouter({ resolveWorkspaceRoot: (req) => rootForRequest(req) }));
+configureAccountingHost({ apiCall, subscribe, localeTag, projectScope });  // the Vue surface
+```
+
+Both are opt-in and default to today's behaviour. The invariants behind them:
+
+1. **A bookId is unique within a root and nowhere else.** Anything keyed by bookId alone —
+   a channel, a rebuild queue, a card — is a cross-project collision waiting to happen.
+2. **`workspaceRoot: null` is the safety net.** With N roots, a forgotten root is not a
+   crash but a silent read or write against the wrong project; explicit-root mode turns it
+   into a clear throw.
+3. **A project is named by an opaque id, never a path.** Channel names and card envelopes
+   reach the browser; an absolute root there publishes the user's home directory.
+4. **The model never picks a project.** `manageAccounting`'s schema has no project
+   parameter (pinned by a test), and this package never resolves one off a request body —
+   only the host's own `resolveWorkspaceRoot` does.
+
 ## Dev loop
 
 ```bash

--- a/packages/plugins/accounting-plugin/README.md
+++ b/packages/plugins/accounting-plugin/README.md
@@ -23,6 +23,7 @@ configureAccountingServer({
   logger,
   channelScopeForRoot: (root) => projectIdForRoot(root), // opaque id, or null for the default root
 });
+initAccountingEventPublisher(pubsub);     // unchanged — the scope comes from the dep above
 app.use(createAccountingRouter({ resolveWorkspaceRoot: (req) => rootForRequest(req) }));
 configureAccountingHost({ apiCall, subscribe, localeTag, projectScope });  // the Vue surface
 ```

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/accounting-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Double-entry accounting plugin for MulmoClaude and MulmoTerminal. Three surfaces: ./shared (isomorphic enums/meta, browser-safe), ./vue (chat View/Preview + canvas app), ./server (createAccountingRouter — the workspace-file-backed backend, wired via dependency injection so it pulls zero host-only infra).",
   "type": "module",
   "exports": {

--- a/packages/plugins/accounting-plugin/src/server/context.ts
+++ b/packages/plugins/accounting-plugin/src/server/context.ts
@@ -26,9 +26,27 @@ export type AccountingLogger = StructuredLogger;
 
 export interface AccountingServerDeps {
   /** Absolute path to the workspace root (where `data/` lives). Used as
-   *  the default when a service/io call doesn't pass an explicit root. */
-  workspaceRoot: string;
+   *  the default when a service/io call doesn't pass an explicit root.
+   *
+   *  `null` declares STRICT mode: this host always passes an explicit
+   *  root per call, and `defaultWorkspaceRoot()` throws instead of
+   *  guessing. A multi-root host (MulmoTerminal, one root per project
+   *  directory) MUST use it — with N roots a forgotten option is not a
+   *  crash but a silent read/write against the wrong project. Mirrors
+   *  `CollectionHost.workspaceRoot: string | null` in
+   *  `@mulmoclaude/core/collection/server`. */
+  workspaceRoot: string | null;
   logger: AccountingLogger;
+  /** Optional: map an absolute root to the OPAQUE scope id the host uses
+   *  for that project, used to namespace pub/sub channel names so two
+   *  roots owning one bookId do not cross-notify. Return `null` for the
+   *  host's default root, which keeps channel names byte-identical to a
+   *  single-root host's (`accounting:<bookId>`).
+   *
+   *  It must be an opaque id, NEVER a path: channel names reach the
+   *  browser, and an absolute root there publishes the user's home
+   *  directory to the client. Same rule as a collection view token. */
+  channelScopeForRoot?: (workspaceRoot: string) => string | null;
 }
 
 let deps: AccountingServerDeps | null = null;
@@ -40,12 +58,30 @@ export function configureAccountingServer(context: AccountingServerDeps): void {
 
 /** Default workspace root for io calls that don't pass one explicitly.
  *  Throws if the host never configured the server — a real wiring bug
- *  (unit tests always pass an explicit root, so they never hit this). */
+ *  (unit tests always pass an explicit root, so they never hit this) —
+ *  and also under STRICT mode (`workspaceRoot: null`), where there is no
+ *  ambient root to fall back to and a missing option is a bug rather
+ *  than a default. */
 export function defaultWorkspaceRoot(): string {
   if (!deps) {
     throw new Error("@mulmoclaude/accounting-plugin: configureAccountingServer() must be called before serving accounting requests");
   }
+  if (deps.workspaceRoot === null) {
+    throw new Error(
+      "@mulmoclaude/accounting-plugin: this host is configured with workspaceRoot: null (explicit-root mode), so every call must pass a workspaceRoot. A call reached the engine without one.",
+    );
+  }
   return deps.workspaceRoot;
+}
+
+/** The opaque channel scope for a root, or `null` when the host declared
+ *  none (single-root hosts, and a multi-root host's default root). Used
+ *  by the event publisher; never contains a path. */
+export function channelScopeFor(workspaceRoot?: string): string | null {
+  if (!deps?.channelScopeForRoot) return null;
+  const root = workspaceRoot ?? (deps.workspaceRoot === null ? null : deps.workspaceRoot);
+  if (root === null) return null;
+  return deps.channelScopeForRoot(root);
 }
 
 const consoleLogger: AccountingLogger = {

--- a/packages/plugins/accounting-plugin/src/server/context.ts
+++ b/packages/plugins/accounting-plugin/src/server/context.ts
@@ -76,12 +76,18 @@ export function defaultWorkspaceRoot(): string {
 
 /** The opaque channel scope for a root, or `null` when the host declared
  *  none (single-root hosts, and a multi-root host's default root). Used
- *  by the event publisher; never contains a path. */
+ *  by the event publisher; never contains a path.
+ *
+ *  A missing root throws under explicit-root mode, exactly as
+ *  `defaultWorkspaceRoot()` does. Returning `null` there would be worse
+ *  than the io-path bug it mirrors: the event would go out on the
+ *  UNSCOPED channel name, which every project's default-scope
+ *  subscriber receives. The publisher catches it and logs, so a dropped
+ *  root costs one event and a warning rather than a silent cross-project
+ *  notification. */
 export function channelScopeFor(workspaceRoot?: string): string | null {
   if (!deps?.channelScopeForRoot) return null;
-  const root = workspaceRoot ?? (deps.workspaceRoot === null ? null : deps.workspaceRoot);
-  if (root === null) return null;
-  return deps.channelScopeForRoot(root);
+  return deps.channelScopeForRoot(workspaceRoot ?? defaultWorkspaceRoot());
 }
 
 const consoleLogger: AccountingLogger = {

--- a/packages/plugins/accounting-plugin/src/server/context.ts
+++ b/packages/plugins/accounting-plugin/src/server/context.ts
@@ -90,6 +90,18 @@ export function channelScopeFor(workspaceRoot?: string): string | null {
   return deps.channelScopeForRoot(workspaceRoot ?? defaultWorkspaceRoot());
 }
 
+/** Whether the host declared project scoping at all.
+ *
+ *  The difference matters where a card records the project it belongs
+ *  to: on a scoped host, "no scope" is a REAL answer (the default root)
+ *  and must be recorded as `null`, not left out — an omitted field means
+ *  "ask the host what is active now", which is precisely the drift a
+ *  pinned card exists to prevent. On an unscoped host the field is left
+ *  out entirely and every payload stays byte-identical to today's. */
+export function isProjectScopedHost(): boolean {
+  return Boolean(deps?.channelScopeForRoot);
+}
+
 const consoleLogger: AccountingLogger = {
   error: (namespace, msg, data) => console.error(`[${namespace}] ${msg}`, data ?? ""),
   warn: (namespace, msg, data) => console.warn(`[${namespace}] ${msg}`, data ?? ""),

--- a/packages/plugins/accounting-plugin/src/server/eventPublisher.ts
+++ b/packages/plugins/accounting-plugin/src/server/eventPublisher.ts
@@ -21,9 +21,16 @@ export function initAccountingEventPublisher(instance: IPubSub): void {
   pubsub = instance;
 }
 
-function safePublish(channel: string, payload: unknown): void {
+/** `channelFor` is called INSIDE the guard, not before it: resolving the
+ *  scope can throw (a write that reached the publisher with no root
+ *  under explicit-root mode), and a lost event with a warning beats
+ *  either crashing the write or publishing to the unscoped channel that
+ *  every project can hear. */
+function safePublish(channelFor: () => string, payload: unknown): void {
   if (!pubsub) return;
+  let channel = "(unresolved)";
   try {
+    channel = channelFor();
     pubsub.publish(channel, payload);
   } catch (err) {
     // Same fire-and-forget rationale as the file-change publisher:
@@ -44,14 +51,14 @@ function safePublish(channel: string, payload: unknown): void {
  *  `channelScopeFor`). Omit it — as a single-root host's service calls
  *  do — and the name is what it has always been. */
 export function publishBookChange(bookId: string, payload: AccountingBookChannelPayload, workspaceRoot?: string): void {
-  safePublish(accountingBookChannel(bookId, channelScopeFor(workspaceRoot)), payload);
+  safePublish(() => accountingBookChannel(bookId, channelScopeFor(workspaceRoot)), payload);
 }
 
 /** Fired when the *list* of books changes (createBook, deleteBook).
  *  Payload is intentionally empty — subscribers refetch from
  *  /api/accounting. Scoped by root like `publishBookChange`. */
 export function publishBooksChanged(workspaceRoot?: string): void {
-  safePublish(accountingBooksChannel(channelScopeFor(workspaceRoot)), {});
+  safePublish(() => accountingBooksChannel(channelScopeFor(workspaceRoot)), {});
 }
 
 /** Test-only — drop the module singleton so each test starts clean. */

--- a/packages/plugins/accounting-plugin/src/server/eventPublisher.ts
+++ b/packages/plugins/accounting-plugin/src/server/eventPublisher.ts
@@ -7,8 +7,12 @@
 // `src/config/pubsubChannels.ts` so the publisher cannot drift from
 // the View-side subscribers.
 
-import { bookChannel as accountingBookChannel, ACCOUNTING_BOOKS_CHANNEL, type BookChannelPayload as AccountingBookChannelPayload } from "../shared";
-import { log, type IPubSub } from "./context.js";
+import {
+  bookChannel as accountingBookChannel,
+  booksChannel as accountingBooksChannel,
+  type BookChannelPayload as AccountingBookChannelPayload,
+} from "../shared";
+import { channelScopeFor, log, type IPubSub } from "./context.js";
 import { errorMessage } from "../shared";
 
 let pubsub: IPubSub | null = null;
@@ -33,16 +37,21 @@ function safePublish(channel: string, payload: unknown): void {
 
 /** Per-book change notification. `period` should be the entry's
  *  YYYY-MM bucket (or the earliest invalidated month for snapshot
- *  events). */
-export function publishBookChange(bookId: string, payload: AccountingBookChannelPayload): void {
-  safePublish(accountingBookChannel(bookId), payload);
+ *  events).
+ *
+ *  `workspaceRoot` is the root the write happened under; the channel
+ *  name is namespaced by the host's opaque scope for it (see
+ *  `channelScopeFor`). Omit it — as a single-root host's service calls
+ *  do — and the name is what it has always been. */
+export function publishBookChange(bookId: string, payload: AccountingBookChannelPayload, workspaceRoot?: string): void {
+  safePublish(accountingBookChannel(bookId, channelScopeFor(workspaceRoot)), payload);
 }
 
 /** Fired when the *list* of books changes (createBook, deleteBook).
  *  Payload is intentionally empty — subscribers refetch from
- *  /api/accounting. */
-export function publishBooksChanged(): void {
-  safePublish(ACCOUNTING_BOOKS_CHANNEL, {});
+ *  /api/accounting. Scoped by root like `publishBookChange`. */
+export function publishBooksChanged(workspaceRoot?: string): void {
+  safePublish(accountingBooksChannel(channelScopeFor(workspaceRoot)), {});
 }
 
 /** Test-only — drop the module singleton so each test starts clean. */

--- a/packages/plugins/accounting-plugin/src/server/index.ts
+++ b/packages/plugins/accounting-plugin/src/server/index.ts
@@ -8,8 +8,19 @@
 //   configureAccountingServer({ workspaceRoot, logger });
 //   initAccountingEventPublisher(pubsub);
 //   app.use(createAccountingRouter());
+//
+// Multi-root hosts (MulmoTerminal — one root per project directory)
+// wire the same three, differently:
+//   configureAccountingServer({ workspaceRoot: null, logger, channelScopeForRoot });
+//   app.use(createAccountingRouter({ resolveWorkspaceRoot }));
+// `workspaceRoot: null` makes a forgotten root throw rather than
+// silently resolve another project's books; `channelScopeForRoot` maps
+// a root to the host's OPAQUE project id, which namespaces the pub/sub
+// channel names. Both are opt-in: omit them and behaviour is exactly a
+// single-workspace host's.
 
 export { createAccountingRouter } from "./router.js";
+export type { AccountingRouterOptions, AccountingDispatchRequest, AccountingActionBody } from "./router.js";
 export { configureAccountingServer } from "./context.js";
 export type { AccountingServerDeps, AccountingLogger, IPubSub } from "./context.js";
 export { initAccountingEventPublisher } from "./eventPublisher.js";

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -36,10 +36,10 @@ import {
 } from "./service.js";
 import type { BookSummary } from "../shared/types.js";
 import { ACCOUNTING_ACTIONS, ACCOUNTING_API } from "../shared";
-import { log } from "./context.js";
+import { channelScopeFor, log } from "./context.js";
 import { asyncHandler, type ErrorBody } from "./http.js";
 
-interface AccountingActionBody {
+export interface AccountingActionBody {
   action: string;
   [key: string]: unknown;
 }
@@ -65,32 +65,47 @@ interface OpenBookToolResult {
    *  openBook doesn't need a follow-up getBooks round-trip to learn
    *  what other books exist before its next action. */
   books: BookSummary[];
+  /** The host's OPAQUE scope id for the root this book lives under, so
+   *  the mounted card fetches ITS OWN project rather than whatever the
+   *  host has selected when it renders. Absent for a single-root host
+   *  (and for a multi-root host's default root), which keeps the
+   *  envelope byte-identical to what it has always been.
+   *
+   *  Stamped by the SERVER from the resolved root — it is never read
+   *  off the request body, so the model cannot pick a project. */
+  scope?: string;
 }
 
 type ActionRest = Omit<AccountingActionBody, "action">;
-type ActionHandler = (rest: ActionRest) => Promise<unknown>;
+/** `root` is the workspace root this request resolved to — `undefined`
+ *  means "the host's configured one", the single-root path. Every
+ *  handler MUST pass it on to the service layer: under a multi-root
+ *  host a dropped root is not an error but a silent read or write
+ *  against the wrong project. */
+type ActionHandler = (rest: ActionRest, root: string | undefined) => Promise<unknown>;
 
 // Each action is a tiny adapter that pulls the typed slice it needs
 // out of the loosely-typed body. Parsing of the slice shape itself
 // lives inside the service layer (parseEntry, parseOpening,
 // parseAccountInput) so the adapters can stay one-liners.
 
-async function handleOpenBook(rest: ActionRest): Promise<OpenBookToolResult> {
+async function handleOpenBook(rest: ActionRest, root: string | undefined): Promise<OpenBookToolResult> {
   // openBook requires an explicit `bookId` that resolves to an
   // existing book. On a fresh workspace the LLM is expected to
   // call `createBook` first and then `openBook` with the new id.
   if (typeof rest.bookId !== "string" || rest.bookId === "") {
     throw new AccountingError(400, "openBook: bookId is required. Call 'getBooks' to enumerate, or 'createBook' first on a fresh workspace.");
   }
-  const list = await listBooks();
+  const list = await listBooks(root);
   if (!list.books.some((book) => book.id === rest.bookId)) {
     throw new AccountingError(404, `openBook: book ${JSON.stringify(rest.bookId)} not found`);
   }
   const initialTab = typeof rest.initialTab === "string" ? rest.initialTab : undefined;
-  return { kind: "accounting-app", bookId: rest.bookId, initialTab, books: list.books };
+  const scope = channelScopeFor(root);
+  return { kind: "accounting-app", bookId: rest.bookId, initialTab, books: list.books, ...(scope ? { scope } : {}) };
 }
 
-async function handleGetReport(rest: ActionRest): Promise<unknown> {
+async function handleGetReport(rest: ActionRest, root: string | undefined): Promise<unknown> {
   const kind = typeof rest.kind === "string" ? rest.kind : "";
   const periodInput = optionalReportPeriod(rest.period);
   const bookId = optionalString(rest.bookId);
@@ -110,11 +125,11 @@ async function handleGetReport(rest: ActionRest): Promise<unknown> {
   if (periodSent && !periodInput) throw periodRequired(`getReport ${kind || "(no kind)"}`);
   if (kind === "balance") {
     if (!periodInput) throw periodRequired("getReport balance");
-    return getBalanceSheetReport({ bookId, period: periodInput });
+    return getBalanceSheetReport({ bookId, period: periodInput }, root);
   }
   if (kind === "pl") {
     if (!periodInput) throw periodRequired("getReport pl");
-    return getProfitLossReport({ bookId, period: periodInput });
+    return getProfitLossReport({ bookId, period: periodInput }, root);
   }
   if (kind === "ledger") {
     // period is optional for ledger — full-history view from the
@@ -124,81 +139,100 @@ async function handleGetReport(rest: ActionRest): Promise<unknown> {
     if (typeof rest.accountCode !== "string" || rest.accountCode === "") {
       throw new AccountingError(400, "getReport ledger: accountCode is required");
     }
-    return getLedgerReport({ bookId, accountCode: rest.accountCode, period: periodInput });
+    return getLedgerReport({ bookId, accountCode: rest.accountCode, period: periodInput }, root);
   }
   throw new AccountingError(400, `getReport: unknown kind ${JSON.stringify(kind)}`);
 }
 
 const ACTION_HANDLERS: Record<string, ActionHandler> = {
   [ACCOUNTING_ACTIONS.openBook]: handleOpenBook,
-  [ACCOUNTING_ACTIONS.getBooks]: () => listBooks(),
-  [ACCOUNTING_ACTIONS.createBook]: async (rest) => {
+  [ACCOUNTING_ACTIONS.getBooks]: (_rest, root) => listBooks(root),
+  [ACCOUNTING_ACTIONS.createBook]: async (rest, root) => {
     // Surface bookId at the top level so the dispatch envelope's
     // `data` carries it like every other write action — the View
     // uses it to preselect the new book on mount.
-    const result = await createBook({
-      name: typeof rest.name === "string" ? rest.name : "",
-      currency: typeof rest.currency === "string" ? rest.currency : undefined,
-      country: typeof rest.country === "string" ? rest.country : undefined,
-      // Passed through raw — the service coerces + validates it (number,
-      // numeric string, or a legacy "Q1".."Q4" token), 400ing garbage.
-      fiscalYearEnd: rest.fiscalYearEnd,
-    });
+    const result = await createBook(
+      {
+        name: typeof rest.name === "string" ? rest.name : "",
+        currency: typeof rest.currency === "string" ? rest.currency : undefined,
+        country: typeof rest.country === "string" ? rest.country : undefined,
+        // Passed through raw — the service coerces + validates it (number,
+        // numeric string, or a legacy "Q1".."Q4" token), 400ing garbage.
+        fiscalYearEnd: rest.fiscalYearEnd,
+      },
+      root,
+    );
     return { bookId: result.book.id, ...result };
   },
-  [ACCOUNTING_ACTIONS.updateBook]: async (rest) => {
-    const result = await updateBook({
-      bookId: typeof rest.bookId === "string" ? rest.bookId : "",
-      name: typeof rest.name === "string" ? rest.name : undefined,
-      country: typeof rest.country === "string" ? rest.country : undefined,
-      // Passed through raw — the service coerces + validates it.
-      fiscalYearEnd: rest.fiscalYearEnd,
-    });
+  [ACCOUNTING_ACTIONS.updateBook]: async (rest, root) => {
+    const result = await updateBook(
+      {
+        bookId: typeof rest.bookId === "string" ? rest.bookId : "",
+        name: typeof rest.name === "string" ? rest.name : undefined,
+        country: typeof rest.country === "string" ? rest.country : undefined,
+        // Passed through raw — the service coerces + validates it.
+        fiscalYearEnd: rest.fiscalYearEnd,
+      },
+      root,
+    );
     return { bookId: result.book.id, ...result };
   },
-  [ACCOUNTING_ACTIONS.deleteBook]: (rest) => deleteBook({ bookId: typeof rest.bookId === "string" ? rest.bookId : "", confirm: rest.confirm === true }),
-  [ACCOUNTING_ACTIONS.getAccounts]: (rest) => listAccounts({ bookId: optionalString(rest.bookId) }),
+  [ACCOUNTING_ACTIONS.deleteBook]: (rest, root) =>
+    deleteBook({ bookId: typeof rest.bookId === "string" ? rest.bookId : "", confirm: rest.confirm === true }, root),
+  [ACCOUNTING_ACTIONS.getAccounts]: (rest, root) => listAccounts({ bookId: optionalString(rest.bookId) }, root),
   // `account` / `entries` / `lines` travel to the service as `unknown`:
   // the parsers there own the narrowing, so a bad field keeps its own
   // message ("debit must be a non-negative finite number") instead of
   // collapsing into a generic shape error the LLM can't repair from.
-  [ACCOUNTING_ACTIONS.upsertAccount]: (rest) => upsertAccount({ bookId: optionalString(rest.bookId), account: rest.account }),
-  [ACCOUNTING_ACTIONS.addEntries]: (rest) => addEntries({ bookId: optionalString(rest.bookId), entries: rest.entries }),
-  [ACCOUNTING_ACTIONS.voidEntry]: (rest) =>
-    voidEntry({
-      bookId: optionalString(rest.bookId),
-      entryId: typeof rest.entryId === "string" ? rest.entryId : "",
-      reason: optionalString(rest.reason),
-      voidDate: optionalString(rest.voidDate),
-    }),
-  [ACCOUNTING_ACTIONS.getJournalEntries]: (rest) =>
-    listEntries({
-      bookId: optionalString(rest.bookId),
-      from: optionalString(rest.from),
-      to: optionalString(rest.to),
-      accountCode: optionalString(rest.accountCode),
-    }),
-  [ACCOUNTING_ACTIONS.getOpeningBalances]: (rest) => getOpeningBalances({ bookId: optionalString(rest.bookId) }),
-  [ACCOUNTING_ACTIONS.setOpeningBalances]: (rest) =>
-    setOpeningBalances({
-      bookId: optionalString(rest.bookId),
-      asOfDate: typeof rest.asOfDate === "string" ? rest.asOfDate : "",
-      // Omitted `lines` means the zero-line opening marker that unlocks
-      // the View's gate, so it stays an empty array rather than a 400.
-      lines: rest.lines ?? [],
-      memo: optionalString(rest.memo),
-    }),
+  [ACCOUNTING_ACTIONS.upsertAccount]: (rest, root) => upsertAccount({ bookId: optionalString(rest.bookId), account: rest.account }, root),
+  [ACCOUNTING_ACTIONS.addEntries]: (rest, root) => addEntries({ bookId: optionalString(rest.bookId), entries: rest.entries }, root),
+  [ACCOUNTING_ACTIONS.voidEntry]: (rest, root) =>
+    voidEntry(
+      {
+        bookId: optionalString(rest.bookId),
+        entryId: typeof rest.entryId === "string" ? rest.entryId : "",
+        reason: optionalString(rest.reason),
+        voidDate: optionalString(rest.voidDate),
+      },
+      root,
+    ),
+  [ACCOUNTING_ACTIONS.getJournalEntries]: (rest, root) =>
+    listEntries(
+      {
+        bookId: optionalString(rest.bookId),
+        from: optionalString(rest.from),
+        to: optionalString(rest.to),
+        accountCode: optionalString(rest.accountCode),
+      },
+      root,
+    ),
+  [ACCOUNTING_ACTIONS.getOpeningBalances]: (rest, root) => getOpeningBalances({ bookId: optionalString(rest.bookId) }, root),
+  [ACCOUNTING_ACTIONS.setOpeningBalances]: (rest, root) =>
+    setOpeningBalances(
+      {
+        bookId: optionalString(rest.bookId),
+        asOfDate: typeof rest.asOfDate === "string" ? rest.asOfDate : "",
+        // Omitted `lines` means the zero-line opening marker that unlocks
+        // the View's gate, so it stays an empty array rather than a 400.
+        lines: rest.lines ?? [],
+        memo: optionalString(rest.memo),
+      },
+      root,
+    ),
   [ACCOUNTING_ACTIONS.getReport]: handleGetReport,
-  [ACCOUNTING_ACTIONS.getTimeSeries]: (rest) =>
-    getTimeSeriesReport({
-      bookId: optionalString(rest.bookId),
-      metric: rest.metric,
-      granularity: rest.granularity,
-      from: rest.from,
-      to: rest.to,
-      accountCode: rest.accountCode,
-    }),
-  [ACCOUNTING_ACTIONS.rebuildSnapshots]: (rest) => rebuildSnapshots({ bookId: optionalString(rest.bookId) }),
+  [ACCOUNTING_ACTIONS.getTimeSeries]: (rest, root) =>
+    getTimeSeriesReport(
+      {
+        bookId: optionalString(rest.bookId),
+        metric: rest.metric,
+        granularity: rest.granularity,
+        from: rest.from,
+        to: rest.to,
+        accountCode: rest.accountCode,
+      },
+      root,
+    ),
+  [ACCOUNTING_ACTIONS.rebuildSnapshots]: (rest, root) => rebuildSnapshots({ bookId: optionalString(rest.bookId) }, root),
 };
 
 // Actions whose tool-result envelope should carry a `data` field so
@@ -324,7 +358,7 @@ function previewMessage(action: string, fields: Record<string, unknown>): string
   return head ? `${head} ${VIEW_VISIBLE_TRAILER}` : VIEW_VISIBLE_TRAILER;
 }
 
-async function dispatch(body: AccountingActionBody): Promise<unknown> {
+async function dispatch(body: AccountingActionBody, root: string | undefined): Promise<unknown> {
   const { action, ...rest } = body;
   const handler = ownEntry(ACTION_HANDLERS, action);
   if (!handler) throw new AccountingError(400, `unknown action ${JSON.stringify(action)}`);
@@ -335,7 +369,7 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   // because the result envelope is persisted to the chat log.
   // Direct browser callers (the AccountingApp view) ignore the field.
   // Service responses that already set `action` win via the spread.
-  const result = await handler(rest);
+  const result = await handler(rest, root);
   // `isRecord` rejects arrays where the previous `typeof === "object"`
   // check accepted them — an array result would have spread into
   // `{0: …, 1: …}`. Every service function returns a plain object, so
@@ -367,11 +401,33 @@ async function dispatch(body: AccountingActionBody): Promise<unknown> {
   return { action, ...handlerFields, ...messageField, ...dataField };
 }
 
+/** The request shape the dispatch route hands a host resolver — the
+ *  same one the route itself is typed with, so a host can read headers,
+ *  query and the parsed body without casting. */
+export type AccountingDispatchRequest = Request<object, unknown, AccountingActionBody>;
+
+export interface AccountingRouterOptions {
+  /** Resolve the workspace root ONE request operates on, for a host
+   *  that serves more than one (MulmoTerminal: one root per project
+   *  directory). Return `undefined` to use the host's configured root.
+   *
+   *  The resolver is entirely host-owned and the package never reads a
+   *  root or a project id off the request body itself. That is what
+   *  keeps the model out of it: `manageAccounting`'s tool schema has no
+   *  project parameter, so an LLM cannot name a project even by
+   *  guessing — the host derives the scope from the session, exactly as
+   *  `manageCollection` does. A host that DOES accept a project id from
+   *  a browser must resolve it against its own list of projects and
+   *  never accept a path (see `AccountingServerDeps.channelScopeForRoot`). */
+  resolveWorkspaceRoot?: (req: AccountingDispatchRequest) => string | undefined;
+}
+
 /** Build the accounting Express router. The host injects its workspace
  *  root + logger via `configureAccountingServer(...)` and pub/sub via
  *  `initAccountingEventPublisher(...)`, then mounts the returned router
- *  with `app.use(...)`. */
-export function createAccountingRouter(): Router {
+ *  with `app.use(...)`. Pass `resolveWorkspaceRoot` to serve more than
+ *  one root; omit it and every request uses the configured one. */
+export function createAccountingRouter(options: AccountingRouterOptions = {}): Router {
   const router = Router();
   router.post(
     ACCOUNTING_API.dispatch.path,
@@ -389,9 +445,10 @@ export function createAccountingRouter(): Router {
           return;
         }
         const { action } = body;
+        const root = options.resolveWorkspaceRoot?.(req);
         log.info("accounting", "POST dispatch: start", { action });
         try {
-          const result = await dispatch(body);
+          const result = await dispatch(body, root);
           log.info("accounting", "POST dispatch: ok", { action });
           res.json(result);
         } catch (err) {

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -445,9 +445,14 @@ export function createAccountingRouter(options: AccountingRouterOptions = {}): R
           return;
         }
         const { action } = body;
-        const root = options.resolveWorkspaceRoot?.(req);
         log.info("accounting", "POST dispatch: start", { action });
         try {
+          // Inside the try: a host resolver rejects an unknown project id
+          // by throwing, and that is a 4xx about the request, not a
+          // server fault — resolving it out here would skip the
+          // AccountingError mapping below and answer a bad project with
+          // a generic 500.
+          const root = options.resolveWorkspaceRoot?.(req);
           const result = await dispatch(body, root);
           log.info("accounting", "POST dispatch: ok", { action });
           res.json(result);

--- a/packages/plugins/accounting-plugin/src/server/router.ts
+++ b/packages/plugins/accounting-plugin/src/server/router.ts
@@ -36,7 +36,7 @@ import {
 } from "./service.js";
 import type { BookSummary } from "../shared/types.js";
 import { ACCOUNTING_ACTIONS, ACCOUNTING_API } from "../shared";
-import { channelScopeFor, log } from "./context.js";
+import { channelScopeFor, isProjectScopedHost, log } from "./context.js";
 import { asyncHandler, type ErrorBody } from "./http.js";
 
 export interface AccountingActionBody {
@@ -67,13 +67,19 @@ interface OpenBookToolResult {
   books: BookSummary[];
   /** The host's OPAQUE scope id for the root this book lives under, so
    *  the mounted card fetches ITS OWN project rather than whatever the
-   *  host has selected when it renders. Absent for a single-root host
-   *  (and for a multi-root host's default root), which keeps the
-   *  envelope byte-identical to what it has always been.
+   *  host has selected when it renders.
+   *
+   *  `null` is a real answer on a project-scoped host — the default root
+   *  — and is spelled out rather than omitted, because an ABSENT field
+   *  means "resolve the host's active project at mount" and a host that
+   *  switches project between the tool result and the render would then
+   *  point a default-root card at the new one. The field is absent only
+   *  on a host that declared no scoping at all, which keeps a
+   *  single-root envelope byte-identical to what it has always been.
    *
    *  Stamped by the SERVER from the resolved root — it is never read
    *  off the request body, so the model cannot pick a project. */
-  scope?: string;
+  scope?: string | null;
 }
 
 type ActionRest = Omit<AccountingActionBody, "action">;
@@ -101,8 +107,8 @@ async function handleOpenBook(rest: ActionRest, root: string | undefined): Promi
     throw new AccountingError(404, `openBook: book ${JSON.stringify(rest.bookId)} not found`);
   }
   const initialTab = typeof rest.initialTab === "string" ? rest.initialTab : undefined;
-  const scope = channelScopeFor(root);
-  return { kind: "accounting-app", bookId: rest.bookId, initialTab, books: list.books, ...(scope ? { scope } : {}) };
+  const scopeField = isProjectScopedHost() ? { scope: channelScopeFor(root) } : {};
+  return { kind: "accounting-app", bookId: rest.bookId, initialTab, books: list.books, ...scopeField };
 }
 
 async function handleGetReport(rest: ActionRest, root: string | undefined): Promise<unknown> {

--- a/packages/plugins/accounting-plugin/src/server/service.ts
+++ b/packages/plugins/accounting-plugin/src/server/service.ts
@@ -248,7 +248,7 @@ export async function createBook(
   await writeAccounts(bookId, [...DEFAULT_ACCOUNTS], workspaceRoot);
   const nextConfig: AccountingConfig = { books: [...config.books, book] };
   await writeConfig(nextConfig, workspaceRoot);
-  publishBooksChanged();
+  publishBooksChanged(workspaceRoot);
   return { book };
 }
 
@@ -283,7 +283,7 @@ export async function updateBook(
     books: config.books.map((book) => (book.id === input.bookId ? next : book)),
   };
   await writeConfig(nextConfig, workspaceRoot);
-  publishBooksChanged();
+  publishBooksChanged(workspaceRoot);
   return { book: next };
 }
 
@@ -302,12 +302,12 @@ export async function deleteBook(
   // Stop any in-flight rebuild before removing the directory; otherwise
   // writeSnapshot could re-create the tree via mkdir-recursive after
   // we delete it, leaving an orphaned book folder on disk.
-  cancelRebuild(input.bookId);
-  await awaitRebuildIdle(input.bookId);
+  cancelRebuild(input.bookId, workspaceRoot);
+  await awaitRebuildIdle(input.bookId, workspaceRoot);
   await removeBookDir(input.bookId, workspaceRoot);
   const remaining = config.books.filter((book) => book.id !== input.bookId);
   await writeConfig({ books: remaining }, workspaceRoot);
-  publishBooksChanged();
+  publishBooksChanged(workspaceRoot);
   // Capture the name BEFORE the splice so the LLM-facing message
   // can reference the human-readable book the user just deleted.
   return { deletedBookId: input.bookId, deletedBookName: target.name };
@@ -373,7 +373,7 @@ export async function upsertAccount(
     scheduleRebuild(bookId, "0000-00", workspaceRoot);
     await invalidateAllSnapshots(bookId, workspaceRoot);
   }
-  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.accounts });
+  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.accounts }, workspaceRoot);
   return { bookId, account, accounts: next };
 }
 
@@ -442,7 +442,7 @@ export async function addEntries(
   // new pending mark before our invalidate races with its write.
   scheduleRebuild(bookId, earliestPeriod, workspaceRoot);
   await invalidateSnapshotsFrom(bookId, earliestPeriod, workspaceRoot);
-  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.journal, period: earliestPeriod });
+  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.journal, period: earliestPeriod }, workspaceRoot);
   return { bookId, entries: built };
 }
 
@@ -475,7 +475,7 @@ export async function voidEntry(
   const fromPeriod = target.date < voidDate ? periodFromDate(target.date) : periodFromDate(voidDate);
   scheduleRebuild(bookId, fromPeriod, workspaceRoot);
   await invalidateSnapshotsFrom(bookId, fromPeriod, workspaceRoot);
-  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.journal, period: fromPeriod });
+  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.journal, period: fromPeriod }, workspaceRoot);
   return { bookId, reverseEntry: reverse, markerEntry: marker };
 }
 
@@ -566,7 +566,7 @@ export async function setOpeningBalances(
   await appendJournal(bookId, opening, workspaceRoot);
   scheduleRebuild(bookId, "0000-00", workspaceRoot);
   await invalidateAllSnapshots(bookId, workspaceRoot);
-  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.opening });
+  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.opening }, workspaceRoot);
   return { bookId, openingEntry: opening, replacedExisting: existing !== null };
 }
 
@@ -760,7 +760,7 @@ export async function rebuildSnapshots(input: { bookId?: string | undefined }, w
   const config = await loadOrInitConfig(workspaceRoot);
   const bookId = resolveBookId(config, input.bookId);
   const result = await rebuildAllSnapshots(bookId, workspaceRoot);
-  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsReady });
+  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsReady }, workspaceRoot);
   return { bookId, rebuilt: result.rebuilt };
 }
 

--- a/packages/plugins/accounting-plugin/src/server/snapshotCache.ts
+++ b/packages/plugins/accounting-plugin/src/server/snapshotCache.ts
@@ -172,7 +172,14 @@ const rebuildQueues = new Map<string, RebuildQueueEntry>();
  *  throws — deliberately loud: a `cancelRebuild` / `awaitRebuildIdle`
  *  that quietly keyed a queue nobody scheduled would return while the
  *  real rebuild is still writing, which is how `deleteBook` races a
- *  `writeSnapshot` back into existence. */
+ *  `writeSnapshot` back into existence.
+ *
+ *  Lexical resolution only — symlinks are deliberately NOT resolved,
+ *  matching `canonicalRoot` in `@mulmoclaude/core`'s collection engine,
+ *  so one project has one identity across both packages. A host that
+ *  hands the engine a real path in one call and a symlink alias in the
+ *  next would split the queue; the fix belongs in the host's own root
+ *  resolution, which is where the two packages agree it lives. */
 function rootKey(workspaceRoot: string | undefined): string {
   return path.resolve(workspaceRoot ?? defaultWorkspaceRoot());
 }

--- a/packages/plugins/accounting-plugin/src/server/snapshotCache.ts
+++ b/packages/plugins/accounting-plugin/src/server/snapshotCache.ts
@@ -25,6 +25,8 @@
 // are diagnostics that let tests assert on queue state without
 // sleep-and-poll. Production code never needs them.
 
+import path from "node:path";
+
 import {
   invalidateSnapshotsFrom as ioInvalidateFrom,
   invalidateAllSnapshots as ioInvalidateAll,
@@ -35,7 +37,7 @@ import {
 } from "./io.js";
 import { aggregateBalances, sortedBalancesFromMap } from "./report.js";
 import { publishBookChange } from "./eventPublisher.js";
-import { log } from "./context.js";
+import { defaultWorkspaceRoot, log } from "./context.js";
 import { errorMessage, BOOK_EVENT_KINDS as ACCOUNTING_BOOK_EVENT_KINDS } from "../shared";
 import type { MonthSnapshot } from "./types.js";
 import type { AccountBalance, JournalEntry } from "../shared/types.js";
@@ -155,14 +157,38 @@ interface RebuildQueueEntry {
   cancelled: boolean;
 }
 
+// Keyed by (root, bookId), not by bookId. A bookId is unique WITHIN a
+// root and nowhere else, so a multi-root host (MulmoTerminal, one root
+// per project directory) running two projects that both hold a book
+// called `main` would otherwise share one queue: project B's write
+// would cancel project A's rebuild, and `awaitRebuildIdle` would
+// return while the other project's rebuild is still writing.
 const rebuildQueues = new Map<string, RebuildQueueEntry>();
+
+/** Canonical key for the root a rebuild belongs to. An absent root
+ *  resolves to the host's configured one, so a call that passes it
+ *  explicitly and one that relies on the default share a queue. Under
+ *  explicit-root mode there is no default and `defaultWorkspaceRoot()`
+ *  throws — deliberately loud: a `cancelRebuild` / `awaitRebuildIdle`
+ *  that quietly keyed a queue nobody scheduled would return while the
+ *  real rebuild is still writing, which is how `deleteBook` races a
+ *  `writeSnapshot` back into existence. */
+function rootKey(workspaceRoot: string | undefined): string {
+  return path.resolve(workspaceRoot ?? defaultWorkspaceRoot());
+}
+
+function queueKey(bookId: string, workspaceRoot: string | undefined): string {
+  // NUL cannot appear in either half (a book id is `[A-Za-z0-9_-]`,
+  // a path cannot contain it), so the join is unambiguous.
+  return `${rootKey(workspaceRoot)}\u0000${bookId}`;
+}
 
 function minPeriod(lhs: string | null, rhs: string): string {
   if (lhs === null) return rhs;
   return lhs < rhs ? lhs : rhs;
 }
 
-function isInvalidatedDuringRebuild(bookId: string, period: string): boolean {
+function isInvalidatedDuringRebuild(key: string, period: string): boolean {
   // A pending invalidation that covers `period` means the queued
   // follow-up rebuild will redo this period. Skip the in-flight
   // write so we don't pollute the cache with stale data while a
@@ -170,32 +196,32 @@ function isInvalidatedDuringRebuild(bookId: string, period: string): boolean {
   // sequence "rebuild reads journal → caller writes a new entry →
   // caller invalidates → rebuild writes (stale) snapshot" leaves
   // the cache lying about the latest state.
-  const queue = rebuildQueues.get(bookId);
+  const queue = rebuildQueues.get(key);
   return queue !== undefined && queue.pendingFromPeriod !== null && period >= queue.pendingFromPeriod;
 }
 
-function isCancelled(bookId: string): boolean {
-  return rebuildQueues.get(bookId)?.cancelled === true;
+function isCancelled(key: string): boolean {
+  return rebuildQueues.get(key)?.cancelled === true;
 }
 
-async function runRebuild(bookId: string, fromPeriod: string, workspaceRoot: string | undefined): Promise<void> {
+async function runRebuild(key: string, bookId: string, fromPeriod: string, workspaceRoot: string | undefined): Promise<void> {
   const startedAt = Date.now();
   log.info("accounting", "snapshot rebuild started", { bookId, fromPeriod });
-  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsRebuilding, period: fromPeriod });
+  publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsRebuilding, period: fromPeriod }, workspaceRoot);
   const periods = await listJournalPeriods(bookId, workspaceRoot);
   const targets = periods.filter((monthKey) => monthKey >= fromPeriod);
   let written = 0;
   for (const monthKey of targets) {
-    if (isCancelled(bookId)) break;
-    if (isInvalidatedDuringRebuild(bookId, monthKey)) break;
+    if (isCancelled(key)) break;
+    if (isInvalidatedDuringRebuild(key, monthKey)) break;
     // Compute fresh from journal — bypasses getOrBuildSnapshot's
     // own write side-effect so the staleness check below is the
     // only writer in the rebuild path.
     const balances = await balancesAtEndOf(bookId, monthKey, workspaceRoot);
-    if (isCancelled(bookId)) break;
-    if (isInvalidatedDuringRebuild(bookId, monthKey)) break;
+    if (isCancelled(key)) break;
+    if (isInvalidatedDuringRebuild(key, monthKey)) break;
     await writeSnapshot(bookId, { period: monthKey, balances, builtAt: new Date().toISOString() }, workspaceRoot);
-    if (isCancelled(bookId)) {
+    if (isCancelled(key)) {
       // The book was deleted between our last check and the write —
       // `writeSnapshot` will have re-created the book directory tree
       // via mkdir-recursive. Undo it so we don't leave an orphaned
@@ -203,7 +229,7 @@ async function runRebuild(bookId: string, fromPeriod: string, workspaceRoot: str
       await ioInvalidateFrom(bookId, monthKey, workspaceRoot);
       break;
     }
-    if (isInvalidatedDuringRebuild(bookId, monthKey)) {
+    if (isInvalidatedDuringRebuild(key, monthKey)) {
       // A concurrent invalidate raced ahead between our last check
       // and the disk write. The data we just wrote may be stale
       // relative to the latest journal — undo so the queued
@@ -212,12 +238,12 @@ async function runRebuild(bookId: string, fromPeriod: string, workspaceRoot: str
       break;
     }
     written += 1;
-    publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsReady, period: monthKey });
+    publishBookChange(bookId, { kind: ACCOUNTING_BOOK_EVENT_KINDS.snapshotsReady, period: monthKey }, workspaceRoot);
   }
   log.info("accounting", "snapshot rebuild done", { bookId, periods: written, durationMs: Date.now() - startedAt });
 }
 
-function startRebuild(bookId: string, fromPeriod: string, workspaceRoot: string | undefined): RebuildQueueEntry {
+function startRebuild(key: string, bookId: string, fromPeriod: string, workspaceRoot: string | undefined): RebuildQueueEntry {
   const entry: RebuildQueueEntry = {
     running: Promise.resolve(),
     pendingFromPeriod: null,
@@ -226,7 +252,7 @@ function startRebuild(bookId: string, fromPeriod: string, workspaceRoot: string 
     runningFromPeriod: fromPeriod,
     cancelled: false,
   };
-  entry.running = runRebuild(bookId, fromPeriod, workspaceRoot)
+  entry.running = runRebuild(key, bookId, fromPeriod, workspaceRoot)
     .catch((err) => {
       // A rebuild failure is logged but does not poison the queue —
       // the next `scheduleRebuild` call will start a fresh promise.
@@ -234,24 +260,24 @@ function startRebuild(bookId: string, fromPeriod: string, workspaceRoot: string 
     })
     .then(() => {
       // Drain any work that piled up while we were running.
-      const current = rebuildQueues.get(bookId);
+      const current = rebuildQueues.get(key);
       if (!current) return;
       // If the book was cancelled mid-rebuild (e.g. deleteBook ran),
       // drop the queue entry entirely — we must not start a successor
       // that would re-create the deleted book directory.
       if (current.cancelled) {
-        rebuildQueues.delete(bookId);
+        rebuildQueues.delete(key);
         return;
       }
       if (current.pendingFromPeriod !== null) {
         const nextFrom = current.pendingFromPeriod;
         const nextRoot = current.pendingWorkspaceRoot;
         const carriedCount = current.coalescedWriteCount;
-        const successor = startRebuild(bookId, nextFrom, nextRoot);
+        const successor = startRebuild(key, bookId, nextFrom, nextRoot);
         successor.coalescedWriteCount += carriedCount;
-        rebuildQueues.set(bookId, successor);
+        rebuildQueues.set(key, successor);
       } else {
-        rebuildQueues.delete(bookId);
+        rebuildQueues.delete(key);
       }
     });
   return entry;
@@ -262,9 +288,10 @@ function startRebuild(bookId: string, fromPeriod: string, workspaceRoot: string 
  *  follow-up rebuild that covers the minimum `fromPeriod` seen.
  *  Returns immediately — the rebuild runs on its own promise chain. */
 export function scheduleRebuild(bookId: string, fromPeriod: string, workspaceRoot?: string): void {
-  const existing = rebuildQueues.get(bookId);
+  const key = queueKey(bookId, workspaceRoot);
+  const existing = rebuildQueues.get(key);
   if (!existing) {
-    rebuildQueues.set(bookId, startRebuild(bookId, fromPeriod, workspaceRoot));
+    rebuildQueues.set(key, startRebuild(key, bookId, fromPeriod, workspaceRoot));
     return;
   }
   existing.pendingFromPeriod = minPeriod(existing.pendingFromPeriod, fromPeriod);
@@ -276,9 +303,10 @@ export function scheduleRebuild(bookId: string, fromPeriod: string, workspaceRoo
  *  `bookId`. Also called by `deleteBook` after `cancelRebuild` to
  *  ensure a previously running rebuild has fully stopped before the
  *  caller removes the book's directory on disk. */
-export async function awaitRebuildIdle(bookId: string): Promise<void> {
-  while (rebuildQueues.has(bookId)) {
-    const entry = rebuildQueues.get(bookId);
+export async function awaitRebuildIdle(bookId: string, workspaceRoot?: string): Promise<void> {
+  const key = queueKey(bookId, workspaceRoot);
+  while (rebuildQueues.has(key)) {
+    const entry = rebuildQueues.get(key);
     if (!entry) return;
     await entry.running;
   }
@@ -289,8 +317,8 @@ export async function awaitRebuildIdle(bookId: string): Promise<void> {
  *  `removeBookDir` cannot race with a `writeSnapshot` that would
  *  re-create the directory tree. Pair with `awaitRebuildIdle(bookId)`
  *  to wait for the in-flight rebuild to finish bailing. */
-export function cancelRebuild(bookId: string): void {
-  const entry = rebuildQueues.get(bookId);
+export function cancelRebuild(bookId: string, workspaceRoot?: string): void {
+  const entry = rebuildQueues.get(queueKey(bookId, workspaceRoot));
   if (!entry) return;
   entry.cancelled = true;
   // Drop pending too — a cancelled book should not get a successor
@@ -300,13 +328,16 @@ export function cancelRebuild(bookId: string): void {
 
 /** Test/diagnostic: snapshot of the per-book queue state. Stable
  *  enough to assert against; fields may grow over time. */
-export function inspectRebuildQueue(bookId: string): {
+export function inspectRebuildQueue(
+  bookId: string,
+  workspaceRoot?: string,
+): {
   running: boolean;
   runningFromPeriod: string | null;
   pendingFromPeriod: string | null;
   coalescedWriteCount: number;
 } {
-  const entry = rebuildQueues.get(bookId);
+  const entry = rebuildQueues.get(queueKey(bookId, workspaceRoot));
   if (!entry) {
     return { running: false, runningFromPeriod: null, pendingFromPeriod: null, coalescedWriteCount: 0 };
   }

--- a/packages/plugins/accounting-plugin/src/shared/api.ts
+++ b/packages/plugins/accounting-plugin/src/shared/api.ts
@@ -14,3 +14,16 @@ export const ACCOUNTING_API = {
     method: "POST",
   },
 } as const;
+
+/** Body field carrying the host's OPAQUE project id on a dispatch
+ *  request, for a host that serves more than one root. The package
+ *  writes it (the Vue client, from `configureAccountingHost`'s
+ *  `projectScope`) and the HOST reads it, through the
+ *  `resolveWorkspaceRoot` resolver it passes to `createAccountingRouter`
+ *  — the package itself never resolves it, so a project can only ever
+ *  be named by the host's own client, never by the LLM (the
+ *  `manageAccounting` tool schema has no such parameter).
+ *
+ *  It is an id the host can look up, NEVER a path. A single-root host
+ *  neither sends nor reads it, and its requests are unchanged. */
+export const ACCOUNTING_PROJECT_FIELD = "project";

--- a/packages/plugins/accounting-plugin/src/shared/channels.ts
+++ b/packages/plugins/accounting-plugin/src/shared/channels.ts
@@ -16,9 +16,17 @@
 
 /** Channel factory for per-book event streams. Subscribers:
  *  `useAccountingChannel(bookId)`. Publisher: the package's server
- *  surface `eventPublisher`. */
-export function bookChannel(bookId: string): string {
-  return `accounting:${bookId}`;
+ *  surface `eventPublisher`.
+ *
+ *  `scope` is the host's OPAQUE project id for the root the book lives
+ *  under, for a multi-root host where a bookId is unique within a root
+ *  and nowhere else — without it, a write to `main` in project A
+ *  refreshes an open view of `main` in project B. Absent / `null` means
+ *  the host's default root, and the name stays byte-identical to a
+ *  single-root host's. It is an id, never a path: these names reach the
+ *  browser. */
+export function bookChannel(bookId: string, scope?: string | null): string {
+  return scope ? `accounting:${scope}:${bookId}` : `accounting:${bookId}`;
 }
 
 /** Book-list-level channel — a book was created / deleted. Subscribers
@@ -27,6 +35,14 @@ export function bookChannel(bookId: string): string {
  *  the host META stays the codegen-discoverable source for the
  *  aggregator merge). */
 export const ACCOUNTING_BOOKS_CHANNEL = "accounting:books";
+
+/** Scoped form of `ACCOUNTING_BOOKS_CHANNEL` — same rules as
+ *  `bookChannel`'s `scope`. Unscoped it IS `ACCOUNTING_BOOKS_CHANNEL`.
+ *  A book id cannot contain `:` (see `isSafeBookId`), so a scoped books
+ *  channel can never collide with a scoped per-book one. */
+export function booksChannel(scope?: string | null): string {
+  return scope ? `accounting:${scope}:books` : ACCOUNTING_BOOKS_CHANNEL;
+}
 
 /** Event kinds that ride `bookChannel(bookId)`. Single source of
  *  truth for both publishers (server/accounting) and subscribers

--- a/packages/plugins/accounting-plugin/src/shared/channels.ts
+++ b/packages/plugins/accounting-plugin/src/shared/channels.ts
@@ -38,10 +38,17 @@ export const ACCOUNTING_BOOKS_CHANNEL = "accounting:books";
 
 /** Scoped form of `ACCOUNTING_BOOKS_CHANNEL` — same rules as
  *  `bookChannel`'s `scope`. Unscoped it IS `ACCOUNTING_BOOKS_CHANNEL`.
- *  A book id cannot contain `:` (see `isSafeBookId`), so a scoped books
- *  channel can never collide with a scoped per-book one. */
+ *
+ *  The `#` is load-bearing: `books` is a legal book id (`isSafeBookId`),
+ *  so a plain `accounting:<scope>:books` would be exactly
+ *  `bookChannel("books", scope)` and the two streams would cross. `#` is
+ *  not a legal id character, so the scoped names cannot collide. The
+ *  UNSCOPED pair still can — `accounting:books` has meant the book list
+ *  since before scopes existed and renaming it would break every
+ *  subscriber — which is a pre-existing spurious-refresh quirk for a
+ *  book literally named `books`, not something this scope introduces. */
 export function booksChannel(scope?: string | null): string {
-  return scope ? `accounting:${scope}:books` : ACCOUNTING_BOOKS_CHANNEL;
+  return scope ? `accounting:${scope}:#books` : ACCOUNTING_BOOKS_CHANNEL;
 }
 
 /** Event kinds that ride `bookChannel(bookId)`. Single source of

--- a/packages/plugins/accounting-plugin/src/vue/View.vue
+++ b/packages/plugins/accounting-plugin/src/vue/View.vue
@@ -135,7 +135,8 @@ import Ledger from "./components/Ledger.vue";
 import BalanceSheet from "./components/BalanceSheet.vue";
 import ProfitLoss from "./components/ProfitLoss.vue";
 import BookSettings from "./components/BookSettings.vue";
-import { getOpeningBalances, getAccounts, getBooks, type Account, type BookSummary } from "./api";
+import { provideAccountingApi, type Account, type BookSummary } from "./api";
+import { hostProjectScope } from "./hostContext";
 import { ACCOUNTING_ACTIONS } from "../shared";
 import { useAccountingChannel, useAccountingBooksChannel } from "./useAccountingChannel";
 import { errorMessage } from "../shared/errors";
@@ -154,6 +155,10 @@ interface AccountingAppPayload {
    *  entries returned by the service. Each carries a server-stamped
    *  `id` we use to highlight the row in JournalList. */
   entries?: { id?: string }[];
+  /** The host's opaque project id, stamped by the server on the
+   *  envelope that opened this card. It pins the card to the project it
+   *  was opened for — see `cardScope` below. */
+  scope?: string;
   /** Present on `voidEntry` envelopes — the kind="void-marker" row
    *  posted alongside the reversing entry. We surface this row (not
    *  the reverseEntry) because the marker is the visual "this entry
@@ -187,6 +192,18 @@ function isTabKey(value: string | undefined): value is TabKey {
 }
 
 const initialPayload = computed<AccountingAppPayload>(() => props.selectedResult?.data ?? props.selectedResult?.jsonData ?? {});
+
+// The project this card belongs to, resolved ONCE at mount and never
+// again. A multi-root host can change its active project while this
+// card stays open; without pinning, every request and subscription
+// below would follow it and the card would silently start reading —
+// and writing — another project's books under the same bookId. An
+// envelope with no scope (a single-root host, or one made before the
+// server stamped it) falls back to whatever the host considered active
+// at mount, which for a single-root host is always `null`.
+const cardScope = initialPayload.value.scope ?? hostProjectScope();
+// Binds every child component's api client to that project too.
+const api = provideAccountingApi(cardScope);
 const initialTab = computed<TabKey>(() => (isTabKey(initialPayload.value.initialTab) ? initialPayload.value.initialTab : "journal"));
 
 const currentTab = ref<TabKey>(initialTab.value);
@@ -244,8 +261,8 @@ const activeFiscalYearEnd = computed(() => activeBook.value?.fiscalYearEnd);
 // SSE round-trip drives the table/report refetch. No parallel
 // localVersion bump — it only ever fired the same watchers a second
 // time in the same tick.
-const { version: bookVersion } = useAccountingChannel(activeBookId);
-useAccountingBooksChannel(() => void refetchBooks());
+const { version: bookVersion } = useAccountingChannel(activeBookId, undefined, cardScope);
+useAccountingBooksChannel(() => void refetchBooks(), cardScope);
 
 function pickInitialBookId(): string | null {
   // Priority: explicit `initialPayload.bookId` (carried in the
@@ -270,7 +287,7 @@ async function refetchBooks(): Promise<void> {
   // with `activeBook` already pointing at a now-stale entry.
   const previousActive = activeBook.value;
   try {
-    const result = await getBooks();
+    const result = await api.getBooks();
     if (!result.ok) {
       // Surface load failures as a distinct error state so the user
       // doesn't see "No books yet" (and the auto-open modal) when
@@ -370,7 +387,7 @@ async function refetchAccounts(): Promise<void> {
     accounts.value = [];
     return;
   }
-  const result = await getAccounts(activeBookId.value);
+  const result = await api.getAccounts(activeBookId.value);
   if (!result.ok) return;
   accounts.value = result.data.accounts;
 }
@@ -381,7 +398,7 @@ async function refetchOpening(): Promise<void> {
     activeOpeningDate.value = undefined;
     return;
   }
-  const result = await getOpeningBalances(activeBookId.value);
+  const result = await api.getOpeningBalances(activeBookId.value);
   if (!result.ok) return;
   hasOpening.value = result.data.opening !== null;
   activeOpeningDate.value = result.data.opening?.date;

--- a/packages/plugins/accounting-plugin/src/vue/View.vue
+++ b/packages/plugins/accounting-plugin/src/vue/View.vue
@@ -156,9 +156,10 @@ interface AccountingAppPayload {
    *  `id` we use to highlight the row in JournalList. */
   entries?: { id?: string }[];
   /** The host's opaque project id, stamped by the server on the
-   *  envelope that opened this card. It pins the card to the project it
-   *  was opened for — see `cardScope` below. */
-  scope?: string;
+   *  envelope that opened this card — `null` meaning the default root.
+   *  It pins the card to the project it was opened for; see `cardScope`
+   *  below. */
+  scope?: string | null;
   /** Present on `voidEntry` envelopes — the kind="void-marker" row
    *  posted alongside the reversing entry. We surface this row (not
    *  the reverseEntry) because the marker is the visual "this entry
@@ -193,17 +194,25 @@ function isTabKey(value: string | undefined): value is TabKey {
 
 const initialPayload = computed<AccountingAppPayload>(() => props.selectedResult?.data ?? props.selectedResult?.jsonData ?? {});
 
-// The project this card belongs to, resolved ONCE at mount and never
-// again. A multi-root host can change its active project while this
-// card stays open; without pinning, every request and subscription
-// below would follow it and the card would silently start reading —
-// and writing — another project's books under the same bookId. An
-// envelope with no scope (a single-root host, or one made before the
-// server stamped it) falls back to whatever the host considered active
-// at mount, which for a single-root host is always `null`.
-const cardScope = initialPayload.value.scope ?? hostProjectScope();
-// Binds every child component's api client to that project too.
-const api = provideAccountingApi(cardScope);
+// The project this card belongs to — taken from the ENVELOPE that
+// opened it, not from whatever the host considers active. A multi-root
+// host can change its active project while this card stays open, and
+// following that would silently repoint the card's reads and writes at
+// another project's books under the same bookId.
+//
+// PRESENCE, not truthiness: `null` is a real scope (the host's default
+// root) and binds like any other. Only a genuinely absent field — a
+// host that declared no scoping, or a card made before the server
+// stamped it — falls back to what the host considers active, which on a
+// single-root host is always `null` anyway.
+const cardScope = computed<string | null>(() => {
+  const payload = initialPayload.value;
+  return "scope" in payload ? (payload.scope ?? null) : hostProjectScope();
+});
+// Binds every child component's api client to that project too, and
+// follows the card this View is showing: `selectedResult` can be
+// retargeted at another result without remounting.
+const api = provideAccountingApi(() => cardScope.value);
 const initialTab = computed<TabKey>(() => (isTabKey(initialPayload.value.initialTab) ? initialPayload.value.initialTab : "journal"));
 
 const currentTab = ref<TabKey>(initialTab.value);
@@ -261,8 +270,11 @@ const activeFiscalYearEnd = computed(() => activeBook.value?.fiscalYearEnd);
 // SSE round-trip drives the table/report refetch. No parallel
 // localVersion bump — it only ever fired the same watchers a second
 // time in the same tick.
-const { version: bookVersion } = useAccountingChannel(activeBookId, undefined, cardScope);
-useAccountingBooksChannel(() => void refetchBooks(), cardScope);
+const { version: bookVersion } = useAccountingChannel(activeBookId, undefined, () => cardScope.value);
+useAccountingBooksChannel(
+  () => void refetchBooks(),
+  () => cardScope.value,
+);
 
 function pickInitialBookId(): string | null {
   // Priority: explicit `initialPayload.bookId` (carried in the

--- a/packages/plugins/accounting-plugin/src/vue/api.ts
+++ b/packages/plugins/accounting-plugin/src/vue/api.ts
@@ -57,11 +57,12 @@ export type {
 export interface OpenAppPayload {
   kind: "accounting-app";
   /** The host's opaque project id for the root this book lives under,
-   *  stamped by the server on an `openBook` result. Absent for a
-   *  single-root host. A host that renders cards from more than one
-   *  project keys them by `(scope, bookId)` — a bookId is unique within
-   *  a root and nowhere else. */
-  scope?: string;
+   *  stamped by the server on an `openBook` result. `null` is the
+   *  default root; the field is absent only on a host that declared no
+   *  scoping. A host that renders cards from more than one project keys
+   *  them by `(scope, bookId)` — a bookId is unique within a root and
+   *  nowhere else. */
+  scope?: string | null;
   /** `null` when the workspace has zero books — the View renders the
    *  empty state and prompts for book creation. */
   bookId: string | null;
@@ -302,16 +303,18 @@ const hostScopedApi = makeApi(hostProjectScope);
 
 const API_KEY: InjectionKey<AccountingApi> = Symbol("accounting-api");
 
-/** Bind a component tree to ONE project for its whole life.
+/** Bind a component tree to the project its surface belongs to.
  *
  *  A card was opened against the project its server envelope named
  *  (`OpenAppPayload.scope`). If its requests kept resolving the host's
- *  CURRENT project instead, then switching projects would silently
- *  repoint an already-open card's reads and writes at another project's
- *  books — same bookId, different company. Call this once, in the
- *  mounted app's setup, with the scope the card was opened for. */
-export function provideAccountingApi(scope: string | null): AccountingApi {
-  const api = createAccountingApi(scope);
+ *  CURRENT project instead, switching projects would silently repoint
+ *  an already-open card's reads and writes at another project's books —
+ *  same bookId, different company. Call this once in the mounted app's
+ *  setup, passing a GETTER: the surface's own scope can change when it
+ *  is retargeted at another card, and the tree must follow the card it
+ *  is showing rather than the one it first showed. */
+export function provideAccountingApi(getScope: () => string | null): AccountingApi {
+  const api = makeApi(getScope);
   provide(API_KEY, api);
   return api;
 }

--- a/packages/plugins/accounting-plugin/src/vue/api.ts
+++ b/packages/plugins/accounting-plugin/src/vue/api.ts
@@ -8,6 +8,8 @@
 // validation) flow through the same shape. The actual network client is
 // host-injected (see hostContext.ts) so the package stays host-agnostic.
 
+import { inject, provide, type InjectionKey } from "vue";
+
 import { hostApiCall as apiCall, hostProjectScope, type ApiResult } from "./hostContext";
 import {
   ACCOUNTING_ACTIONS,
@@ -71,62 +73,6 @@ export interface OpenAppPayload {
 const DISPATCH_URL = ACCOUNTING_API.dispatch.path;
 const DISPATCH_METHOD = ACCOUNTING_API.dispatch.method;
 
-function call<T>(action: string, args: Record<string, unknown> = {}): Promise<ApiResult<T>> {
-  // The project rides every request, last so a caller cannot shadow it.
-  // Absent (single-root host) the body is byte-identical to before.
-  const project = hostProjectScope();
-  const scopeField = project ? { [ACCOUNTING_PROJECT_FIELD]: project } : {};
-  return apiCall<T>(DISPATCH_URL, { method: DISPATCH_METHOD, body: { action, ...args, ...scopeField } });
-}
-
-// ── Books ────────────────────────────────────────────────────────────
-
-export function getBooks(): Promise<ApiResult<{ books: BookSummary[] }>> {
-  return call(ACCOUNTING_ACTIONS.getBooks);
-}
-
-export function createBook(input: {
-  name: string;
-  currency?: string | undefined;
-  country?: SupportedCountryCode | undefined;
-  /** Closing month 1-12 — required at the form boundary, but the
-   *  server silently defaults an absent value to 12 (December). */
-  fiscalYearEnd?: FiscalYearEnd | undefined;
-}): Promise<ApiResult<{ book: BookSummary }>> {
-  return call(ACCOUNTING_ACTIONS.createBook, input);
-}
-
-export function updateBook(input: {
-  bookId: string;
-  name?: string | undefined;
-  /** Pass `""` to explicitly clear the country (server treats it as
-   *  the "drop the field" sentinel). Any other value must be one of
-   *  the curated `SupportedCountryCode`s. */
-  country?: SupportedCountryCode | "" | undefined;
-  /** Closing month 1-12 — pure metadata, only changes how the
-   *  date-range shortcuts resolve. No "clear" path; absence leaves the
-   *  existing value untouched. */
-  fiscalYearEnd?: FiscalYearEnd | undefined;
-}): Promise<ApiResult<{ book: BookSummary }>> {
-  return call(ACCOUNTING_ACTIONS.updateBook, input);
-}
-
-export function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string; deletedBookName: string }>> {
-  return call(ACCOUNTING_ACTIONS.deleteBook, { bookId, confirm: true });
-}
-
-// ── Accounts ─────────────────────────────────────────────────────────
-
-export function getAccounts(bookId: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
-  return call(ACCOUNTING_ACTIONS.getAccounts, { bookId });
-}
-
-export function upsertAccount(account: Account, bookId: string): Promise<ApiResult<{ bookId: string; account: Account; accounts: Account[] }>> {
-  return call(ACCOUNTING_ACTIONS.upsertAccount, { account, bookId });
-}
-
-// ── Entries ──────────────────────────────────────────────────────────
-
 export interface AddEntriesItemInput {
   date: string;
   lines: JournalLine[];
@@ -136,62 +82,6 @@ export interface AddEntriesItemInput {
    *  `replacesEntryId` separately just before this call — there is
    *  no atomic transaction. */
   replacesEntryId?: string | undefined;
-}
-
-export function addEntries(input: {
-  bookId: string;
-  /** One or more entries to post. The server validates every entry
-   *  before any write, so a single bad entry rejects the whole
-   *  batch. Pass a single-element array to post just one entry. */
-  entries: AddEntriesItemInput[];
-}): Promise<ApiResult<{ bookId: string; entries: JournalEntry[] }>> {
-  return call(ACCOUNTING_ACTIONS.addEntries, input);
-}
-
-export function voidEntry(input: {
-  entryId: string;
-  reason?: string | undefined;
-  bookId: string;
-}): Promise<ApiResult<{ bookId: string; reverseEntry: JournalEntry; markerEntry: JournalEntry }>> {
-  return call(ACCOUNTING_ACTIONS.voidEntry, input);
-}
-
-export function getJournalEntries(input: {
-  from?: string | undefined;
-  to?: string | undefined;
-  accountCode?: string | undefined;
-  bookId: string;
-}): Promise<ApiResult<{ bookId: string; entries: JournalEntry[]; voidedEntryIds: string[] }>> {
-  return call(ACCOUNTING_ACTIONS.getJournalEntries, input);
-}
-
-// ── Opening balances ─────────────────────────────────────────────────
-
-export function getOpeningBalances(bookId: string): Promise<ApiResult<{ bookId: string; opening: JournalEntry | null }>> {
-  return call(ACCOUNTING_ACTIONS.getOpeningBalances, { bookId });
-}
-
-export function setOpeningBalances(input: {
-  asOfDate: string;
-  lines: JournalLine[];
-  memo?: string | undefined;
-  bookId: string;
-}): Promise<ApiResult<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }>> {
-  return call(ACCOUNTING_ACTIONS.setOpeningBalances, input);
-}
-
-// ── Reports ──────────────────────────────────────────────────────────
-
-export function getBalanceSheet(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; balanceSheet: BalanceSheet }>> {
-  return call(ACCOUNTING_ACTIONS.getReport, { kind: "balance", period, bookId });
-}
-
-export function getProfitLoss(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; profitLoss: ProfitLoss }>> {
-  return call(ACCOUNTING_ACTIONS.getReport, { kind: "pl", period, bookId });
-}
-
-export function getLedger(accountCode: string, period: ReportPeriod | undefined, bookId: string): Promise<ApiResult<{ bookId: string; ledger: Ledger }>> {
-  return call(ACCOUNTING_ACTIONS.getReport, { kind: "ledger", accountCode, period, bookId });
 }
 
 export interface TimeSeriesPoint {
@@ -226,15 +116,209 @@ export interface TimeSeriesResult {
   points: TimeSeriesPoint[];
 }
 
-export function getTimeSeries(input: TimeSeriesInput): Promise<ApiResult<TimeSeriesResult>> {
-  // Spread so the named interface is widened into a fresh object
-  // literal — `call()` takes `Record<string, unknown>` which a
-  // declared interface doesn't satisfy structurally in TS.
-  return call(ACCOUNTING_ACTIONS.getTimeSeries, { ...input });
+/** The dispatch seam every helper below is written against. */
+type Call = <T>(action: string, args?: Record<string, unknown>) => Promise<ApiResult<T>>;
+
+/** The one call every helper goes through, bound to a scope RESOLVER
+ *  rather than a fixed scope, so the host-scoped client tracks a host
+ *  that changes its active project while a pinned one does not. Absent
+ *  (single-root host) every request body is byte-identical to what it
+ *  was before scopes existed. */
+function makeCall(getScope: () => string | null): Call {
+  return function call<T>(action: string, args: Record<string, unknown> = {}): Promise<ApiResult<T>> {
+    // The project rides every request, last so a caller cannot shadow it.
+    const project = getScope();
+    const scopeField = project ? { [ACCOUNTING_PROJECT_FIELD]: project } : {};
+    return apiCall<T>(DISPATCH_URL, { method: DISPATCH_METHOD, body: { action, ...args, ...scopeField } });
+  };
 }
 
-// ── Admin ────────────────────────────────────────────────────────────
+/** Books — the list and its lifecycle. */
+function booksApi(call: Call) {
+  function getBooks(): Promise<ApiResult<{ books: BookSummary[] }>> {
+    return call(ACCOUNTING_ACTIONS.getBooks);
+  }
 
-export function rebuildSnapshots(bookId: string): Promise<ApiResult<{ bookId: string; rebuilt: string[] }>> {
-  return call(ACCOUNTING_ACTIONS.rebuildSnapshots, { bookId });
+  function createBook(input: {
+    name: string;
+    currency?: string | undefined;
+    country?: SupportedCountryCode | undefined;
+    /** Closing month 1-12 — required at the form boundary, but the
+     *  server silently defaults an absent value to 12 (December). */
+    fiscalYearEnd?: FiscalYearEnd | undefined;
+  }): Promise<ApiResult<{ book: BookSummary }>> {
+    return call(ACCOUNTING_ACTIONS.createBook, input);
+  }
+
+  function updateBook(input: {
+    bookId: string;
+    name?: string | undefined;
+    /** Pass `""` to explicitly clear the country (server treats it as
+     *  the "drop the field" sentinel). Any other value must be one of
+     *  the curated `SupportedCountryCode`s. */
+    country?: SupportedCountryCode | "" | undefined;
+    /** Closing month 1-12 — pure metadata, only changes how the
+     *  date-range shortcuts resolve. No "clear" path; absence leaves the
+     *  existing value untouched. */
+    fiscalYearEnd?: FiscalYearEnd | undefined;
+  }): Promise<ApiResult<{ book: BookSummary }>> {
+    return call(ACCOUNTING_ACTIONS.updateBook, input);
+  }
+
+  function deleteBook(bookId: string): Promise<ApiResult<{ deletedBookId: string; deletedBookName: string }>> {
+    return call(ACCOUNTING_ACTIONS.deleteBook, { bookId, confirm: true });
+  }
+
+  return {
+    getBooks,
+    createBook,
+    updateBook,
+    deleteBook,
+  };
+}
+
+/** The chart of accounts. */
+function accountsApi(call: Call) {
+  function getAccounts(bookId: string): Promise<ApiResult<{ bookId: string; accounts: Account[] }>> {
+    return call(ACCOUNTING_ACTIONS.getAccounts, { bookId });
+  }
+
+  function upsertAccount(account: Account, bookId: string): Promise<ApiResult<{ bookId: string; account: Account; accounts: Account[] }>> {
+    return call(ACCOUNTING_ACTIONS.upsertAccount, { account, bookId });
+  }
+
+  return {
+    getAccounts,
+    upsertAccount,
+  };
+}
+
+/** Journal entries and the opening balance. */
+function journalApi(call: Call) {
+  function addEntries(input: {
+    bookId: string;
+    /** One or more entries to post. The server validates every entry
+     *  before any write, so a single bad entry rejects the whole
+     *  batch. Pass a single-element array to post just one entry. */
+    entries: AddEntriesItemInput[];
+  }): Promise<ApiResult<{ bookId: string; entries: JournalEntry[] }>> {
+    return call(ACCOUNTING_ACTIONS.addEntries, input);
+  }
+
+  function voidEntry(input: {
+    entryId: string;
+    reason?: string | undefined;
+    bookId: string;
+  }): Promise<ApiResult<{ bookId: string; reverseEntry: JournalEntry; markerEntry: JournalEntry }>> {
+    return call(ACCOUNTING_ACTIONS.voidEntry, input);
+  }
+
+  function getJournalEntries(input: {
+    from?: string | undefined;
+    to?: string | undefined;
+    accountCode?: string | undefined;
+    bookId: string;
+  }): Promise<ApiResult<{ bookId: string; entries: JournalEntry[]; voidedEntryIds: string[] }>> {
+    return call(ACCOUNTING_ACTIONS.getJournalEntries, input);
+  }
+
+  function getOpeningBalances(bookId: string): Promise<ApiResult<{ bookId: string; opening: JournalEntry | null }>> {
+    return call(ACCOUNTING_ACTIONS.getOpeningBalances, { bookId });
+  }
+
+  function setOpeningBalances(input: {
+    asOfDate: string;
+    lines: JournalLine[];
+    memo?: string | undefined;
+    bookId: string;
+  }): Promise<ApiResult<{ bookId: string; openingEntry: JournalEntry; replacedExisting: boolean }>> {
+    return call(ACCOUNTING_ACTIONS.setOpeningBalances, input);
+  }
+
+  return {
+    addEntries,
+    voidEntry,
+    getJournalEntries,
+    getOpeningBalances,
+    setOpeningBalances,
+  };
+}
+
+/** Reports, series, and snapshot maintenance. */
+function reportsApi(call: Call) {
+  function getBalanceSheet(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; balanceSheet: BalanceSheet }>> {
+    return call(ACCOUNTING_ACTIONS.getReport, { kind: "balance", period, bookId });
+  }
+
+  function getProfitLoss(period: ReportPeriod, bookId: string): Promise<ApiResult<{ bookId: string; profitLoss: ProfitLoss }>> {
+    return call(ACCOUNTING_ACTIONS.getReport, { kind: "pl", period, bookId });
+  }
+
+  function getLedger(accountCode: string, period: ReportPeriod | undefined, bookId: string): Promise<ApiResult<{ bookId: string; ledger: Ledger }>> {
+    return call(ACCOUNTING_ACTIONS.getReport, { kind: "ledger", accountCode, period, bookId });
+  }
+
+  function getTimeSeries(input: TimeSeriesInput): Promise<ApiResult<TimeSeriesResult>> {
+    // Spread so the named interface is widened into a fresh object
+    // literal — `call()` takes `Record<string, unknown>` which a
+    // declared interface doesn't satisfy structurally in TS.
+    return call(ACCOUNTING_ACTIONS.getTimeSeries, { ...input });
+  }
+
+  function rebuildSnapshots(bookId: string): Promise<ApiResult<{ bookId: string; rebuilt: string[] }>> {
+    return call(ACCOUNTING_ACTIONS.rebuildSnapshots, { bookId });
+  }
+
+  return {
+    getBalanceSheet,
+    getProfitLoss,
+    getLedger,
+    getTimeSeries,
+    rebuildSnapshots,
+  };
+}
+
+/** Build an api client bound to ONE project scope. */
+function makeApi(getScope: () => string | null) {
+  const call = makeCall(getScope);
+  return { ...booksApi(call), ...accountsApi(call), ...journalApi(call), ...reportsApi(call) };
+}
+
+/** The full accounting client surface, bound to one project. */
+export type AccountingApi = ReturnType<typeof makeApi>;
+
+/** A client pinned to one project for good — `null` meaning the host's
+ *  default root. Use it for anything whose project is decided once
+ *  (a card, a panel); use the tree-injected client (`useAccountingApi`)
+ *  inside components. */
+export function createAccountingApi(scope: string | null): AccountingApi {
+  return makeApi(() => scope);
+}
+
+/** Follows whatever project the HOST currently considers active. Used
+ *  by any surface mounted outside a scoped tree, and by every
+ *  single-root host, where the scope is always `null`. */
+const hostScopedApi = makeApi(hostProjectScope);
+
+const API_KEY: InjectionKey<AccountingApi> = Symbol("accounting-api");
+
+/** Bind a component tree to ONE project for its whole life.
+ *
+ *  A card was opened against the project its server envelope named
+ *  (`OpenAppPayload.scope`). If its requests kept resolving the host's
+ *  CURRENT project instead, then switching projects would silently
+ *  repoint an already-open card's reads and writes at another project's
+ *  books — same bookId, different company. Call this once, in the
+ *  mounted app's setup, with the scope the card was opened for. */
+export function provideAccountingApi(scope: string | null): AccountingApi {
+  const api = createAccountingApi(scope);
+  provide(API_KEY, api);
+  return api;
+}
+
+/** The api client for the surrounding tree, falling back to the
+ *  host-scoped one for a surface nobody bound (a single-root host's
+ *  every surface). */
+export function useAccountingApi(): AccountingApi {
+  return inject(API_KEY, hostScopedApi);
 }

--- a/packages/plugins/accounting-plugin/src/vue/api.ts
+++ b/packages/plugins/accounting-plugin/src/vue/api.ts
@@ -8,10 +8,11 @@
 // validation) flow through the same shape. The actual network client is
 // host-injected (see hostContext.ts) so the package stays host-agnostic.
 
-import { hostApiCall as apiCall, type ApiResult } from "./hostContext";
+import { hostApiCall as apiCall, hostProjectScope, type ApiResult } from "./hostContext";
 import {
   ACCOUNTING_ACTIONS,
   ACCOUNTING_API,
+  ACCOUNTING_PROJECT_FIELD,
   type SupportedCountryCode,
   type FiscalYearEnd,
   type TimeSeriesGranularity,
@@ -53,6 +54,12 @@ export type {
 
 export interface OpenAppPayload {
   kind: "accounting-app";
+  /** The host's opaque project id for the root this book lives under,
+   *  stamped by the server on an `openBook` result. Absent for a
+   *  single-root host. A host that renders cards from more than one
+   *  project keys them by `(scope, bookId)` — a bookId is unique within
+   *  a root and nowhere else. */
+  scope?: string;
   /** `null` when the workspace has zero books — the View renders the
    *  empty state and prompts for book creation. */
   bookId: string | null;
@@ -65,7 +72,11 @@ const DISPATCH_URL = ACCOUNTING_API.dispatch.path;
 const DISPATCH_METHOD = ACCOUNTING_API.dispatch.method;
 
 function call<T>(action: string, args: Record<string, unknown> = {}): Promise<ApiResult<T>> {
-  return apiCall<T>(DISPATCH_URL, { method: DISPATCH_METHOD, body: { action, ...args } });
+  // The project rides every request, last so a caller cannot shadow it.
+  // Absent (single-root host) the body is byte-identical to before.
+  const project = hostProjectScope();
+  const scopeField = project ? { [ACCOUNTING_PROJECT_FIELD]: project } : {};
+  return apiCall<T>(DISPATCH_URL, { method: DISPATCH_METHOD, body: { action, ...args, ...scopeField } });
 }
 
 // ── Books ────────────────────────────────────────────────────────────

--- a/packages/plugins/accounting-plugin/src/vue/components/AccountsModal.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/AccountsModal.vue
@@ -67,13 +67,15 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
 import { useAccountingI18n } from "../lang";
-import { upsertAccount, type Account, type AccountType } from "../api";
+import { useAccountingApi, type Account, type AccountType } from "../api";
 import AccountRow from "./AccountRow.vue";
 import AccountEditor from "./AccountEditor.vue";
 import type { AccountDraft } from "./accountDraft";
 import { validateAccountDraft, type AccountValidationError } from "./accountValidation";
 import { suggestNextCode } from "./accountNumbering";
 import { errorMessage } from "../../shared/errors";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -210,7 +212,7 @@ async function onSave(next: AccountDraft): Promise<void> {
       const existing = props.accounts.find((entry) => entry.code === account.code);
       if (existing?.active === false) account.active = false;
     }
-    const result = await upsertAccount(account, props.bookId);
+    const result = await api.upsertAccount(account, props.bookId);
     if (!result.ok) {
       error.value = result.error;
       return;
@@ -262,7 +264,7 @@ async function onToggleActive(account: Account): Promise<void> {
     // existing flag and would otherwise turn Reactivate into a
     // no-op.
     next.active = !willDeactivate;
-    const result = await upsertAccount(next, props.bookId);
+    const result = await api.upsertAccount(next, props.bookId);
     if (!result.ok) {
       toggleError.value = result.error;
       return;

--- a/packages/plugins/accounting-plugin/src/vue/components/BalanceSheet.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/BalanceSheet.vue
@@ -75,7 +75,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { getBalanceSheet, type BalanceSheet } from "../api";
+import { useAccountingApi, type BalanceSheet } from "../api";
 import {
   formatAmount as formatAmountWithCurrency,
   decemberOfPreviousYearString,
@@ -84,6 +84,8 @@ import {
   previousMonthString,
 } from "../../shared";
 import { useLatestRequest } from "./useLatestRequest";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -177,7 +179,7 @@ async function refresh(): Promise<void> {
   loading.value = true;
   error.value = null;
   try {
-    const result = await getBalanceSheet({ kind: "month", period: period.value }, props.bookId);
+    const result = await api.getBalanceSheet({ kind: "month", period: period.value }, props.bookId);
     if (!isCurrent(token)) return;
     if (!result.ok) {
       error.value = result.error;

--- a/packages/plugins/accounting-plugin/src/vue/components/BookSettings.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/BookSettings.vue
@@ -107,7 +107,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { deleteBook, rebuildSnapshots, updateBook } from "../api";
+import { useAccountingApi } from "../api";
 import {
   SUPPORTED_COUNTRY_CODES,
   isSupportedCountryCode,
@@ -118,6 +118,8 @@ import {
   resolveFiscalYearEnd,
   type FiscalYearEnd,
 } from "../../shared";
+
+const api = useAccountingApi();
 
 const { t, locale } = useAccountingI18n();
 
@@ -190,7 +192,7 @@ async function onRebuild(): Promise<void> {
   rebuildOk.value = null;
   rebuildError.value = null;
   try {
-    const result = await rebuildSnapshots(props.bookId);
+    const result = await api.rebuildSnapshots(props.bookId);
     if (!result.ok) {
       rebuildError.value = result.error;
       return;
@@ -212,7 +214,7 @@ async function onSaveBookInfo(): Promise<void> {
     // empty string is the sentinel that clears the country server-side.
     const rawCountry = selectedCountry.value;
     const country: SupportedCountryCode | "" = rawCountry === "" || isSupportedCountryCode(rawCountry) ? rawCountry : "";
-    const result = await updateBook({
+    const result = await api.updateBook({
       bookId: props.bookId,
       name: selectedName.value.trim(),
       country,
@@ -234,7 +236,7 @@ async function onDelete(): Promise<void> {
   deleting.value = true;
   deleteError.value = null;
   try {
-    const result = await deleteBook(props.bookId);
+    const result = await api.deleteBook(props.bookId);
     if (!result.ok) {
       deleteError.value = result.error;
       return;

--- a/packages/plugins/accounting-plugin/src/vue/components/JournalEntryForm.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/JournalEntryForm.vue
@@ -176,11 +176,13 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { addEntries, voidEntry, type Account, type JournalEntry, type JournalLine } from "../api";
+import { useAccountingApi, type Account, type JournalEntry, type JournalLine } from "../api";
 import { formatAmount, inputStepFor, localDateString, countryHasFeature, type SupportedCountryCode } from "../../shared";
 import { isTaxAccountCode } from "./accountNumbering";
 import AccountsModal from "./AccountsModal.vue";
 import { errorMessage } from "../../shared/errors";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -383,7 +385,7 @@ async function onSubmit(): Promise<void> {
     const editingId = props.entryToEdit?.id;
     if (editingId) {
       editAttempted.value = true;
-      const voidResult = await voidEntry({
+      const voidResult = await api.voidEntry({
         bookId: props.bookId,
         entryId: editingId,
         reason: t("pluginAccounting.entryForm.editVoidReason"),
@@ -393,7 +395,7 @@ async function onSubmit(): Promise<void> {
         return;
       }
     }
-    const result = await addEntries({
+    const result = await api.addEntries({
       bookId: props.bookId,
       entries: [
         {

--- a/packages/plugins/accounting-plugin/src/vue/components/JournalList.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/JournalList.vue
@@ -200,12 +200,14 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { getJournalEntries, voidEntry, type Account, type JournalEntry, type JournalEntryKind, type JournalLine } from "../api";
+import { useAccountingApi, type Account, type JournalEntry, type JournalEntryKind, type JournalLine } from "../api";
 import { formatAmount, currentFiscalYearRange, resolveFiscalYearEnd, type DateRange, type FiscalYearEnd, type SupportedCountryCode } from "../../shared";
 import { useLatestRequest } from "./useLatestRequest";
 import DateRangePicker from "./DateRangePicker.vue";
 import JournalEntryForm from "./JournalEntryForm.vue";
 import { errorMessage } from "../../shared/errors";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -398,7 +400,7 @@ async function refresh(): Promise<void> {
   loading.value = true;
   error.value = null;
   try {
-    const result = await getJournalEntries({
+    const result = await api.getJournalEntries({
       bookId: props.bookId,
       from: range.value.from || undefined,
       to: range.value.to || undefined,
@@ -456,7 +458,7 @@ async function onVoid(entry: JournalEntry): Promise<void> {
   const reason = window.prompt(t("pluginAccounting.journalList.voidReason"));
   if (reason === null) return;
   try {
-    const result = await voidEntry({ entryId: entry.id, reason: reason || undefined, bookId: props.bookId });
+    const result = await api.voidEntry({ entryId: entry.id, reason: reason || undefined, bookId: props.bookId });
     if (!result.ok) error.value = result.error;
   } catch (err) {
     error.value = errorMessage(err);

--- a/packages/plugins/accounting-plugin/src/vue/components/Ledger.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/Ledger.vue
@@ -68,11 +68,13 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { getLedger, type Account, type Ledger, type ReportPeriod } from "../api";
+import { useAccountingApi, type Account, type Ledger, type ReportPeriod } from "../api";
 import { formatAmount as formatAmountWithCurrency, currentFiscalYearRange, resolveFiscalYearEnd, type DateRange, type FiscalYearEnd } from "../../shared";
 import { isTaxAccountCode } from "./accountNumbering";
 import { useLatestRequest } from "./useLatestRequest";
 import DateRangePicker from "./DateRangePicker.vue";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -153,7 +155,7 @@ async function refresh(): Promise<void> {
   loading.value = true;
   error.value = null;
   try {
-    const result = await getLedger(accountCode.value, periodFromRange(range.value), props.bookId);
+    const result = await api.getLedger(accountCode.value, periodFromRange(range.value), props.bookId);
     // Drop the result if a newer refresh started (bookId or
     // accountCode changed under us) — otherwise a slower earlier
     // request could overwrite the fresh ledger.

--- a/packages/plugins/accounting-plugin/src/vue/components/NewBookForm.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/NewBookForm.vue
@@ -63,7 +63,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from "vue";
 import { useAccountingI18n } from "../lang";
-import { createBook, type BookSummary } from "../api";
+import { useAccountingApi, type BookSummary } from "../api";
 import {
   SUPPORTED_CURRENCY_CODES,
   localizedCurrencyName,
@@ -76,6 +76,8 @@ import {
   fiscalYearEndMonthLabel,
   type FiscalYearEnd,
 } from "../../shared";
+
+const api = useAccountingApi();
 
 const { t, locale } = useAccountingI18n();
 
@@ -202,7 +204,7 @@ async function onSubmit(): Promise<void> {
     // empty string is the dropdown's "(choose a country)" sentinel
     // and must not land on disk as a literal "" value.
     const pickedCountry: SupportedCountryCode | undefined = country.value === "" ? undefined : country.value;
-    const result = await createBook({
+    const result = await api.createBook({
       name: name.value.trim(),
       currency: currency.value,
       country: pickedCountry,

--- a/packages/plugins/accounting-plugin/src/vue/components/OpeningBalancesForm.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/OpeningBalancesForm.vue
@@ -93,11 +93,13 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { getOpeningBalances, setOpeningBalances, type Account, type JournalEntry, type JournalLine } from "../api";
+import { useAccountingApi, type Account, type JournalEntry, type JournalLine } from "../api";
 import { formatAmount, inputStepFor, localDateString } from "../../shared";
 import { useLatestRequest } from "./useLatestRequest";
 import AccountsModal from "./AccountsModal.vue";
 import { errorMessage } from "../../shared/errors";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -216,7 +218,7 @@ async function loadExisting(): Promise<void> {
   // opening doesn't inherit the previous book's draft values.
   const token = beginLoad();
   const next = freshRows();
-  const result = await getOpeningBalances(props.bookId);
+  const result = await api.getOpeningBalances(props.bookId);
   // Drop the result if the user has switched books since this
   // call started — otherwise stale rows would land on the new
   // book's form.
@@ -244,7 +246,7 @@ async function onSubmit(): Promise<void> {
   error.value = null;
   successMessage.value = null;
   try {
-    const result = await setOpeningBalances({ bookId: props.bookId, asOfDate: asOfDate.value, lines: toApiLines() });
+    const result = await api.setOpeningBalances({ bookId: props.bookId, asOfDate: asOfDate.value, lines: toApiLines() });
     if (!result.ok) {
       error.value = result.error;
       return;

--- a/packages/plugins/accounting-plugin/src/vue/components/ProfitLoss.vue
+++ b/packages/plugins/accounting-plugin/src/vue/components/ProfitLoss.vue
@@ -82,10 +82,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useAccountingI18n } from "../lang";
-import { getProfitLoss, type ProfitLoss } from "../api";
+import { useAccountingApi, type ProfitLoss } from "../api";
 import { formatAmount as formatAmountWithCurrency, currentFiscalYearRange, resolveFiscalYearEnd, type DateRange, type FiscalYearEnd } from "../../shared";
 import { useLatestRequest } from "./useLatestRequest";
 import DateRangePicker from "./DateRangePicker.vue";
+
+const api = useAccountingApi();
 
 const { t } = useAccountingI18n();
 
@@ -135,7 +137,7 @@ async function refresh(): Promise<void> {
     // (both empty) means "every entry" rather than an empty window.
     const fromBound = range.value.from || "0000-01-01";
     const toBound = range.value.to || "9999-12-31";
-    const result = await getProfitLoss({ kind: "range", from: fromBound, to: toBound }, props.bookId);
+    const result = await api.getProfitLoss({ kind: "range", from: fromBound, to: toBound }, props.bookId);
     if (!isCurrent(token)) return;
     if (!result.ok) {
       error.value = result.error;

--- a/packages/plugins/accounting-plugin/src/vue/hostContext.ts
+++ b/packages/plugins/accounting-plugin/src/vue/hostContext.ts
@@ -35,10 +35,22 @@ export type AccountingSubscribe = (channel: string, handler: (payload: unknown) 
  *  this tag onto it, so it shares NO i18n resources with the host. */
 export type AccountingLocaleTag = () => string;
 
+/** Project seam — the host's OPAQUE id for the project (root) the
+ *  mounted accounting surface belongs to, or `null` for the host's
+ *  default root. A single-root host omits it entirely and every
+ *  request and channel name stays exactly what it is today.
+ *
+ *  It rides dispatch requests as `ACCOUNTING_PROJECT_FIELD` and
+ *  namespaces the pub/sub channel names, so two projects that both hold
+ *  a book called `main` neither read nor refresh each other. It must be
+ *  an id the host can resolve, never a path — it reaches the browser. */
+export type AccountingProjectScope = () => string | null;
+
 export interface AccountingHostContext {
   apiCall: AccountingApiCall;
   subscribe: AccountingSubscribe;
   localeTag: AccountingLocaleTag;
+  projectScope?: AccountingProjectScope;
 }
 
 let ctx: AccountingHostContext | null = null;
@@ -67,4 +79,11 @@ export function hostSubscribe(channel: string, handler: (payload: unknown) => vo
  *  vue-i18n instance (see `./lang`). */
 export function hostLocaleTag(): string {
   return requireCtx().localeTag();
+}
+
+/** The host's opaque project id for the mounted surface, or `null` when
+ *  the host serves a single root (MulmoClaude) or the surface belongs to
+ *  its default one. */
+export function hostProjectScope(): string | null {
+  return ctx?.projectScope?.() ?? null;
 }

--- a/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
+++ b/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
@@ -18,8 +18,8 @@
 // own `./shared` so publisher and subscriber stay in lockstep.
 
 import { ref, watch, onUnmounted, type Ref } from "vue";
-import { bookChannel, ACCOUNTING_BOOKS_CHANNEL, BOOK_EVENT_KINDS, type BookChannelPayload } from "../shared";
-import { hostSubscribe } from "./hostContext";
+import { bookChannel, booksChannel, BOOK_EVENT_KINDS, type BookChannelPayload } from "../shared";
+import { hostProjectScope, hostSubscribe } from "./hostContext";
 
 const BOOK_EVENT_KIND_VALUES = Object.values(BOOK_EVENT_KINDS);
 
@@ -48,7 +48,11 @@ export function useAccountingChannel(bookId: Ref<string | null>, onPayload?: (pa
     unsubscribe = null;
     version.value = 0;
     if (!nextBookId) return;
-    unsubscribe = hostSubscribe(bookChannel(nextBookId), (data) => {
+    // Scoped by the host's opaque project id (null for a single-root
+    // host, which keeps the name `accounting:<bookId>`): a bookId is
+    // unique within a root, so without it a write in one project would
+    // refresh an open view of the same-named book in another.
+    unsubscribe = hostSubscribe(bookChannel(nextBookId, hostProjectScope()), (data) => {
       version.value += 1;
       const event = toBookChannelPayload(data);
       if (event) onPayload?.(event);
@@ -67,6 +71,6 @@ export function useAccountingChannel(bookId: Ref<string | null>, onPayload?: (pa
  *  BookSwitcher.vue to refetch the dropdown contents when a sibling
  *  tab adds / deletes a book. */
 export function useAccountingBooksChannel(onChange: () => void): void {
-  const unsubscribe = hostSubscribe(ACCOUNTING_BOOKS_CHANNEL, onChange);
+  const unsubscribe = hostSubscribe(booksChannel(hostProjectScope()), onChange);
   onUnmounted(() => unsubscribe());
 }

--- a/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
+++ b/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
@@ -39,7 +39,17 @@ export interface UseAccountingChannelReturn {
   version: Ref<number>;
 }
 
-export function useAccountingChannel(bookId: Ref<string | null>, onPayload?: (payload: BookChannelPayload) => void): UseAccountingChannelReturn {
+/** `scope` pins the subscription to one project for the life of the
+ *  caller — pass the scope the surface was opened for. Omit it and the
+ *  channel follows whatever project the host currently considers
+ *  active, which is right for a surface the host itself scopes and
+ *  always `null` on a single-root host. */
+export function useAccountingChannel(
+  bookId: Ref<string | null>,
+  onPayload?: (payload: BookChannelPayload) => void,
+  scope?: string | null,
+): UseAccountingChannelReturn {
+  const channelScope = scope === undefined ? hostProjectScope() : scope;
   const version = ref(0);
   let unsubscribe: (() => void) | null = null;
 
@@ -52,7 +62,7 @@ export function useAccountingChannel(bookId: Ref<string | null>, onPayload?: (pa
     // host, which keeps the name `accounting:<bookId>`): a bookId is
     // unique within a root, so without it a write in one project would
     // refresh an open view of the same-named book in another.
-    unsubscribe = hostSubscribe(bookChannel(nextBookId, hostProjectScope()), (data) => {
+    unsubscribe = hostSubscribe(bookChannel(nextBookId, channelScope), (data) => {
       version.value += 1;
       const event = toBookChannelPayload(data);
       if (event) onPayload?.(event);
@@ -70,7 +80,7 @@ export function useAccountingChannel(bookId: Ref<string | null>, onPayload?: (pa
 /** Subscribe to "the list of books changed" events. Use in
  *  BookSwitcher.vue to refetch the dropdown contents when a sibling
  *  tab adds / deletes a book. */
-export function useAccountingBooksChannel(onChange: () => void): void {
-  const unsubscribe = hostSubscribe(booksChannel(hostProjectScope()), onChange);
+export function useAccountingBooksChannel(onChange: () => void, scope?: string | null): void {
+  const unsubscribe = hostSubscribe(booksChannel(scope === undefined ? hostProjectScope() : scope), onChange);
   onUnmounted(() => unsubscribe());
 }

--- a/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
+++ b/packages/plugins/accounting-plugin/src/vue/useAccountingChannel.ts
@@ -17,7 +17,7 @@
 // (see hostContext.ts) — the channel NAMES come from this package's
 // own `./shared` so publisher and subscriber stay in lockstep.
 
-import { ref, watch, onUnmounted, type Ref } from "vue";
+import { computed, ref, watch, onUnmounted, type Ref } from "vue";
 import { bookChannel, booksChannel, BOOK_EVENT_KINDS, type BookChannelPayload } from "../shared";
 import { hostProjectScope, hostSubscribe } from "./hostContext";
 
@@ -39,17 +39,30 @@ export interface UseAccountingChannelReturn {
   version: Ref<number>;
 }
 
-/** `scope` pins the subscription to one project for the life of the
- *  caller — pass the scope the surface was opened for. Omit it and the
- *  channel follows whatever project the host currently considers
- *  active, which is right for a surface the host itself scopes and
- *  always `null` on a single-root host. */
+/** The project a subscription belongs to: a fixed value, a getter for
+ *  one that can change (the selected card's), or omitted to follow
+ *  whatever project the host currently considers active. */
+export type AccountingChannelScope = string | null | (() => string | null);
+
+/** Resolves the scope REACTIVELY, so a subscription re-binds instead of
+ *  sitting on a channel that stopped being the caller's. A host whose
+ *  `projectScope` getter reads reactive state gets that for free on the
+ *  host-following path too; one that does not simply never changes. */
+function resolveScope(scope: AccountingChannelScope | undefined): Ref<string | null> {
+  return computed(() => (scope === undefined ? hostProjectScope() : typeof scope === "function" ? scope() : scope));
+}
+
+/** `scope` binds the subscription to one project — pass the scope the
+ *  surface was opened for. Omit it and the channel follows whatever
+ *  project the host currently considers active, which is right for a
+ *  surface the host itself scopes and always `null` on a single-root
+ *  host. */
 export function useAccountingChannel(
   bookId: Ref<string | null>,
   onPayload?: (payload: BookChannelPayload) => void,
-  scope?: string | null,
+  scope?: AccountingChannelScope,
 ): UseAccountingChannelReturn {
-  const channelScope = scope === undefined ? hostProjectScope() : scope;
+  const channelScope = resolveScope(scope);
   const version = ref(0);
   let unsubscribe: (() => void) | null = null;
 
@@ -62,14 +75,17 @@ export function useAccountingChannel(
     // host, which keeps the name `accounting:<bookId>`): a bookId is
     // unique within a root, so without it a write in one project would
     // refresh an open view of the same-named book in another.
-    unsubscribe = hostSubscribe(bookChannel(nextBookId, channelScope), (data) => {
+    unsubscribe = hostSubscribe(bookChannel(nextBookId, channelScope.value), (data) => {
       version.value += 1;
       const event = toBookChannelPayload(data);
       if (event) onPayload?.(event);
     });
   }
 
-  watch(bookId, bind, { immediate: true });
+  // The scope is watched alongside the book: a card retargeted at
+  // another project must leave the old project's channel, not keep
+  // receiving its events under the same bookId.
+  watch([bookId, channelScope], ([nextBookId]) => bind(nextBookId), { immediate: true });
   onUnmounted(() => {
     unsubscribe?.();
     unsubscribe = null;
@@ -79,8 +95,21 @@ export function useAccountingChannel(
 
 /** Subscribe to "the list of books changed" events. Use in
  *  BookSwitcher.vue to refetch the dropdown contents when a sibling
- *  tab adds / deletes a book. */
-export function useAccountingBooksChannel(onChange: () => void, scope?: string | null): void {
-  const unsubscribe = hostSubscribe(booksChannel(scope === undefined ? hostProjectScope() : scope), onChange);
-  onUnmounted(() => unsubscribe());
+ *  tab adds / deletes a book. Re-binds on a scope change, like
+ *  `useAccountingChannel`. */
+export function useAccountingBooksChannel(onChange: () => void, scope?: AccountingChannelScope): void {
+  const channelScope = resolveScope(scope);
+  let unsubscribe: (() => void) | null = null;
+  watch(
+    channelScope,
+    (nextScope) => {
+      unsubscribe?.();
+      unsubscribe = hostSubscribe(booksChannel(nextScope), onChange);
+    },
+    { immediate: true },
+  );
+  onUnmounted(() => {
+    unsubscribe?.();
+    unsubscribe = null;
+  });
 }

--- a/packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts
@@ -56,6 +56,9 @@ let server: Server;
 let baseUrl: string;
 let rootA: string;
 let rootB: string;
+/** The scoped host's DEFAULT root — a real project whose opaque id is
+ *  `null`, which is a different thing from a host with no scoping. */
+let rootDefault: string;
 
 // The host's own resolver: an opaque project id from the request body,
 // looked up against the host's list. A path is never accepted.
@@ -98,8 +101,10 @@ const dispatch = (payload: Record<string, unknown>): Promise<DispatchResult> => 
 before(async () => {
   rootA = makeTmp();
   rootB = makeTmp();
+  rootDefault = makeTmp();
   PROJECT_IDS.pa = rootA;
   PROJECT_IDS.pb = rootB;
+  PROJECT_IDS.pw = rootDefault;
 
   const app = express();
   app.use(express.json());
@@ -123,6 +128,7 @@ describe("explicit-root mode", () => {
       workspaceRoot: null,
       logger: silentLogger,
       channelScopeForRoot: (root) => (root === rootA ? "pa" : root === rootB ? "pb" : null),
+      // …so `rootDefault` maps to `null`: the host's default project.
     });
   });
 
@@ -197,6 +203,17 @@ describe("explicit-root mode", () => {
     const opened = await dispatch({ action: ACCOUNTING_ACTIONS.openBook, bookId, [ACCOUNTING_PROJECT_FIELD]: "pb" });
     assert.equal(opened.status, 200);
     assert.equal(opened.body.scope, "pb");
+  });
+
+  it("a default-root card still records its identity, as an explicit null", async () => {
+    // Absent would mean "ask the host what is active when you mount",
+    // and a host that switches project between the tool result and the
+    // render would then point this card at the new one.
+    const created = await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Head Office", [ACCOUNTING_PROJECT_FIELD]: "pw" });
+    const opened = await dispatch({ action: ACCOUNTING_ACTIONS.openBook, bookId: created.body.bookId, [ACCOUNTING_PROJECT_FIELD]: "pw" });
+    assert.equal(opened.status, 200);
+    assert.equal("scope" in opened.body, true, "a scoped host always records the card's project");
+    assert.equal(opened.body.scope, null);
   });
 
   it("channel names are namespaced by the scope, never by a path", async () => {

--- a/packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts
@@ -1,0 +1,208 @@
+// Multi-root contract for the accounting engine.
+//
+// A bookId is unique WITHIN a root and nowhere else. A host that serves
+// one root per project directory (MulmoTerminal) therefore needs three
+// things this suite pins, and a single-workspace host (MulmoClaude)
+// needs all three to be invisible:
+//
+//   1. every dispatch action reaches the service with the request's own
+//      root, so two projects holding a book called `main` never read or
+//      write each other's data;
+//   2. explicit-root mode (`workspaceRoot: null`) turns a FORGOTTEN root
+//      into a throw instead of a silent hit on another project;
+//   3. channel names and the openBook envelope carry the host's opaque
+//      project scope — and, unscoped, are byte-identical to today's.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import express from "express";
+import type { Server } from "node:http";
+
+import { configureAccountingServer } from "../../src/server/context.js";
+import { createAccountingRouter, type AccountingDispatchRequest } from "../../src/server/router.js";
+import { initAccountingEventPublisher, _resetAccountingEventPublisherForTesting } from "../../src/server/eventPublisher.js";
+import { listBooks } from "../../src/server/service.js";
+import { _resetRebuildQueueForTesting, inspectRebuildQueue, scheduleRebuild } from "../../src/server/snapshotCache.js";
+import { ACCOUNTING_ACTIONS, ACCOUNTING_API, ACCOUNTING_PROJECT_FIELD } from "../../src/shared/index.js";
+
+const silentLogger = { error() {}, warn() {}, info() {}, debug() {} };
+
+interface DispatchResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+const tmpRoots: string[] = [];
+const makeTmp = (): string => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mulmo-acct-multiroot-"));
+  tmpRoots.push(dir);
+  return dir;
+};
+
+const recordingPubSub = (): { pubsub: { publish: (channel: string, payload: unknown) => void }; channels: string[] } => {
+  const channels: string[] = [];
+  return { pubsub: { publish: (channel) => void channels.push(channel) }, channels };
+};
+
+const listen = async (app: express.Express): Promise<Server> =>
+  new Promise((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+let server: Server;
+let baseUrl: string;
+let rootA: string;
+let rootB: string;
+
+// The host's own resolver: an opaque project id from the request body,
+// looked up against the host's list. A path is never accepted.
+const PROJECT_IDS: Record<string, string> = {};
+const resolveWorkspaceRoot = (req: AccountingDispatchRequest): string | undefined => {
+  const raw = (req.body as Record<string, unknown>)[ACCOUNTING_PROJECT_FIELD];
+  return typeof raw === "string" ? PROJECT_IDS[raw] : undefined;
+};
+
+const dispatch = async (payload: Record<string, unknown>): Promise<DispatchResult> => {
+  const response = await fetch(`${baseUrl}${ACCOUNTING_API.dispatch.path}`, {
+    method: ACCOUNTING_API.dispatch.method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+};
+
+before(async () => {
+  rootA = makeTmp();
+  rootB = makeTmp();
+  PROJECT_IDS.pa = rootA;
+  PROJECT_IDS.pb = rootB;
+
+  const app = express();
+  app.use(express.json());
+  app.use(createAccountingRouter({ resolveWorkspaceRoot }));
+  server = await listen(app);
+  const address = server.address();
+  assert.ok(address !== null && typeof address === "object", "server must be listening on a TCP port");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  await _resetRebuildQueueForTesting();
+  _resetAccountingEventPublisherForTesting();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  for (const dir of tmpRoots) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("explicit-root mode", () => {
+  beforeEach(() => {
+    configureAccountingServer({
+      workspaceRoot: null,
+      logger: silentLogger,
+      channelScopeForRoot: (root) => (root === rootA ? "pa" : root === rootB ? "pb" : null),
+    });
+  });
+
+  it("a call with no root throws instead of guessing a project", async () => {
+    await assert.rejects(listBooks(), /every call must pass a workspaceRoot/);
+  });
+
+  it("the same call with an explicit root succeeds", async () => {
+    const { books } = await listBooks(rootA);
+    assert.ok(Array.isArray(books));
+  });
+
+  it("two roots holding the same book id do not see each other's data", async () => {
+    const created = await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Books A", [ACCOUNTING_PROJECT_FIELD]: "pa" });
+    assert.equal(created.status, 200);
+    const { bookId } = created.body;
+    assert.equal(typeof bookId, "string");
+
+    const listA = await dispatch({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pa" });
+    const listB = await dispatch({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pb" });
+    assert.equal((listA.body.books as unknown[]).length, 1);
+    assert.deepEqual(listB.body.books, []);
+
+    // …and the write landed only under project A's directory.
+    assert.ok(existsSync(path.join(rootA, "data", "accounting", "config.json")));
+    assert.ok(!existsSync(path.join(rootB, "data", "accounting", "config.json")));
+  });
+
+  it("openBook stamps the host's opaque scope onto the card envelope", async () => {
+    const created = await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Books B", [ACCOUNTING_PROJECT_FIELD]: "pb" });
+    const bookId = created.body.bookId as string;
+    const opened = await dispatch({ action: ACCOUNTING_ACTIONS.openBook, bookId, [ACCOUNTING_PROJECT_FIELD]: "pb" });
+    assert.equal(opened.status, 200);
+    assert.equal(opened.body.scope, "pb");
+  });
+
+  it("channel names are namespaced by the scope, never by a path", async () => {
+    const { pubsub, channels } = recordingPubSub();
+    initAccountingEventPublisher(pubsub);
+    await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Channel A", [ACCOUNTING_PROJECT_FIELD]: "pa" });
+    assert.deepEqual(channels, ["accounting:pa:books"]);
+    assert.ok(!channels.some((channel) => channel.includes(rootA)));
+  });
+
+  it("a rebuild queue is per (root, bookId), so one project cannot drain another's", async () => {
+    scheduleRebuild("shared", "2026-01", rootA);
+    assert.equal(inspectRebuildQueue("shared", rootA).running, true);
+    assert.equal(inspectRebuildQueue("shared", rootB).running, false);
+    await _resetRebuildQueueForTesting();
+  });
+});
+
+describe("single-root back-compat", () => {
+  let soloServer: Server;
+  let soloUrl: string;
+
+  before(async () => {
+    // No resolver, no channelScopeForRoot — MulmoClaude's wiring.
+    configureAccountingServer({ workspaceRoot: rootA, logger: silentLogger });
+    const app = express();
+    app.use(express.json());
+    app.use(createAccountingRouter());
+    soloServer = await listen(app);
+    const address = soloServer.address();
+    assert.ok(address !== null && typeof address === "object");
+    soloUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => soloServer.close(() => resolve()));
+  });
+
+  it("publishes on the unscoped channel names and omits the card scope", async () => {
+    const { pubsub, channels } = recordingPubSub();
+    initAccountingEventPublisher(pubsub);
+    const created = await fetch(`${soloUrl}${ACCOUNTING_API.dispatch.path}`, {
+      method: ACCOUNTING_API.dispatch.method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: ACCOUNTING_ACTIONS.createBook, name: "Solo" }),
+    });
+    const body = (await created.json()) as Record<string, unknown>;
+    assert.deepEqual(channels, ["accounting:books"]);
+
+    const opened = await fetch(`${soloUrl}${ACCOUNTING_API.dispatch.path}`, {
+      method: ACCOUNTING_API.dispatch.method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: ACCOUNTING_ACTIONS.openBook, bookId: body.bookId }),
+    });
+    const envelope = (await opened.json()) as Record<string, unknown>;
+    assert.equal("scope" in envelope, false, "a single-root host's envelope must be byte-identical to today's");
+  });
+
+  it("a project id in the body is ignored when the host wired no resolver", async () => {
+    const response = await fetch(`${soloUrl}${ACCOUNTING_API.dispatch.path}`, {
+      method: ACCOUNTING_API.dispatch.method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pb" }),
+    });
+    const body = (await response.json()) as { books: unknown[] };
+    // Project B has its own book; this must still be project A's list.
+    assert.ok(body.books.some((book) => (book as { name: string }).name === "Solo"));
+    assert.ok(!body.books.some((book) => (book as { name: string }).name === "Books B"));
+  });
+});

--- a/packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts
@@ -24,7 +24,7 @@ import type { Server } from "node:http";
 import { configureAccountingServer } from "../../src/server/context.js";
 import { createAccountingRouter, type AccountingDispatchRequest } from "../../src/server/router.js";
 import { initAccountingEventPublisher, _resetAccountingEventPublisherForTesting } from "../../src/server/eventPublisher.js";
-import { listBooks } from "../../src/server/service.js";
+import { AccountingError, addEntries, createBook, listBooks } from "../../src/server/service.js";
 import { _resetRebuildQueueForTesting, inspectRebuildQueue, scheduleRebuild } from "../../src/server/snapshotCache.js";
 import { ACCOUNTING_ACTIONS, ACCOUNTING_API, ACCOUNTING_PROJECT_FIELD } from "../../src/shared/index.js";
 
@@ -62,17 +62,38 @@ let rootB: string;
 const PROJECT_IDS: Record<string, string> = {};
 const resolveWorkspaceRoot = (req: AccountingDispatchRequest): string | undefined => {
   const raw = (req.body as Record<string, unknown>)[ACCOUNTING_PROJECT_FIELD];
-  return typeof raw === "string" ? PROJECT_IDS[raw] : undefined;
+  if (typeof raw !== "string") return undefined;
+  const root = PROJECT_IDS[raw];
+  // What a real host does with an id it cannot look up: refuse the
+  // request, rather than quietly serving another project's books.
+  if (root === undefined) throw new AccountingError(404, `unknown project ${JSON.stringify(raw)}`);
+  return root;
 };
 
-const dispatch = async (payload: Record<string, unknown>): Promise<DispatchResult> => {
-  const response = await fetch(`${baseUrl}${ACCOUNTING_API.dispatch.path}`, {
-    method: ACCOUNTING_API.dispatch.method,
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(payload),
-  });
-  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+/** One place every request in this file goes through, so a network
+ *  failure or a non-JSON body fails as itself instead of as a confusing
+ *  assertion further down. The status is RETURNED rather than asserted:
+ *  several tests here are about a 4xx being a 4xx. */
+const request = async (url: string, payload: Record<string, unknown>): Promise<DispatchResult> => {
+  let response: Response;
+  try {
+    response = await fetch(`${url}${ACCOUNTING_API.dispatch.path}`, {
+      method: ACCOUNTING_API.dispatch.method,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    throw new Error(`accounting dispatch request failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const text = await response.text();
+  try {
+    return { status: response.status, body: JSON.parse(text) as Record<string, unknown> };
+  } catch {
+    throw new Error(`accounting dispatch returned ${response.status} with a non-JSON body: ${text.slice(0, 200)}`);
+  }
 };
+
+const dispatch = (payload: Record<string, unknown>): Promise<DispatchResult> => request(baseUrl, payload);
 
 before(async () => {
   rootA = makeTmp();
@@ -115,23 +136,63 @@ describe("explicit-root mode", () => {
   });
 
   it("two roots holding the same book id do not see each other's data", async () => {
-    const created = await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Books A", [ACCOUNTING_PROJECT_FIELD]: "pa" });
-    assert.equal(created.status, 200);
-    const { bookId } = created.body;
-    assert.equal(typeof bookId, "string");
+    // The collision case itself: ONE id, two projects, different
+    // companies. The ids are set through the service because the
+    // dispatch route generates them — the point is the pair, not how
+    // they were named.
+    await createBook({ id: "main", name: "A Ltd" }, rootA);
+    await createBook({ id: "main", name: "B Ltd" }, rootB);
+    for (const [root, amount] of [
+      [rootA, 100],
+      [rootB, 250],
+    ] as const) {
+      await addEntries(
+        {
+          bookId: "main",
+          entries: [
+            {
+              date: "2026-04-01",
+              lines: [
+                { accountCode: "1000", debit: amount },
+                { accountCode: "4000", credit: amount },
+              ],
+            },
+          ],
+        },
+        root,
+      );
+    }
 
     const listA = await dispatch({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pa" });
     const listB = await dispatch({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pb" });
-    assert.equal((listA.body.books as unknown[]).length, 1);
-    assert.deepEqual(listB.body.books, []);
+    assert.deepEqual(
+      (listA.body.books as { name: string }[]).map((book) => book.name),
+      ["A Ltd"],
+    );
+    assert.deepEqual(
+      (listB.body.books as { name: string }[]).map((book) => book.name),
+      ["B Ltd"],
+    );
 
-    // …and the write landed only under project A's directory.
-    assert.ok(existsSync(path.join(rootA, "data", "accounting", "config.json")));
-    assert.ok(!existsSync(path.join(rootB, "data", "accounting", "config.json")));
+    // …and reading the SAME bookId through each project returns that
+    // project's numbers, not the other's.
+    const amountsFor = async (project: string): Promise<number[]> => {
+      const result = await dispatch({ action: ACCOUNTING_ACTIONS.getJournalEntries, bookId: "main", [ACCOUNTING_PROJECT_FIELD]: project });
+      const entries = result.body.entries as { lines: { debit?: number }[] }[];
+      return entries.flatMap((entry) => entry.lines.map((line) => line.debit ?? 0)).filter((debit) => debit > 0);
+    };
+    assert.deepEqual(await amountsFor("pa"), [100]);
+    assert.deepEqual(await amountsFor("pb"), [250]);
+
+    // Each write landed under its own root's directory.
+    for (const root of [rootA, rootB]) {
+      assert.ok(existsSync(path.join(root, "data", "accounting", "books", "main", "journal")));
+    }
   });
 
   it("openBook stamps the host's opaque scope onto the card envelope", async () => {
     const created = await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Books B", [ACCOUNTING_PROJECT_FIELD]: "pb" });
+    assert.equal(created.status, 200);
     const bookId = created.body.bookId as string;
     const opened = await dispatch({ action: ACCOUNTING_ACTIONS.openBook, bookId, [ACCOUNTING_PROJECT_FIELD]: "pb" });
     assert.equal(opened.status, 200);
@@ -142,8 +203,14 @@ describe("explicit-root mode", () => {
     const { pubsub, channels } = recordingPubSub();
     initAccountingEventPublisher(pubsub);
     await dispatch({ action: ACCOUNTING_ACTIONS.createBook, name: "Channel A", [ACCOUNTING_PROJECT_FIELD]: "pa" });
-    assert.deepEqual(channels, ["accounting:pa:books"]);
+    assert.deepEqual(channels, ["accounting:pa:#books"]);
     assert.ok(!channels.some((channel) => channel.includes(rootA)));
+  });
+
+  it("a project id the host cannot look up is a 4xx, not a 500", async () => {
+    const response = await dispatch({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "no-such-project" });
+    assert.equal(response.status, 404);
+    assert.match(String(response.body.error), /unknown project/);
   });
 
   it("a rebuild queue is per (root, bookId), so one project cannot drain another's", async () => {
@@ -177,30 +244,16 @@ describe("single-root back-compat", () => {
   it("publishes on the unscoped channel names and omits the card scope", async () => {
     const { pubsub, channels } = recordingPubSub();
     initAccountingEventPublisher(pubsub);
-    const created = await fetch(`${soloUrl}${ACCOUNTING_API.dispatch.path}`, {
-      method: ACCOUNTING_API.dispatch.method,
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ action: ACCOUNTING_ACTIONS.createBook, name: "Solo" }),
-    });
-    const body = (await created.json()) as Record<string, unknown>;
+    const created = await request(soloUrl, { action: ACCOUNTING_ACTIONS.createBook, name: "Solo" });
     assert.deepEqual(channels, ["accounting:books"]);
 
-    const opened = await fetch(`${soloUrl}${ACCOUNTING_API.dispatch.path}`, {
-      method: ACCOUNTING_API.dispatch.method,
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ action: ACCOUNTING_ACTIONS.openBook, bookId: body.bookId }),
-    });
-    const envelope = (await opened.json()) as Record<string, unknown>;
-    assert.equal("scope" in envelope, false, "a single-root host's envelope must be byte-identical to today's");
+    const opened = await request(soloUrl, { action: ACCOUNTING_ACTIONS.openBook, bookId: created.body.bookId });
+    assert.equal("scope" in opened.body, false, "a single-root host's envelope must be byte-identical to today's");
   });
 
   it("a project id in the body is ignored when the host wired no resolver", async () => {
-    const response = await fetch(`${soloUrl}${ACCOUNTING_API.dispatch.path}`, {
-      method: ACCOUNTING_API.dispatch.method,
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pb" }),
-    });
-    const body = (await response.json()) as { books: unknown[] };
+    const response = await request(soloUrl, { action: ACCOUNTING_ACTIONS.getBooks, [ACCOUNTING_PROJECT_FIELD]: "pb" });
+    const body = response.body as { books: unknown[] };
     // Project B has its own book; this must still be project A's list.
     assert.ok(body.books.some((book) => (book as { name: string }).name === "Solo"));
     assert.ok(!body.books.some((book) => (book as { name: string }).name === "Books B"));

--- a/packages/plugins/accounting-plugin/test/accounting/test_service.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_service.ts
@@ -42,9 +42,11 @@ after(() => {
 
 // Helper for tests that follow up an entry-write with a read — drain
 // any background rebuild before asserting so we don't race the
-// snapshot writer.
-async function drainRebuilds(bookId: string): Promise<void> {
-  await awaitRebuildIdle(bookId);
+// snapshot writer. The root is required: a rebuild queue is keyed by
+// (root, bookId), so draining without one waits on a queue nobody
+// scheduled and returns while the real rebuild is still writing.
+async function drainRebuilds(bookId: string, root: string): Promise<void> {
+  await awaitRebuildIdle(bookId, root);
 }
 
 describe("createBook id validation", () => {
@@ -363,7 +365,7 @@ describe("addEntries / listEntries", () => {
     const raw = await fsPromises.readFile(journalFile, "utf-8");
     const lines = raw.split("\n").filter((line) => line !== "");
     assert.equal(lines.length, 2, "same-period batch must land in one JSONL with both entries");
-    await drainRebuilds(bookId);
+    await drainRebuilds(bookId, root);
     const list = await listEntries({ bookId }, root);
     assert.equal(list.entries.length, 2);
   });
@@ -424,7 +426,7 @@ describe("addEntries / listEntries", () => {
         root,
       );
     await Promise.all([makeBatch(0), makeBatch(100), makeBatch(200)]);
-    await drainRebuilds(bookId);
+    await drainRebuilds(bookId, root);
     const list = await listEntries({ bookId }, root);
     assert.equal(list.entries.length, 15, "every entry from every concurrent batch must persist");
   });
@@ -482,7 +484,7 @@ describe("addEntries / listEntries", () => {
       },
       root,
     );
-    await drainRebuilds(bookId);
+    await drainRebuilds(bookId, root);
     const list = await listEntries({ bookId }, root);
     assert.equal(list.entries.length, 1);
     const [storedEntry] = list.entries;
@@ -785,7 +787,7 @@ describe("reports end-to-end", () => {
       },
       root,
     );
-    await drainRebuilds(bookId);
+    await drainRebuilds(bookId, root);
     const report = await getBalanceSheetReport({ bookId, period: { kind: "month", period: "2026-04" } }, root);
     assert.ok(Math.abs(report.balanceSheet.imbalance) < 0.0001, `imbalance was ${report.balanceSheet.imbalance}`);
     const equity = report.balanceSheet.sections.find((section) => section.type === "equity");
@@ -831,7 +833,7 @@ describe("reports end-to-end", () => {
       },
       root,
     );
-    await drainRebuilds(bookId);
+    await drainRebuilds(bookId, root);
     const balanceSheet = await getBalanceSheetReport({ bookId, period: { kind: "month", period: "2026-04" } }, root);
     const [assetSection] = balanceSheet.balanceSheet.sections;
     assert.ok(assetSection);

--- a/packages/plugins/accounting-plugin/test/accounting/test_snapshotCache.ts
+++ b/packages/plugins/accounting-plugin/test/accounting/test_snapshotCache.ts
@@ -140,9 +140,9 @@ describe("scheduleRebuild + queue", () => {
 
     scheduleRebuild("default", "2026-02", root);
     // The queue is busy immediately after scheduling.
-    assert.equal(inspectRebuildQueue("default").running, true);
+    assert.equal(inspectRebuildQueue("default", root).running, true);
 
-    await awaitRebuildIdle("default");
+    await awaitRebuildIdle("default", root);
     // Snapshots for the invalidated periods are back on disk.
     assert.ok((await readSnapshot("default", "2026-02", root)) !== null);
     assert.ok((await readSnapshot("default", "2026-03", root)) !== null);
@@ -162,11 +162,11 @@ describe("scheduleRebuild + queue", () => {
     for (let idx = 0; idx < 5; idx += 1) {
       scheduleRebuild("default", "2026-02", root);
     }
-    const state = inspectRebuildQueue("default");
+    const state = inspectRebuildQueue("default", root);
     assert.equal(state.running, true);
     assert.ok(state.coalescedWriteCount >= 5, `expected ≥5 coalesced writes, got ${state.coalescedWriteCount}`);
 
-    await awaitRebuildIdle("default");
+    await awaitRebuildIdle("default", root);
 
     const channelEvents = events.get(accountingBookChannel("default")) ?? [];
     const rebuildingCount = channelEvents.filter((event) => event.kind === "snapshots-rebuilding").length;
@@ -180,7 +180,7 @@ describe("scheduleRebuild + queue", () => {
     await seed(root);
 
     scheduleRebuild("default", "2026-01", root);
-    await awaitRebuildIdle("default");
+    await awaitRebuildIdle("default", root);
 
     const channelEvents = events.get(accountingBookChannel("default")) ?? [];
     const firstRebuilding = channelEvents.findIndex((event) => event.kind === "snapshots-rebuilding");
@@ -202,7 +202,7 @@ describe("scheduleRebuild + queue", () => {
     const lazy = await getOrBuildSnapshot("default", "2026-03", root);
     assert.ok(balancesEqual(lazy.balances, fromJournal));
 
-    await awaitRebuildIdle("default");
+    await awaitRebuildIdle("default", root);
     const afterRebuild = await getOrBuildSnapshot("default", "2026-03", root);
     assert.ok(balancesEqual(afterRebuild.balances, fromJournal));
   });
@@ -210,7 +210,7 @@ describe("scheduleRebuild + queue", () => {
   it("awaitRebuildIdle on an idle book resolves immediately", async () => {
     // Microtask resolution — using a promise.race against a
     // setImmediate sentinel verifies we don't hang.
-    const idle = awaitRebuildIdle("never-scheduled");
+    const idle = awaitRebuildIdle("never-scheduled", makeTmp());
     const sentinel = new Promise<string>((resolve) => setImmediate(() => resolve("timeout")));
     const result = await Promise.race([idle.then(() => "idle"), sentinel]);
     assert.equal(result, "idle");
@@ -224,14 +224,14 @@ describe("scheduleRebuild + queue", () => {
 
     // First scheduled rebuild succeeds, draining the queue.
     scheduleRebuild("default", "2026-01", root);
-    await awaitRebuildIdle("default");
+    await awaitRebuildIdle("default", root);
 
     // Second one starts fresh (`running` flips back to true) — proves
     // the entry was cleared after the first finished.
     scheduleRebuild("default", "2026-02", root);
-    assert.equal(inspectRebuildQueue("default").running, true);
-    await awaitRebuildIdle("default");
-    assert.equal(inspectRebuildQueue("default").running, false);
+    assert.equal(inspectRebuildQueue("default", root).running, true);
+    await awaitRebuildIdle("default", root);
+    assert.equal(inspectRebuildQueue("default", root).running, false);
 
     const channelEvents = events.get(accountingBookChannel("default")) ?? [];
     const rebuildingCount = channelEvents.filter((event) => event.kind === "snapshots-rebuilding").length;

--- a/packages/plugins/accounting-plugin/test/test_apiScope.ts
+++ b/packages/plugins/accounting-plugin/test/test_apiScope.ts
@@ -1,0 +1,52 @@
+// A card's api client stays on the project the card was opened for.
+//
+// The failure this pins is quiet and expensive: in a multi-root host a
+// card opened against project A keeps its bookId, so once the host's
+// active project moves to B, an unpinned client reads — and writes —
+// B's book of the same id. Same numbers on screen, wrong company's
+// books underneath.
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { createAccountingApi } from "../src/vue/api";
+import { configureAccountingHost, type ApiResult } from "../src/vue/hostContext";
+import { ACCOUNTING_PROJECT_FIELD } from "../src/shared";
+
+const bodies: Record<string, unknown>[] = [];
+let hostScope: string | null = null;
+
+beforeEach(() => {
+  bodies.length = 0;
+  hostScope = null;
+  configureAccountingHost({
+    apiCall: <T>(_path: string, opts: { body?: unknown }): Promise<ApiResult<T>> => {
+      bodies.push(opts.body as Record<string, unknown>);
+      return Promise.resolve({ ok: true, data: { books: [] } as T });
+    },
+    subscribe: () => () => {},
+    localeTag: () => "en",
+    projectScope: () => hostScope,
+  });
+});
+
+describe("client project scope", () => {
+  it("a pinned client keeps its project when the host moves on", async () => {
+    hostScope = "project-a";
+    const api = createAccountingApi("project-a");
+    hostScope = "project-b";
+    await api.getBooks();
+    assert.equal(bodies[0]?.[ACCOUNTING_PROJECT_FIELD], "project-a");
+  });
+
+  it("a client pinned to the default root never names a project", async () => {
+    hostScope = "project-b";
+    await createAccountingApi(null).getBooks();
+    assert.equal(ACCOUNTING_PROJECT_FIELD in (bodies[0] ?? {}), false);
+  });
+
+  it("a single-root host's request body is unchanged", async () => {
+    await createAccountingApi(null).getBooks();
+    assert.deepEqual(bodies[0], { action: "getBooks" });
+  });
+});

--- a/plans/feat-accounting-project-root.md
+++ b/plans/feat-accounting-project-root.md
@@ -1,0 +1,84 @@
+# feat(accounting-plugin): make the accounting engine safely multi-root
+
+Written 2026-08-09. **In English**, like its two siblings
+(`feat-collection-multi-root.md`, `feat-collection-multi-root-2.md`) — the rest of `plans/`
+is Japanese.
+
+## Why
+
+MulmoTerminal's project work (`../mulmoterminal/plans/project-architecture.md` §5) treats
+collections / accounting / wiki / resources as **one** problem: every shared subsystem is
+bound at boot to one process-wide workspace root, and the fix is the same in each — replace
+the boot-time binding with a per-request root resolution. Collections went first
+(`@mulmoclaude/core@3.0.0` and `3.1.0`). Accounting is next, and MulmoTerminal's own
+comment in `server/backends/accounting.ts` predicted the seam:
+
+> The single-root DI … is exactly what the FOCUSED freelance product wants. A generic
+> accounting-in-MulmoTerminal would later swap this for a per-request cwd resolver.
+
+This PR is the upstream half — the part MulmoTerminal cannot do for itself. Whether
+accounting SHOULD follow the selected project is still MulmoTerminal's product decision
+(D7 keeps it workspace-bound, and hides the panel outside the workspace, until then); this
+change only removes the technical reason it cannot.
+
+**MulmoClaude's behaviour does not change.** It is a single-workspace host, it wires none
+of the new options, and every item is additive with a default that preserves today's path.
+
+## What shipped
+
+All inside `packages/plugins/accounting-plugin`, mirroring the collection engine's shape so
+a host wires both the same way.
+
+1. **Explicit-root mode.** `AccountingServerDeps.workspaceRoot` widens to `string | null`.
+   With `null`, `defaultWorkspaceRoot()` throws instead of guessing — because with N roots a
+   forgotten option is not a crash but a silent read or write against the wrong project.
+2. **A per-request root.** `createAccountingRouter({ resolveWorkspaceRoot })` — a host-owned
+   resolver — and the root threaded through every one of the 15 dispatch actions into the
+   service layer, which was already root-parameterised end to end.
+3. **Channel names carry the scope.** `bookChannel(bookId, scope?)` / `booksChannel(scope?)`,
+   fed by `AccountingServerDeps.channelScopeForRoot`. A bookId is unique within a root and
+   nowhere else, so without this a write to `main` in project A refreshes an open view of
+   `main` in project B. Unscoped the names are byte-identical to today's.
+4. **The rebuild queue is keyed by `(root, bookId)`**, not by bookId. Two projects holding a
+   book of the same name previously shared one queue: B's write would cancel A's rebuild and
+   `awaitRebuildIdle` would return while the other project's rebuild was still writing.
+5. **The card envelope carries the scope.** `openBook` stamps the host's opaque project id,
+   so a mounted card fetches ITS OWN project rather than whatever the host has selected when
+   it renders. Absent for a single-root host.
+6. **The Vue surface can be scoped**: `configureAccountingHost({ …, projectScope })` — the
+   opaque id rides dispatch requests as `ACCOUNTING_PROJECT_FIELD` and namespaces the
+   channels the View subscribes to.
+7. **Remote-host prep.** `createListAccountingBooks` resolves a scope from its params,
+   defaulting to the host root, so the day a phone can pick a project the parameter is
+   additive and no handler changes (the §8 shape from the collections round).
+
+### The rules the shape encodes
+
+- **A project is named by an opaque id, never a path.** Channel names and card envelopes
+  reach the browser; a root there publishes the user's home directory.
+- **The model never picks a project.** `manageAccounting`'s schema has no project parameter
+  — pinned by `test/plugins/test_accounting_tool_schema.ts` — and the package never reads a
+  root or project off a request body. Only the host's own resolver does.
+- **A bookId is unique within a root and nowhere else.** Anything keyed by bookId alone is a
+  cross-project collision waiting to happen.
+
+## Not in scope
+
+- MulmoClaude app code, workspace layout, storage formats, route paths (`/api/accounting`
+  stays one dispatch route; a project rides the body, not the URL).
+- Whether MulmoTerminal shows accounting per project — its product decision, and its own
+  work: the host flag wiring, `resolveProjectRoot` reuse, and the per-project panel.
+- Wiki and resources, the other two subsystems in the same family.
+
+## Testing
+
+`packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts` covers two-root
+isolation through the real router, the explicit-root throw, scope-namespaced channels, the
+stamped card envelope, per-`(root, bookId)` queues, and — the item that protects MulmoClaude
+— a single-root host whose channels, envelope and request bodies are unchanged.
+
+## Delivery
+
+`@mulmoclaude/accounting-plugin` 2.1.0 → **2.2.0** (every change is additive), the launcher's
+declared range swept in the same PR. MulmoTerminal picks it up with a version bump and does
+its side.

--- a/plans/feat-accounting-project-root.md
+++ b/plans/feat-accounting-project-root.md
@@ -42,9 +42,11 @@ a host wires both the same way.
 4. **The rebuild queue is keyed by `(root, bookId)`**, not by bookId. Two projects holding a
    book of the same name previously shared one queue: B's write would cancel A's rebuild and
    `awaitRebuildIdle` would return while the other project's rebuild was still writing.
-5. **The card envelope carries the scope, and the card is PINNED to it.** `openBook` stamps
-   the host's opaque project id; `View.vue` reads it once at mount and binds its whole
-   subtree — every request and both channel subscriptions — to that project through
+5. **The card envelope carries the scope, and the card is BOUND to it.** `openBook` stamps
+   the host's opaque project id — as an explicit `null` for the host's default root, because
+   an absent field means "ask the host what is active now" and a host that switched project
+   between the tool result and the render would repoint the card. `View.vue` reads it and
+   binds its whole subtree — every request and both channel subscriptions — to that project through
    `provideAccountingApi` / `useAccountingApi`. Stamping alone would not have been enough:
    the host can change its active project while a card stays open, and an unpinned card
    would then read and write another project's book under the same bookId.

--- a/plans/feat-accounting-project-root.md
+++ b/plans/feat-accounting-project-root.md
@@ -42,11 +42,15 @@ a host wires both the same way.
 4. **The rebuild queue is keyed by `(root, bookId)`**, not by bookId. Two projects holding a
    book of the same name previously shared one queue: B's write would cancel A's rebuild and
    `awaitRebuildIdle` would return while the other project's rebuild was still writing.
-5. **The card envelope carries the scope.** `openBook` stamps the host's opaque project id,
-   so a mounted card fetches ITS OWN project rather than whatever the host has selected when
-   it renders. Absent for a single-root host.
-6. **The Vue surface can be scoped**: `configureAccountingHost({ …, projectScope })` — the
-   opaque id rides dispatch requests as `ACCOUNTING_PROJECT_FIELD` and namespaces the
+5. **The card envelope carries the scope, and the card is PINNED to it.** `openBook` stamps
+   the host's opaque project id; `View.vue` reads it once at mount and binds its whole
+   subtree — every request and both channel subscriptions — to that project through
+   `provideAccountingApi` / `useAccountingApi`. Stamping alone would not have been enough:
+   the host can change its active project while a card stays open, and an unpinned card
+   would then read and write another project's book under the same bookId.
+6. **The Vue surface can be scoped**: `configureAccountingHost({ …, projectScope })` for a
+   surface the host scopes itself, `createAccountingApi(scope)` for one pinned to a project.
+   The opaque id rides dispatch requests as `ACCOUNTING_PROJECT_FIELD` and namespaces the
    channels the View subscribes to.
 7. **Remote-host prep.** `createListAccountingBooks` resolves a scope from its params,
    defaulting to the host root, so the day a phone can pick a project the parameter is
@@ -72,10 +76,13 @@ a host wires both the same way.
 
 ## Testing
 
-`packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts` covers two-root
-isolation through the real router, the explicit-root throw, scope-namespaced channels, the
-stamped card envelope, per-`(root, bookId)` queues, and — the item that protects MulmoClaude
-— a single-root host whose channels, envelope and request bodies are unchanged.
+`packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts` covers the collision
+case itself (one bookId, two projects, different numbers, read through the real router), the
+explicit-root throw, an unknown project id answered as a 4xx rather than a 500,
+scope-namespaced channels, the stamped card envelope, per-`(root, bookId)` queues, and — the
+item that protects MulmoClaude — a single-root host whose channels, envelope and request
+bodies are unchanged. `test/test_apiScope.ts` pins the client half: a card keeps its project
+after the host's active project moves on.
 
 ## Delivery
 

--- a/server/remoteHost/handlers/listAccountingBooks.ts
+++ b/server/remoteHost/handlers/listAccountingBooks.ts
@@ -15,13 +15,30 @@ import type { CommandHandler, JsonObject } from "../commandChannel.js";
 
 export interface ListAccountingBooksDeps {
   listBooks: typeof listBooks;
+  /** Resolve which project's books a command asks for. MulmoClaude is a
+   *  single-workspace host and wires none, so every command resolves the
+   *  configured workspace exactly as it always has.
+   *
+   *  It exists so the handler is written as "resolve a scope from the
+   *  params, defaulting to the host's root" rather than calling the
+   *  workspace accessor inline: the day a multi-root host (MulmoTerminal)
+   *  lets a phone pick a project, the parameter is additive and no
+   *  handler changes. Three rules the resolver must keep, because a
+   *  phone is a genuinely remote client:
+   *    · a project is named by an OPAQUE id the host looks up, never by
+   *      a path — a root in a command or an artifact publishes the
+   *      user's home directory over the wire;
+   *    · the phone must be able to LEARN the list ({ id, label } pairs
+   *      from the host), so it never has to construct a scope itself;
+   *    · the rendered artifact stays host-built, which is what makes the
+   *      first rule hold without trusting the client. */
+  resolveWorkspaceRoot?: (params: JsonObject) => string | undefined;
 }
 
 export const createListAccountingBooks =
   (deps: ListAccountingBooksDeps): CommandHandler =>
-  // Takes no params (the `__` prefix marks it intentionally unused per lint).
-  async (__params: JsonObject) => {
-    const { books } = await deps.listBooks();
+  async (params: JsonObject) => {
+    const { books } = await deps.listBooks(deps.resolveWorkspaceRoot?.(params));
     // No `toJsonObject` needed here, unlike the sibling handlers: the `.map`
     // rebuilds each entry as an anonymous object literal, and those DO get
     // TypeScript's implicit index signature. `BookSummary`'s own lack of one

--- a/test/plugins/test_accounting_tool_schema.ts
+++ b/test/plugins/test_accounting_tool_schema.ts
@@ -1,0 +1,30 @@
+// The accounting tool's parameters are a contract with the MODEL, and
+// the model must never choose a project.
+//
+// A project id is an opaque value the SERVER derives from a path (a
+// session's cwd, a request's resolved root). An LLM has no way to know
+// one, and accepting one from the caller would make the client the
+// source of the root — the thing every other part of the multi-root
+// work refuses (see plans/feat-accounting-project-root.md). The same
+// reasoning already settled `presentCollection`, whose schema is pinned
+// the same way.
+//
+// So a later "helpful" parameter here is a test failure, not a feature.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import toolDefinition from "../../src/plugins/accounting/definition.js";
+
+const FORBIDDEN_PARAMS = ["project", "projectId", "root", "workspaceRoot", "workspace", "scope", "path"];
+
+test("manageAccounting's schema lets the model name no project or path", () => {
+  const { properties } = toolDefinition.parameters as { properties: Record<string, unknown> };
+  for (const name of FORBIDDEN_PARAMS) {
+    assert.equal(
+      Object.hasOwn(properties, name),
+      false,
+      `manageAccounting must not accept a '${name}' parameter — the host resolves the root from the session`,
+    );
+  }
+});


### PR DESCRIPTION
## Why

MulmoTerminal wants a book to live in **any project directory**, the way a collection now can
(`@mulmoclaude/core@3.0.0` / `3.1.0`). Its own architecture note treats collections /
accounting / wiki / resources as **one** problem — every shared subsystem is bound at boot to
one process-wide workspace root, and the fix is the same in each: replace the boot-time
binding with a per-request root resolution. The seam was even named in advance, in
MulmoTerminal's `server/backends/accounting.ts`:

> A generic accounting-in-MulmoTerminal would later swap this for a per-request cwd resolver
> (the dispatch request already carries the session cwd).

The accounting engine was already root-parameterised down in io and service, but bound to one
workspace at the top: every dispatch action resolved the ambient root, and everything keyed by
`bookId` alone collides the moment two project directories each hold a book of that name.

**MulmoClaude's behaviour does not change.** It is a single-workspace host, it wires none of
the new options, and every item is additive with a default that preserves today's path — its
requests, channel names and card envelopes are byte-identical, pinned by a back-compat suite.

Whether accounting SHOULD follow the selected project is still MulmoTerminal's product
decision (D7 keeps it workspace-bound, and hides the panel outside the workspace, until then).
This PR only removes the technical reason it cannot.

## What changed

All inside `packages/plugins/accounting-plugin`, mirroring the collection engine's shape so a
host wires both the same way.

- **Explicit-root mode.** `AccountingServerDeps.workspaceRoot` widens to `string | null`. With
  `null`, `defaultWorkspaceRoot()` throws instead of guessing — with N roots a forgotten option
  is not a crash but a silent read or write against the wrong project.
- **A per-request root.** `createAccountingRouter({ resolveWorkspaceRoot })`, with the root
  threaded through every one of the 15 dispatch actions into the service layer.
- **Channel names carry the scope.** `bookChannel(bookId, scope?)` / `booksChannel(scope?)`,
  fed by the new `channelScopeForRoot` dep. Unscoped the names are byte-identical to today's.
- **The rebuild queue is keyed by `(root, bookId)`** — a real bug, not just future-proofing:
  two projects holding a book of the same name previously shared one queue, so B's write
  cancelled A's in-flight rebuild and `awaitRebuildIdle` returned while the other project's
  rebuild was still writing (the race `deleteBook` calls it to avoid).
- **The card envelope carries the scope.** `openBook` stamps the host's opaque project id, so a
  mounted card fetches its own project rather than whatever the host has selected when it
  renders. Absent for a single-root host.
- **The Vue surface can be scoped**: `configureAccountingHost({ …, projectScope })` — the
  opaque id rides dispatch requests as `ACCOUNTING_PROJECT_FIELD` and namespaces the channels
  the View subscribes to.
- **Remote-host prep.** `createListAccountingBooks` resolves a scope from its params,
  defaulting to the host root, so the day a phone can pick a project the parameter is additive
  and no handler changes (the §8 shape from the collections round).

### The rules the shape encodes

- **A project is named by an opaque id, never a path.** Channel names and card envelopes reach
  the browser; a root there publishes the user's home directory.
- **The model never picks a project.** `manageAccounting`'s schema has no project parameter —
  now pinned by `test/plugins/test_accounting_tool_schema.ts` — and the package never reads a
  root or project id off a request body. Only the host's own resolver does.
- **A bookId is unique within a root and nowhere else.** Anything keyed by bookId alone is a
  cross-project collision waiting to happen.

## Testing

New `packages/plugins/accounting-plugin/test/accounting/test_multiRoot.ts`: two-root isolation
through the real router, the explicit-root throw, scope-namespaced channels, the stamped card
envelope, per-`(root, bookId)` queues, and — the item that protects MulmoClaude — a single-root
host whose channels, envelope and request bodies are unchanged.

Two existing tests were drained without a root (`awaitRebuildIdle(bookId)` while the rebuild
was scheduled under a tmp root), which under the new keying waits on a queue nobody scheduled;
they now pass the root. That surfaced as an intermittent failure in `test_service.ts` and is
fixed — 8 consecutive full-suite runs are green.

Ran `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` (9189 pass / 0 fail
across the repo, 316 in the plugin).

## Release

`@mulmoclaude/accounting-plugin` 2.1.0 → **2.2.0** (everything is additive), the launcher's
declared range swept in the same PR, CHANGELOG `Ships` line updated. Publishing happens after
merge, on request.

Plan record: `plans/feat-accounting-project-root.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Enable the accounting plugin to operate safely in multi-root hosts while preserving behaviour for single-workspace hosts.

New Features:
- Add per-request workspace root resolution to the accounting router so hosts can serve multiple project roots.
- Introduce opaque project scope propagation through dispatch bodies, card envelopes, and Vue channels to isolate books per project.
- Expose host configuration seams for explicit-root mode and channel scoping in the accounting server and Vue host context.

Bug Fixes:
- Key snapshot rebuild queues by both workspace root and bookId to prevent cross-project interference and early completion races.

Enhancements:
- Scope accounting pub/sub channel names by project while keeping unscoped names backward-compatible.
- Extend server and shared types (dispatch bodies, router options, channels) to support multi-root accounting without changing MulmoClaude behaviour.
- Add tests covering multi-root routing, scoped channels, explicit-root failures, and tool schema guarantees that models cannot select projects.

Build:
- Bump @mulmoclaude/accounting-plugin to version 2.2.0 and update MulmoClaude to depend on the new range.

Documentation:
- Document multi-root wiring for accounting hosts in the plugin README and record the feature plan and changelog entry.
- Add a test to pin manageAccounting’s tool schema so it cannot accept project or path parameters.

Tests:
- Introduce multi-root accounting tests and strengthen snapshot cache and service tests to account for root-aware rebuild queues and back-compat behaviour.

Chores:
- Add a plan document describing the multi-root accounting design and invariants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-project accounting support with isolated books, events, and rebuild processing.
  * Added safe project scoping for local and remote accounting requests.
  * Preserved existing single-workspace behavior and channel formats.
* **Documentation**
  * Documented host integration, project scoping, workspace-root configuration, and safety requirements.
* **Chores**
  * Updated the accounting plugin to version 2.2.0.
* **Tests**
  * Added coverage for multi-project isolation, scoped events, rebuild queues, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->