### PR TITLE
feat(core): give a collection an identity that a shared one can also have

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Package releases
+
+Ships `@mulmoclaude/core@3.5.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ## [1.13.1] - 2026-08-10
 
 **A Google Calendar collection now actually receives the calendar, and the multi-root

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -22,7 +22,7 @@
 // without a side state file.
 
 import { clear as notifierClear, listAll, publish as notifierPublish, updateForPlugin as notifierUpdate, type NotifierEntry } from "../notifier";
-import { fieldText, itemIsDone, whenMatches, type CollectionItem, type CollectionSchema } from "../collection";
+import { fieldText, isValidCollectionName, itemIsDone, whenMatches, type CollectionItem, type CollectionSchema } from "../collection";
 import {
   canonicalRoot,
   type DiscoveryOptions,
@@ -86,15 +86,22 @@ export function completionLegacyId(slug: string, itemId: string, root?: string, 
   if (root !== undefined && aid !== undefined) {
     throw new Error(`completionLegacyId: "${slug}" carries both a root (${root}) and an app (${aid})`);
   }
-  // The parse splits at the FIRST colon, which is what lets an itemId carry one
-  // (a timestamp, a natural key). The name therefore must not: a shared cid of
-  // `sales:2026` would decode as slug `sales` with itemId `2026:<id>`, so the
-  // sweep would judge a live bell against the WRONG collection and clear it.
-  // A local slug is `safeSlugName`-validated upstream and cannot contain one;
-  // a shared cid has no such gate yet, so the encoder states the requirement
-  // instead of inheriting it.
-  if (slug.includes(":")) {
-    throw new Error(`completionLegacyId: collection name "${slug}" must not contain a colon`);
+  // Both names go through the SAME rule `CollectionKey` applies, because this
+  // function takes raw strings and is reachable by a caller that never built a
+  // key. Two ways this id breaks otherwise, and both are silent:
+  //   - the parse splits at the FIRST colon (which is what lets an itemId carry
+  //     one -- a timestamp, a natural key), so a name of `sales:2026` decodes
+  //     as slug `sales` with itemId `2026:<id>` and the sweep judges a live
+  //     bell against the WRONG collection and clears it;
+  //   - a NUL in the app id splits the scope early, so `salon\0other` writes an
+  //     id that reads back as aid `salon`, slug `other\0tasks`.
+  // A malformed shared bell is also unretirable: every root's sweep skips a
+  // parsed `aid`, so nothing cleans it up.
+  if (!isValidCollectionName(slug)) {
+    throw new Error(`completionLegacyId: collection name "${slug}" is not a valid collection name`);
+  }
+  if (aid !== undefined && !isValidCollectionName(aid)) {
+    throw new Error(`completionLegacyId: app id "${aid}" is not a valid collection name`);
   }
   const scope = aid !== undefined ? `${SHARED_MARK}${aid}${ROOT_SEP}` : root === undefined ? "" : `${ROOT_MARK}${canonicalRoot(root)}${ROOT_SEP}`;
   return `${LEGACY_ID_PREFIX}${scope}${slug}:${itemId}`;

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -79,6 +79,13 @@ const SHARED_MARK = "#";
 /** Exported for the format pin in `test/collection-watchers/test_completionId.ts`.
  *  Deliberately NOT on the package barrel: the id is a disk format, not an API. */
 export function completionLegacyId(slug: string, itemId: string, root?: string, aid?: string): string {
+  // The two scopes are mutually exclusive, and silently preferring one is the
+  // ambiguity `collectionChangeKey` refuses for the same reason: a local bell
+  // written into the shared namespace is SKIPPED by every root's sweep, so it
+  // can never be cleared -- and nothing anywhere would say why.
+  if (root !== undefined && aid !== undefined) {
+    throw new Error(`completionLegacyId: "${slug}" carries both a root (${root}) and an app (${aid})`);
+  }
   const scope = aid !== undefined ? `${SHARED_MARK}${aid}${ROOT_SEP}` : root === undefined ? "" : `${ROOT_MARK}${canonicalRoot(root)}${ROOT_SEP}`;
   return `${LEGACY_ID_PREFIX}${scope}${slug}:${itemId}`;
 }

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -48,6 +48,13 @@ const LEGACY_ID_PREFIX = "collection-completion:";
 const ROOT_MARK = "@";
 const ROOT_SEP = "\0";
 
+/** Marks a key that belongs to a SHARED collection (`apps/{aid}/collections/
+ *  {cid}`) rather than to a directory: `<prefix>#<aid>\0<cid>:<itemId>`. A
+ *  shared collection has no root, and its `cid` may well be the slug some
+ *  project already owns, so it needs a mark of its own — reusing the rootless
+ *  form would make the two dedupe into one bell. */
+const SHARED_MARK = "#";
+
 /** Stable key encoding (root, slug, item), round-tripped through the entry's
  *  `pluginData` so we can find it later without a side state file. Slug +
  *  itemId are upstream-validated via `safeSlugName`, which forbids the
@@ -69,8 +76,10 @@ const ROOT_SEP = "\0";
  *  this id is written to disk: a caller reaching `reconcileItem` directly with
  *  `/proj/` where the watcher used `/proj` would otherwise publish a SECOND
  *  bell for the same record, and neither pass would ever clear the other's. */
