### PR TITLE
feat(core): a project root can declare that it has no user scope

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Package releases
 
+#### A project root can declare that it has no user scope
+
+`@mulmoclaude/core@3.3.0`. `~` and a project are separate worlds: standing in a project
+directory, a collection under `~/.claude/skills` must not be reachable at all — not listed, and
+not resolvable by slug. A host with one workspace could not say that before, because the user
+skills dir was a single string applied to every root. MulmoClaude is one workspace and is
+unaffected: it returns the same path for its one root, user scope still merges in, and a project
+slug still shadows a user one.
+
+- `CollectionHost.paths.userSkillsDir` becomes `(workspaceRoot) => string | null` — the shape
+  `skillsStagingDir` already has. A host that supplied a bare string must wrap it (`() => DIR`);
+  that is the whole migration.
+- `null` skips the user pass in `discoverCollections` AND the user fallback in `loadCollection`.
+  The second half is the one that matters: `loadCollection` is what `getSchema`, `getItems`,
+  `putItems`, the detail route, the view-token mint and the watcher all go through, so a listing
+  filter alone would leave a slug typed by the agent — or arriving in a URL — resolving into
+  another world and writing to its data dir. A user-only slug is now a MISS for such a root, and
+  `putSchema` / `putItems` answer "unknown collection" instead of writing into `~/.claude/skills`.
+- `DiscoveryOptions.userSkillsDir` accepts `null` for "this call has no user scope"; `undefined`
+  still means "ask the host binding". The two are distinguished explicitly rather than with `??`,
+  which could not express the difference.
+
 #### The two pieces a multi-root host was still missing
 
 `@mulmoclaude/core@3.2.0`, `@mulmoclaude/collection-plugin@3.1.0`. Both are additive, and
@@ -108,7 +130,7 @@ Roots are canonicalised (`path.resolve`) wherever one becomes an identity — a 
 change payload, a bell id — so `/work/proj` and `/work/proj/` are one project rather than two.
 Symlinks are deliberately not resolved; see `canonicalRoot`.
 
