### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.13.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,50 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-08-10
+
+**A Google Calendar collection now actually receives the calendar, and the multi-root
+groundwork lands without changing anything for a single-workspace host.**
+
+### Highlights
+
+#### A calendar collection could sit at a handful of records forever (#2850, #2853)
+
+A `googleCalendar` collection would stall at 0, 1, or a couple of dozen records out of
+years of history, reporting success with **no error**, and further Sync presses added
+nothing. Only events touched after the collection existed kept arriving.
+
+A Google sync token is keyed by `calendarId` and nothing else, so every consumer of that
+calendar shares one cursor. Whoever walked first stored it, and the next collection
+resumed from a window it had never received — its "first sync" was a delta. Two ways in,
+both hit by the reporter: the standalone `google` tool's `calendarSync` stores a token
+(and discards its events), and a second collection created on a calendar a sibling had
+already synced. The on-create first sync (#2427) asked the same wrong question — it read
+"the calendar has a token" as "this has already synced" — so for an affected collection
+it never ran at all.
+
+A collection now records its own backfill beside its records
+(`<dataPath>/.calendar-sync.json`) and the sync walks the whole calendar while any
+collection on it still lacks one. The `google` tool keeps a separate cursor. A walk cut
+short by the page guard used to be byte-identical to a completed one; it now reports
+itself and withholds the backfill marker instead of leaving a half-copied calendar
+looking finished.
+
+#### Remote host stopped mistaking its own downtime for a dead channel (#2845, #2846)
+
+Presence and give-up are counted in beats that actually ran rather than by wall clock, so
+a laptop that slept no longer reads as a phone that went away.
+
+#### Multi-root groundwork (#2844, #2848, #2849, #2852)
+
+Collections, the accounting engine and card scope can each operate against an explicit
+project root, and a root may declare that it has no user scope. **None of it is reachable
+from MulmoClaude**, which is a single workspace and passes no root anywhere — behaviour is
+unchanged here. It is what lets a multi-root host (MulmoTerminal) stop resolving one
+project's records against another's.
+
+Ships `@mulmoclaude/core@3.4.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ### Package releases
 
 #### A project root can declare that it has no user scope

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.13.1",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Release bookkeeping for **`mulmoclaude@1.13.1`**, which is **already published to npm** — this PR carries the version bumps and the CHANGELOG entry that the `/publish-mulmoclaude` flow commits after the publish, so the `v1.13.1` tag can be cut at a commit whose root `package.json` says 1.13.1.

Published in this wave, bottom-up:

| package | from | to | notes |
|---|---|---|---|
| `@mulmoclaude/core` | 3.3.0 | **3.4.0** | the #2850 calendar-backfill fix |
| `@mulmoclaude/google-plugin` | 2.1.0 | **2.2.0** | own calendar cursor; needs core ^3.4.0 |
| `mulmoclaude` | 1.13.0 | **1.13.1** | launcher, last |

All three are tagged and have GitHub releases (the two scoped ones `--latest=false`).

## Items to Confirm / Review

1. **Patch, not minor.** Four of the seven PRs since `v1.13.0` are `feat` (#2844, #2848, #2849, #2852 — the multi-root work), which would normally argue for 1.14.0. I chose patch because that work is unreachable from a single-workspace host — the CHANGELOG for it says so explicitly ("None of the three is reachable from a single-workspace host, which passes no root anywhere"), so the app's user-visible change since 1.13.0 is two bug fixes (#2846, #2850). Say the word if you'd rather this had been 1.14.0; the number is already on npm, so correcting it means a follow-up release rather than an edit.
2. **The `Ships` line** was verified with `yarn check:changelog-ships`, not retyped by hand — it answers "which versions does this launcher pull in", not "what did we publish this week".

## Verification

- `node scripts/mulmoclaude/deps.mjs` — no missing dependencies
- `node scripts/mulmoclaude/drift.mjs` — no workspace drift against the **registry**-published dists
- `MulmoClaude publish smoke` green on `main` at `23d896c8b` (the merge this release ships)
- `node scripts/mulmoclaude/tarball.mjs` — pack → clean install → boot → **HTTP 200**, 5 runtime plugins
- Every internal launcher dep confirmed resolvable on the public registry **before** publishing
- Post-publish: `npx --registry=https://registry.npmjs.org/ mulmoclaude@1.13.1 --version` → `mulmoclaude 1.13.1` from a clean dir
- `yarn check:launcher-sync` and `yarn check:changelog-ships` both OK

## Not done here

`v1.13.1` tag + the `--latest` app release are cut **after** this merges, per §9b — the tag must point at the commit whose root `package.json` is 1.13.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Release mulmoclaude 1.13.1 with updated launcher metadata and documented changes.

New Features:
- Document multi-root groundwork enabling collections and accounting to target explicit project roots while remaining unreachable from the single-workspace launcher.

Bug Fixes:
- Document fixes for Google Calendar collections stalling due to shared sync tokens and ensure proper backfill tracking per collection.
- Document improved remote presence handling so hosts no longer misinterpret downtime (such as sleep) as dead channels.

Enhancements:
- Update root and launcher package versions to 1.13.1 to align the monorepo with the already-published release.
- Record the set of plugin and core package versions shipped with the 1.13.1 launcher in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and package versions to 1.13.1.

* **Documentation**
  * Added release notes covering improved Google Calendar synchronization, remote-host liveness tracking, and groundwork for multi-root support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->