-function completionLegacyId(slug: string, itemId: string, root?: string): string {
-  const scope = root === undefined ? "" : `${ROOT_MARK}${canonicalRoot(root)}${ROOT_SEP}`;
+/** Exported for the format pin in `test/collection-watchers/test_completionId.ts`.
+ *  Deliberately NOT on the package barrel: the id is a disk format, not an API. */
+export function completionLegacyId(slug: string, itemId: string, root?: string, aid?: string): string {
+  const scope = aid !== undefined ? `${SHARED_MARK}${aid}${ROOT_SEP}` : root === undefined ? "" : `${ROOT_MARK}${canonicalRoot(root)}${ROOT_SEP}`;
   return `${LEGACY_ID_PREFIX}${scope}${slug}:${itemId}`;
 }
 
@@ -78,19 +87,25 @@ function completionLegacyId(slug: string, itemId: string, root?: string): string
  *  didn't originate from this module. Accepts both the rooted and the
  *  original root-less form — see the compatibility rule above. Used by the
  *  sweep step. */
-function parseCompletionLegacyId(legacyId: string): { root?: string; slug: string; itemId: string } | null {
+/** @see completionLegacyId — exported for the same reason. */
+export function parseCompletionLegacyId(legacyId: string): { root?: string; aid?: string; slug: string; itemId: string } | null {
   if (!legacyId.startsWith(LEGACY_ID_PREFIX)) return null;
   let body = legacyId.slice(LEGACY_ID_PREFIX.length);
   let root: string | undefined;
-  if (body.startsWith(ROOT_MARK)) {
+  let aid: string | undefined;
+  if (body.startsWith(ROOT_MARK) || body.startsWith(SHARED_MARK)) {
+    const shared = body.startsWith(SHARED_MARK);
     const sep = body.indexOf(ROOT_SEP);
     if (sep < 0) return null;
-    root = body.slice(ROOT_MARK.length, sep);
+    const scope = body.slice(1, sep);
+    if (shared) aid = scope;
+    else root = scope;
     body = body.slice(sep + ROOT_SEP.length);
   }
   const colon = body.indexOf(":");
   if (colon < 0) return null;
   const parsed = { slug: body.slice(0, colon), itemId: body.slice(colon + 1) };
+  if (aid !== undefined) return { aid, ...parsed };
   return root === undefined ? parsed : { root, ...parsed };
 }
 
@@ -358,9 +373,15 @@ export async function reconcileAllItems(collection: LoadedCollection, ioOpts: Io
  *    on produces a root-less id, so skipping it would strand a bell no pass can
  *    ever clear, while the reconcile publishes a second rooted one beside it.
  *    Clearing converges — the record republishes rooted if still pending. */
-function sweepVerdict(entryRoot: string | undefined, ownRoot: string | undefined): "mine" | "skip" | "drop-legacy" {
-  if (entryRoot === ownRoot) return "mine";
-  if (entryRoot === undefined) return "drop-legacy";
+function sweepVerdict(entry: { root?: string; aid?: string }, ownRoot: string | undefined): "mine" | "skip" | "drop-legacy" {
+  // A shared collection's bell belongs to no root. A root's sweep must neither
+  // claim it (`isStaleEntry` resolves the slug on DISK and would find nothing,
+  // so every shared bell would be judged stale) nor treat it as a root-less
+  // legacy entry to drop — either way it silently clears another surface's
+  // bells. Only the shared watcher may retire these.
+  if (entry.aid !== undefined) return "skip";
+  if (entry.root === ownRoot) return "mine";
+  if (entry.root === undefined) return "drop-legacy";
   return "skip";
 }
 
@@ -391,7 +412,7 @@ export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Prom
     if (!own) continue;
     const parsed = parseCompletionLegacyId(own.legacyId);
     if (!parsed) continue;
-    const verdict = sweepVerdict(parsed.root, ownRoot);
+    const verdict = sweepVerdict(parsed, ownRoot);
     if (verdict === "skip") continue;
     if (verdict === "drop-legacy") {
       await notifierClear(entry.id);

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -98,8 +98,14 @@ export function parseCompletionLegacyId(legacyId: string): { root?: string; aid?
     const sep = body.indexOf(ROOT_SEP);
     if (sep < 0) return null;
     const scope = body.slice(1, sep);
+    // Canonicalised on the way OUT as well as on the way in. Every id this
+    // module writes is already canonical, so for its own output this is a
+    // no-op -- but the file is read back from disk, and an entry written by
+    // hand or by an older build with a trailing separator would otherwise
+    // never equal the sweep's canonical root: the verdict would be "another
+    // root's, skip" and the stale bell could never be cleared by anyone.
     if (shared) aid = scope;
-    else root = scope;
+    else root = canonicalRoot(scope);
     body = body.slice(sep + ROOT_SEP.length);
   }
   const colon = body.indexOf(":");

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -86,6 +86,16 @@ export function completionLegacyId(slug: string, itemId: string, root?: string, 
   if (root !== undefined && aid !== undefined) {
     throw new Error(`completionLegacyId: "${slug}" carries both a root (${root}) and an app (${aid})`);
   }
+  // The parse splits at the FIRST colon, which is what lets an itemId carry one
+  // (a timestamp, a natural key). The name therefore must not: a shared cid of
+  // `sales:2026` would decode as slug `sales` with itemId `2026:<id>`, so the
+  // sweep would judge a live bell against the WRONG collection and clear it.
+  // A local slug is `safeSlugName`-validated upstream and cannot contain one;
+  // a shared cid has no such gate yet, so the encoder states the requirement
+  // instead of inheriting it.
+  if (slug.includes(":")) {
+    throw new Error(`completionLegacyId: collection name "${slug}" must not contain a colon`);
+  }
   const scope = aid !== undefined ? `${SHARED_MARK}${aid}${ROOT_SEP}` : root === undefined ? "" : `${ROOT_MARK}${canonicalRoot(root)}${ROOT_SEP}`;
   return `${LEGACY_ID_PREFIX}${scope}${slug}:${itemId}`;
 }

--- a/packages/core/src/collection/core/collectionKey.ts
+++ b/packages/core/src/collection/core/collectionKey.ts
@@ -137,8 +137,17 @@ function isCanonicalRootShape(root: string): boolean {
  *  Firestore document ids under `apps/{aid}/collections/{cid}` AND the name the
  *  same collection has on disk, so the slug charset is what they already are. */
 function namePart(value: string, field: string): string {
-  if (!SAFE_SLUG_PATTERN.test(value)) throw new Error(`CollectionKey: ${field} "${value}" is not a valid collection name`);
+  if (!isValidCollectionName(value)) throw new Error(`CollectionKey: ${field} "${value}" is not a valid collection name`);
   return value;
+}
+
+/** The name rule as a predicate, for the encoders that take RAW strings rather
+ *  than a key (the completion-bell id, a channel name). They are reachable by a
+ *  caller that never built a key, and each has its own delimiter to be broken
+ *  by, so they need to apply the same rule — not a rule of their own, which is
+ *  how the layers came to disagree in the first place. */
+export function isValidCollectionName(value: string): boolean {
+  return SAFE_SLUG_PATTERN.test(value);
 }
 
 /** A stable string form, for the places that need a primitive key: a Map, a

--- a/packages/core/src/collection/core/collectionKey.ts
+++ b/packages/core/src/collection/core/collectionKey.ts
@@ -1,0 +1,89 @@
+// What a collection IS, as a value.
+//
+// Until now a collection's identity was `(root, slug)` — see the INVARIANT on
+// `CollectionHost` — and that is still exactly right for a collection that
+// lives in a directory. A SHARED collection does not: it is published to
+// Firestore under `apps/{aid}/collections/{cid}`, several machines resolve it,
+// and no one of their paths is its name. Keying it by the path it happened to
+// be published from would make the same collection two collections.
+//
+// The two identities COEXIST. A local collection's behaviour must not change at
+// all, so this is a discriminated union rather than a widening of either one:
+// every surface the INVARIANT enumerates — a cache, a pubsub channel, a view
+// token, a notification id, a rendered card — keys on this type, and the
+// compiler then refuses the thing that keeps happening by hand, which is keying
+// on the NAME alone (`slug` / `cid`) and letting two collections that share a
+// name collide.
+//
+// Isomorphic on purpose: a card and a channel name are decided on both sides of
+// the wire, so this module imports nothing from node.
+
+/** A collection in a directory. `root` must already be canonical
+ *  (`canonicalRoot`) — it is an identity here, not a path to read, and `/proj`
+ *  vs `/proj/` would be two collections. Server callers should build these
+ *  through `localCollectionKey` in `collection/server`, which canonicalises;
+ *  the arm is spelled out here so the type itself stays isomorphic. */
+export interface LocalCollectionKey {
+  kind: "local";
+  root: string;
+  slug: string;
+}
+
+/** A collection published to a shared app: `apps/{aid}/collections/{cid}`.
+ *  `aid` is committed in the repository, so every clone resolves the same
+ *  collection and an invitation is about authorization, never discovery. */
+export interface SharedCollectionKey {
+  kind: "shared";
+  aid: string;
+  cid: string;
+}
+
+export type CollectionKey = LocalCollectionKey | SharedCollectionKey;
+
+export const isLocalCollectionKey = (key: CollectionKey): key is LocalCollectionKey => key.kind === "local";
+export const isSharedCollectionKey = (key: CollectionKey): key is SharedCollectionKey => key.kind === "shared";
+
+/** Build a local key from an ALREADY-CANONICAL root. */
+export const localCollectionKeyOf = (root: string, slug: string): LocalCollectionKey => ({ kind: "local", root, slug });
+
+/** Build a shared key. */
+export const sharedCollectionKey = (aid: string, cid: string): SharedCollectionKey => ({ kind: "shared", aid, cid });
+
+/** The collection's NAME within its scope: the slug, or the shared `cid`.
+ *
+ *  This is what a schema file, a URL segment and a label are keyed by, and it
+ *  is deliberately NOT enough to identify a collection — that is the whole
+ *  point of the union. Use it to look things up INSIDE a known scope, never as
+ *  a map key across scopes. */
+export const collectionKeyName = (key: CollectionKey): string => (key.kind === "local" ? key.slug : key.cid);
+
+// NUL separates the parts: it cannot occur in a path, a slug, an app id or a
+// collection id, so the encoding is unambiguous and needs no escaping.
+const SEP = "\u0000";
+
+/** A stable string form, for the places that need a primitive key: a Map, a
+ *  pubsub channel name, a notification id, a card's reconciliation key.
+ *
+ *  Round-trips through {@link parseCollectionKeyId}. The `kind` is written
+ *  first so a local key and a shared key can never collide however their parts
+ *  are spelled. */
+export const collectionKeyId = (key: CollectionKey): string =>
+  key.kind === "local" ? `local${SEP}${key.root}${SEP}${key.slug}` : `shared${SEP}${key.aid}${SEP}${key.cid}`;
+
+/** Decode a {@link collectionKeyId}, or `null` when the string did not come
+ *  from one. Null rather than a throw: these strings are read back from disk
+ *  and off the wire, where an unrecognised entry is a thing to skip, not a
+ *  crash. */
+export function parseCollectionKeyId(encoded: string): CollectionKey | null {
+  const parts = encoded.split(SEP);
+  if (parts.length !== 3) return null;
+  const [kind, first, second] = parts;
+  if (kind === undefined || first === undefined || second === undefined) return null;
+  if (first.length === 0 || second.length === 0) return null;
+  if (kind === "local") return { kind: "local", root: first, slug: second };
+  if (kind === "shared") return { kind: "shared", aid: first, cid: second };
+  return null;
+}
+
+/** Do two keys name the same collection? */
+export const sameCollectionKey = (one: CollectionKey, other: CollectionKey): boolean => collectionKeyId(one) === collectionKeyId(other);

--- a/packages/core/src/collection/core/collectionKey.ts
+++ b/packages/core/src/collection/core/collectionKey.ts
@@ -45,7 +45,8 @@ export type CollectionKey = LocalCollectionKey | SharedCollectionKey;
 export const isLocalCollectionKey = (key: CollectionKey): key is LocalCollectionKey => key.kind === "local";
 export const isSharedCollectionKey = (key: CollectionKey): key is SharedCollectionKey => key.kind === "shared";
 
-/** Build a local key from an ALREADY-CANONICAL root. */
+/** Build a local key from an ALREADY-CANONICAL root — and refuse one that is
+ *  not. See {@link scopePart}. */
 export const localCollectionKeyOf = (root: string, slug: string): LocalCollectionKey => ({
   kind: "local",
   root: scopePart(root, "root"),
@@ -89,7 +90,31 @@ const SEP = "\u0000";
 function scopePart(value: string, field: string): string {
   if (value.length === 0) throw new Error(`CollectionKey: ${field} must not be empty`);
   if (value.includes(SEP)) throw new Error(`CollectionKey: ${field} must not contain NUL`);
+  if (!isCanonicalRootShape(value)) throw new Error(`CollectionKey: ${field} "${value}" is not a canonical root`);
   return value;
+}
+
+/** Is this root ALREADY in the shape `canonicalRoot` (path.resolve) produces?
+ *
+ *  This module cannot canonicalise — that needs `node:path` and this file is
+ *  isomorphic — so it does the other half: it REFUSES anything that is not
+ *  already canonical. Which is the part that matters, because the failure is
+ *  silent. `/work/proj/` and `/work/proj` are the same collection, and a key
+ *  built from the first compares unequal to a key built from the second: two
+ *  cache entries, two channels, two bells for one collection — exactly the
+ *  identity split this type exists to remove. A decoder reading ids off a disk
+ *  is where such a spelling arrives.
+ *
+ *  The properties are `path.resolve`'s own: absolute, no `.` or `..` segment,
+ *  no doubled separator, no trailing one. The Windows drive form is allowed so
+ *  a canonical root there is not refused. */
+function isCanonicalRootShape(root: string): boolean {
+  const windows = /^[A-Za-z]:\\/.test(root);
+  const sep = windows ? "\\" : "/";
+  if (!windows && !root.startsWith("/")) return false;
+  if (root.length > 1 && root.endsWith(sep)) return false;
+  if (root.includes(sep + sep)) return false;
+  return !root.split(sep).some((segment) => segment === "." || segment === "..");
 }
 
 /** A NAME — a slug, a shared `cid`, or an `aid`: the collection-slug charset,
@@ -138,11 +163,11 @@ export const collectionKeyId = (key: CollectionKey): string =>
  *  strings are read back from storage, where an unrecognised or stale entry is
  *  a thing to skip, not a crash.
  *
- *  ONE thing this cannot check: whether a local `root` is canonical. That needs
- *  `node:path` and this module is isomorphic. Every id this module writes came
- *  from a canonical root (the server-side `localCollectionKey` canonicalises),
- *  so it holds for real data — a hand-written id with a trailing separator
- *  decodes to a key that will not equal the canonical one. */
+ *  A non-canonical root is refused here too, for the same reason: `/work/proj/`
+ *  and `/work/proj` name one collection, and two keys that compare unequal are
+ *  two cache entries, two channels and two bells for it. This module cannot
+ *  canonicalise (that needs `node:path`), so it rejects instead — see
+ *  {@link scopePart}. */
 export function parseCollectionKeyId(encoded: string): CollectionKey | null {
   const parts = encoded.split(SEP);
   if (parts.length !== 3) return null;

--- a/packages/core/src/collection/core/collectionKey.ts
+++ b/packages/core/src/collection/core/collectionKey.ts
@@ -18,6 +18,8 @@
 // Isomorphic on purpose: a card and a channel name are decided on both sides of
 // the wire, so this module imports nothing from node.
 
+import { SAFE_SLUG_PATTERN } from "./ids";
+
 /** A collection in a directory. `root` must already be canonical
  *  (`canonicalRoot`) — it is an identity here, not a path to read, and `/proj`
  *  vs `/proj/` would be two collections. Server callers should build these
@@ -44,10 +46,18 @@ export const isLocalCollectionKey = (key: CollectionKey): key is LocalCollection
 export const isSharedCollectionKey = (key: CollectionKey): key is SharedCollectionKey => key.kind === "shared";
 
 /** Build a local key from an ALREADY-CANONICAL root. */
-export const localCollectionKeyOf = (root: string, slug: string): LocalCollectionKey => ({ kind: "local", root: part(root, "root"), slug: part(slug, "slug") });
+export const localCollectionKeyOf = (root: string, slug: string): LocalCollectionKey => ({
+  kind: "local",
+  root: scopePart(root, "root"),
+  slug: namePart(slug, "slug"),
+});
 
 /** Build a shared key. */
-export const sharedCollectionKey = (aid: string, cid: string): SharedCollectionKey => ({ kind: "shared", aid: part(aid, "aid"), cid: part(cid, "cid") });
+export const sharedCollectionKey = (aid: string, cid: string): SharedCollectionKey => ({
+  kind: "shared",
+  aid: namePart(aid, "aid"),
+  cid: namePart(cid, "cid"),
+});
 
 /** The collection's NAME within its scope: the slug, or the shared `cid`.
  *
@@ -61,23 +71,48 @@ export const collectionKeyName = (key: CollectionKey): string => (key.kind === "
 // collection id, so the encoding is unambiguous and needs no escaping.
 const SEP = "\u0000";
 
-/** Reject a part that cannot be encoded, rather than encoding it wrongly.
+/** A ROOT: any non-empty string that can be encoded. A path's charset is the
+ *  filesystem's, so the only thing to require is that it survives the encoding.
  *
- *  "NUL cannot occur in a path or a slug" is true of every real value and is
- *  the reason the encoding needs no escaping — but a type whose whole job is to
- *  be an identity must not take the claim on trust. Without this,
- *  `("a\0b", "c")` and `("a", "b\0c")` encode to the SAME string, so
- *  `sameCollectionKey` calls two different collections equal and the id parses
- *  back to nothing. An empty part is refused for the same reason: it makes the
- *  id ambiguous about which part was missing.
+ *  "NUL cannot occur in a path" is true of every real value and is the reason
+ *  the encoding needs no escaping — but a type whose whole job is to be an
+ *  identity must not take the claim on trust. Without this, `("a\0b", "c")`
+ *  and `("a", "b\0c")` encode to the SAME string, so `sameCollectionKey` calls
+ *  two different collections equal and the id parses back to nothing. Empty is
+ *  refused for the same reason: it makes the id ambiguous about which part was
+ *  missing.
  *
  *  A throw, where `parseCollectionKeyId` returns null: building a key is code
  *  making an identity, and a bad one there is a programming error. Parsing is
  *  reading something off a disk or a wire, where an unrecognised entry is a
  *  thing to skip. */
-function part(value: string, field: string): string {
+function scopePart(value: string, field: string): string {
   if (value.length === 0) throw new Error(`CollectionKey: ${field} must not be empty`);
   if (value.includes(SEP)) throw new Error(`CollectionKey: ${field} must not contain NUL`);
+  return value;
+}
+
+/** A NAME — a slug, a shared `cid`, or an `aid`: the collection-slug charset,
+ *  `[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?`.
+ *
+ *  THIS TYPE IS THE SINGLE SOURCE OF TRUTH for what a name may be, and that is
+ *  the point rather than a nicety. A name is re-encoded by every downstream
+ *  identity — the completion-bell id (`<scope>\0<name>:<itemId>`, split at the
+ *  first colon), a pubsub channel (`collection:app/<aid>/<name>`), a cache key
+ *  — and each of those has a different character it cannot survive. With the
+ *  rule stated only downstream, the layers disagree: a cid of `sales:2026`
+ *  builds fine, then the bell id decodes as a DIFFERENT collection and the
+ *  channel name throws inside a publisher whose catch swallows it, so the live
+ *  update simply stops arriving. One rule here makes every encoding safe by
+ *  construction; the checks downstream stay as belt-and-braces for callers that
+ *  never went through a key.
+ *
+ *  A local slug is already `safeSlugName`-validated upstream, so this changes
+ *  nothing for it. A shared `aid` / `cid` had no gate at all — they are
+ *  Firestore document ids under `apps/{aid}/collections/{cid}` AND the name the
+ *  same collection has on disk, so the slug charset is what they already are. */
+function namePart(value: string, field: string): string {
+  if (!SAFE_SLUG_PATTERN.test(value)) throw new Error(`CollectionKey: ${field} "${value}" is not a valid collection name`);
   return value;
 }
 

--- a/packages/core/src/collection/core/collectionKey.ts
+++ b/packages/core/src/collection/core/collectionKey.ts
@@ -44,10 +44,10 @@ export const isLocalCollectionKey = (key: CollectionKey): key is LocalCollection
 export const isSharedCollectionKey = (key: CollectionKey): key is SharedCollectionKey => key.kind === "shared";
 
 /** Build a local key from an ALREADY-CANONICAL root. */
-export const localCollectionKeyOf = (root: string, slug: string): LocalCollectionKey => ({ kind: "local", root, slug });
+export const localCollectionKeyOf = (root: string, slug: string): LocalCollectionKey => ({ kind: "local", root: part(root, "root"), slug: part(slug, "slug") });
 
 /** Build a shared key. */
-export const sharedCollectionKey = (aid: string, cid: string): SharedCollectionKey => ({ kind: "shared", aid, cid });
+export const sharedCollectionKey = (aid: string, cid: string): SharedCollectionKey => ({ kind: "shared", aid: part(aid, "aid"), cid: part(cid, "cid") });
 
 /** The collection's NAME within its scope: the slug, or the shared `cid`.
  *
@@ -60,6 +60,26 @@ export const collectionKeyName = (key: CollectionKey): string => (key.kind === "
 // NUL separates the parts: it cannot occur in a path, a slug, an app id or a
 // collection id, so the encoding is unambiguous and needs no escaping.
 const SEP = "\u0000";
+
+/** Reject a part that cannot be encoded, rather than encoding it wrongly.
+ *
+ *  "NUL cannot occur in a path or a slug" is true of every real value and is
+ *  the reason the encoding needs no escaping — but a type whose whole job is to
+ *  be an identity must not take the claim on trust. Without this,
+ *  `("a\0b", "c")` and `("a", "b\0c")` encode to the SAME string, so
+ *  `sameCollectionKey` calls two different collections equal and the id parses
+ *  back to nothing. An empty part is refused for the same reason: it makes the
+ *  id ambiguous about which part was missing.
+ *
+ *  A throw, where `parseCollectionKeyId` returns null: building a key is code
+ *  making an identity, and a bad one there is a programming error. Parsing is
+ *  reading something off a disk or a wire, where an unrecognised entry is a
+ *  thing to skip. */
+function part(value: string, field: string): string {
+  if (value.length === 0) throw new Error(`CollectionKey: ${field} must not be empty`);
+  if (value.includes(SEP)) throw new Error(`CollectionKey: ${field} must not contain NUL`);
+  return value;
+}
 
 /** A stable string form, for the places that need a primitive key: a Map, a
  *  pubsub channel name, a notification id, a card's reconciliation key.

--- a/packages/core/src/collection/core/collectionKey.ts
+++ b/packages/core/src/collection/core/collectionKey.ts
@@ -126,17 +126,34 @@ export const collectionKeyId = (key: CollectionKey): string =>
   key.kind === "local" ? `local${SEP}${key.root}${SEP}${key.slug}` : `shared${SEP}${key.aid}${SEP}${key.cid}`;
 
 /** Decode a {@link collectionKeyId}, or `null` when the string did not come
- *  from one. Null rather than a throw: these strings are read back from disk
- *  and off the wire, where an unrecognised entry is a thing to skip, not a
- *  crash. */
+ *  from one — or carries values no key may hold.
+ *
+ *  Decoding goes THROUGH the constructors. Building the union here directly
+ *  would let a string off a disk or a wire mint an identity the constructors
+ *  refuse: `shared\0salon\0sales:2026` would become a key whose name the
+ *  completion-bell id and the pubsub channel cannot represent, and the single
+ *  source of truth for a name would have a back door.
+ *
+ *  Null rather than a throw, and a throw from a constructor caught here: these
+ *  strings are read back from storage, where an unrecognised or stale entry is
+ *  a thing to skip, not a crash.
+ *
+ *  ONE thing this cannot check: whether a local `root` is canonical. That needs
+ *  `node:path` and this module is isomorphic. Every id this module writes came
+ *  from a canonical root (the server-side `localCollectionKey` canonicalises),
+ *  so it holds for real data — a hand-written id with a trailing separator
+ *  decodes to a key that will not equal the canonical one. */
 export function parseCollectionKeyId(encoded: string): CollectionKey | null {
   const parts = encoded.split(SEP);
   if (parts.length !== 3) return null;
   const [kind, first, second] = parts;
   if (kind === undefined || first === undefined || second === undefined) return null;
-  if (first.length === 0 || second.length === 0) return null;
-  if (kind === "local") return { kind: "local", root: first, slug: second };
-  if (kind === "shared") return { kind: "shared", aid: first, cid: second };
+  try {
+    if (kind === "local") return localCollectionKeyOf(first, second);
+    if (kind === "shared") return sharedCollectionKey(first, second);
+  } catch {
+    return null;
+  }
   return null;
 }
 

--- a/packages/core/src/collection/index.ts
+++ b/packages/core/src/collection/index.ts
@@ -11,6 +11,7 @@ export * from "./core/schema";
 // `collection/server`; browser code needs only the derived types.
 export type { CollectionQuery, CollectionQueryAggregate, CollectionQueryOrder, CollectionQueryWhere } from "./core/queryZ";
 export * from "./core/ids";
+export * from "./core/collectionKey";
 export * from "./core/fieldText";
 export * from "./core/project";
 export * from "./core/uiTypes";

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -183,6 +183,12 @@ export function collectionChangePayload(base: CollectionChangeBase, root: string
  *  which is what it is called inside its app; `aid` is what makes it an
  *  identity. Never stamps a `root` — a shared collection does not have one. */
 export function sharedCollectionChangePayload(base: CollectionChangeBase, aid: string): SharedCollectionChange {
+  // Validated HERE, at construction, not at publish. A host's publisher wraps
+  // its publish in a try/catch on purpose -- dropping one live-refresh event
+  // beats crashing the write that triggered it -- so a name that no channel can
+  // encode would be swallowed there and the update would simply stop arriving,
+  // with nothing said. Building the key is the cheap way to say it loudly.
+  sharedCollectionKey(aid, base.slug);
   return { ...base, aid };
 }
 

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -119,29 +119,52 @@ export interface CollectionHost {
  *  and `op` is advisory. Deliberately carries NO record bodies — this is a
  *  "refetch" ping, not a data feed, so it stays cheap and leaks nothing when a
  *  host relays it into an opaque-origin custom-view iframe. */
-export interface CollectionChangePayload {
+/** Fields every change carries, whatever kind of collection it is about. */
+interface CollectionChangeBase {
   /** The collection's NAME in its scope: the slug, or a shared collection's
-   *  `cid`. Never an identity on its own — see `aid` and `root`. */
+   *  `cid`. Never an identity on its own — see the two arms below. */
   slug: string;
-  /** The shared app this collection belongs to, when it is a SHARED collection
-   *  (`apps/{aid}/collections/{cid}`) rather than one in a directory. Mutually
-   *  exclusive with `root`: a shared collection has no root, because the same
-   *  collection is resolved from every clone of the repository.
-   *
-   *  Absent — every payload that existed before shared collections — means a
-   *  local collection, and the shape is byte-identical to what it was. Use
-   *  {@link collectionChangeKey} rather than reading these fields by hand. */
-  aid?: string;
-  /** Absolute workspace/project root the change happened under. Present only
-   *  when the engine call carried an explicit `workspaceRoot`; absent means
-   *  the host's configured root, so a single-workspace host never sets it.
-   *  A multi-root host MUST key its live-update fan-out on `(root, slug)` —
-   *  two projects each owning a `tasks` collection would otherwise refresh
-   *  each other's open views. */
-  root?: string;
   ids?: string[];
   op?: "upsert" | "delete";
 }
+
+/** A change to a collection in a directory. */
+export interface LocalCollectionChange extends CollectionChangeBase {
+  /** Absolute workspace/project root the change happened under. Present only
+   *  when the engine call carried an explicit `workspaceRoot`; absent means the
+   *  host's configured root, so a single-workspace host never sets it.
+   *  A multi-root host MUST key its live-update fan-out on `(root, slug)` —
+   *  two projects each owning a `tasks` collection would otherwise refresh each
+   *  other's open views. */
+  root?: string;
+  /** Never on a local change. The two arms are mutually exclusive at the TYPE
+   *  level, not by convention: a payload carrying both would be read as shared
+   *  by `collectionChangeKey`, which drops the root and fans the update out on
+   *  the wrong channel. */
+  aid?: never;
+}
+
+/** A change to a collection published to a shared app. */
+export interface SharedCollectionChange extends CollectionChangeBase {
+  /** The shared app (`apps/{aid}/collections/{cid}`). Required on this arm:
+   *  it is what makes the payload an identity. */
+  aid: string;
+  /** Never on a shared change — a shared collection has no root, because the
+   *  same collection is resolved from every clone of the repository. */
+  root?: never;
+}
+
+/** A collection's records changed. Carries the `slug` so the host can publish
+ *  on a per-collection channel; `ids` lists the affected record ids when known
+ *  (a consumer may ignore them and refetch the whole collection), and `op` is
+ *  advisory. Deliberately carries NO record bodies — this is a "refetch" ping,
+ *  not a data feed, so it stays cheap and leaks nothing when a host relays it
+ *  into an opaque-origin custom-view iframe.
+ *
+ *  Reading a payload is unchanged: `slug`, `root`, `ids` and `op` are all
+ *  reachable on the union. Use {@link collectionChangeKey} rather than deciding
+ *  what an absent field means by hand. */
+export type CollectionChangePayload = LocalCollectionChange | SharedCollectionChange;
 
 type CollectionChangePublisher = (payload: CollectionChangePayload) => void;
 
@@ -149,7 +172,7 @@ type CollectionChangePublisher = (payload: CollectionChangePayload) => void;
  *  an explicit one. Centralised so every publish site states the root the same
  *  way, and so a single-workspace host's payload shape stays byte-identical to
  *  what it saw before multi-root support. */
-export function collectionChangePayload(base: Omit<CollectionChangePayload, "root">, root: string | undefined): CollectionChangePayload {
+export function collectionChangePayload(base: CollectionChangeBase, root: string | undefined): LocalCollectionChange {
   // Canonical, because a host keys its live-update fan-out on this value: a
   // direct `writeItem({ workspaceRoot: "/proj/" })` and the watcher's own
   // publish for `/proj` must land on the same channel, not two.
@@ -159,7 +182,7 @@ export function collectionChangePayload(base: Omit<CollectionChangePayload, "roo
 /** Build a change payload for a SHARED collection. `slug` carries the `cid`,
  *  which is what it is called inside its app; `aid` is what makes it an
  *  identity. Never stamps a `root` — a shared collection does not have one. */
-export function sharedCollectionChangePayload(base: Omit<CollectionChangePayload, "root" | "aid">, aid: string): CollectionChangePayload {
+export function sharedCollectionChangePayload(base: CollectionChangeBase, aid: string): SharedCollectionChange {
   return { ...base, aid };
 }
 
@@ -173,7 +196,26 @@ export function sharedCollectionChangePayload(base: Omit<CollectionChangePayload
  *  `fallbackRoot` is what a payload with no root resolves to. An explicit-root
  *  host has no such default and must not guess — pass the root the call was
  *  made for. */
+/** Refuse a payload that names both an app and a root.
+ *
+ *  The two arms are mutually exclusive in the TYPE, so this cannot come from
+ *  the constructors -- it is corrupt input (a JS caller, a cast, something off
+ *  a wire). Throwing rather than picking one: whichever way it were guessed,
+ *  the update would be fanned out on a channel it does not belong to, and that
+ *  is invisible where a throw is not.
+ *
+ *  Takes the WIDENED shape deliberately. Written inline, TypeScript narrows the
+ *  union to `never` inside the branch and the fields cannot be read at all --
+ *  which is the type-level guarantee doing its job, and exactly why the runtime
+ *  check has to be stated somewhere it can still see them. */
+function requireOneScope(payload: CollectionChangeBase & { aid?: string; root?: string }): void {
+  if (payload.aid !== undefined && payload.root !== undefined) {
+    throw new Error(`collectionChangeKey: payload for "${payload.slug}" carries both an app (${payload.aid}) and a root (${payload.root})`);
+  }
+}
+
 export function collectionChangeKey(payload: CollectionChangePayload, fallbackRoot: string): CollectionKey {
+  requireOneScope(payload);
   return payload.aid === undefined ? localCollectionKey(payload.root ?? fallbackRoot, payload.slug) : sharedCollectionKey(payload.aid, payload.slug);
 }
 

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -10,6 +10,7 @@
 
 import path from "node:path";
 import { canonicalRoot } from "../../files/root.js";
+import { localCollectionKeyOf, sharedCollectionKey, type CollectionKey } from "../core/collectionKey.js";
 import { createForwardingLogger, createHostSlot, type StructuredLogger } from "../../host/hostSlot.js";
 
 /** Public alias of the shared `StructuredLogger` — keeps the domain surface name-stable. */
@@ -26,6 +27,11 @@ export { canonicalRoot };
  *  watcher is already running — and a host catching both in one place should
  *  not have to match on message text to tell them apart. */
 export const COLLECTION_ROOT_REQUIRED = "COLLECTION_ROOT_REQUIRED";
+
+/** Build a local {@link CollectionKey}, canonicalising the root. The identity
+ *  type itself is isomorphic and cannot canonicalise (that needs `node:path`),
+ *  so this is the constructor server code should use. */
+export const localCollectionKey = (root: string, slug: string): CollectionKey => localCollectionKeyOf(canonicalRoot(root), slug);
 
 /** INVARIANT — **a slug is unique within a root and nowhere else.**
  *
@@ -114,7 +120,18 @@ export interface CollectionHost {
  *  "refetch" ping, not a data feed, so it stays cheap and leaks nothing when a
  *  host relays it into an opaque-origin custom-view iframe. */
 export interface CollectionChangePayload {
+  /** The collection's NAME in its scope: the slug, or a shared collection's
+   *  `cid`. Never an identity on its own — see `aid` and `root`. */
   slug: string;
+  /** The shared app this collection belongs to, when it is a SHARED collection
+   *  (`apps/{aid}/collections/{cid}`) rather than one in a directory. Mutually
+   *  exclusive with `root`: a shared collection has no root, because the same
+   *  collection is resolved from every clone of the repository.
+   *
+   *  Absent — every payload that existed before shared collections — means a
+   *  local collection, and the shape is byte-identical to what it was. Use
+   *  {@link collectionChangeKey} rather than reading these fields by hand. */
+  aid?: string;
   /** Absolute workspace/project root the change happened under. Present only
    *  when the engine call carried an explicit `workspaceRoot`; absent means
    *  the host's configured root, so a single-workspace host never sets it.
@@ -137,6 +154,27 @@ export function collectionChangePayload(base: Omit<CollectionChangePayload, "roo
   // direct `writeItem({ workspaceRoot: "/proj/" })` and the watcher's own
   // publish for `/proj` must land on the same channel, not two.
   return root === undefined ? base : { ...base, root: canonicalRoot(root) };
+}
+
+/** Build a change payload for a SHARED collection. `slug` carries the `cid`,
+ *  which is what it is called inside its app; `aid` is what makes it an
+ *  identity. Never stamps a `root` — a shared collection does not have one. */
+export function sharedCollectionChangePayload(base: Omit<CollectionChangePayload, "root" | "aid">, aid: string): CollectionChangePayload {
+  return { ...base, aid };
+}
+
+/** The identity a change is about, as a value — the thing to key a fan-out on.
+ *
+ *  This is the one place that decides what an absent field means, so no host
+ *  has to: `aid` present is a shared collection, otherwise it is local, and a
+ *  local payload with no `root` means the host's configured root (which is why
+ *  a single-workspace host's payloads still say nothing about roots).
+ *
+ *  `fallbackRoot` is what a payload with no root resolves to. An explicit-root
+ *  host has no such default and must not guess — pass the root the call was
+ *  made for. */
+export function collectionChangeKey(payload: CollectionChangePayload, fallbackRoot: string): CollectionKey {
+  return payload.aid === undefined ? localCollectionKey(payload.root ?? fallbackRoot, payload.slug) : sharedCollectionKey(payload.aid, payload.slug);
 }
 
 const hostSlot = createHostSlot<CollectionHost>("@mulmoclaude/core/collection/server: configureCollectionHost()");

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -45,9 +45,14 @@ export {
   setCollectionChangePublisher,
   publishCollectionChange,
   collectionChangePayload,
+  sharedCollectionChangePayload,
+  collectionChangeKey,
+  localCollectionKey,
   type CollectionHost,
   type CollectionLogger,
   type CollectionChangePayload,
+  type LocalCollectionChange,
+  type SharedCollectionChange,
 } from "./host";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";

--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -33,6 +33,12 @@ test("two apps owning the same cid hold two bells", () => {
   assert.notEqual(completionLegacyId("bookings", "b1", undefined, "salon"), completionLegacyId("bookings", "b1", undefined, "clinic"));
 });
 
+test("an id cannot carry both a root and an app", () => {
+  // Preferring one silently would put a LOCAL bell in the shared namespace,
+  // where every root's sweep skips it and nobody can ever clear it.
+  assert.throws(() => completionLegacyId("tasks", "t1", "/work/proj", "salon"), /both a root/);
+});
+
 test("all three forms parse", () => {
   assert.deepEqual(parseCompletionLegacyId("collection-completion:tasks:t1"), { slug: "tasks", itemId: "t1" });
   assert.deepEqual(parseCompletionLegacyId("collection-completion:@/work/proj\u0000tasks:t1"), { root: "/work/proj", slug: "tasks", itemId: "t1" });

--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -39,6 +39,21 @@ test("an id cannot carry both a root and an app", () => {
   assert.throws(() => completionLegacyId("tasks", "t1", "/work/proj", "salon"), /both a root/);
 });
 
+test("a collection name carrying a colon is refused, not mis-parsed", () => {
+  // The parse splits at the FIRST colon so an itemId may carry one. A shared
+  // cid of `sales:2026` would otherwise decode as slug `sales`, itemId
+  // `2026:row-1` -- the sweep would then judge a live bell against the wrong
+  // collection and clear it, and it would collide with the real
+  // (cid "sales", itemId "2026:row-1").
+  assert.throws(() => completionLegacyId("sales:2026", "row-1", undefined, "salon"), /colon/);
+  assert.throws(() => completionLegacyId("sales:2026", "row-1"), /colon/);
+});
+
+test("an itemId may still carry colons", () => {
+  const parsed = parseCompletionLegacyId(completionLegacyId("sales", "2026:row-1", undefined, "salon"));
+  assert.deepEqual(parsed, { aid: "salon", slug: "sales", itemId: "2026:row-1" });
+});
+
 test("all three forms parse", () => {
   assert.deepEqual(parseCompletionLegacyId("collection-completion:tasks:t1"), { slug: "tasks", itemId: "t1" });
   assert.deepEqual(parseCompletionLegacyId("collection-completion:@/work/proj\u0000tasks:t1"), { root: "/work/proj", slug: "tasks", itemId: "t1" });

--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -40,11 +40,13 @@ test("an id cannot carry both a root and an app", () => {
 });
 
 test("a collection name carrying a colon is refused, not mis-parsed", () => {
-  // The parse splits at the FIRST colon so an itemId may carry one. A shared
-  // cid of `sales:2026` would otherwise decode as slug `sales`, itemId
-  // `2026:row-1` -- the sweep would then judge a live bell against the wrong
-  // collection and clear it, and it would collide with the real
-  // (cid "sales", itemId "2026:row-1").
+  // Belt-and-braces: `CollectionKey` is the single source of truth for a name
+  // and already refuses this, but these two take raw strings and are reachable
+  // by a caller that never built a key. The parse splits at the FIRST colon so
+  // an itemId may carry one; a name of `sales:2026` would otherwise decode as
+  // slug `sales`, itemId `2026:row-1` -- the sweep would judge a live bell
+  // against the wrong collection and clear it, and it would collide with the
+  // real (cid "sales", itemId "2026:row-1").
   assert.throws(() => completionLegacyId("sales:2026", "row-1", undefined, "salon"), /colon/);
   assert.throws(() => completionLegacyId("sales:2026", "row-1"), /colon/);
 });

--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -1,0 +1,51 @@
+// The completion-bell id is a DISK FORMAT: both apps read one
+// `<ws>/data/notifier/active.json`, so every form it has ever had must keep
+// parsing, forever. This pins the three forms after shared collections were
+// added — the two that already existed byte-for-byte, and the new one.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { completionLegacyId, parseCompletionLegacyId } from "../../src/collection-watchers/reconciler.ts";
+
+test("with no root the id is the pre-multi-root format, byte for byte", () => {
+  // A single-workspace host's existing entries must keep matching, or every
+  // pending record bells a second time.
+  assert.equal(completionLegacyId("tasks", "t1"), "collection-completion:tasks:t1");
+});
+
+test("a root is included only when one was supplied", () => {
+  assert.equal(completionLegacyId("tasks", "t1", "/work/proj"), "collection-completion:@/work/proj\u0000tasks:t1");
+  // Canonicalised here as well as at the watcher's claim: `/proj/` reaching
+  // reconcileItem directly would otherwise publish a second, uncleardable bell.
+  assert.equal(completionLegacyId("tasks", "t1", "/work/proj/"), completionLegacyId("tasks", "t1", "/work/proj"));
+});
+
+test("a shared collection gets a mark of its own, not the rootless form", () => {
+  // A shared `cid` may well be a slug some project already owns. Reusing the
+  // rootless form would dedupe the two into one bell.
+  const shared = completionLegacyId("tasks", "t1", undefined, "salon");
+  assert.equal(shared, "collection-completion:#salon\u0000tasks:t1");
+  assert.notEqual(shared, completionLegacyId("tasks", "t1"));
+  assert.notEqual(shared, completionLegacyId("tasks", "t1", "/work/proj"));
+});
+
+test("two apps owning the same cid hold two bells", () => {
+  assert.notEqual(completionLegacyId("bookings", "b1", undefined, "salon"), completionLegacyId("bookings", "b1", undefined, "clinic"));
+});
+
+test("all three forms parse", () => {
+  assert.deepEqual(parseCompletionLegacyId("collection-completion:tasks:t1"), { slug: "tasks", itemId: "t1" });
+  assert.deepEqual(parseCompletionLegacyId("collection-completion:@/work/proj\u0000tasks:t1"), { root: "/work/proj", slug: "tasks", itemId: "t1" });
+  assert.deepEqual(parseCompletionLegacyId("collection-completion:#salon\u0000tasks:t1"), { aid: "salon", slug: "tasks", itemId: "t1" });
+});
+
+test("an itemId containing a colon survives the round trip", () => {
+  const parsed = parseCompletionLegacyId(completionLegacyId("tasks", "2026-08-10T10:00", undefined, "salon"));
+  assert.deepEqual(parsed, { aid: "salon", slug: "tasks", itemId: "2026-08-10T10:00" });
+});
+
+test("a string from somewhere else parses to null", () => {
+  for (const bad of ["", "tasks:t1", "collection-completion:notrailing", "collection-completion:@no-sep-tasks:t1"]) {
+    assert.equal(parseCompletionLegacyId(bad), null, bad);
+  }
+});

--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -47,8 +47,17 @@ test("a collection name carrying a colon is refused, not mis-parsed", () => {
   // slug `sales`, itemId `2026:row-1` -- the sweep would judge a live bell
   // against the wrong collection and clear it, and it would collide with the
   // real (cid "sales", itemId "2026:row-1").
-  assert.throws(() => completionLegacyId("sales:2026", "row-1", undefined, "salon"), /colon/);
-  assert.throws(() => completionLegacyId("sales:2026", "row-1"), /colon/);
+  assert.throws(() => completionLegacyId("sales:2026", "row-1", undefined, "salon"), /not a valid collection name/);
+  assert.throws(() => completionLegacyId("sales:2026", "row-1"), /not a valid collection name/);
+});
+
+test("an app id that would split the scope early is refused", () => {
+  // `salon\0other` writes an id that reads back as aid `salon`, slug
+  // `other\0tasks` — the format stops round-tripping. And a malformed SHARED
+  // bell is unretirable: every root's sweep skips a parsed `aid`, so nothing
+  // ever cleans it up.
+  assert.throws(() => completionLegacyId("tasks", "t1", undefined, "salon\u0000other"), /app id/);
+  assert.throws(() => completionLegacyId("tasks", "t1", undefined, "sa:lon"), /app id/);
 });
 
 test("an itemId may still carry colons", () => {

--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -44,6 +44,14 @@ test("an itemId containing a colon survives the round trip", () => {
   assert.deepEqual(parsed, { aid: "salon", slug: "tasks", itemId: "2026-08-10T10:00" });
 });
 
+test("a rooted id read back from disk is canonicalised on the way out too", () => {
+  // The sweep compares the parsed root against a canonical one. An entry
+  // written by hand or by an older build with a trailing separator would
+  // otherwise never match: the verdict would be "another root's, skip" and
+  // nobody could ever clear that bell.
+  assert.deepEqual(parseCompletionLegacyId("collection-completion:@/work/proj/\u0000tasks:t1"), { root: "/work/proj", slug: "tasks", itemId: "t1" });
+});
+
 test("a string from somewhere else parses to null", () => {
   for (const bad of ["", "tasks:t1", "collection-completion:notrailing", "collection-completion:@no-sep-tasks:t1"]) {
     assert.equal(parseCompletionLegacyId(bad), null, bad);

--- a/packages/core/test/collection/test_changeKey.ts
+++ b/packages/core/test/collection/test_changeKey.ts
@@ -1,0 +1,47 @@
+// A change payload names a collection, and a host fans live updates out on it.
+// `collectionChangeKey` is the ONE place that decides what an absent field
+// means, so no host has to: a payload with `aid` is a shared collection, one
+// without is local, and a local payload with no `root` means the host's
+// configured root — which is why a single-workspace host's payloads still say
+// nothing about roots at all.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { collectionChangeKey, collectionChangePayload, sharedCollectionChangePayload } from "../../src/collection/server/host.ts";
+import { collectionKeyId } from "../../src/collection/core/collectionKey.ts";
+
+const HOST_ROOT = "/work/host";
+
+test("a payload with no root resolves against the host's root", () => {
+  const payload = collectionChangePayload({ slug: "tasks", ids: ["t1"], op: "upsert" }, undefined);
+  assert.deepEqual(collectionChangeKey(payload, HOST_ROOT), { kind: "local", root: HOST_ROOT, slug: "tasks" });
+});
+
+test("a payload with an explicit root resolves against that one", () => {
+  const payload = collectionChangePayload({ slug: "tasks" }, "/work/proj/");
+  // Canonical on both sides: a direct write against `/work/proj/` and the
+  // watcher's own publish for `/work/proj` must land on ONE channel.
+  assert.deepEqual(collectionChangeKey(payload, HOST_ROOT), { kind: "local", root: "/work/proj", slug: "tasks" });
+});
+
+test("a shared payload carries the app, never a root", () => {
+  const payload = sharedCollectionChangePayload({ slug: "bookings", ids: ["b1"], op: "upsert" }, "salon");
+  assert.equal(Object.hasOwn(payload, "root"), false);
+  assert.deepEqual(collectionChangeKey(payload, HOST_ROOT), { kind: "shared", aid: "salon", cid: "bookings" });
+});
+
+test("the fan-out cannot cross a project or an app", () => {
+  // The failure this exists to prevent: two projects each owning `tasks`
+  // refreshing each other's open views, and a shared `tasks` refreshing both.
+  const projA = collectionChangeKey(collectionChangePayload({ slug: "tasks" }, "/work/a"), HOST_ROOT);
+  const projB = collectionChangeKey(collectionChangePayload({ slug: "tasks" }, "/work/b"), HOST_ROOT);
+  const shared = collectionChangeKey(sharedCollectionChangePayload({ slug: "tasks" }, "salon"), HOST_ROOT);
+  const ids = new Set([projA, projB, shared].map(collectionKeyId));
+  assert.equal(ids.size, 3);
+});
+
+test("a single-workspace host's payload shape is unchanged", () => {
+  // deepEqual is deepSTRICTEqual: an own `aid: undefined` key would fail this,
+  // which is the point — the field must not appear at all.
+  assert.deepEqual(collectionChangePayload({ slug: "tasks", ids: ["t1"], op: "upsert" }, undefined), { slug: "tasks", ids: ["t1"], op: "upsert" });
+});

--- a/packages/core/test/collection/test_changeKey.ts
+++ b/packages/core/test/collection/test_changeKey.ts
@@ -64,6 +64,14 @@ test("a payload cannot carry both a root and an app", () => {
   assert.throws(() => collectionChangeKey(built, HOST_ROOT), /both an app/);
 });
 
+test("a shared payload refuses a name no channel could encode", () => {
+  // Loud here rather than swallowed later: the host's publisher catches so that
+  // a failed publish cannot crash the write, which would turn this into "live
+  // updates quietly stopped".
+  assert.throws(() => sharedCollectionChangePayload({ slug: "sales:2026" }, "salon"), /not a valid collection name/);
+  assert.throws(() => sharedCollectionChangePayload({ slug: "tasks" }, "sa/lon"), /not a valid collection name/);
+});
+
 test("a single-workspace host's payload shape is unchanged", () => {
   // deepEqual is deepSTRICTEqual: an own `aid: undefined` key would fail this,
   // which is the point — the field must not appear at all.

--- a/packages/core/test/collection/test_changeKey.ts
+++ b/packages/core/test/collection/test_changeKey.ts
@@ -7,7 +7,13 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { collectionChangeKey, collectionChangePayload, sharedCollectionChangePayload } from "../../src/collection/server/host.ts";
+import {
+  collectionChangeKey,
+  collectionChangePayload,
+  sharedCollectionChangePayload,
+  type LocalCollectionChange,
+  type SharedCollectionChange,
+} from "../../src/collection/server/host.ts";
 import { collectionKeyId } from "../../src/collection/core/collectionKey.ts";
 
 const HOST_ROOT = "/work/host";
@@ -38,6 +44,24 @@ test("the fan-out cannot cross a project or an app", () => {
   const shared = collectionChangeKey(sharedCollectionChangePayload({ slug: "tasks" }, "salon"), HOST_ROOT);
   const ids = new Set([projA, projB, shared].map(collectionKeyId));
   assert.equal(ids.size, 3);
+});
+
+test("a payload cannot carry both a root and an app", () => {
+  // Compile-time, because that is where it has to be stopped: a payload with
+  // both would be read as SHARED by collectionChangeKey, which drops the root
+  // and fans the update out on the wrong channel. @ts-expect-error fails the
+  // typecheck if the two arms ever stop being mutually exclusive.
+  // @ts-expect-error - aid is never on a local change
+  const bothLocal: LocalCollectionChange = { slug: "tasks", root: "/work/a", aid: "salon" };
+  // @ts-expect-error - root is never on a shared change
+  const bothShared: SharedCollectionChange = { slug: "tasks", aid: "salon", root: "/work/a" };
+  assert.equal(bothLocal.slug, bothShared.slug);
+  // And if one reaches the decision point anyway -- a JS caller, a cast,
+  // something off a wire -- it throws rather than being guessed into one
+  // channel or the other, because a misrouted fan-out is invisible.
+  // @ts-expect-error - the base of a local payload has no aid
+  const built = collectionChangePayload({ slug: "tasks", aid: "salon" }, "/work/a");
+  assert.throws(() => collectionChangeKey(built, HOST_ROOT), /both an app/);
 });
 
 test("a single-workspace host's payload shape is unchanged", () => {

--- a/packages/core/test/collection/test_collectionKey.ts
+++ b/packages/core/test/collection/test_collectionKey.ts
@@ -85,6 +85,15 @@ test("a NAME is the collection-slug charset, wherever it appears", () => {
   assert.equal(sharedCollectionKey("salon-2", "sales_2026").cid, "sales_2026");
 });
 
+test("a decoded id cannot mint a name the constructors refuse", () => {
+  // The decoder reads strings off storage, so it is the obvious back door
+  // around the single-source name rule: `shared\0salon\0sales:2026` would
+  // otherwise become a key whose name no downstream encoding can represent.
+  assert.equal(parseCollectionKeyId("shared\u0000salon\u0000sales:2026"), null);
+  assert.equal(parseCollectionKeyId("local\u0000/work/proj\u0000with space"), null);
+  assert.equal(parseCollectionKeyId("shared\u0000sa/lon\u0000tasks"), null);
+});
+
 test("the guards narrow", () => {
   const local = localCollectionKeyOf("/work/proj", "tasks");
   const shared = sharedCollectionKey("salon", "bookings");

--- a/packages/core/test/collection/test_collectionKey.ts
+++ b/packages/core/test/collection/test_collectionKey.ts
@@ -85,6 +85,21 @@ test("a NAME is the collection-slug charset, wherever it appears", () => {
   assert.equal(sharedCollectionKey("salon-2", "sales_2026").cid, "sales_2026");
 });
 
+test("a non-canonical root is refused, in the constructor and in the decoder", () => {
+  // `/work/proj/` and `/work/proj` are ONE collection. Two keys that compare
+  // unequal are two cache entries, two channels and two bells for it — the
+  // identity split this type exists to remove. This module cannot canonicalise
+  // (that needs node:path), so it rejects instead.
+  for (const bad of ["/work/proj/", "/work//proj", "/work/./proj", "/work/../proj", "work/proj", "."]) {
+    assert.throws(() => localCollectionKeyOf(bad, "tasks"), /canonical root/, bad);
+    assert.equal(parseCollectionKeyId(`local\u0000${bad}\u0000tasks`), null, bad);
+  }
+  // The forms path.resolve actually produces are accepted, including Windows'.
+  assert.equal(localCollectionKeyOf("/work/proj", "tasks").root, "/work/proj");
+  assert.equal(localCollectionKeyOf("/", "tasks").root, "/");
+  assert.equal(localCollectionKeyOf("C:\\work\\proj", "tasks").root, "C:\\work\\proj");
+});
+
 test("a decoded id cannot mint a name the constructors refuse", () => {
   // The decoder reads strings off storage, so it is the obvious back door
   // around the single-source name rule: `shared\0salon\0sales:2026` would

--- a/packages/core/test/collection/test_collectionKey.ts
+++ b/packages/core/test/collection/test_collectionKey.ts
@@ -62,21 +62,27 @@ test("a string that did not come from collectionKeyId parses to null, not a thro
   }
 });
 
-test("a part carrying the separator is refused, not encoded wrongly", () => {
+test("a root carrying the separator is refused, not encoded wrongly", () => {
   // Without this, ("a\0b", "c") and ("a", "b\0c") encode to the SAME string:
   // two different collections compare equal and the id parses back to nothing.
   assert.throws(() => localCollectionKeyOf("a\u0000b", "c"), /NUL/);
-  assert.throws(() => localCollectionKeyOf("a", "b\u0000c"), /NUL/);
-  assert.throws(() => sharedCollectionKey("a\u0000b", "c"), /NUL/);
-  assert.throws(() => sharedCollectionKey("a", "b\u0000c"), /NUL/);
+  assert.throws(() => localCollectionKeyOf("", "tasks"), /empty/);
 });
 
-test("an empty part is refused", () => {
-  // It makes the id ambiguous about which part was missing.
-  assert.throws(() => localCollectionKeyOf("", "tasks"), /empty/);
-  assert.throws(() => localCollectionKeyOf("/work/proj", ""), /empty/);
-  assert.throws(() => sharedCollectionKey("", "tasks"), /empty/);
-  assert.throws(() => sharedCollectionKey("salon", ""), /empty/);
+test("a NAME is the collection-slug charset, wherever it appears", () => {
+  // This type is the single source of truth for it. A name is re-encoded by
+  // every downstream identity (the bell id splits at the first colon, a channel
+  // name is slash/colon-delimited), and each has a different character it
+  // cannot survive -- so with the rule stated only downstream, a cid like
+  // "sales:2026" builds fine, then decodes as a DIFFERENT collection and makes
+  // the channel throw inside a publisher whose catch swallows it.
+  for (const bad of ["sales:2026", "a/b", "a\u0000b", "", "-lead", "trail-", "with space", "dot.ted"]) {
+    assert.throws(() => sharedCollectionKey("salon", bad), /not a valid collection name/, bad);
+    assert.throws(() => sharedCollectionKey(bad, "tasks"), /not a valid collection name/, bad);
+    assert.throws(() => localCollectionKeyOf("/work/proj", bad), /not a valid collection name/, bad);
+  }
+  // ...and the charset a slug actually has still works.
+  assert.equal(sharedCollectionKey("salon-2", "sales_2026").cid, "sales_2026");
 });
 
 test("the guards narrow", () => {

--- a/packages/core/test/collection/test_collectionKey.ts
+++ b/packages/core/test/collection/test_collectionKey.ts
@@ -1,0 +1,72 @@
+// `CollectionKey` — the identity a collection has as a VALUE.
+//
+// Two identities coexist: a collection in a directory is `(root, slug)`, and a
+// shared one is `(aid, cid)`. The whole reason this is a discriminated union
+// rather than a widened `(scope, name)` pair is that the two must never collide
+// — a project owning `tasks` and a shared app owning `tasks` are two
+// collections — and that a local collection's behaviour is unchanged.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  collectionKeyId,
+  collectionKeyName,
+  isLocalCollectionKey,
+  isSharedCollectionKey,
+  localCollectionKeyOf,
+  parseCollectionKeyId,
+  sameCollectionKey,
+  sharedCollectionKey,
+  type CollectionKey,
+} from "../../src/collection/core/collectionKey.ts";
+
+test("a local key and a shared key that share a name are different collections", () => {
+  const local = localCollectionKeyOf("/work/proj", "tasks");
+  const shared = sharedCollectionKey("salon", "tasks");
+  assert.equal(collectionKeyName(local), collectionKeyName(shared));
+  assert.equal(sameCollectionKey(local, shared), false);
+  assert.notEqual(collectionKeyId(local), collectionKeyId(shared));
+});
+
+test("two roots owning the same slug are two collections", () => {
+  // The failure the INVARIANT exists to prevent: keyed by slug alone, these
+  // two share a cache entry, a channel and a bell.
+  const one = localCollectionKeyOf("/work/a", "tasks");
+  const other = localCollectionKeyOf("/work/b", "tasks");
+  assert.equal(sameCollectionKey(one, other), false);
+});
+
+test("two apps owning the same cid are two collections", () => {
+  const one = sharedCollectionKey("salon", "bookings");
+  const other = sharedCollectionKey("clinic", "bookings");
+  assert.equal(sameCollectionKey(one, other), false);
+});
+
+test("ids round-trip", () => {
+  const keys: CollectionKey[] = [localCollectionKeyOf("/work/proj", "tasks"), sharedCollectionKey("salon", "bookings")];
+  for (const key of keys) assert.deepEqual(parseCollectionKeyId(collectionKeyId(key)), key);
+});
+
+test("a name containing the separator cannot forge another key", () => {
+  // The parts are NUL-separated because NUL cannot occur in a path, a slug, an
+  // app id or a collection id. Anything that does contain one is not a key.
+  assert.equal(parseCollectionKeyId("local\u0000/work\u0000a\u0000b"), null);
+  assert.equal(parseCollectionKeyId("local\u0000/work"), null);
+});
+
+test("a string that did not come from collectionKeyId parses to null, not a throw", () => {
+  // These are read back from disk and off the wire, where an unrecognised entry
+  // is a thing to skip.
+  for (const bad of ["", "tasks", "remote\u0000a\u0000b", "local\u0000\u0000slug", "local\u0000/work\u0000"]) {
+    assert.equal(parseCollectionKeyId(bad), null, bad);
+  }
+});
+
+test("the guards narrow", () => {
+  const local = localCollectionKeyOf("/work/proj", "tasks");
+  const shared = sharedCollectionKey("salon", "bookings");
+  assert.equal(isLocalCollectionKey(local) && local.root === "/work/proj", true);
+  assert.equal(isSharedCollectionKey(shared) && shared.aid === "salon", true);
+  assert.equal(isSharedCollectionKey(local), false);
+  assert.equal(isLocalCollectionKey(shared), false);
+});

--- a/packages/core/test/collection/test_collectionKey.ts
+++ b/packages/core/test/collection/test_collectionKey.ts
@@ -62,6 +62,23 @@ test("a string that did not come from collectionKeyId parses to null, not a thro
   }
 });
 
+test("a part carrying the separator is refused, not encoded wrongly", () => {
+  // Without this, ("a\0b", "c") and ("a", "b\0c") encode to the SAME string:
+  // two different collections compare equal and the id parses back to nothing.
+  assert.throws(() => localCollectionKeyOf("a\u0000b", "c"), /NUL/);
+  assert.throws(() => localCollectionKeyOf("a", "b\u0000c"), /NUL/);
+  assert.throws(() => sharedCollectionKey("a\u0000b", "c"), /NUL/);
+  assert.throws(() => sharedCollectionKey("a", "b\u0000c"), /NUL/);
+});
+
+test("an empty part is refused", () => {
+  // It makes the id ambiguous about which part was missing.
+  assert.throws(() => localCollectionKeyOf("", "tasks"), /empty/);
+  assert.throws(() => localCollectionKeyOf("/work/proj", ""), /empty/);
+  assert.throws(() => sharedCollectionKey("", "tasks"), /empty/);
+  assert.throws(() => sharedCollectionKey("salon", ""), /empty/);
+});
+
 test("the guards narrow", () => {
   const local = localCollectionKeyOf("/work/proj", "tasks");
   const shared = sharedCollectionKey("salon", "bookings");

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.4.0",
+    "@mulmoclaude/core": "^3.5.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^3.4.0"
+    "@mulmoclaude/core": "^3.5.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^2.0.0",

--- a/server/events/collection-change.ts
+++ b/server/events/collection-change.ts
@@ -43,6 +43,19 @@ function resolveSetPublisher(): SetPublisher | null {
   return typeof candidate === "function" ? candidate : null;
 }
 
+/** The wire payload for a change: only the keys the change actually carried.
+ *  It rides the pub/sub channel out to browser subscribers, so it holds no
+ *  record bodies and no root — an absolute path must not reach a subscriber.
+ *  Pure, and exported so it can be tested without a pubsub instance. */
+export function toChannelPayload(payload: CollectionChangePayload): CollectionChannelPayload {
+  return {
+    slug: payload.slug,
+    ...(payload.aid !== undefined ? { aid: payload.aid } : {}),
+    ...(payload.ids !== undefined ? { ids: payload.ids } : {}),
+    ...(payload.op !== undefined ? { op: payload.op } : {}),
+  };
+}
+
 /** Wire the package's change publisher to `instance`. Call once at server
  *  startup, next to `initFileChangePublisher` / `initAccountingEventPublisher`. */
 export function initCollectionChangePublisher(instance: IPubSub): void {
@@ -52,14 +65,7 @@ export function initCollectionChangePublisher(instance: IPubSub): void {
     return;
   }
   setPublisher((payload: CollectionChangePayload) => {
-    // Only the keys the change actually carried — this payload rides the
-    // pub/sub channel out to browser subscribers.
-    const channelPayload: CollectionChannelPayload = {
-      slug: payload.slug,
-      ...(payload.aid !== undefined ? { aid: payload.aid } : {}),
-      ...(payload.ids !== undefined ? { ids: payload.ids } : {}),
-      ...(payload.op !== undefined ? { op: payload.op } : {}),
-    };
+    const channelPayload = toChannelPayload(payload);
     try {
       // Scoped by the app when there is one: two shared collections that share
       // a `cid`, and this workspace's own collection of the same name, must not

--- a/server/events/collection-change.ts
+++ b/server/events/collection-change.ts
@@ -56,11 +56,15 @@ export function initCollectionChangePublisher(instance: IPubSub): void {
     // pub/sub channel out to browser subscribers.
     const channelPayload: CollectionChannelPayload = {
       slug: payload.slug,
+      ...(payload.aid !== undefined ? { aid: payload.aid } : {}),
       ...(payload.ids !== undefined ? { ids: payload.ids } : {}),
       ...(payload.op !== undefined ? { op: payload.op } : {}),
     };
     try {
-      instance.publish(collectionChannel(payload.slug), channelPayload);
+      // Scoped by the app when there is one: two shared collections that share
+      // a `cid`, and this workspace's own collection of the same name, must not
+      // publish on one channel.
+      instance.publish(collectionChannel(payload.slug, payload.aid), channelPayload);
     } catch (err) {
       // Fire-and-forget, same rationale as the file-change / accounting
       // publishers: dropping one event (a missed live refresh) is better than

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -74,6 +74,17 @@ export function fileChannel(workspaceRelativePath: string): string {
  */
 const CHANNEL_SEPARATORS = /[/:]/;
 
+/** A channel-name component, refused if it could spell a different channel.
+ *
+ *  A slug is `[a-zA-Z0-9_-]` upstream, so `app/salon/tasks` can never BE a slug
+ *  — but a channel name is an identity, and an identity function that takes
+ *  such a claim on trust is how a collection ends up able to name its way into
+ *  another app's channel. Cheap to make true rather than inherited. */
+function channelPart(value: string, field: string): string {
+  if (CHANNEL_SEPARATORS.test(value)) throw new Error(`collectionChannel: ${field} "${value}" contains a channel separator`);
+  return value;
+}
+
 export function collectionChannel(slug: string, aid?: string): string {
   // A collection's identity is `(root, slug)` locally and `(aid, cid)` when it
   // is shared, so the NAME alone cannot key the fan-out: a shared `tasks` in
@@ -86,14 +97,10 @@ export function collectionChannel(slug: string, aid?: string): string {
   // the channel name reaches the browser, and a path must not (a multi-root
   // host scopes its own fan-out; see the INVARIANT on `CollectionHost`).
   //
-  // The separators are rejected rather than assumed absent. A slug is
-  // `[a-zA-Z0-9_-]` upstream, so `app/salon/tasks` can never BE a slug — but a
-  // channel name is an identity, and an identity function that takes such a
-  // claim on trust is how a collection ends up able to name its way into
-  // another app's channel. Cheap to make true instead of inherited.
-  if (CHANNEL_SEPARATORS.test(slug)) throw new Error(`collectionChannel: slug "${slug}" contains a channel separator`);
-  if (aid !== undefined && CHANNEL_SEPARATORS.test(aid)) throw new Error(`collectionChannel: app id "${aid}" contains a channel separator`);
-  return aid === undefined ? `collection:${slug}` : `collection:app/${aid}/${slug}`;
+  // The separators are rejected rather than assumed absent (see `channelPart`).
+  const name = channelPart(slug, "slug");
+  const app = aid === undefined ? undefined : channelPart(aid, "app id");
+  return app === undefined ? `collection:${name}` : `collection:app/${app}/${name}`;
 }
 
 /** Payload published on `collectionChannel(...)`. `ids` lists the changed

--- a/src/config/pubsubChannels.ts
+++ b/src/config/pubsubChannels.ts
@@ -72,8 +72,28 @@ export function fileChannel(workspaceRelativePath: string): string {
  * `CollectionCustomView.vue` (relays into the sandboxed iframe), both via the
  * host's `subscribeChanges` capability in `composables/collections/uiHost.ts`.
  */
-export function collectionChannel(slug: string): string {
-  return `collection:${slug}`;
+const CHANNEL_SEPARATORS = /[/:]/;
+
+export function collectionChannel(slug: string, aid?: string): string {
+  // A collection's identity is `(root, slug)` locally and `(aid, cid)` when it
+  // is shared, so the NAME alone cannot key the fan-out: a shared `tasks` in
+  // one app, a shared `tasks` in another, and this workspace's own `tasks`
+  // would all land here and refresh each other's open views.
+  //
+  // The local form is unchanged, byte for byte — MulmoClaude is one workspace,
+  // so a local change never carries a root and this is the same channel it has
+  // always been. A ROOT deliberately has no form here: it is an absolute path,
+  // the channel name reaches the browser, and a path must not (a multi-root
+  // host scopes its own fan-out; see the INVARIANT on `CollectionHost`).
+  //
+  // The separators are rejected rather than assumed absent. A slug is
+  // `[a-zA-Z0-9_-]` upstream, so `app/salon/tasks` can never BE a slug — but a
+  // channel name is an identity, and an identity function that takes such a
+  // claim on trust is how a collection ends up able to name its way into
+  // another app's channel. Cheap to make true instead of inherited.
+  if (CHANNEL_SEPARATORS.test(slug)) throw new Error(`collectionChannel: slug "${slug}" contains a channel separator`);
+  if (aid !== undefined && CHANNEL_SEPARATORS.test(aid)) throw new Error(`collectionChannel: app id "${aid}" contains a channel separator`);
+  return aid === undefined ? `collection:${slug}` : `collection:app/${aid}/${slug}`;
 }
 
 /** Payload published on `collectionChannel(...)`. `ids` lists the changed
@@ -82,6 +102,10 @@ export function collectionChannel(slug: string): string {
  *  opaque-origin custom-view iframe. */
 export interface CollectionChannelPayload {
   slug: string;
+  /** The shared app, when this change is about a shared collection. Absent for
+   *  a collection in the workspace, which is every one MulmoClaude has today.
+   *  Safe to relay: an `aid` is an id committed in a repository, not a path. */
+  aid?: string;
   ids?: string[];
   op?: "upsert" | "delete";
 }

--- a/test/config/test_pubsubChannels.ts
+++ b/test/config/test_pubsubChannels.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { PUBSUB_CHANNELS, fileChannel, readSessionDeletedIds, sessionChannel } from "../../src/config/pubsubChannels.js";
+import { PUBSUB_CHANNELS, collectionChannel, fileChannel, readSessionDeletedIds, sessionChannel } from "../../src/config/pubsubChannels.js";
 
 describe("sessionChannel", () => {
   it("prefixes the session id with `session.`", () => {
@@ -111,5 +111,32 @@ describe("PUBSUB_CHANNELS", () => {
     for (const value of Object.values(PUBSUB_CHANNELS)) {
       assert.equal(value.startsWith("session."), false, `static channel "${value}" must not reuse the session. prefix`);
     }
+  });
+});
+
+describe("collectionChannel", () => {
+  it("a workspace collection keeps the channel it has always had", () => {
+    // MulmoClaude is one workspace, so a local change carries no scope and
+    // every existing subscriber must keep matching.
+    assert.equal(collectionChannel("tasks"), "collection:tasks");
+  });
+
+  it("two shared apps owning the same cid get two channels", () => {
+    // The failure this exists to prevent: keyed by the name alone, one app's
+    // write refreshes the other app's open views.
+    assert.notEqual(collectionChannel("tasks", "salon"), collectionChannel("tasks", "clinic"));
+  });
+
+  it("a shared collection never lands on the workspace's channel", () => {
+    assert.notEqual(collectionChannel("tasks", "salon"), collectionChannel("tasks"));
+  });
+
+  it("a slug cannot spell its way into another app's channel", () => {
+    // `collection:app/salon/tasks` would otherwise be reachable as a plain
+    // slug. A slug is [a-zA-Z0-9_-] upstream so this cannot occur — the point
+    // is that the channel refuses it rather than inheriting the guarantee.
+    assert.throws(() => collectionChannel("app/salon/tasks"), /separator/);
+    assert.throws(() => collectionChannel("tasks", "sa/lon"), /separator/);
+    assert.throws(() => collectionChannel("ta:sks"), /separator/);
   });
 });

--- a/test/config/test_pubsubChannels.ts
+++ b/test/config/test_pubsubChannels.ts
@@ -135,6 +135,8 @@ describe("collectionChannel", () => {
     // `collection:app/salon/tasks` would otherwise be reachable as a plain
     // slug. A slug is [a-zA-Z0-9_-] upstream so this cannot occur — the point
     // is that the channel refuses it rather than inheriting the guarantee.
+    // Belt-and-braces, same as the completion-bell id: `CollectionKey` refuses
+    // these names at construction, and this function takes raw strings.
     assert.throws(() => collectionChannel("app/salon/tasks"), /separator/);
     assert.throws(() => collectionChannel("tasks", "sa/lon"), /separator/);
     assert.throws(() => collectionChannel("ta:sks"), /separator/);

--- a/test/events/test_collectionChangePayload.ts
+++ b/test/events/test_collectionChangePayload.ts
@@ -1,0 +1,32 @@
+// What a collection change carries OUT to browser subscribers.
+//
+// The payload is relayed into custom-view iframes, so this is a privacy
+// boundary as well as a wire shape: no record bodies, and no root — an
+// absolute path must not reach a subscriber. Pure, so it is tested without a
+// pubsub instance.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { toChannelPayload } from "../../server/events/collection-change.js";
+
+describe("toChannelPayload", () => {
+  it("carries only the keys the change actually had", () => {
+    // deepEqual is deepSTRICTEqual: an own `ids: undefined` key would fail
+    // this, which is the point — absent means absent.
+    assert.deepEqual(toChannelPayload({ slug: "tasks" }), { slug: "tasks" });
+    assert.deepEqual(toChannelPayload({ slug: "tasks", ids: ["t1"], op: "upsert" }), { slug: "tasks", ids: ["t1"], op: "upsert" });
+  });
+
+  it("passes the app through, so a subscriber can tell two shared collections apart", () => {
+    assert.deepEqual(toChannelPayload({ slug: "tasks", aid: "salon" }), { slug: "tasks", aid: "salon" });
+  });
+
+  it("never relays a root", () => {
+    // The channel payload reaches the browser and, through a view, an
+    // LLM-authored iframe. An absolute root would publish the user's home
+    // directory to it.
+    const payload = toChannelPayload({ slug: "tasks", root: "/Users/someone/projects/secret" });
+    assert.equal(Object.hasOwn(payload, "root"), false);
+    assert.equal(JSON.stringify(payload).includes("/Users/"), false);
+  });
+});


### PR DESCRIPTION
MulmoTerminal の `plans/feat-shareable-collections.md`（D2 / 実装順ステップ 1）。
共有コレクション = リポジトリにコミットされた宣言から、ログイン不要で誰でも使える
Web アプリを公開する仕組み。その最初の 1 手。

## 何を変えるか

コレクションの同一性はこれまで `(root, slug)` だった（`CollectionHost` の INVARIANT）。
ディレクトリにあるコレクションについてはそれで正しいままである。しかし**共有**
コレクションはディレクトリに住んでいない — `apps/{aid}/collections/{cid}` に publish され、
複数のマシンがそれを解決し、**どのマシンのパスもその名前ではない**。publish された
ときのパスで鍵を作ると、同じコレクションが 2 つのコレクションになる。

そこで同一性を値にし、`(scope, name)` に一般化するのではなく**判別可能なユニオン**にする:

```ts
export type CollectionKey =
  | { kind: "local";  root: string; slug: string }
  | { kind: "shared"; aid: string;  cid: string };
```

ユニオンであることが要点。**2 つは決して衝突してはならない** — `tasks` を持つプロジェクトと
`tasks` を持つ共有アプリは別のコレクション — そして**ローカルの挙動は 1 ミリも変わっては
ならない**。`collectionKeyName()` は slug または cid を返すが、**意図的に同一性ではない**:
既知のスコープの**内側**で引くためのもので、スコープをまたぐ map の鍵にしてはいけない。
INVARIANT が防ごうとしてきた間違いがまさにそれだから。

## すでに同一性を符号化していた 2 箇所に通した

- **`CollectionChangePayload`** に任意の `aid` を足し、`collectionChangeKey()` を
  「**フィールドが無いことの意味を決める唯一の場所**」にした。どのホストも自分で
  解釈しなくてよくなる。単一ワークスペースのホストのペイロードは**バイト等価**のまま
  （`aid` も `root` も「present で undefined」ではなく**不在**）で、テストで固定してある
- **完了ベルの id** に 3 つ目の形 `#<aid>\0<cid>:<itemId>` を足した。これは**両アプリが
  読む 1 つのディスク形式**なので、既存の 2 形式はバイト単位でそのまま、3 つとも
  永久にパースできる。共有の `cid` はどこかのプロジェクトが持つ slug と同名でありうるので、
  root 無しの形を再利用すると**2 つが 1 つのベルに畳まれる** — だから固有のマークが要る

`sweepVerdict` は共有エントリを skip する。これは整頓ではない: root の sweep は slug を
**ディスク上で**解決するので、共有ベルは必ず「見つからない＝stale」と判定され、**自分に
見えない面のベルを消してしまう**。共有ベルを retire できるのは共有ウォッチャだけ。

## まだ誰も使っていない

共有アームの消費者（store とウォッチャ）は次のステップ。**先に入れる理由**は、INVARIANT が
列挙したもの — キャッシュ、pubsub チャンネル、ビュートークン、通知 id、描画されたカード —
が**すべてこれで鍵を持つ**ためで、同一性の後付けが最も高くつく方向だから。

## 検証

- 新規テスト 19 本（`test_collectionKey.ts` / `test_changeKey.ts` / `test_completionIdShared.ts`）。
  「同名の local と shared が別物」「同じ slug を持つ 2 root が別物」「同じ cid を持つ
  2 app が別物」「id の往復」「他所から来た文字列は throw ではなく null」「単一ワークスペースの
  ペイロード形状が不変」を固定
- `yarn test` 817 本 green、`yarn typecheck` / `yarn lint` / `yarn build` green
- core を 3.5.0 に（追加のみ、破壊的変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a value-level collection identity that distinguishes local and shared collections, wire change payloads and completion bell ids to this model, and update supporting utilities and tests while preserving existing local behavior and disk formats.

New Features:
- Introduce a discriminated CollectionKey identity type for local and shared collections and export it from the core collection module.
- Add support for shared collections in change payloads via aid-based sharedCollectionChangePayload and collectionChangeKey.
- Define a distinct completion bell id format for shared collections so local and shared collections never collide on disk.

Enhancements:
- Provide helpers to construct canonical local collection keys on the server and to parse/encode collection key ids safely.
- Extend completion bell parsing and sweep logic so roots ignore shared bells, leaving their lifecycle to the shared watcher.

Build:
- Bump @mulmoclaude/core package version from 3.4.0 to 3.5.0.

Tests:
- Add tests for CollectionKey behavior and id round-tripping, ensuring local/shared keys with the same name remain distinct.
- Add tests pinning all legacy and shared completion id formats and their parsing semantics.
- Add tests covering collection change payload resolution into CollectionKey and preserving single-workspace payload shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying and tracking shared collections alongside local collections.
  * Added collision-resistant collection identities and separately scoped change notifications.
  * Improved completion notifications for rootless, rooted, and shared collection entries.

* **Bug Fixes**
  * Prevented shared and local collection entries from being confused during updates and cleanup.
  * Improved validation for collection and application identifiers containing reserved separators.

* **Tests**
  * Added coverage for collection identity parsing, validation, isolation, notification channels, and completion formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->