-Ships `@mulmoclaude/core@3.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.1.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.3.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.1.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 #### `@mulmoclaude/core` 3.0.0 → 3.0.1 — remote host stops mistaking its own downtime for a dead channel (#2845, #2846)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,9 +19,12 @@ skills dir was a single string applied to every root. MulmoClaude is one workspa
 unaffected: it returns the same path for its one root, user scope still merges in, and a project
 slug still shadows a user one.
 
-- `CollectionHost.paths.userSkillsDir` becomes `(workspaceRoot) => string | null` — the shape
-  `skillsStagingDir` already has. A host that supplied a bare string must wrap it (`() => DIR`);
-  that is the whole migration.
+- `CollectionHost.paths.userSkillsDir` accepts `(workspaceRoot) => string | null` — the shape
+  `skillsStagingDir` already has. The bare `string` form still works, read as "this path, for
+  every root", which is what keeps this a minor: a caret range floats across minors, so a host
+  pinned at `^3.2.0` installs this version without touching its code, and a required callable
+  would turn that into a TypeError on its first discovery — a crash, not an opt-out. Prefer the
+  function form; the string is deprecated.
 - `null` skips the user pass in `discoverCollections` AND the user fallback in `loadCollection`.
   The second half is the one that matters: `loadCollection` is what `getSchema`, `getItems`,
   `putItems`, the detail route, the view-token mint and the watcher all go through, so a listing

--- a/e2e-live/fixtures/live-google.ts
+++ b/e2e-live/fixtures/live-google.ts
@@ -124,15 +124,14 @@ const schemaFor = (slug: string, calendarId: string): Record<string, unknown> =>
 // The engine reads the workspace layout off its host binding, so a spec that
 // calls `pushCalendarForCollection` must wire one. Bound once at module scope
 // with a placeholder root — every call passes its own root explicitly, and only
-// the path factories below are actually exercised. `userSkillsDir` points at
-// nothing on purpose: user-scope discovery must not pick up the developer's own
-// collections mid-test.
-const NO_USER_SKILLS_DIR = path.join(tmpdir(), "e2e-live-no-user-skills");
+// the path factories below are actually exercised. `userSkillsDir` declares no
+// user scope on purpose: user-scope discovery must not pick up the developer's
+// own collections mid-test.
 configureCollectionHost({
   workspaceRoot: path.join(tmpdir(), "e2e-live-google-placeholder"),
   log: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
   paths: {
-    userSkillsDir: NO_USER_SKILLS_DIR,
+    userSkillsDir: () => null,
     projectSkillsDir: (root: string) => path.join(root, ".claude", "skills"),
     feedsRoot: (root: string) => path.join(root, "feeds"),
     skillsStagingDir: (root: string) => path.join(root, "data", "skills"),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -3,7 +3,10 @@
 // Scans both user (`~/.claude/skills/`) and project
 // (`<workspace>/.claude/skills/`) scopes; project wins on slug
 // collision (mirrors the rule in
-// `server/workspace/skills/discovery.ts`).
+// `server/workspace/skills/discovery.ts`). A host may declare a root to
+// have NO user scope (`paths.userSkillsDir` → null), and then there is no
+// shadowing to reason about: that root sees its own collections and feeds,
+// and nothing else.
 //
 // The schema validator itself lives in `../core/schemaZ` (the zod single
 // source of truth every `../core/schema` type derives from); this module
@@ -195,6 +198,15 @@ async function collectFromDir(skillsRoot: string, source: CollectionSource, work
   return results;
 }
 
+/** The user-scope dir this call should scan, or `null` for none. The single
+ *  place the "explicit override beats the host binding, and either may say
+ *  none" rule is spelled — `??` cannot express it, because `undefined` there
+ *  means "ask the host" and would silently re-enable a scope the caller
+ *  passed `null` to switch off. */
+function resolveUserDir(opts: DiscoveryOptions, workspaceRoot: string): string | null {
+  return opts.userSkillsDir !== undefined ? opts.userSkillsDir : userSkillsDir(workspaceRoot);
+}
+
 export interface DiscoveryOptions {
   /** Override the workspace root for project-scope skill discovery.
    *  Default: the live `workspacePath`. Tests point this at a
@@ -205,8 +217,16 @@ export interface DiscoveryOptions {
   /** Override `~/.claude/skills/` for tests. Production callers
    *  leave this unset. Without an override, even a test-scoped
    *  workspaceRoot still scans the real user home — which can leak
-   *  unrelated skills into the result. */
-  userSkillsDir?: string | undefined;
+   *  unrelated skills into the result.
+   *
+   *  Three distinct values, and the difference matters — a caller that
+   *  thinks it opted out and did not is exactly the failure the scope
+   *  isolation removes:
+   *  - `undefined` (or absent): ask the host binding for this root, which
+   *    may itself answer `null`.
+   *  - a path: scan that dir as user scope.
+   *  - `null`: this call has NO user scope. The host is not consulted. */
+  userSkillsDir?: string | null | undefined;
 }
 
 /** Discover every schema-driven collection available to this
@@ -218,14 +238,16 @@ export interface DiscoveryOptions {
  *  regardless of override). */
 export async function discoverCollections(opts: DiscoveryOptions = {}): Promise<LoadedCollection[]> {
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
-  const userDir = opts.userSkillsDir ?? userSkillsDir();
+  const userDir = resolveUserDir(opts, workspaceRoot);
   const projectDir = projectSkillsDir(workspaceRoot);
   // Feeds (the non-skill `<workspace>/feeds/` registry) are scanned as a
   // third root. They merge FIRST so a real skill collection (user or
   // project) always overrides a feed on slug collision — a feed must
   // never shadow a genuine skill-backed collection.
   const feedCollections = await collectFromDir(feedsRoot(workspaceRoot), "feed", workspaceRoot);
-  const userCollections = await collectFromDir(userDir, "user", workspaceRoot);
+  // A root with no user scope skips the pass entirely (not an empty dir scan)
+  // — see the `userSkillsDir` contract in `host.ts`.
+  const userCollections = userDir === null ? [] : await collectFromDir(userDir, "user", workspaceRoot);
   const projectCollections = await collectFromDir(projectDir, "project", workspaceRoot);
   const merged = new Map<string, LoadedCollection>();
   for (const entry of feedCollections) merged.set(entry.slug, entry);
@@ -240,14 +262,16 @@ export async function loadCollection(slug: string, opts: DiscoveryOptions = {}):
   const safeName = safeSlugName(slug);
   if (safeName === null) return null;
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
-  const userDir = opts.userSkillsDir ?? userSkillsDir();
+  const userDir = resolveUserDir(opts, workspaceRoot);
   const projectDir = projectSkillsDir(workspaceRoot);
   // Project first (overrides user), then user, then the feeds registry
   // last — mirroring the merge precedence in `discoverCollections` so a
   // skill collection always wins over a feed of the same slug.
   const projectCollection = await loadOneCollection(projectDir, safeName, "project", workspaceRoot);
   if (projectCollection) return projectCollection;
-  const userCollection = await loadOneCollection(userDir, safeName, "user", workspaceRoot);
+  // No user scope for this root: skip the fallback, so a slug that exists
+  // ONLY in user scope is a MISS rather than a quiet hop into another world.
+  const userCollection = userDir === null ? null : await loadOneCollection(userDir, safeName, "user", workspaceRoot);
   if (userCollection) return userCollection;
   return loadOneCollection(feedsRoot(workspaceRoot), safeName, "feed", workspaceRoot);
 }

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -55,8 +55,22 @@ export interface CollectionHost {
   /** Host workspace layout — supplied as the host's own path helpers so the
    *  package owns no layout literals and works against a test/alt root. */
   paths: {
-    /** Absolute user-scope skills dir (host-specific, e.g. `~/.claude/skills`). */
-    userSkillsDir: string;
+    /** Absolute user-scope skills dir for a root (host-specific, e.g.
+     *  `~/.claude/skills`), or `null` when this root has NO user scope.
+     *
+     *  A single-workspace host (MulmoClaude) returns the same path for its one
+     *  root and behaves exactly as before — user scope merges into the
+     *  workspace and a project slug still shadows a user one.
+     *
+     *  A multi-root host returns `null` for a plain project directory: `~` and
+     *  a project are separate worlds, and a project that could resolve a
+     *  machine-global collection would depend on something no clone of it can
+     *  have. Under `null` the user pass is skipped in BOTH discovery and
+     *  `loadCollection` — a user-only slug is then a miss, not a quiet hop
+     *  into another world. Resolution is where the guarantee has to hold:
+     *  filtering only the listing would still let a slug typed by the agent,
+     *  or arriving in a URL, write into `~/.claude/skills` from a project. */
+    userSkillsDir: (workspaceRoot: string) => string | null;
     /** Absolute project-scope skills dir for a workspace (`<root>/.claude/skills`). */
     projectSkillsDir: (workspaceRoot: string) => string;
     /** Absolute feeds-registry root for a workspace (`<root>/data/feeds`). */
@@ -182,8 +196,8 @@ export function peekWorkspaceRoot(): string | null {
 // Workspace-layout accessors — thin wrappers over the host binding, named to
 // match the host helpers they replace so the moved engine modules keep their
 // call sites. Each throws (via requireHost) if the host never configured.
-export function userSkillsDir(): string {
-  return requireHost().paths.userSkillsDir;
+export function userSkillsDir(workspaceRoot: string): string | null {
+  return requireHost().paths.userSkillsDir(workspaceRoot);
 }
 export function projectSkillsDir(workspaceRoot: string): string {
   return requireHost().paths.projectSkillsDir(workspaceRoot);

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -69,8 +69,15 @@ export interface CollectionHost {
      *  `loadCollection` — a user-only slug is then a miss, not a quiet hop
      *  into another world. Resolution is where the guarantee has to hold:
      *  filtering only the listing would still let a slug typed by the agent,
-     *  or arriving in a URL, write into `~/.claude/skills` from a project. */
-    userSkillsDir: (workspaceRoot: string) => string | null;
+     *  or arriving in a URL, write into `~/.claude/skills` from a project.
+     *
+     *  A bare `string` is the pre-3.3.0 form and still works, read as "this
+     *  path, for every root". It is accepted rather than required-away because
+     *  a caret range floats across minors: a host pinned at `^3.2.0` installs
+     *  this version without touching its code, and a required callable would
+     *  turn that into a TypeError on its first discovery — a crash, not an
+     *  opt-out. Prefer the function form; the string is deprecated. */
+    userSkillsDir: string | ((workspaceRoot: string) => string | null);
     /** Absolute project-scope skills dir for a workspace (`<root>/.claude/skills`). */
     projectSkillsDir: (workspaceRoot: string) => string;
     /** Absolute feeds-registry root for a workspace (`<root>/data/feeds`). */
@@ -196,8 +203,12 @@ export function peekWorkspaceRoot(): string | null {
 // Workspace-layout accessors — thin wrappers over the host binding, named to
 // match the host helpers they replace so the moved engine modules keep their
 // call sites. Each throws (via requireHost) if the host never configured.
+/** The user-scope skills dir for a root, or `null` when it has none. The one
+ *  place the pre-3.3.0 `string` binding is normalized, so nothing downstream
+ *  has to know the host might not have upgraded its shape yet. */
 export function userSkillsDir(workspaceRoot: string): string | null {
-  return requireHost().paths.userSkillsDir(workspaceRoot);
+  const binding = requireHost().paths.userSkillsDir;
+  return typeof binding === "string" ? binding : binding(workspaceRoot);
 }
 export function projectSkillsDir(workspaceRoot: string): string {
   return requireHost().paths.projectSkillsDir(workspaceRoot);

--- a/packages/core/test/collection-registry/test_importWriter.ts
+++ b/packages/core/test/collection-registry/test_importWriter.ts
@@ -16,7 +16,7 @@ configureCollectionHost({
   workspaceRoot: null,
   log: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
   paths: {
-    userSkillsDir: path.join(tmpdir(), "iw-user-skills-empty"),
+    userSkillsDir: () => path.join(tmpdir(), "iw-user-skills-empty"),
     projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
     feedsRoot: (root) => path.join(root, "data", "feeds"),
     skillsStagingDir: (root) => path.join(root, "data", "skills"),

--- a/packages/core/test/collection-watchers/test_completionIdentity.ts
+++ b/packages/core/test/collection-watchers/test_completionIdentity.ts
@@ -28,7 +28,7 @@ configureCollectionHost({
   workspaceRoot: root,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(root, ".user-skills"),
+    userSkillsDir: (wsRoot) => path.join(wsRoot, ".user-skills"),
     projectSkillsDir: (wsRoot) => path.join(wsRoot, ".claude", "skills"),
     feedsRoot: (wsRoot) => path.join(wsRoot, "data", "feeds"),
     skillsStagingDir: (wsRoot) => path.join(wsRoot, "data", "skills"),

--- a/packages/core/test/collection-watchers/test_reconciler.ts
+++ b/packages/core/test/collection-watchers/test_reconciler.ts
@@ -32,7 +32,7 @@ configureCollectionHost({
   workspaceRoot: root,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(root, ".user-skills"),
+    userSkillsDir: (wsRoot) => path.join(wsRoot, ".user-skills"),
     projectSkillsDir: (wsRoot) => path.join(wsRoot, ".claude", "skills"),
     feedsRoot: (wsRoot) => path.join(wsRoot, "data", "feeds"),
     skillsStagingDir: (wsRoot) => path.join(wsRoot, "data", "skills"),

--- a/packages/core/test/collection-watchers/test_watcher.ts
+++ b/packages/core/test/collection-watchers/test_watcher.ts
@@ -29,7 +29,7 @@ configureCollectionHost({
   workspaceRoot: root,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(root, ".user-skills"),
+    userSkillsDir: (wsRoot) => path.join(wsRoot, ".user-skills"),
     projectSkillsDir: (wsRoot) => path.join(wsRoot, ".claude", "skills"),
     feedsRoot: (wsRoot) => path.join(wsRoot, "data", "feeds"),
     skillsStagingDir: (wsRoot) => path.join(wsRoot, "data", "skills"),

--- a/packages/core/test/collection-watchers/test_watcherRoot.ts
+++ b/packages/core/test/collection-watchers/test_watcherRoot.ts
@@ -35,7 +35,7 @@ configureCollectionHost({
   workspaceRoot: root,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(root, ".user-skills"),
+    userSkillsDir: (wsRoot) => path.join(wsRoot, ".user-skills"),
     projectSkillsDir: (wsRoot) => path.join(wsRoot, ".claude", "skills"),
     feedsRoot: (wsRoot) => path.join(wsRoot, "data", "feeds"),
     skillsStagingDir: (wsRoot) => path.join(wsRoot, "data", "skills"),

--- a/packages/core/test/collection/test_authoringCoherence.ts
+++ b/packages/core/test/collection/test_authoringCoherence.ts
@@ -25,7 +25,7 @@ configureCollectionHost({
   workspaceRoot: null,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(makeTempDir("ac-user-skills-"), "empty"),
+    userSkillsDir: () => null,
     projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
     feedsRoot: (root) => path.join(root, "data", "feeds"),
     skillsStagingDir: (root) => (stagingEnabled ? path.join(root, "data", "skills") : null),

--- a/packages/core/test/collection/test_changePayloadBackCompat.ts
+++ b/packages/core/test/collection/test_changePayloadBackCompat.ts
@@ -25,7 +25,7 @@ configureCollectionHost({
   workspaceRoot: root,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(root, ".user-skills"),
+    userSkillsDir: (wsRoot) => path.join(wsRoot, ".user-skills"),
     projectSkillsDir: (wsRoot) => path.join(wsRoot, ".claude", "skills"),
     feedsRoot: (wsRoot) => path.join(wsRoot, "data", "feeds"),
     skillsStagingDir: (wsRoot) => path.join(wsRoot, "data", "skills"),

--- a/packages/core/test/collection/test_legacyUserSkillsDir.ts
+++ b/packages/core/test/collection/test_legacyUserSkillsDir.ts
@@ -36,8 +36,13 @@ function writeCollectionSkill(skillsRoot: string, slug: string, title: string): 
 const userSkillsRoot = makeTempDir("lu-user-skills-");
 writeCollectionSkill(userSkillsRoot, "user-only", "User only");
 
+// Two roots, because "this path, for EVERY root" is the whole reading of the
+// legacy form — one root could pass while a second silently lost user scope.
 const workspaceRoot = makeTempDir("lu-workspace-");
 writeCollectionSkill(path.join(workspaceRoot, ".claude", "skills"), "notes", "Project notes");
+
+const secondRoot = makeTempDir("lu-second-");
+writeCollectionSkill(path.join(secondRoot, ".claude", "skills"), "other", "Other project");
 
 configureCollectionHost({
   workspaceRoot,
@@ -55,10 +60,12 @@ configureCollectionHost({
 });
 
 test("a string userSkillsDir still merges user scope into every root — no crash, no silent opt-out", async () => {
-  const found = await discoverCollections({ workspaceRoot });
-  assert.deepEqual(
-    found.map((entry) => entry.slug),
-    ["notes", "user-only"],
-  );
-  assert.equal((await loadCollection("user-only", { workspaceRoot }))?.source, "user");
+  for (const [root, own] of [
+    [workspaceRoot, "notes"],
+    [secondRoot, "other"],
+  ] as const) {
+    const found = await discoverCollections({ workspaceRoot: root });
+    assert.deepEqual(found.map((entry) => entry.slug).sort(), [own, "user-only"].sort());
+    assert.equal((await loadCollection("user-only", { workspaceRoot: root }))?.source, "user");
+  }
 });

--- a/packages/core/test/collection/test_legacyUserSkillsDir.ts
+++ b/packages/core/test/collection/test_legacyUserSkillsDir.ts
@@ -1,0 +1,64 @@
+// The pre-3.3.0 host binding still works.
+//
+// `paths.userSkillsDir` became `(root) => string | null` so a multi-root host
+// could declare a root with NO user scope. The bare `string` form is kept
+// because a caret range floats across minors: a host pinned at `^3.2.0`
+// installs 3.3.0 without touching its code, and a REQUIRED callable would turn
+// that into a TypeError on its first discovery — a crash, not an opt-out.
+//
+// The binding under test is deliberately a plain string, as MulmoClaude's own
+// `configure.ts` wrote it before this release.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { configureCollectionHost, discoverCollections, loadCollection } from "../../src/collection/server/index.ts";
+import { makeTempDir } from "../helpers/tempDir.js";
+
+const noopLog = { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} };
+
+function writeCollectionSkill(skillsRoot: string, slug: string, title: string): void {
+  const skillDir = path.join(skillsRoot, slug);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    path.join(skillDir, "schema.json"),
+    JSON.stringify({
+      title,
+      icon: "list",
+      primaryKey: "id",
+      dataPath: `data/${slug}`,
+      fields: { id: { type: "string", label: "Id", primary: true } },
+    }),
+  );
+}
+
+const userSkillsRoot = makeTempDir("lu-user-skills-");
+writeCollectionSkill(userSkillsRoot, "user-only", "User only");
+
+const workspaceRoot = makeTempDir("lu-workspace-");
+writeCollectionSkill(path.join(workspaceRoot, ".claude", "skills"), "notes", "Project notes");
+
+configureCollectionHost({
+  workspaceRoot,
+  log: noopLog,
+  paths: {
+    // The 3.2.0 shape, verbatim.
+    userSkillsDir: userSkillsRoot,
+    projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+    feedsRoot: (root) => path.join(root, "data", "feeds"),
+    skillsStagingDir: () => null,
+    archiveDir: "data/archive",
+    collectionsRegistriesConfig: (root) => path.join(root, "config", "collections-registries.json"),
+  },
+  isPresetSlug: () => false,
+});
+
+test("a string userSkillsDir still merges user scope into every root — no crash, no silent opt-out", async () => {
+  const found = await discoverCollections({ workspaceRoot });
+  assert.deepEqual(
+    found.map((entry) => entry.slug),
+    ["notes", "user-only"],
+  );
+  assert.equal((await loadCollection("user-only", { workspaceRoot }))?.source, "user");
+});

--- a/packages/core/test/collection/test_multiRoot.ts
+++ b/packages/core/test/collection/test_multiRoot.ts
@@ -36,7 +36,9 @@ configureCollectionHost({
   workspaceRoot: null,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(makeTempDir("mr-user-skills-"), "empty"),
+    // No user scope: these roots are projects, and the test asserts on what
+    // each root owns, not on what the developer's home happens to hold.
+    userSkillsDir: () => null,
     projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
     feedsRoot: (root) => path.join(root, "data", "feeds"),
     skillsStagingDir: (root) => path.join(root, "data", "skills"),

--- a/packages/core/test/collection/test_nullStaging.ts
+++ b/packages/core/test/collection/test_nullStaging.ts
@@ -33,7 +33,7 @@ configureCollectionHost({
   workspaceRoot: null,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(makeTempDir("ns-user-skills-"), "empty"),
+    userSkillsDir: () => null,
     projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
     feedsRoot: (root) => path.join(root, "data", "feeds"),
     // The whole point: this root has no staging tree.

--- a/packages/core/test/collection/test_scopeIsolation.ts
+++ b/packages/core/test/collection/test_scopeIsolation.ts
@@ -1,0 +1,130 @@
+// Scope isolation (plans/feat-collection-scope-isolation.md).
+//
+// A host with more than one root can declare that a root has NO user scope
+// (`paths.userSkillsDir` → null): `~` and a project are separate worlds, so a
+// collection under `~/.claude/skills` must be unreachable from a project root —
+// not listed, and not RESOLVABLE by slug.
+//
+// The resolvable half is the point. A host-side filter on the listing leaves
+// `loadCollection` intact, and that is what getSchema / getItems / putItems /
+// the detail route / the view-token mint / the watcher all go through — so a
+// slug typed by the agent, or arriving in a URL, would still resolve to the
+// user-scope collection and write into its data dir. These tests assert the
+// miss, which a listing filter could not deliver.
+//
+// The same host binds a workspace root to a real path, so the merged behaviour
+// MulmoClaude depends on (user scope visible, project shadowing user) is pinned
+// in the same file as the isolation it must not become.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync, existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { configureCollectionHost, discoverCollections, loadCollection, makeManageCollectionTool } from "../../src/collection/server/index.ts";
+import { makeTempDir } from "../helpers/tempDir.js";
+
+const noopLog = { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} };
+
+/** Write a minimal per-file collection skill under `<skillsRoot>/<slug>`. */
+function writeCollectionSkill(skillsRoot: string, slug: string, title: string): void {
+  const skillDir = path.join(skillsRoot, slug);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    path.join(skillDir, "schema.json"),
+    JSON.stringify({
+      title,
+      icon: "list",
+      primaryKey: "id",
+      dataPath: `data/${slug}`,
+      fields: { id: { type: "string", label: "Id", primary: true }, name: { type: "string", label: "Name" } },
+    }),
+  );
+}
+
+// One machine-global user scope, holding a slug that exists NOWHERE else
+// (`user-only`) plus a `tasks` the workspace root also has — the collision the
+// merged world resolves and the isolated one never sees.
+const userSkillsRoot = makeTempDir("si-user-skills-");
+writeCollectionSkill(userSkillsRoot, "user-only", "User only");
+writeCollectionSkill(userSkillsRoot, "tasks", "User tasks");
+
+// The managed workspace: user scope merges into it, exactly as today.
+const workspaceRoot = makeTempDir("si-workspace-");
+writeCollectionSkill(path.join(workspaceRoot, ".claude", "skills"), "tasks", "Workspace tasks");
+
+// A plain project directory: separate world, no user scope.
+const projectRoot = makeTempDir("si-project-");
+writeCollectionSkill(path.join(projectRoot, ".claude", "skills"), "notes", "Project notes");
+
+configureCollectionHost({
+  // Explicit-root mode, so nothing can fall back to an ambient root and pass
+  // an isolation assertion by accident.
+  workspaceRoot: null,
+  log: noopLog,
+  paths: {
+    // The multi-root answer the plan asks for, in the one-line shape a host
+    // writes it: a managed workspace has user scope, a project root does not.
+    userSkillsDir: (root) => (root === workspaceRoot ? userSkillsRoot : null),
+    projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+    feedsRoot: (root) => path.join(root, "data", "feeds"),
+    skillsStagingDir: () => null,
+    archiveDir: "data/archive",
+    collectionsRegistriesConfig: (root) => path.join(root, "config", "collections-registries.json"),
+  },
+  isPresetSlug: () => false,
+});
+
+const slugsIn = async (root: string): Promise<string[]> => (await discoverCollections({ workspaceRoot: root })).map((entry) => entry.slug);
+
+test("a project root lists only its own collections — the user scope is not merged in", async () => {
+  assert.deepEqual(await slugsIn(projectRoot), ["notes"]);
+});
+
+test("a project root MISSES a user-only slug instead of hopping into another world", async () => {
+  // The assertion a listing filter could not make: resolution itself refuses.
+  assert.equal(await loadCollection("user-only", { workspaceRoot: projectRoot }), null);
+  // And the slug the two worlds share resolves to nothing here either — this
+  // root simply has no `tasks`.
+  assert.equal(await loadCollection("tasks", { workspaceRoot: projectRoot }), null);
+});
+
+test("a workspace root still merges user scope, and its own collection still shadows a user one", async () => {
+  assert.deepEqual(await slugsIn(workspaceRoot), ["tasks", "user-only"]);
+
+  const shadowed = await loadCollection("tasks", { workspaceRoot });
+  assert.equal(shadowed?.source, "project");
+  assert.equal(shadowed?.schema.title, "Workspace tasks");
+
+  const userScoped = await loadCollection("user-only", { workspaceRoot });
+  assert.equal(userScoped?.source, "user");
+  assert.equal(userScoped?.skillDir, path.join(userSkillsRoot, "user-only"));
+});
+
+test("an explicit `userSkillsDir: null` switches the scope off for one call, and `undefined` asks the host", async () => {
+  // `??` could not express this: `undefined` there means "ask the host", so a
+  // caller that passed null to opt OUT would have been silently opted back in.
+  assert.equal(await loadCollection("user-only", { workspaceRoot, userSkillsDir: null }), null);
+  assert.deepEqual(await slugsIn(workspaceRoot), ["tasks", "user-only"]);
+  assert.equal((await loadCollection("user-only", { workspaceRoot, userSkillsDir: undefined }))?.source, "user");
+});
+
+test("putSchema / putItems for a user-only slug fail as unknown from a project root, writing nothing into the user scope", async () => {
+  const tool = makeManageCollectionTool({ workspaceRoot: projectRoot, stagedSkillAuthoring: false });
+  const schemaFile = path.join(userSkillsRoot, "user-only", "schema.json");
+  const before = readFileSync(schemaFile, "utf-8");
+
+  const putSchema = await tool.handler({
+    action: "putSchema",
+    slug: "user-only",
+    schema: { title: "Hijacked", icon: "list", primaryKey: "id", dataPath: "data/user-only", fields: { id: { type: "string", label: "Id", primary: true } } },
+  });
+  assert.match(putSchema, /unknown collection 'user-only'/);
+
+  const putItems = await tool.handler({ action: "putItems", slug: "user-only", items: [{ id: "x1", name: "from the project" }] });
+  assert.match(putItems, /unknown collection 'user-only'/);
+
+  // The user scope is untouched: same schema, and no record dir conjured under it.
+  assert.equal(readFileSync(schemaFile, "utf-8"), before);
+  assert.deepEqual(readdirSync(path.join(userSkillsRoot, "user-only")), ["schema.json"]);
+  assert.equal(existsSync(path.join(projectRoot, "data", "user-only")), false);
+});

--- a/packages/core/test/feeds/_setup.ts
+++ b/packages/core/test/feeds/_setup.ts
@@ -49,7 +49,7 @@ configureCollectionHost({
   workspaceRoot: PLACEHOLDER_ROOT,
   log: noopLog,
   paths: {
-    userSkillsDir: path.join(PLACEHOLDER_ROOT, ".user-skills"),
+    userSkillsDir: () => path.join(PLACEHOLDER_ROOT, ".user-skills"),
     projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
     feedsRoot: (root) => path.join(root, "feeds"),
     skillsStagingDir: (root) => path.join(root, "data", "skills"),

--- a/packages/core/test/host/test_hostSlot.ts
+++ b/packages/core/test/host/test_hostSlot.ts
@@ -105,7 +105,7 @@ test("collection host slot: getWorkspaceRoot throws unset, log no-ops unset, bot
     workspaceRoot: "/ws",
     log: logger,
     paths: {
-      userSkillsDir: "/ws/.user-skills",
+      userSkillsDir: () => "/ws/.user-skills",
       projectSkillsDir: (root) => `${root}/.claude/skills`,
       feedsRoot: (root) => `${root}/data/feeds`,
       skillsStagingDir: (root) => `${root}/data/skills`,

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.2.0",
+    "@mulmoclaude/core": "^3.3.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.1.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/plans/feat-collection-scope-isolation.md
+++ b/plans/feat-collection-scope-isolation.md
@@ -1,0 +1,105 @@
+# feat(core): a project root must not resolve a USER-scope collection
+
+Written 2026-08-09 for an implementing agent. **In English**, continuing
+`plans/feat-collection-multi-root-3.md` — the rest of `plans/` is Japanese.
+
+The multi-root arc is otherwise finished: MulmoTerminal now serves collections from any project
+directory (receptron/mulmoterminal#1571 … #1590). This is the last thing the ENGINE decides for a
+host that has more than one root, and it needs a decision the host cannot express today.
+
+**The rule the host owner stated, verbatim in effect:** `~` and a project are separate worlds.
+Standing in `~/git/ai/mag2`, a collection under `~/.claude/skills` must not be reachable **at all**
+— not listed, and not resolvable by slug. The reverse already holds (project scope is per root).
+
+**MulmoClaude is unaffected.** It is one workspace and wants user scope merged into it exactly as
+today; the change below is additive with a default that preserves that. Say so in the PR and name
+what you ran.
+
+---
+
+## 1. What makes it reachable today
+
+Both entry points read ONE global user dir and apply it to every root
+(`packages/core/src/collection/server/discovery.ts`):
+
+```ts
+async function discoverCollections(opts = {}) {
+  const userDir = opts.userSkillsDir ?? userSkillsDir();      // host binding: a plain string
+  const userCollections = await collectFromDir(userDir, "user", workspaceRoot);
+  // merged: feed, then user, then project — project wins a slug collision
+}
+
+async function loadCollection(slug, opts = {}) {
+  const projectCollection = await loadOneCollection(projectSkillsDir(workspaceRoot), …);
+  if (projectCollection) return projectCollection;
+  const userCollection = await loadOneCollection(userDir, …);  // ← the fallback, for ANY root
+  …
+}
+```
+
+`paths.userSkillsDir` is `string`. A host with several roots cannot say "this one has no user
+scope", so the fallback in `loadCollection` applies everywhere.
+
+**A host-side filter on the LISTING would not do it**, which is why this is an upstream ask rather
+than a MulmoTerminal patch. `loadCollection` is what `getSchema`, `getItems`, `putItems`, the
+detail route, the view-token mint and the watcher all go through: hide the entry from a list and a
+slug typed by the agent — or arriving in a URL — still resolves to the user-scope collection and
+writes to its data dir. The guarantee has to hold where resolution happens.
+
+## 2. The change
+
+Make the user dir root-parameterised and nullable — **the same shape `skillsStagingDir` already
+has**, added in core 3.1.0 for the same kind of "this root does not have that base" statement:
+
+```ts
+paths: {
+  /** Absolute user-scope skills dir for a root, or `null` when this root has NO user scope.
+   *
+   *  A single-workspace host returns the same path for its one root and behaves exactly as
+   *  before. A host serving several roots returns null for a project directory: `~` and a
+   *  project are separate worlds, and a project that could resolve a machine-global collection
+   *  would depend on something no clone of it can have. */
+  userSkillsDir: (workspaceRoot: string) => string | null;
+  …
+}
+```
+
+- `discoverCollections`: skip the user pass when it is null. The merge order is otherwise
+  unchanged (feed, user, project).
+- `loadCollection`: skip the user fallback when it is null — so an unknown slug is a MISS, not a
+  quiet hop into another world.
+- The per-call `opts.userSkillsDir` should be able to say "none" too. Today `opts.userSkillsDir ??
+  userSkillsDir()` cannot express it: `undefined` means "use the host's". Accept `null` for none,
+  or keep the option purely for tests and let the host binding decide — either is fine, but say
+  which in the JSDoc, because a caller that thinks it opted out and did not is exactly the failure
+  this removes.
+
+Everything else the user scope touches should follow the same answer for consistency — the write
+targets, the archive path and the delete path all pick a base per root already, so grep
+`userSkillsDir(` and check each call site rather than only the two above.
+
+## 3. Consequences worth stating in the code
+
+- **A slug collision stops being a collision.** Today a project's `tasks` shadows a user `tasks`
+  (project wins the merge). With isolation there is no shadowing to reason about: a project sees
+  its own, and nothing else.
+- **A miss is a miss.** `loadCollection` returning null for a slug that exists only in user scope
+  is the intended answer for a project root, and the host will surface it as "no such collection"
+  — which is true, in that world.
+
+## 4. Verifying
+
+`packages/core` runs `tsx --test test/**/test_*.ts`; collection tests live in
+`packages/core/test/collection/`.
+
+1. **A project root with `userSkillsDir → null`**: `discoverCollections` lists only its own (and
+   feeds), and `loadCollection` returns null for a slug that exists ONLY in user scope — the
+   assertion that a listing filter could not make.
+2. **A workspace root with a path**: both behave exactly as today, including a project slug
+   shadowing a user one.
+3. **Writes**: a `putSchema` / `putItems` for that user-only slug fails as "unknown collection"
+   rather than writing into `~/.claude/skills` from a project.
+
+Then MulmoTerminal binds `userSkillsDir: (root) => (isManagedWorkspace(root) ? <~/.claude/skills> : null)`
+— the same one-line shape it already uses for `skillsStagingDir` — and brings its own skill
+scanner (`server/backends/remoteHost/skills.ts`, which reads both dirs) into line.

--- a/server/workspace/collections/configure.ts
+++ b/server/workspace/collections/configure.ts
@@ -16,7 +16,10 @@ configureCollectionHost({
   workspaceRoot: workspacePath,
   log,
   paths: {
-    userSkillsDir: USER_SKILLS_DIR,
+    // One workspace, so every root has the same user scope — the merge
+    // (user under project) is unchanged. A multi-root host answers `null`
+    // for a project directory instead; see the contract in core's `host.ts`.
+    userSkillsDir: () => USER_SKILLS_DIR,
     projectSkillsDir,
     feedsRoot,
     skillsStagingDir: (root) => path.join(root, WORKSPACE_DIRS.skillsStaging),

--- a/test/workspace/collections/test_io.ts
+++ b/test/workspace/collections/test_io.ts
@@ -37,7 +37,7 @@ import type { CollectionSchema } from "../../../server/workspace/collections/typ
 // `configureCollectionHost` is a no-op if called again with the same object,
 // which keeps re-runs idempotent.
 const TEST_HOST_PATHS = {
-  userSkillsDir: "/dev/null/.claude/skills",
+  userSkillsDir: () => "/dev/null/.claude/skills",
   projectSkillsDir: (root: string) => path.join(root, ".claude", "skills"),
   feedsRoot: (root: string) => path.join(root, "feeds"),
   skillsStagingDir: (root: string) => path.join(root, "data", "skills"),


### PR DESCRIPTION
Implements `plans/feat-collection-scope-isolation.md` (added here), the last thing the ENGINE decides for a host with more than one root.

## The rule

`~` and a project are separate worlds. Standing in a project directory, a collection under `~/.claude/skills` must not be reachable **at all** — not listed, and not resolvable by slug. The reverse already holds (project scope is per root).

**MulmoClaude is unaffected.** It is one workspace, binds `() => USER_SKILLS_DIR`, and behaves exactly as today: user scope merges in, and a project slug still shadows a user one.

## Why not a host-side filter on the listing

`loadCollection` is what `getSchema`, `getItems`, `putItems`, the detail route, the view-token mint and the watcher all go through. Hide the entry from a list and a slug typed by the agent — or arriving in a URL — still resolves to the user-scope collection and writes to its data dir. The guarantee has to hold where resolution happens, which is why this is an engine change rather than a MulmoTerminal patch.

## The change

`CollectionHost.paths.userSkillsDir` becomes `(workspaceRoot) => string | null` — the same shape `skillsStagingDir` already has, added in core 3.1.0 for the same kind of "this root does not have that base" statement.

- `discoverCollections`: skips the user pass when null. Merge order otherwise unchanged (feed, user, project).
- `loadCollection`: skips the user fallback when null — an unknown slug is a MISS, not a quiet hop into another world.
- `DiscoveryOptions.userSkillsDir` accepts `null` for "this call has no user scope"; `undefined` still means "ask the host binding". A new `resolveUserDir` helper spells that precedence once, because `??` cannot express it: `undefined` there means "ask the host" and would silently re-enable a scope the caller passed `null` to switch off.

`grep userSkillsDir(` confirms discovery is the only consumer in `src/` — the write targets, the archive path and the delete path all operate on an already-loaded collection, so blocking resolution covers them. `test_scopeIsolation.ts` verifies that rather than assuming it.

## Consequences, stated in the code

- **A slug collision stops being a collision** for an isolated root: it sees its own, and nothing else. No shadowing to reason about.
- **A miss is a miss.** `loadCollection` returning null for a user-only slug is the intended answer for a project root — the host surfaces "no such collection", which is true in that world.

## Tests

New `packages/core/test/collection/test_scopeIsolation.ts` (5 tests). One host binds a workspace root to a real user dir and a project root to `null`, so the isolation and the merged behaviour MulmoClaude depends on are pinned side by side:

1. The project root lists only its own collections.
2. It MISSES `user-only` **and** the `tasks` slug the two worlds share — the assertion a listing filter could not make.
3. The workspace root still merges user scope, and its own `tasks` still shadows the user one.
4. An explicit `userSkillsDir: null` switches the scope off for one call; `undefined` asks the host.
5. `putSchema` / `putItems` for `user-only` from the project root fail as "unknown collection", with the user-scope `schema.json` byte-unchanged and no record dir conjured under it.

## Ran

`yarn test` (exit 0, 27 suites, 0 failures — including the 795 in `packages/core`), `yarn typecheck`, `yarn build`, `yarn format --check` all clean; `yarn lint` reports 0 errors (43 pre-existing warnings).

## Release

`@mulmoclaude/core` 3.2.0 → **3.3.0**, launcher dep range swept to `^3.3.0` (the launcher's own `version` untouched), CHANGELOG entry + `Ships` line updated so `check-changelog-ships.mjs` passes. Plugin ranges left where they are, per the no-cascade rule.

A host that supplied a bare string must wrap it (`() => DIR`) — that is the whole migration. Shipped as a minor to match how `skillsStagingDir`'s null contract went out in 3.1.0.

## Follow-up (other repo)

MulmoTerminal binds `userSkillsDir: (root) => (isManagedWorkspace(root) ? <~/.claude/skills> : null)` — the one-line shape it already uses for `skillsStagingDir` — and brings `server/backends/remoteHost/skills.ts` (which reads both dirs) into line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Allow collection hosts to declare per-root absence of user scope so project roots cannot discover or resolve user-scope collections, and bump core to 3.3.0.

New Features:
- Support per-workspaceRoot configuration of user-scope skills directory, including explicitly disabling user scope for specific roots.

Enhancements:
- Update collection discovery and loading to respect roots with no user scope, preventing user-scope collections from being listed or resolved in isolated project roots.
- Clarify the distinction between host-provided and per-call user skills directory overrides, including a null value for explicit opt-out.

Build:
- Increment @mulmoclaude/core to version 3.3.0 and update MulmoClaude to depend on the new core version.

Documentation:
- Document collection scope isolation behaviour and the new userSkillsDir contract in the changelog and add a design plan for project roots without user scope.

Tests:
- Add scope isolation tests covering listing, resolution, and write behaviour for roots with and without user scope, and adapt existing tests and fixtures to the new host path shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project roots can independently opt out of user-scope collections.
  - Collection discovery and loading now skip unavailable user-scope data while preserving project-over-user precedence.
  - Workspace-specific user-scope resolution improves isolation across multiple project roots.
  - Legacy user-scope configurations remain supported.

- **Bug Fixes**
  - Prevented user collections from leaking between projects.
  - Prevented project operations from modifying user-only collections when user scope is unavailable.

- **Documentation**
  - Added release notes for `@mulmoclaude/core` 3.3.0 and updated the release roster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->