### PR TITLE
feat(collections): 共有コレクションの store を (aid, cid) で実装

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Package releases
 
-Ships `@mulmoclaude/core@3.5.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/assets/helps/collection-skills.md
+++ b/packages/core/assets/helps/collection-skills.md
@@ -1191,8 +1191,9 @@ Notes:
   APP and comes from `app.json` at the repository root; `cid` is always the slug.
 - The repository must declare its app, or the collection is refused at discovery:
 
+  `<repository root>/app.json`:
+
   ```json
-  // <repository root>/app.json
   { "aid": "app_salon_7f3a" }
   ```
 

--- a/packages/core/assets/helps/collection-skills.md
+++ b/packages/core/assets/helps/collection-skills.md
@@ -166,7 +166,7 @@ skipped, never crashes the host):
 | `icon`                 | A **Material Symbols** name (`receipt_long`, `people`, `schedule`, `menu_book`). Required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `dataPath`             | Records folder, relative to the collection's own root (the workspace or project folder it lives in) — e.g. `data/recipes/items`. Must stay under that root. **Required**, unless `dataSource` or `storage` is set instead: declare exactly ONE of the three. (There is no default — `data/<slug>/items` is a naming CONVENTION, not a fallback.)                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `dataSource`           | Optional. `{ "type": "csv", "path": "data/students.csv" }` — the records ARE the rows of an external data file (relative to the collection's own root, containment-checked like `dataPath`). Makes the collection **read-only** in every UI/tool write path; see "External data (CSV) collections" below. Mutually exclusive with `dataPath`, `singleton`, `ingest`, `spawn`, and `mutate` actions.                                                                                                                                                                                                     |
-| `storage`              | Optional. `{ "type": "sqlite", "path": "data/<name>.db" }` — records live in a single SQLite database file instead of per-record JSON files; the collection stays **writable** and behaves identically everywhere else. Declare exactly ONE of `dataPath` / `dataSource` / `storage`. Cannot combine with `spawn`, `completionField`, or `triggerField` (v1). See "Alternative storage (sqlite)" below.                                                                                                                                                            |
+| `storage`              | Optional. `{ "type": "sqlite", "path": "data/<name>.db" }` — records live in a single SQLite database file instead of per-record JSON files — or `{ "type": "firestore" }`, a SHARED collection whose records live in the app's Firestore (only when the user asks for sharing). Either way the collection stays **writable** and behaves identically everywhere else. Declare exactly ONE of `dataPath` / `dataSource` / `storage`. See "Alternative storage (sqlite)" and "Shared storage (firestore)" below.                                                                                                                                                            |
 | `primaryKey`           | The field name whose value is the filename. That field MUST set `primary: true`. The value must be a valid record id (see the **Records** section's id-charset rule). Required.                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `singleton`            | Optional. When set, at most one record exists, pinned to this exact id (e.g. `me`). Host pre-fills + locks the create form and hides Add once it exists.                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `fields`               | Ordered map of field-name → field spec. **Insertion order = column order** in the table. Required.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
@@ -1170,6 +1170,53 @@ Minimal example:
     "id": { "type": "string", "label": "ID", "primary": true },
     "item": { "type": "string", "label": "Item" },
     "total": { "type": "number", "label": "Total" }
+  }
+}
+```
+
+## Shared storage (firestore) — `storage`
+
+`{ "type": "firestore" }` keeps a collection's records in a SHARED app rather
+than on this machine: they live at `apps/{aid}/collections/{cid}/items`, where
+`aid` is the app id and `cid` is this collection's slug.
+
+**Only declare this when the user asks for a shared collection.** It is not a
+faster `dataPath` — the records are remote, every read is a round trip, and the
+collection is unusable while remote-host is disconnected.
+
+Notes:
+
+- The `storage` block takes NOTHING else. No `path`, no `cid`, no `aid` —
+  writing any of them is a validation error, not a dropped key. `aid` is one per
+  APP and comes from `app.json` at the repository root; `cid` is always the slug.
+- The repository must declare its app, or the collection is refused at discovery:
+
+  ```json
+  // <repository root>/app.json
+  { "aid": "app_salon_7f3a" }
+  ```
+
+- Requires a connected remote-host session. Disconnected, every operation fails
+  with an actionable message — it never reports an empty collection.
+- Authorization is the app's member roster (keyed by email), not the path. A
+  signed-in user who is not on the roster gets `permission-denied`.
+- Live updates from OTHER members are not delivered yet; this host re-reads on
+  its own clock. Bells (`completionField` / `triggerField`) and `spawn` work.
+- Deleting the collection is REFUSED: its records are also other members', and
+  the delete can neither archive nor remove them.
+
+Minimal example:
+
+```json
+{
+  "title": "Bookings",
+  "icon": "event",
+  "storage": { "type": "firestore" },
+  "primaryKey": "id",
+  "fields": {
+    "id": { "type": "string", "label": "ID", "primary": true },
+    "customerName": { "type": "string", "label": "Customer" },
+    "startAt": { "type": "date", "label": "Start" }
   }
 }
 ```

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -1002,3 +1002,55 @@ Ask the user for the server log around the session start — the broker prints
 `[mcp-server] publishing N tools: …` and, when a promised tool is missing,
 `[mcp-server] advertised but NOT published (check plugin load above): …`. That
 second line, with the plugin-load errors above it, is what a bug report needs.
+
+## A shared collection (`storage: firestore`) is empty, refused, or missing
+
+### Symptoms
+
+- Reading or writing a collection fails with `shared collection unavailable:
+  connect remote-host first`.
+- A collection whose `schema.json` declares `"storage": { "type": "firestore" }`
+  never appears in the list at all.
+- Reads and writes fail with `permission-denied` from Firestore even though the
+  session is connected.
+
+### Cause + fix
+
+These are three different states, and the fix differs. Do NOT treat any of them
+as "the collection has no records" — a shared collection's records live in its
+app's Firestore, so an empty screen would be indistinguishable from data loss.
+The backend deliberately fails loudly instead of returning nothing.
+
+1. **`connect remote-host first`** — there is no authenticated session, or the
+   signed-in user has no email address. The records are not on this machine and
+   nothing can be read or written until the user connects remote-host. Tell them
+   that; do not retry in a loop and do not fall back to a local file.
+
+2. **The collection never appears** — discovery REFUSED the schema, and the
+   reason is in the server log under `collections` (`schema.json rejected after
+   validation, skipping`). For a shared collection the usual reason is the app
+   declaration: `apps/{aid}/collections/{cid}/items` needs an `aid`, which comes
+   from `app.json` at the repository root, not from the schema.
+
+   ```json
+   // <repository root>/app.json
+   { "aid": "app_salon_7f3a" }
+   ```
+
+   `aid` must be alphanumeric with `-` / `_` inside it (the same charset as a
+   collection slug); `sales:2026` or a path is refused, because that name is
+   re-encoded downstream as a document id and a channel name. Never put `aid`,
+   `cid` or `path` in the schema's `storage` block — it takes none of them, and
+   writing one is a validation error rather than a silently-dropped key.
+
+3. **`permission-denied` while connected** — the app's member roster is what
+   authorizes a shared collection, and it is keyed by EMAIL. The signed-in
+   address must be listed in `apps/{aid}.members` with a role for that
+   collection (or `*`). This is not something the host can fix locally: the
+   app's owner has to add the address. Report which address is signed in — that
+   is the fact the owner needs.
+
+Deleting a shared collection is refused outright: the delete can neither archive
+nor remove documents that other members also read, and removing its records
+first does not unlock it. Retiring the whole app is a Firestore project
+administrator's recursive delete, not something this app does.

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -1032,8 +1032,9 @@ The backend deliberately fails loudly instead of returning nothing.
    declaration: `apps/{aid}/collections/{cid}/items` needs an `aid`, which comes
    from `app.json` at the repository root, not from the schema.
 
+   `<repository root>/app.json`:
+
    ```json
-   // <repository root>/app.json
    { "aid": "app_salon_7f3a" }
    ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",
@@ -66,6 +66,12 @@
       "import": "./dist/collection/paths.js",
       "require": "./dist/collection/paths.cjs",
       "default": "./dist/collection/paths.js"
+    },
+    "./collection/firestore": {
+      "types": "./dist/collection/firestore.d.ts",
+      "import": "./dist/collection/firestore.js",
+      "require": "./dist/collection/firestore.cjs",
+      "default": "./dist/collection/firestore.js"
     },
     "./collection/registry": {
       "types": "./dist/collection/registry/index.d.ts",

--- a/packages/core/src/collection-watchers/reconciler.ts
+++ b/packages/core/src/collection-watchers/reconciler.ts
@@ -156,18 +156,48 @@ export function resolveDisplayLabel(schema: CollectionSchema, item: CollectionIt
 // `collection-watchers` barrel keeps its public surface (MulmoTerminal).
 export { itemIsDone };
 
+/** WHICH obligation a bell is about — the scope half of its identity.
+ *
+ *  A collection in a directory is scoped by its ROOT: two projects owning a
+ *  `tasks` each hold their own bells. A SHARED collection is scoped by its APP:
+ *  the same `(aid, cid, itemId)` is ONE obligation however many checkouts of
+ *  the repository can see it, so keying it by root would put a duplicate bell
+ *  in front of the user per worktree, and each root's sweep would manage only
+ *  its own copy.
+ *
+ *  Mutually exclusive by construction — `bellScopeOf` produces one or the
+ *  other, and `completionLegacyId` throws on both. */
+interface BellScope {
+  root?: string | undefined;
+  aid?: string | undefined;
+}
+
+/** The scope a collection's bells belong to.
+ *
+ *  A shared collection's `appId` wins over the call's `workspaceRoot`: the
+ *  root is where this host happens to have the repository checked out, which
+ *  is exactly the fact that must NOT reach the identity. A local collection is
+ *  unchanged — its root is present only when the call carried an explicit one,
+ *  so a single-workspace host's ids stay byte-identical to what it has already
+ *  written to `active.json`. */
+function bellScopeOf(collection: Pick<LoadedCollection, "appId">, ioOpts: IoOptions): BellScope {
+  return collection.appId === undefined ? { root: ioOpts.workspaceRoot } : { aid: collection.appId };
+}
+
+const scopedLegacyId = (slug: string, itemId: string, scope: BellScope): string => completionLegacyId(slug, itemId, scope.root, scope.aid);
+
 /** Every active bell entry whose key matches this (slug, itemId).
  *  Returns multiple when defensive cleanup is needed. Scans `listAll()`
  *  — cheap because the active set is bounded. */
-async function findActiveEntries(slug: string, itemId: string, root: string | undefined): Promise<NotifierEntry[]> {
+async function findActiveEntries(slug: string, itemId: string, scope: BellScope): Promise<NotifierEntry[]> {
   const adapter = requireAdapter();
-  const legacyId = completionLegacyId(slug, itemId, root);
+  const legacyId = scopedLegacyId(slug, itemId, scope);
   const entries = await listAll();
   return entries.filter((entry) => adapter.readEntry(entry.pluginData)?.legacyId === legacyId);
 }
 
-async function findActiveEntryIds(slug: string, itemId: string, root: string | undefined): Promise<string[]> {
-  return (await findActiveEntries(slug, itemId, root)).map((entry) => entry.id);
+async function findActiveEntryIds(slug: string, itemId: string, scope: BellScope): Promise<string[]> {
+  return (await findActiveEntries(slug, itemId, scope)).map((entry) => entry.id);
 }
 
 /** Per-key in-flight lock. Serializes concurrent `ensureItemNotification`
@@ -199,9 +229,9 @@ async function ensureItemNotification(
   itemId: string,
   displayLabel: string,
   priority: CompletionPriority,
-  root: string | undefined,
+  scope: BellScope,
 ): Promise<void> {
-  const legacyId = completionLegacyId(slug, itemId, root);
+  const legacyId = scopedLegacyId(slug, itemId, scope);
   // Drain any in-flight publish for this key BEFORE our check + set. The
   // drain + claim runs synchronously between `ensureLocks.get` and
   // `ensureLocks.set`, so two callers can't both observe an empty slot.
@@ -211,7 +241,7 @@ async function ensureItemNotification(
     if (!inflight) break;
     await inflight.promise;
   }
-  const lock: EnsureLock = { promise: doEnsureItemNotification({ slug, schema, itemId, legacyId, displayLabel, priority, root }) };
+  const lock: EnsureLock = { promise: doEnsureItemNotification({ slug, schema, itemId, legacyId, displayLabel, priority, scope }) };
   ensureLocks.set(legacyId, lock);
   try {
     await lock.promise;
@@ -228,14 +258,14 @@ async function ensureItemNotification(
  *  place (preserving id / position / createdAt) so a record whose flagged
  *  value changed while it stayed pending re-colours the bell without a
  *  clear+republish flicker. No-op when the stored priority already matches. */
-async function reconcileEntrySeverity(
-  slug: string,
-  itemId: string,
-  entries: NotifierEntry[],
-  priority: CompletionPriority,
-  root: string | undefined,
-): Promise<void> {
+async function reconcileEntrySeverity(slug: string, itemId: string, entries: NotifierEntry[], priority: CompletionPriority, scope: BellScope): Promise<void> {
   const adapter = requireAdapter();
+  // The adapter's shape carries a ROOT and nothing else, and its signature is
+  // public API (MulmoTerminal implements it). A shared bell therefore hands it
+  // no root — which is true: the obligation belongs to an app, not to a
+  // checkout, and navigation resolves by slug either way. Only the IDENTITY
+  // (`legacyId`) had to learn about apps, which is what the sweep keys on.
+  const { root } = scope;
   for (const entry of entries) {
     const parsed = adapter.readEntry(entry.pluginData);
     if (!parsed || parsed.priority === priority) continue;
@@ -260,15 +290,17 @@ interface EnsureInput {
   legacyId: string;
   displayLabel: string;
   priority: CompletionPriority;
-  root: string | undefined;
+  scope: BellScope;
 }
 
-async function doEnsureItemNotification({ slug, schema, itemId, legacyId, displayLabel, priority, root }: EnsureInput): Promise<void> {
+async function doEnsureItemNotification({ slug, schema, itemId, legacyId, displayLabel, priority, scope }: EnsureInput): Promise<void> {
   const adapter = requireAdapter();
+  // See `reconcileEntrySeverity` for why the adapter gets the root only.
+  const { root } = scope;
   try {
-    const existing = await findActiveEntries(slug, itemId, root);
+    const existing = await findActiveEntries(slug, itemId, scope);
     if (existing.length > 0) {
-      await reconcileEntrySeverity(slug, itemId, existing, priority, root);
+      await reconcileEntrySeverity(slug, itemId, existing, priority, scope);
       return;
     }
     const navigateTarget = adapter.buildNavigateTarget(slug, itemId, root);
@@ -292,9 +324,16 @@ async function doEnsureItemNotification({ slug, schema, itemId, legacyId, displa
 /** Idempotently clear EVERY bell entry that matches this (slug, itemId).
  *  Silent no-op when nothing matches. The "every" is defensive: if a
  *  duplicate ever slips through, this drains the lot. */
-export async function clearItemNotification(slug: string, itemId: string, root?: string): Promise<void> {
+export async function clearItemNotification(slug: string, itemId: string, root?: string, aid?: string): Promise<void> {
+  await clearScoped(slug, itemId, { root, aid });
+}
+
+/** The scoped form every internal caller uses. `clearItemNotification` keeps
+ *  its positional `(slug, itemId, root?)` shape because it is public API
+ *  (MulmoTerminal calls it); `aid` is additive. */
+async function clearScoped(slug: string, itemId: string, scope: BellScope): Promise<void> {
   try {
-    const ids = await findActiveEntryIds(slug, itemId, root);
+    const ids = await findActiveEntryIds(slug, itemId, scope);
     for (const entryId of ids) {
       await notifierClear(entryId);
     }
@@ -316,15 +355,15 @@ export async function reconcileItem(collection: LoadedCollection, itemId: string
   // The bell's root follows the same rule as the change payload's: present
   // only when THIS call carried an explicit `workspaceRoot`, so a
   // single-workspace host's ids stay byte-identical to what it already wrote.
-  const root = ioOpts.workspaceRoot;
+  const scope = bellScopeOf(collection, ioOpts);
   if (!schema.completionField) {
     // Schema doesn't track completion — drop any stale entry.
-    await clearItemNotification(slug, itemId, root);
+    await clearScoped(slug, itemId, scope);
     return;
   }
   const item = await storeFor(collection, ioOpts).read(itemId);
   if (item === null) {
-    await clearItemNotification(slug, itemId, root);
+    await clearScoped(slug, itemId, scope);
     return;
   }
   // Recurrence: predicate-gated + create-if-absent, idempotent and
@@ -332,7 +371,7 @@ export async function reconcileItem(collection: LoadedCollection, itemId: string
   // below so marking an item done still spawns its successor.
   await maybeSpawnSuccessor(collection, item, itemId, ioOpts);
   if (itemIsDone(schema, item)) {
-    await clearItemNotification(slug, itemId, root);
+    await clearScoped(slug, itemId, scope);
     return;
   }
   // Time gate: when the schema declares `triggerField`, suppress the bell
@@ -348,7 +387,7 @@ export async function reconcileItem(collection: LoadedCollection, itemId: string
       log().warn("trigger date unparseable, suppressing bell", { slug, itemId, triggerField: schema.triggerField });
     }
     if (due !== true) {
-      await clearItemNotification(slug, itemId, root);
+      await clearScoped(slug, itemId, scope);
       return;
     }
   }
@@ -356,10 +395,10 @@ export async function reconcileItem(collection: LoadedCollection, itemId: string
   // records matching the predicate. Convergent — a record that stops
   // matching has its bell cleared.
   if (!whenMatches(schema.notifyWhen, item)) {
-    await clearItemNotification(slug, itemId, root);
+    await clearScoped(slug, itemId, scope);
     return;
   }
-  await ensureItemNotification(slug, schema, itemId, resolveDisplayLabel(schema, item, itemId), notifyPriorityForItem(schema, item), root);
+  await ensureItemNotification(slug, schema, itemId, resolveDisplayLabel(schema, item, itemId), notifyPriorityForItem(schema, item), scope);
 }
 
 /** Boot-time reconcile: walk every record of the collection once (through
@@ -403,13 +442,19 @@ export async function reconcileAllItems(collection: LoadedCollection, ioOpts: Io
  *    on produces a root-less id, so skipping it would strand a bell no pass can
  *    ever clear, while the reconcile publishes a second rooted one beside it.
  *    Clearing converges — the record republishes rooted if still pending. */
-function sweepVerdict(entry: { root?: string; aid?: string }, ownRoot: string | undefined): "mine" | "skip" | "drop-legacy" {
-  // A shared collection's bell belongs to no root. A root's sweep must neither
-  // claim it (`isStaleEntry` resolves the slug on DISK and would find nothing,
-  // so every shared bell would be judged stale) nor treat it as a root-less
-  // legacy entry to drop — either way it silently clears another surface's
-  // bells. Only the shared watcher may retire these.
-  if (entry.aid !== undefined) return "skip";
+function sweepVerdict(entry: { root?: string; aid?: string }, ownRoot: string | undefined): "mine" | "skip" | "shared" | "drop-legacy" {
+  // A shared collection's bell belongs to an APP, not to a root, so no root's
+  // sweep can claim it on the strength of its own root. It must not be dropped
+  // as a root-less legacy entry either — that would silently clear a live bell.
+  //
+  // WHO MAY RETIRE ONE, then: a sweep that can resolve THAT app's collection on
+  // this host. That check is deferred to `isStaleEntry` (it needs a disk read),
+  // which compares the resolved collection's `appId` against the entry's and
+  // leaves anything else alone. The rule follows from what the judgement needs
+  // rather than from who happens to be running: judging a shared bell means
+  // reading its records, and a host without the app cannot — every check would
+  // read "gone" and clear bells belonging to an app it has never seen.
+  if (entry.aid !== undefined) return "shared";
   if (entry.root === ownRoot) return "mine";
   if (entry.root === undefined) return "drop-legacy";
   return "skip";
@@ -420,11 +465,47 @@ function sweepVerdict(entry: { root?: string; aid?: string }, ownRoot: string | 
  *  `notifyWhen`. The reverse of the reconcile invariant, applied to an entry
  *  whose record the forward pass can never walk to (a delete leaves a bell that
  *  a walk over the SURVIVING records cannot clear). */
-async function isStaleEntry(slug: string, itemId: string, opts: DiscoveryOptions): Promise<boolean> {
+async function isStaleEntry(slug: string, itemId: string, opts: DiscoveryOptions, aid?: string): Promise<boolean> {
   const collection = await loadCollection(slug, opts);
+  // A SHARED entry is only this sweep's to judge when this host actually has
+  // that app's collection. Two ways it isn't, and both must leave the bell
+  // alone rather than clear it: the slug resolves to nothing here (another
+  // machine's app), or it resolves to a DIFFERENT collection that merely shares
+  // the name — a local `tasks` must never retire the shared app's `tasks`.
+  if (aid !== undefined && collection?.appId !== aid) return false;
   if (!collection || !collection.schema.completionField) return true;
+  return recordNoLongerBells(collection, itemId, opts);
+}
+
+/** The record half of the staleness question: gone, done, or outside
+ *  `notifyWhen`. Split out so the caller stays one decision — WHOSE entry this
+ *  is — and this one stays the other. */
+async function recordNoLongerBells(collection: LoadedCollection, itemId: string, opts: DiscoveryOptions): Promise<boolean> {
   const item = await storeFor(collection, opts).read(itemId);
   return item === null || itemIsDone(collection.schema, item) || !whenMatches(collection.schema.notifyWhen, item);
+}
+
+/** One entry's fate: whose it is (`sweepVerdict`), then — when it is this
+ *  sweep's to judge — whether its record still justifies the bell. Extracted so
+ *  the loop above stays a walk and this stays the decision. */
+async function sweepOneEntry(
+  entryId: string,
+  parsed: { root?: string; aid?: string; slug: string; itemId: string },
+  ownRoot: string | undefined,
+  opts: DiscoveryOptions,
+): Promise<void> {
+  const verdict = sweepVerdict(parsed, ownRoot);
+  if (verdict === "skip") return;
+  if (verdict === "drop-legacy") {
+    await notifierClear(entryId);
+    return;
+  }
+  const { slug, itemId } = parsed;
+  try {
+    if (await isStaleEntry(slug, itemId, opts, verdict === "shared" ? parsed.aid : undefined)) await notifierClear(entryId);
+  } catch (err) {
+    log().warn("sweep entry failed", { slug, itemId, error: errMsg(err) });
+  }
 }
 
 export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Promise<void> {
@@ -442,18 +523,7 @@ export async function sweepStaleActiveEntries(opts: DiscoveryOptions = {}): Prom
     if (!own) continue;
     const parsed = parseCompletionLegacyId(own.legacyId);
     if (!parsed) continue;
-    const verdict = sweepVerdict(parsed, ownRoot);
-    if (verdict === "skip") continue;
-    if (verdict === "drop-legacy") {
-      await notifierClear(entry.id);
-      continue;
-    }
-    const { slug, itemId } = parsed;
-    try {
-      if (await isStaleEntry(slug, itemId, opts)) await notifierClear(entry.id);
-    } catch (err) {
-      log().warn("sweep entry failed", { slug, itemId, error: errMsg(err) });
-    }
+    await sweepOneEntry(entry.id, parsed, ownRoot, opts);
   }
 }
 

--- a/packages/core/src/collection-watchers/watcher.ts
+++ b/packages/core/src/collection-watchers/watcher.ts
@@ -37,6 +37,12 @@
 // a `dataSource` (or any per-backend) early-exit here, check it against all
 // four — the surviving ones below are view-refresh publishes, not skips.
 //
+// Path 2 exists only for stores that implement `watch`. A store WITHOUT it
+// (today: a shared collection's, until onSnapshot lands) never reports a
+// change at all, so for those the clock tick has to stand in for path 2 as
+// well — a full re-derivation plus a sweep, not just the date-trigger pass
+// (`tickUnwatchedCollections`).
+//
 // ONE GENERATION PER ROOT — the multi-root boundary.
 //
 // Every piece of watcher state (`watchers`, `itemSlots`, `collectionSlots`, the
@@ -69,6 +75,7 @@ import {
   canonicalRoot,
   collectionChangePayload,
   discoverCollections,
+  firestoreHandle,
   itemFilePath,
   loadCollection,
   peekWorkspaceRoot,
@@ -430,9 +437,74 @@ async function tickTimeTriggers(gen: WatcherGeneration, now: Date = evalNow()): 
     // the CLOCK — the one state change that arrives without the file moving.
     // Skipping it here left CSV rows that were pending-but-not-yet-due unable
     // to ever bell unless the file happened to be rewritten.
+    //
+    // A store that reports no changes is handled wholesale below instead — it
+    // needs MORE than this pass, not less, so doing it here too would only
+    // duplicate the work.
+    if (cannotReportChanges(gen, entry.collection)) continue;
     if (!schema.triggerField && !schema.spawn) continue;
     await reconcileAllItems(entry.collection, gen.discoveryOpts, now);
   }
+  await tickUnwatchedCollections(gen, now);
+}
+
+/** True when the collection's store implements no `watch` — nothing will ever
+ *  tell this module its records moved, so the clock tick is its only change
+ *  detection. A capability question, deliberately not a backend one: the day a
+ *  shared collection's store grows an `onSnapshot` watch, it stops being
+ *  special here with no edit to this file. */
+function cannotReportChanges(gen: WatcherGeneration, collection: LoadedCollection): boolean {
+  return storeFor(collection, gen.discoveryOpts).watch === undefined;
+}
+
+/** True when a schema declares behaviour that only a reconcile pass can
+ *  produce: bells (`completionField`), date-triggered bells (`triggerField`),
+ *  or recurrence successors (`spawn`). */
+function needsReconcilePass(schema: LoadedCollection["schema"]): boolean {
+  return Boolean(schema.completionField ?? schema.triggerField ?? schema.spawn);
+}
+
+/** One unwatched collection's reconcile pass. Extracted so the single-flight
+ *  callback doesn't close over loop state.
+ *
+ *  `reconcileAllItems` already swallows a failing store read (it logs and
+ *  returns), so a closed session or a denied rule surfaces there, not as a
+ *  rejection here. This catch is only for the unexpected — it must not let one
+ *  collection's fault abort the rest of the tick. */
+async function reconcileUnwatched(gen: WatcherGeneration, collection: LoadedCollection, now: Date): Promise<void> {
+  try {
+    await runSingleFlight(gen.collectionSlots, collection.slug, () => reconcileAllItems(collection, gen.discoveryOpts, now));
+  } catch (err) {
+    log().warn("unwatched collection reconcile failed", { slug: collection.slug, error: errMsg(err) });
+  }
+}
+
+/** Stand in for the store-change path (2) on backends that don't have one.
+ *
+ *  Gated on `needsReconcilePass` so a collection declaring none of it costs
+ *  nothing: unlike the local backends, every pass here is a network round trip.
+ *
+ *  A collection that DROPS OUT of eligibility (its `completionField` edited
+ *  away, or the collection removed) is not this pass's problem — `syncWatchers`
+ *  already sweeps on a changed schema and on a vanished slug, and the sweep is
+ *  what clears bells the declaration no longer justifies. */
+async function tickUnwatchedCollections(gen: WatcherGeneration, now: Date): Promise<void> {
+  // No session: this tick can learn NOTHING, so it must change nothing.
+  // Skipping the reads avoids a warning per collection per minute for a state
+  // that can last hours (`reconcileAllItems` logs every failed read).
+  // (A shared collection's is the only watch-less store today, and the
+  // remote-host session is what its availability means; a second one would want
+  // this expressed as a store capability instead of asked here.)
+  if (firestoreHandle() === null) return;
+  const pending = [...gen.watchers.values()]
+    .map((entry) => entry.collection)
+    .filter((collection) => cannotReportChanges(gen, collection) && needsReconcilePass(collection.schema));
+  if (pending.length === 0) return;
+  for (const collection of pending) await reconcileUnwatched(gen, collection, now);
+  // A record deleted remotely leaves a stale bell that `reconcileAllItems`
+  // (which only walks records that still exist) can't clear — the same pairing
+  // `scheduleCollectionReconcile` uses for a watched store.
+  await sweepStaleActiveEntries(gen.discoveryOpts);
 }
 
 /** Reconcile the watcher set against the currently-discovered
@@ -481,7 +553,19 @@ function stopVanishedWatchers(gen: WatcherGeneration, liveSlugs: Set<string>): b
  *  modes. The mounted fs.watch is bound to the OLD location, so it must
  *  be remounted, not just re-reconciled. */
 function storagePathChanged(previous: LoadedCollection["schema"], next: LoadedCollection["schema"]): boolean {
-  return previous.dataSource?.path !== next.dataSource?.path || previous.dataPath !== next.dataPath || previous.storage?.path !== next.storage?.path;
+  return (
+    previous.dataSource?.path !== next.dataSource?.path ||
+    previous.dataPath !== next.dataPath ||
+    previous.storage?.type !== next.storage?.type ||
+    storageFilePath(previous.storage) !== storageFilePath(next.storage)
+  );
+}
+
+/** The on-disk path of a storage backend, or undefined when it has none (a
+ *  shared collection keeps its records off this filesystem, so there is no
+ *  mount to move — only a `type` change matters for it). */
+function storageFilePath(storage: LoadedCollection["schema"]["storage"]): string | undefined {
+  return storage?.type === "sqlite" ? storage.path : undefined;
 }
 
 /** Re-reconcile already-watched collections whose schema changed since

--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -235,7 +235,7 @@ export type CollectionStorage = z.infer<typeof StorageZ>;
  *  default (`dataPath`); `csv` is implied by `dataSource`; other kinds are
  *  named explicitly via `storage.type`. The server's store factory registry
  *  (`server/store.ts`) is keyed by this. */
-export type CollectionStorageKind = "file" | "csv" | "sqlite";
+export type CollectionStorageKind = "file" | "csv" | "sqlite" | "firestore";
 
 /** Which storage backend serves this schema's records. Derived, not stored:
  *  existing schemas carry no `storage` key and must keep resolving exactly

--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -272,6 +272,13 @@ export interface CollectionSummary {
    *  know which collection change-channel(s) to watch for a live icon
    *  update (see `useDynamicShortcutIcons`). */
   iconSources?: string[];
+  /** The app a SHARED collection belongs to — present iff the schema declares
+   *  `storage.type: "firestore"`. A client needs it to subscribe to the right
+   *  live-change channel: a shared collection publishes on
+   *  `collection:app/<aid>/<cid>`, and a subscriber that keys on the name alone
+   *  listens to the LOCAL channel, so the refetch never arrives. Not a secret —
+   *  it is committed in the repository every clone reads. */
+  appId?: string;
 }
 
 export interface CollectionDetail extends CollectionSummary {

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -682,15 +682,42 @@ export const DataSourceZ = z.object({
 /** Alternative WRITABLE storage backend for a collection's records —
  *  unlike `dataSource` (external read-only file), a `storage` collection
  *  behaves like a normal writable collection; only where the rows live
- *  changes. v1: `sqlite` — records in a single SQLite database file
- *  (`node:sqlite`, one JSON record per row keyed by the primaryKey).
- *  `path` is workspace-relative and containment-checked exactly like
- *  `dataPath`. The store factory registry (`server/store.ts`) picks the
- *  implementation by `type` (plans/done/refactor-storage-virtualization.md). */
-export const StorageZ = z.object({
-  type: z.literal("sqlite"),
-  path: z.string().min(1),
-});
+ *  changes. The store factory registry (`server/store.ts`) picks the
+ *  implementation by `type` (plans/done/refactor-storage-virtualization.md).
+ *
+ *  A discriminated union rather than one shape with optional keys, because
+ *  only the sqlite variant is a workspace FILE: its `path` is
+ *  workspace-relative and containment-checked exactly like `dataPath`, while
+ *  the firestore variant has no path to check — its records are not on this
+ *  machine at all. Optional keys would let each arm accept the other's, and
+ *  the compiler would stop being the thing that tells you which. */
+export const StorageZ = z.discriminatedUnion("type", [
+  /** Records in a single SQLite database file (`node:sqlite`, one JSON
+   *  record per row keyed by the primaryKey). */
+  z.object({
+    type: z.literal("sqlite"),
+    path: z.string().min(1),
+  }),
+  /** Records as Firestore documents of a SHARED collection, at
+   *  `apps/{aid}/collections/{cid}/items/{id}`.
+   *
+   *  This variant declares NO location, and that is the whole shape of it:
+   *  `aid` comes from the repository's `app.json` (it is one per app, not one
+   *  per collection — four collections share one member roster), and `cid` is
+   *  always this collection's slug. There is nothing left for a schema to say.
+   *
+   *  `.strict()` (the same reason the `spawn` arms use it): stripping an
+   *  unknown key silently would confirm a wrong mental model — an author who
+   *  writes `path` believes their records land there, and an author who writes
+   *  `cid` believes the collection can be named something other than its slug.
+   *  Only this new arm is strict; the sqlite arm stays permissive so an
+   *  existing schema carrying a stray key doesn't start failing. */
+  z
+    .object({
+      type: z.literal("firestore"),
+    })
+    .strict(),
+]);
 
 // ---------------------------------------------------------------------------
 // The whole schema
@@ -796,8 +823,12 @@ const BareCollectionSchemaZ = CollectionObjectZ
   // NOTE: `storage` collections support the full write machinery
   // (`spawn` / `completionField` / `triggerField` / `singleton` / `ingest`
   // / mutate actions) — spawn and the watcher reconcilers go through the
-  // CollectionStore seam, and a db-file watcher drives their
-  // reconciliation (collection-watchers/watcher.ts).
+  // CollectionStore seam. What DRIVES that reconciliation differs by
+  // backend: `sqlite` has a db-file watcher, while `firestore` has no file
+  // to watch and is reconciled on the clock tick instead
+  // (`tickUnwatchedCollections`) until the snapshot listener lands. Either
+  // way the declared behaviour runs — that equivalence is what lets this
+  // refine stay backend-agnostic.
   // A `dataSource` collection is read-only by definition, so schema-level
   // write machinery can never fire: `singleton` pins CREATES, `ingest`
   // REFILLS records, `spawn` WRITES successor records. Rejecting them at

--- a/packages/core/src/collection/firestore.ts
+++ b/packages/core/src/collection/firestore.ts
@@ -1,0 +1,11 @@
+// @mulmoclaude/core/collection/firestore — the ONLY collection entry that
+// pulls the Firestore SDK in at runtime.
+//
+// Kept off `./collection/server` on purpose: `firebase` is an OPTIONAL peer of
+// this package, and a re-export links eagerly, so exporting `createFirestoreDocs`
+// from the main entry would make firebase a hard requirement for every host —
+// including ones with no Firestore at all. A host that wants shared collections
+// imports the adapter from here and hands it to `setFirestoreAccessor`;
+// everyone else never loads this module.
+
+export { createFirestoreDocs, type FirestoreDoc, type FirestoreDocs } from "./server/firestoreDocs";

--- a/packages/core/src/collection/server/appManifest.ts
+++ b/packages/core/src/collection/server/appManifest.ts
@@ -1,0 +1,109 @@
+// The repository's app declaration — `<root>/app.json` — and the one field
+// this step reads from it: `aid`.
+//
+// WHY THE REPOSITORY AND NOT A BINDING. A shared collection's identity is
+// `(aid, cid)`, and `aid` is COMMITTED, so every clone of the repository
+// resolves the same app and an invitation is about authorization rather than
+// discovery. That makes `aid` a property of the collection's LOCATION, exactly
+// like `storage.path` — not a property of the session. A host binding would
+// make it a process global, which is wrong the moment one server process serves
+// several project roots (MulmoTerminal does), because then every repository's
+// collections would point at one app.
+//
+// WHY NOT THE SCHEMA. The unit of sharing is the app, not the collection: four
+// collections share one member roster and one public config, so `aid` sits once
+// per repository rather than once per schema. A per-collection `aid` would also
+// be a second place to change it, and the two would drift.
+//
+// AUTHORED, NOT PUBLISHED. This is the file a human (or the agent) writes. The
+// Firestore document at `apps/{aid}` is a DIFFERENT thing that `publish`
+// derives from it — flattened for the security rules to read, with epoch-millis
+// windows and a derived `memberEmails`. Do not read this file as if it were
+// that one, and do not write this file from anything that publishes.
+//
+// SCOPE. Only `aid` is read here. `members` / `public` belong to `publish`,
+// which does not exist yet. `aidEnv` (a per-worktree app id, so a feature
+// branch cannot mutate the team's live records) also does not: it needs the
+// host to resolve a worktree variable that lives in MulmoTerminal's session
+// environment and NOT in this process's `process.env`, so it arrives as a host
+// resolver hook rather than a direct env read. Both land later; the point of
+// funnelling every read through this one function is that they land HERE and
+// nowhere else.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
+import { isValidCollectionName } from "../core/collectionKey";
+
+/** The app declaration's filename, at the repository root. */
+export const APP_MANIFEST_FILE = "app.json";
+
+/** What this step reads out of `app.json`. Deliberately one field: every key
+ *  added here is a key `publish` and this loader could disagree about. */
+export interface AppManifest {
+  /** The app id — the `{aid}` in `apps/{aid}/collections/{cid}/items`. */
+  aid: string;
+}
+
+/** Why a root has no usable `aid`. Returned rather than thrown because the
+ *  caller is an acceptance gate whose whole job is to turn this into a
+ *  one-line reason a collection was skipped. */
+export type AppManifestFailure = { kind: "missing" } | { kind: "unreadable"; detail: string } | { kind: "malformed"; detail: string };
+
+export type AppManifestResult = { ok: true; manifest: AppManifest } | ({ ok: false } & AppManifestFailure);
+
+/** Read `<root>/app.json` and return its `aid`.
+ *
+ *  SYNCHRONOUS on purpose. The caller is `acceptParsedSchema`, which is sync
+ *  and is shared by discovery and `manageCollection`'s `putSchema` precisely so
+ *  that a schema which would be skipped on the next discovery cannot be written
+ *  as if it were fine. Making this async would split that gate in two, and the
+ *  half that lost the check is the half the author sees. The file is a few
+ *  hundred bytes and is read once per firestore collection per discovery pass.
+ *
+ *  Never cached. `app.json` is edited by hand and by the agent, and a cache
+ *  here would mean the app a collection points at is whatever it was when the
+ *  server started. */
+export function loadAppManifest(root: string): AppManifestResult {
+  let raw: string;
+  try {
+    raw = readFileSync(path.join(root, APP_MANIFEST_FILE), "utf-8");
+  } catch (err) {
+    if (isErrorWithCode(err) && err.code === "ENOENT") return { ok: false, kind: "missing" };
+    return { ok: false, kind: "unreadable", detail: String(err) };
+  }
+  return parseAppManifest(raw);
+}
+
+/** The parse half, exported so it can be tested without a filesystem.
+ *
+ *  `aid` is validated with `isValidCollectionName` — the SAME predicate the
+ *  `CollectionKey` constructors apply — rather than a rule of its own. An `aid`
+ *  is re-encoded downstream as a Firestore document id, a pubsub channel
+ *  segment and a cache key, each with a different character that would break
+ *  it; one rule, stated once, is what keeps those layers from disagreeing.
+ *  Rejecting here rather than at `sharedCollectionKey` only changes WHERE the
+ *  author is told: a reason on the collection they wrote, instead of a throw
+ *  from inside a store call. */
+export function parseAppManifest(raw: string): AppManifestResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, kind: "malformed", detail: `not valid JSON (${String(err)})` };
+  }
+  if (!isRecord(parsed)) return { ok: false, kind: "malformed", detail: "is not a JSON object" };
+  const { aid } = parsed;
+  if (typeof aid !== "string" || aid.length === 0) return { ok: false, kind: "malformed", detail: "declares no `aid` string" };
+  if (!isValidCollectionName(aid)) return { ok: false, kind: "malformed", detail: `\`aid\` '${aid}' is not a valid app id` };
+  return { ok: true, manifest: { aid } };
+}
+
+/** The failure as the one line an author can act on. Kept next to the failure
+ *  type so a new variant cannot be added without wording it. */
+export function appManifestReason(failure: AppManifestFailure, root: string): string {
+  const manifestPath = path.join(root, APP_MANIFEST_FILE);
+  if (failure.kind === "missing") return `a shared collection needs an app: create ${manifestPath} declaring an \`aid\``;
+  if (failure.kind === "unreadable") return `cannot read ${manifestPath}: ${failure.detail}`;
+  return `${manifestPath} ${failure.detail}`;
+}

--- a/packages/core/src/collection/server/delete.ts
+++ b/packages/core/src/collection/server/delete.ts
@@ -31,7 +31,14 @@ export type DeleteCollectionResult =
   | { kind: "user-scope"; slug: string }
   | { kind: "preset"; slug: string }
   | { kind: "unsafe-data-path"; slug: string }
-  | { kind: "path-escape"; slug: string };
+  | { kind: "path-escape"; slug: string }
+  /** A `storage: firestore` collection: its records are documents of a SHARED
+   *  app, which this delete can neither archive nor remove. Deleting the skill
+   *  would leave them in `apps/{aid}/collections/{cid}/items` with no
+   *  collection left to reach them through — and they are not only this
+   *  machine's: other members' live views are served from the same documents.
+   *  Refused outright rather than done partially. */
+  | { kind: "unsupported-backend"; slug: string };
 
 type DeleteRefusal = Exclude<DeleteCollectionResult, { kind: "ok" }>;
 
@@ -46,6 +53,7 @@ export function deleteCollectionRefusalMessage(result: DeleteRefusal): string {
     preset: `collection '${slug}' is a preset (mc-*) and re-seeds on restart; unstar it from the catalog instead`,
     "unsafe-data-path": `collection '${slug}' declares a dataPath outside its own data/${slug}/ subtree; refusing to delete`,
     "path-escape": `a directory for collection '${slug}' escapes the workspace`,
+    "unsupported-backend": `collection '${slug}' is a shared collection — its records are documents of its app, which this delete can neither archive nor remove, and other members read the same documents. Removing its records first does NOT unlock it. To retire the whole app, a Firestore project administrator deletes it recursively (\`firebase firestore:delete "apps/<aid>" --recursive\`, children first); the app owner's client credentials cannot do it.`,
   };
   return messages[result.kind];
 }
@@ -118,6 +126,14 @@ function isDataDirSafe(dataDir: string, slug: string, workspaceRoot: string): bo
  *  `dataSource` collection has no record files to copy (its rows live in
  *  the external data file, which the delete never touches). */
 function restoreRecordsStep(schema: LoadedCollection["schema"]): string {
+  if (schema.storage?.type === "firestore") {
+    // Unreachable while `deleteCollection` refuses shared collections (see
+    // below); kept honest in case that gate ever moves.
+    return `2. Records: NOT archived. This is a shared collection: its records are
+   documents at \`apps/<aid>/collections/<cid>/items\`, which this delete did
+   not touch or export. They are still there, and other members still read
+   them.`;
+  }
   if (schema.storage !== undefined) {
     return `2. Records: copy the archived database file
    \`${path.basename(schema.storage.path)}\` (next to this document) back to
@@ -184,8 +200,16 @@ ${restoreRecordsStep(schema)}
 
 - slug: \`${slug}\`
 - title: ${schema.title}
-- dataPath: \`${schema.dataPath ?? (schema.storage !== undefined ? `(storage) ${schema.storage.path}` : `(dataSource) ${schema.dataSource?.path}`)}\`
+- dataPath: \`${schema.dataPath ?? recordLocationLabel(schema)}\`
 `;
+}
+
+/** Where a non-`dataPath` collection's records live, for the restore doc's
+ *  header line. */
+function recordLocationLabel(schema: LoadedCollection["schema"]): string {
+  if (schema.storage?.type === "firestore") return "(storage) shared app";
+  if (schema.storage !== undefined) return `(storage) ${schema.storage.path}`;
+  return `(dataSource) ${schema.dataSource?.path}`;
 }
 
 /** Copy one skill copy + the records + RESTORE.md into `archiveDir`. */
@@ -254,6 +278,10 @@ export async function deleteCollection(collection: LoadedCollection, opts: Delet
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
   if (collection.source === "user") return { kind: "user-scope", slug };
   if (isPresetSlug(slug)) return { kind: "preset", slug };
+  if (collection.schema.storage?.type === "firestore") {
+    log.warn("collections", "deleteCollection refused: a shared collection's records can be neither archived nor removed here", { slug });
+    return { kind: "unsupported-backend", slug };
+  }
   if (!isDataDirSafe(collection.dataDir, slug, workspaceRoot)) {
     log.warn("collections", "deleteCollection refused: dataDir is not under the per-collection root", { slug, dataDir: collection.dataDir });
     return { kind: "unsafe-data-path", slug };

--- a/packages/core/src/collection/server/discoveredCollection.ts
+++ b/packages/core/src/collection/server/discoveredCollection.ts
@@ -25,6 +25,16 @@ export interface LoadedCollection {
    *  `storage.path`, e.g. a SQLite database — same containment as dataDir).
    *  Present iff the schema declares `storage`. */
   storageFile?: string;
+  /** The app id this collection's records belong to, from the repository's
+   *  `app.json`. Present iff the schema declares `storage.type: "firestore"` —
+   *  a shared collection's identity is `(appId, slug)`, and the store builds
+   *  `apps/{appId}/collections/{slug}/items` from it.
+   *
+   *  Resolved by discovery, exactly like `storageFile`, so the identity is
+   *  settled ONCE and the store never reads `app.json` on a read path. Absent
+   *  is not a fallback: a firestore schema whose root declares no `aid` is
+   *  REFUSED at discovery, so this is present whenever the backend needs it. */
+  appId?: string;
   /** Absolute path to the skill directory this collection was loaded from
    *  (`<skillsRoot>/<slug>/`). Action templates are read from here, path-safely. */
   skillDir: string;

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import { log, getWorkspaceRoot, userSkillsDir, projectSkillsDir, feedsRoot } from "./host";
 import { CollectionSchemaZ } from "../core/schemaZ";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths";
+import { appManifestReason, loadAppManifest } from "./appManifest";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
 import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
@@ -45,7 +46,7 @@ function applyFeedSchemaDefaults(parsed: unknown, slug: string): unknown {
 /** Result of the post-Zod acceptance gates: the resolved record dir (and,
  *  for a `dataSource` schema, the resolved data file) on success, or a
  *  one-line reason discovery would skip the schema. */
-export type SchemaAcceptance = { ok: true; dataDir: string; dataSourceFile?: string; storageFile?: string } | { ok: false; reason: string };
+export type SchemaAcceptance = { ok: true; dataDir: string; dataSourceFile?: string; storageFile?: string; appId?: string } | { ok: false; reason: string };
 
 /** The conventional per-slug records dir a `dataSource` / `storage` collection
  *  gets as its `dataDir` (records never live there, but archive/delete paths
@@ -101,18 +102,40 @@ export function acceptParsedSchema(schema: CollectionSchema, opts: { source: Col
     if (dataDir === null) return { ok: false, reason: `slug '${opts.slug}' yields no workspace-contained data dir` };
     return { ok: true, dataDir, dataSourceFile };
   }
-  if (schema.storage !== undefined) {
-    // An alternative-backend data file (e.g. the SQLite db): same
-    // containment as dataSource, same conventional phantom dataDir.
-    const storageFile = resolveDataDir(schema.storage.path, opts.workspaceRoot);
-    if (storageFile === null) return { ok: false, reason: `storage.path '${schema.storage.path}' escapes the workspace` };
-    const dataDir = resolveDataDir(conventionalDataPath(opts.slug), opts.workspaceRoot);
-    if (dataDir === null) return { ok: false, reason: `slug '${opts.slug}' yields no workspace-contained data dir` };
-    return { ok: true, dataDir, storageFile };
-  }
+  if (schema.storage !== undefined) return acceptStorageSchema(schema.storage, opts);
   const dataDir = resolveDataDir(schema.dataPath ?? "", opts.workspaceRoot);
   if (dataDir === null) return { ok: false, reason: `dataPath '${schema.dataPath}' escapes the workspace` };
   return { ok: true, dataDir };
+}
+
+/** The `storage` arm of the acceptance gate. Every storage backend gets the
+ *  conventional phantom dataDir; what differs is what else has to resolve
+ *  before the collection can exist at all.
+ *
+ *  A FILE-backed backend (sqlite) resolves and containment-checks a
+ *  `storageFile`. A SHARED one (firestore) has no path on this machine — it
+ *  resolves an IDENTITY instead: the `aid` from the repository's `app.json`,
+ *  which together with the slug as `cid` names `apps/{aid}/collections/{cid}`.
+ *
+ *  Resolving it HERE, once, is the point. The store then receives a settled
+ *  `(aid, cid)` and never reads `app.json` itself — otherwise the questions of
+ *  caching, staleness and what to do when the file is missing would be decided
+ *  inside a read path, where the only cheap answer is to return nothing, and
+ *  "this collection is misconfigured" would reach the user as "this collection
+ *  is empty". A missing or malformed `app.json` is a CONFIGURATION error, so it
+ *  is reported the same way an escaping `storage.path` is: the schema is
+ *  refused, with a reason naming the file to create. */
+function acceptStorageSchema(storage: NonNullable<CollectionSchema["storage"]>, opts: { workspaceRoot: string; slug: string }): SchemaAcceptance {
+  const dataDir = resolveDataDir(conventionalDataPath(opts.slug), opts.workspaceRoot);
+  if (dataDir === null) return { ok: false, reason: `slug '${opts.slug}' yields no workspace-contained data dir` };
+  if (storage.type === "sqlite") {
+    const storageFile = resolveDataDir(storage.path, opts.workspaceRoot);
+    if (storageFile === null) return { ok: false, reason: `storage.path '${storage.path}' escapes the workspace` };
+    return { ok: true, dataDir, storageFile };
+  }
+  const manifest = loadAppManifest(opts.workspaceRoot);
+  if (!manifest.ok) return { ok: false, reason: appManifestReason(manifest, opts.workspaceRoot) };
+  return { ok: true, dataDir, appId: manifest.manifest.aid };
 }
 
 async function loadOneCollection(skillsRoot: string, slug: string, source: CollectionSource, workspaceRoot: string): Promise<LoadedCollection | null> {
@@ -165,6 +188,7 @@ async function loadOneCollection(skillsRoot: string, slug: string, source: Colle
     dataDir: acceptance.dataDir,
     ...(acceptance.dataSourceFile !== undefined ? { dataSourceFile: acceptance.dataSourceFile } : {}),
     ...(acceptance.storageFile !== undefined ? { storageFile: acceptance.storageFile } : {}),
+    ...(acceptance.appId !== undefined ? { appId: acceptance.appId } : {}),
     skillDir: path.join(skillsRoot, safeName),
   };
 }

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -307,6 +307,7 @@ export function toSummary(collection: LoadedCollection): CollectionSummary {
     icon: collection.schema.icon,
     source: collection.source,
     ...(collection.schema.dataSource !== undefined ? { readonly: true as const } : {}),
+    ...(collection.appId !== undefined ? { appId: collection.appId } : {}),
   };
 }
 

--- a/packages/core/src/collection/server/firestoreDocs.ts
+++ b/packages/core/src/collection/server/firestoreDocs.ts
@@ -1,0 +1,105 @@
+// The seam between the firestore store and the Firestore SDK.
+//
+// The modular SDK is function-based (`getDocs(query(collection(db, …)))`), so a
+// store that imported those functions directly could not be tested without a
+// real backend — a fake `db` would still be handed to the real functions.
+// Narrowing to this interface makes the backend swappable: core ships
+// `createFirestoreDocs` over the real SDK, and the tests inject an in-memory
+// fake that satisfies the same shape. That is what lets this repository's tests
+// run with no API key and no network.
+//
+// Deliberately minimal and id-keyed: no query builder, no field ordering, no
+// cursors. Everything the store needs is "the documents of one collection path,
+// ordered by document id" — see the store header for why field ordering is
+// avoided entirely.
+//
+// The collection path is an ARGUMENT, not something this module composes. It
+// owns the SDK calls; `firestoreStore` owns where the documents live.
+
+import {
+  collection as firestoreCollection,
+  doc,
+  getDoc,
+  getDocs,
+  orderBy,
+  query as firestoreQuery,
+  runTransaction,
+  setDoc,
+  type Firestore,
+} from "firebase/firestore";
+
+/** One stored record document. `data` is the document's own fields — the
+ *  record itself, not a wrapper around it; see `set` below. The store
+ *  validates its shape, because a document written by hand could be
+ *  anything. */
+export interface FirestoreDoc {
+  id: string;
+  data: unknown;
+}
+
+export interface FirestoreDocs {
+  /** Every document under `collectionPath`, ordered by document id. */
+  list: (collectionPath: string) => Promise<FirestoreDoc[]>;
+  /** One document's fields, or null when it doesn't exist. */
+  get: (collectionPath: string, docId: string) => Promise<unknown | null>;
+  /** Create or replace. */
+  set: (collectionPath: string, docId: string, data: Record<string, unknown>) => Promise<void>;
+  /** Create only. Returns false when the id already exists — atomic, so two
+   *  concurrent creates can't both observe "missing". */
+  create: (collectionPath: string, docId: string, data: Record<string, unknown>) => Promise<boolean>;
+  /** Delete. Returns false when the id didn't exist, so a caller can tell a
+   *  real delete from a typo'd id. */
+  delete: (collectionPath: string, docId: string) => Promise<boolean>;
+}
+
+/** The real implementation over the modular SDK.
+ *
+ *  THE RECORD IS THE DOCUMENT. Its fields are written at the top level, not
+ *  nested under a `data` key. This is not a matter of taste: the deployed
+ *  security rules read `request.resource.data.<field>` and
+ *  `resource.data[submit.emailField]` — a wrapper would put every field one
+ *  level down, so the required-field checks, the status state machine and the
+ *  "your own row" predicate would all read absent values and fail closed. A
+ *  shared record's shape is part of the authorization contract.
+ *
+ *  `orderBy("__name__")` orders by DOCUMENT ID. Ordering by a record field
+ *  would silently EXCLUDE documents missing that field (the trap
+ *  `remote-host/server/hostRunner.ts:158-169` documents), turning a read into a
+ *  partial one; the document id is always present and gives the stable order
+ *  the store contract requires. */
+export function createFirestoreDocs(database: Firestore): FirestoreDocs {
+  return {
+    list: async (collectionPath) => {
+      const snapshot = await getDocs(firestoreQuery(firestoreCollection(database, collectionPath), orderBy("__name__")));
+      return snapshot.docs.map((entry) => ({ id: entry.id, data: entry.data() }));
+    },
+    get: async (collectionPath, docId) => {
+      const snapshot = await getDoc(doc(database, collectionPath, docId));
+      return snapshot.exists() ? snapshot.data() : null;
+    },
+    set: async (collectionPath, docId, data) => {
+      await setDoc(doc(database, collectionPath, docId), data);
+    },
+    create: (collectionPath, docId, data) =>
+      runTransaction(database, async (transaction) => {
+        const ref = doc(database, collectionPath, docId);
+        const existing = await transaction.get(ref);
+        if (existing.exists()) return false;
+        transaction.set(ref, data);
+        return true;
+      }),
+    // Firestore's deleteDoc succeeds on a missing document, so an existence
+    // check is what makes "deleted" distinguishable from "there was nothing".
+    // It runs INSIDE the transaction (like `create`): a plain get-then-delete
+    // would report `true` for a document a concurrent client had already
+    // removed, i.e. claim a delete this call never performed.
+    delete: (collectionPath, docId) =>
+      runTransaction(database, async (transaction) => {
+        const ref = doc(database, collectionPath, docId);
+        const existing = await transaction.get(ref);
+        if (!existing.exists()) return false;
+        transaction.delete(ref);
+        return true;
+      }),
+  };
+}

--- a/packages/core/src/collection/server/firestoreStore.ts
+++ b/packages/core/src/collection/server/firestoreStore.ts
@@ -1,0 +1,198 @@
+// The Firestore store: a SHARED collection's records as Firestore documents.
+//
+// Documents live at `apps/{aid}/collections/{cid}/items/{id}`. The identity is
+// `(aid, cid)`: `aid` comes from the repository's committed `app.json` and is
+// resolved once by discovery (`LoadedCollection.appId`), `cid` is always the
+// collection's slug. Nothing here reads a file or a session to work out WHERE —
+// it is handed a settled identity and builds the path from it.
+//
+// WHAT PROTECTS THESE DOCUMENTS. Not the shape of the path. An earlier draft of
+// this backend wrote under `users/{uid}/…` and leaned on the deployed rule
+// `users/{uid}/{document=**}`, so "the schema cannot name a path" WAS the
+// safety argument. It no longer is, and reading it that way would be a lie: an
+// `aid` is committed in a repository that anyone with a clone can edit. What
+// authorizes a read or a write is the app's MEMBER ROSTER — the rules resolve
+// `request.auth.token.email` against `apps/{aid}.members` and derive a role per
+// collection. Pointing at another app's `aid` is not an escape; it is a request
+// that gets refused, by name, for a caller who is not on that roster.
+//
+// The schema still declares no path, but for a different reason: there is
+// nothing for it to say. `aid` is one per app (four collections share one
+// roster), and `cid` is the slug. See `StorageZ`'s firestore arm.
+//
+// Availability: the authenticated handle belongs to the host's remote-host
+// session, so a shared collection is readable/writable only while that session
+// is open. This follows sqliteStore's precedent for an unavailable engine — the
+// FACTORY never throws (`storeFor` is called from ontology/validate/routes and
+// must not break unrelated screens), each METHOD fails with an actionable
+// message instead. It must never degrade to an empty result: "no records" and
+// "not connected" have to stay distinguishable, or a disconnected session looks
+// like data loss.
+//
+// SDK access goes through the `FirestoreDocs` seam (firestoreDocs.ts), not the
+// modular functions directly — that is what makes the backend testable without
+// a live Firestore.
+//
+// No `query`: there is no Firestore analogue of the DuckDB aggregation the CSV
+// store exposes. Absent `query` is a supported state — the engine-level
+// fallback (`runCollectionQuery`) answers aggregations instead.
+
+import { isRecord } from "@mulmoclaude/common";
+import { sharedCollectionKey, type SharedCollectionKey } from "../core/collectionKey";
+import type { CollectionItem } from "../core/schema";
+import { BackendUnavailableError } from "./backendAvailability";
+import type { LoadedCollection } from "./discoveredCollection";
+import { firestoreHandle, publishCollectionChange, sharedCollectionChangePayload, type FirestoreHandle } from "./host";
+import type { DeleteItemResult, IoOptions, WriteItemResult } from "./io";
+import { safeRecordId } from "./paths";
+import { projectItemFields, type ListOptions, type ListPage, type WriteOptions } from "./storePage";
+import type { CollectionStore } from "./store";
+
+/** What every operation throws when there is no live session. Worded as an
+ *  instruction because it surfaces straight to the user and the agent. */
+const NOT_CONNECTED =
+  "shared collection unavailable: connect remote-host first — these records live in the app's Firestore, not in the workspace, so nothing can be read or written while the session is closed";
+
+/** What a schema declaring `storage.type: "firestore"` must have had resolved
+ *  for it before it can be served. Its absence is a programming error here, not
+ *  a user-facing state: discovery REFUSES such a schema when the repository
+ *  declares no `aid`, so a collection that reached this store has one. */
+const NO_APP = "shared collection has no app id — discovery should have refused this schema; check that the repository's app.json declares an `aid`";
+
+/** The records subcollection of one shared collection.
+ *
+ *  Takes a KEY, never loose strings, and the key is the only way to reach this
+ *  function. `sharedCollectionKey` is where the name rule lives (the charset a
+ *  Firestore document id, a pubsub channel segment and the completion-bell id
+ *  must all survive), so building a path cannot be a way around it. */
+export function sharedItemsPath(key: SharedCollectionKey): string {
+  return `apps/${key.aid}/collections/${key.cid}/items`;
+}
+
+/** The collection's identity, from what discovery resolved. Throws on a
+ *  missing `appId` — see NO_APP. */
+function keyOf(collection: Pick<LoadedCollection, "slug" | "appId">): SharedCollectionKey {
+  if (collection.appId === undefined) throw new Error(NO_APP);
+  // `cid` IS the slug. Fixed here, deliberately, rather than made configurable:
+  // the schema, the views and the skill text sit in a directory named by the
+  // slug, so a second name would need a mapping table between what a collection
+  // is called on disk and what it is called in its app — two names for one
+  // thing, which is the exact collision `CollectionKey` exists to remove.
+  return sharedCollectionKey(collection.appId, collection.slug);
+}
+
+function requireHandle(): FirestoreHandle {
+  const handle = firestoreHandle();
+  if (handle === null) throw new BackendUnavailableError(NOT_CONNECTED);
+  return handle;
+}
+
+/** A stored document's fields → a record. A document written by hand (or by an
+ *  older version) can hold anything, so a non-object is dropped rather than
+ *  surfaced as a broken record — the same fail-soft the file store applies to
+ *  an unparseable `.json`. */
+function toItem(data: unknown): CollectionItem | null {
+  return isRecord(data) ? data : null;
+}
+
+/** Record ids are validated with the SAME helper every other backend uses.
+ *  Firestore would accept ids the file store refuses, but a record should stay
+ *  portable between backends — and an id that can't round-trip to a filename
+ *  would break an export back to a file collection. */
+function withSafeId<T>(itemId: string, onInvalid: () => T, run: (safeId: string, handle: FirestoreHandle) => T): T {
+  const safeId = safeRecordId(itemId);
+  if (safeId === null) return onInvalid();
+  return run(safeId, requireHandle());
+}
+
+async function firestoreList(key: SharedCollectionKey): Promise<CollectionItem[]> {
+  const { docs } = requireHandle();
+  const entries = await docs.list(sharedItemsPath(key));
+  return entries.map((entry) => toItem(entry.data)).filter((item): item is CollectionItem => item !== null);
+}
+
+/** Paging is emulated over a full ordered read rather than pushed into
+ *  Firestore: `offset` has no server-side form there (the cursor API needs the
+ *  preceding document, which a stateless offset/limit call doesn't have), and
+ *  `total` needs the full count anyway. Hence `nativePaging: false` — the
+ *  capability is honest about the cost. */
+async function firestorePage(key: SharedCollectionKey, primaryKey: string, opts: ListOptions): Promise<ListPage> {
+  const items = await firestoreList(key);
+  const offset = Math.max(0, opts.offset ?? 0);
+  const sliced = opts.limit === undefined ? items.slice(offset) : items.slice(offset, offset + Math.max(0, opts.limit));
+  return { items: projectItemFields(sliced, opts.fields, primaryKey), total: items.length, truncated: false };
+}
+
+async function firestoreRead(key: SharedCollectionKey, itemId: string): Promise<CollectionItem | null> {
+  return withSafeId(
+    itemId,
+    () => Promise.resolve(null),
+    async (safeId, { docs }) => toItem(await docs.get(sharedItemsPath(key), safeId)),
+  );
+}
+
+/** Publish the "records changed" ping for a shared collection.
+ *
+ *  `sharedCollectionChangePayload` NEVER stamps a root, and that matters beyond
+ *  tidiness: this payload is relayed to the browser and on into an
+ *  LLM-generated custom-view iframe, so a filesystem path on it would be a
+ *  disclosure. The type makes it unreachable rather than trusting the caller. */
+function publishShared(key: SharedCollectionKey, ids: string[], operation: "upsert" | "delete"): void {
+  publishCollectionChange(sharedCollectionChangePayload({ slug: key.cid, ids, op: operation }, key.aid));
+}
+
+async function firestoreWrite(
+  key: SharedCollectionKey,
+  itemId: string,
+  item: CollectionItem,
+  opts: IoOptions & { refuseOverwrite?: boolean | undefined },
+): Promise<WriteItemResult> {
+  return withSafeId<Promise<WriteItemResult>>(
+    itemId,
+    () => Promise.resolve({ kind: "invalid-id", itemId }),
+    async (safeId, { docs }) => {
+      const collectionPath = sharedItemsPath(key);
+      if (opts.refuseOverwrite) {
+        const created = await docs.create(collectionPath, safeId, item);
+        if (!created) return { kind: "conflict", itemId: safeId };
+      } else {
+        await docs.set(collectionPath, safeId, item);
+      }
+      if (opts.slug) publishShared(key, [safeId], "upsert");
+      return { kind: "ok", itemId: safeId, item };
+    },
+  );
+}
+
+async function firestoreDelete(key: SharedCollectionKey, itemId: string, opts: IoOptions): Promise<DeleteItemResult> {
+  return withSafeId<Promise<DeleteItemResult>>(
+    itemId,
+    () => Promise.resolve({ kind: "invalid-id", itemId }),
+    async (safeId, { docs }) => {
+      const removed = await docs.delete(sharedItemsPath(key), safeId);
+      if (!removed) return { kind: "not-found", itemId: safeId };
+      if (opts.slug) publishShared(key, [safeId], "delete");
+      return { kind: "ok", itemId: safeId };
+    },
+  );
+}
+
+/** The store factory registered for `storage.type === "firestore"`.
+ *  Synchronous and connection-agnostic by contract — see the header. */
+export function firestoreStoreFor(collection: LoadedCollection, opts: IoOptions): CollectionStore {
+  const { primaryKey } = collection.schema;
+  const ioOpts: IoOptions = { ...opts, slug: opts.slug ?? collection.slug };
+  // Every method is `async` and resolves the key INSIDE itself, so a bad
+  // identity rejects the one call instead of throwing out of the factory. The
+  // factory is called from ontology / validate / route handlers that list many
+  // collections; one that throws there takes an unrelated screen down with it.
+  return {
+    capabilities: { writable: true, nativeQuery: false, nativePaging: false },
+    list: async () => firestoreList(keyOf(collection)),
+    page: async (pageOpts = {}) => firestorePage(keyOf(collection), primaryKey, pageOpts),
+    read: async (itemId: string) => firestoreRead(keyOf(collection), itemId),
+    write: async (itemId: string, item: CollectionItem, writeOpts: WriteOptions = {}) =>
+      firestoreWrite(keyOf(collection), itemId, item, { ...ioOpts, refuseOverwrite: writeOpts.refuseOverwrite }),
+    delete: async (itemId: string) => firestoreDelete(keyOf(collection), itemId, ioOpts),
+  };
+}

--- a/packages/core/src/collection/server/firestoreStore.ts
+++ b/packages/core/src/collection/server/firestoreStore.ts
@@ -87,6 +87,40 @@ function requireHandle(): FirestoreHandle {
   return handle;
 }
 
+/** Firestore's own refusal, named.
+ *
+ *  `permission-denied` is the failure a shared collection has most often and
+ *  the one the SDK explains worst ("Missing or insufficient permissions") — it
+ *  says nothing about WHO was refused, which is the only fact that leads to a
+ *  fix. Authorization here is the app's member roster, keyed by email, so the
+ *  signed-in address is what the app's owner needs in order to add it. This is
+ *  the whole reason `FirestoreHandle` carries `email`.
+ *
+ *  Reported as a `BackendUnavailableError` deliberately, even though it is a
+ *  refusal rather than an outage: the layers above catch broadly, and without a
+ *  type to test, `store.read(...).catch(() => null)` reports "record missing"
+ *  and an ontology count reports 0 — a denial would read as an empty
+ *  collection, which is the exact confusion this backend refuses to create. */
+function isPermissionDenied(err: unknown): boolean {
+  return isRecord(err) && err.code === "permission-denied";
+}
+
+function deniedMessage(key: SharedCollectionKey, email: string): string {
+  return `permission denied on shared collection '${key.cid}' of app '${key.aid}' — signed in as ${email}. A shared collection is authorized by the app's member roster (by email), so this address needs a role for '${key.cid}' (or '*'); only the app's owner can add it.`;
+}
+
+/** Run one SDK call, translating a roster denial. Every read and write goes
+ *  through this — a denial reaching one path and not another would mean the
+ *  message a user sees depends on which screen they were on. */
+async function guarded<T>(key: SharedCollectionKey, email: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run();
+  } catch (err) {
+    if (!isPermissionDenied(err)) throw err;
+    throw new BackendUnavailableError(deniedMessage(key, email));
+  }
+}
+
 /** A stored document's fields → a record. A document written by hand (or by an
  *  older version) can hold anything, so a non-object is dropped rather than
  *  surfaced as a broken record — the same fail-soft the file store applies to
@@ -106,8 +140,8 @@ function withSafeId<T>(itemId: string, onInvalid: () => T, run: (safeId: string,
 }
 
 async function firestoreList(key: SharedCollectionKey): Promise<CollectionItem[]> {
-  const { docs } = requireHandle();
-  const entries = await docs.list(sharedItemsPath(key));
+  const { docs, email } = requireHandle();
+  const entries = await guarded(key, email, () => docs.list(sharedItemsPath(key)));
   return entries.map((entry) => toItem(entry.data)).filter((item): item is CollectionItem => item !== null);
 }
 
@@ -127,7 +161,7 @@ async function firestoreRead(key: SharedCollectionKey, itemId: string): Promise<
   return withSafeId(
     itemId,
     () => Promise.resolve(null),
-    async (safeId, { docs }) => toItem(await docs.get(sharedItemsPath(key), safeId)),
+    async (safeId, { docs, email }) => toItem(await guarded(key, email, () => docs.get(sharedItemsPath(key), safeId))),
   );
 }
 
@@ -150,13 +184,13 @@ async function firestoreWrite(
   return withSafeId<Promise<WriteItemResult>>(
     itemId,
     () => Promise.resolve({ kind: "invalid-id", itemId }),
-    async (safeId, { docs }) => {
+    async (safeId, { docs, email }) => {
       const collectionPath = sharedItemsPath(key);
       if (opts.refuseOverwrite) {
-        const created = await docs.create(collectionPath, safeId, item);
+        const created = await guarded(key, email, () => docs.create(collectionPath, safeId, item));
         if (!created) return { kind: "conflict", itemId: safeId };
       } else {
-        await docs.set(collectionPath, safeId, item);
+        await guarded(key, email, () => docs.set(collectionPath, safeId, item));
       }
       if (opts.slug) publishShared(key, [safeId], "upsert");
       return { kind: "ok", itemId: safeId, item };
@@ -168,8 +202,8 @@ async function firestoreDelete(key: SharedCollectionKey, itemId: string, opts: I
   return withSafeId<Promise<DeleteItemResult>>(
     itemId,
     () => Promise.resolve({ kind: "invalid-id", itemId }),
-    async (safeId, { docs }) => {
-      const removed = await docs.delete(sharedItemsPath(key), safeId);
+    async (safeId, { docs, email }) => {
+      const removed = await guarded(key, email, () => docs.delete(sharedItemsPath(key), safeId));
       if (!removed) return { kind: "not-found", itemId: safeId };
       if (opts.slug) publishShared(key, [safeId], "delete");
       return { kind: "ok", itemId: safeId };

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -12,6 +12,10 @@ import path from "node:path";
 import { canonicalRoot } from "../../files/root.js";
 import { localCollectionKeyOf, sharedCollectionKey, type CollectionKey } from "../core/collectionKey.js";
 import { createForwardingLogger, createHostSlot, type StructuredLogger } from "../../host/hostSlot.js";
+// Type-only: this module must not pull the firebase SDK in at runtime (it is an
+// OPTIONAL peer of this package). The adapter ships from
+// `@mulmoclaude/core/collection/firestore` instead.
+import type { FirestoreDocs } from "./firestoreDocs";
 
 /** Public alias of the shared `StructuredLogger` — keeps the domain surface name-stable. */
 export type CollectionLogger = StructuredLogger;
@@ -111,6 +115,32 @@ export interface CollectionHost {
   };
   /** True for a preset-skill slug (host-owned naming convention). */
   isPresetSlug: (slug: string) => boolean;
+}
+
+/** The authenticated Firestore access a shared collection is served through.
+ *
+ *  It carries NO uid, and that is a decision rather than an omission. Nothing
+ *  about a shared collection is keyed by uid any more: the documents live at
+ *  `apps/{aid}/collections/{cid}/items`, and the deployed rules authorize on
+ *  `request.auth.token.email` against the app's member roster. A uid kept
+ *  "just for identity" would be a value nothing checks, sitting next to a path
+ *  it no longer determines — which is how a later reader ends up deriving a
+ *  path from it again.
+ *
+ *  `email` is what the rules actually evaluate, so it is what makes a refusal
+ *  explainable: `permission-denied` is the most common failure a shared
+ *  collection has and the least informative, and naming the principal turns it
+ *  into "signed in as a@b — this app's roster may not list you". A session with
+ *  no verified email is NOT a session here (the accessor answers null): public
+ *  anonymous submission is a visitor's path through the published web app, not
+ *  the host's.
+ *
+ *  `docs` is the narrow document interface rather than a raw `Firestore` so the
+ *  backend stays testable: core ships `createFirestoreDocs` over the real SDK
+ *  (`firestoreDocs.ts`) and tests inject an in-memory fake. */
+export interface FirestoreHandle {
+  docs: FirestoreDocs;
+  email: string;
 }
 
 /** A collection's records changed on disk. Carries the `slug` so the host can
@@ -227,6 +257,7 @@ export function collectionChangeKey(payload: CollectionChangePayload, fallbackRo
 
 const hostSlot = createHostSlot<CollectionHost>("@mulmoclaude/core/collection/server: configureCollectionHost()");
 let changePublisher: CollectionChangePublisher | null = null;
+let firestoreAccessor: (() => FirestoreHandle | null) | null = null;
 
 /** Wire the engine to a host. Call once at server startup, before any
  *  collection storage operation. Re-binding to a *different* host throws —
@@ -252,6 +283,27 @@ export function setCollectionChangePublisher(publish: CollectionChangePublisher 
  *  so this stays a thin pass-through and never throws into the write. */
 export function publishCollectionChange(payload: CollectionChangePayload): void {
   changePublisher?.(payload);
+}
+
+/** Wire the accessor for the host's authenticated Firestore session.
+ *
+ *  Separate from `configureCollectionHost` for the same reason
+ *  `setCollectionChangePublisher` is: the host binding is set at the top of
+ *  server startup, but this session doesn't exist until the user connects
+ *  remote-host (and closes again on disconnect), so it cannot be part of a
+ *  one-shot binding. Optional — left unwired, only shared collections are
+ *  affected, and they report "not connected". Pass `null` to detach. */
+export function setFirestoreAccessor(accessor: (() => FirestoreHandle | null) | null): void {
+  firestoreAccessor = accessor;
+}
+
+/** The host's live Firestore access, or null when there is no session (or the
+ *  host never wired one — every non-shared backend leaves it unset).
+ *  Callers MUST surface null as an actionable "connect remote-host first",
+ *  never as an empty result: silence would be indistinguishable from a
+ *  collection that genuinely has no records. */
+export function firestoreHandle(): FirestoreHandle | null {
+  return firestoreAccessor?.() ?? null;
 }
 
 function requireHost(): CollectionHost {

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -51,9 +51,21 @@ export {
   type CollectionHost,
   type CollectionLogger,
   type CollectionChangePayload,
+  firestoreHandle,
+  setFirestoreAccessor,
+  type FirestoreHandle,
   type LocalCollectionChange,
   type SharedCollectionChange,
 } from "./host";
+// NOTE: `createFirestoreDocs` is deliberately NOT re-exported here. It lives in
+// a module that top-level imports `firebase/firestore`, and a re-export links
+// eagerly — so exporting it would make the OPTIONAL `firebase` peer effectively
+// required for every consumer of this entry, including hosts with no Firestore
+// at all. It ships from the dedicated `@mulmoclaude/core/collection/firestore`
+// subpath instead. The TYPES are safe here: they erase at build time.
+export type { FirestoreDoc, FirestoreDocs } from "./firestoreDocs";
+export { sharedItemsPath } from "./firestoreStore";
+export { loadAppManifest, parseAppManifest, appManifestReason, APP_MANIFEST_FILE, type AppManifest, type AppManifestResult } from "./appManifest";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";
 export * from "./templatePath";

--- a/packages/core/src/collection/server/store.ts
+++ b/packages/core/src/collection/server/store.ts
@@ -49,6 +49,7 @@ import type { LoadedCollection } from "./discoveredCollection";
 import { deleteItem, listItems, readItem, writeItem, type DeleteItemResult, type IoOptions, type WriteItemResult } from "./io";
 import { csvList, csvRead, csvRunQuery } from "./csvStore";
 import { sqliteStoreFor } from "./sqliteStore";
+import { firestoreStoreFor } from "./firestoreStore";
 import { pageFromFullRead, type ListOptions, type ListPage, type WriteOptions } from "./storePage";
 import { closerFor, watchDirectory, watchSingleFile } from "./watchFs";
 
@@ -236,6 +237,7 @@ const storeFactories = new Map<CollectionStorageKind, CollectionStoreFactory>([
   ["file", fileStoreFor],
   ["csv", csvStoreFor],
   ["sqlite", sqliteStoreFor],
+  ["firestore", firestoreStoreFor],
 ]);
 
 /** Pick the store implementation for a discovered collection via the

--- a/packages/core/test/collection-watchers/test_completionIdentity.ts
+++ b/packages/core/test/collection-watchers/test_completionIdentity.ts
@@ -179,6 +179,78 @@ test("a rooted sweep clears LEGACY rootless entries instead of stranding them", 
   for (const entry of await listAll()) await notifierClear(entry.id);
 });
 
+// --- shared collections -----------------------------------------------------
+//
+// A SHARED collection is one obligation however many checkouts can see it: its
+// records live in its app, not in any tree, so a bell keyed by the root the
+// repository happens to be cloned into would put a duplicate in front of the
+// user per worktree — and each root's sweep would manage only its own copy.
+//
+// `appId` is set on the fixture while the records stay on disk, deliberately:
+// what is under test is the bell's IDENTITY, not the Firestore backend.
+
+const APP_ID = "app_test_7f3a";
+const sharedId = `collection-completion:#${APP_ID}\u0000tasks:t1`;
+const asSharedCollection = (dataDir: string): LoadedCollection => ({ ...asCollection(dataDir), appId: APP_ID }) as LoadedCollection;
+
+test("two roots, one shared collection — ONE bell, keyed by the app", async () => {
+  const rootOne = makeTempDir("ci-shared-a-");
+  const rootTwo = makeTempDir("ci-shared-b-");
+  const dirOne = fixture(rootOne);
+  const dirTwo = mkdtempSync(path.join(rootTwo, "coll-"));
+  writeFileSync(path.join(dirTwo, "t1.json"), JSON.stringify({ id: "t1", name: "Pending", done: "no" }));
+
+  await reconcileItem(asSharedCollection(dirOne), "t1", { workspaceRoot: rootOne });
+  await reconcileItem(asSharedCollection(dirTwo), "t1", { workspaceRoot: rootTwo });
+
+  // The second pass finds the first pass's bell rather than publishing beside
+  // it — which is only true if the root never reached the id.
+  assert.deepEqual(await legacyIds(), [sharedId]);
+  // And the deep link carries no root: there is no project to point at.
+  assert.deepEqual(navigateRoots, [undefined]);
+  for (const entry of await listAll()) await notifierClear(entry.id);
+});
+
+test("a local collection of the same name keeps its own bell", async () => {
+  // The shared mark exists for this: a shared `tasks` and a project's own
+  // `tasks` are two collections, and a rootless local id must not collide with
+  // a shared one.
+  const projectRoot = makeTempDir("ci-shared-c-");
+  const dataDir = fixture(root);
+  const projectDir = mkdtempSync(path.join(projectRoot, "coll-"));
+  writeFileSync(path.join(projectDir, "t1.json"), JSON.stringify({ id: "t1", name: "Pending", done: "no" }));
+
+  await reconcileItem(asCollection(dataDir), "t1"); // local, rootless
+  await reconcileItem(asSharedCollection(projectDir), "t1", { workspaceRoot: projectRoot });
+  assert.deepEqual(new Set(await legacyIds()), new Set(["collection-completion:tasks:t1", sharedId]));
+
+  // Clearing the local one leaves the shared one — the clear path and the
+  // dedupe check agree on the same scope.
+  await clearItemNotification("tasks", "t1");
+  assert.deepEqual(await legacyIds(), [sharedId]);
+  for (const entry of await listAll()) await notifierClear(entry.id);
+});
+
+test("a sweep that cannot resolve the app leaves its bell alone", async () => {
+  // Who may retire a shared bell: a host that can resolve THAT app's collection,
+  // because judging one means reading its records. A host without the app would
+  // read "gone" for every check and clear bells for an app it has never seen.
+  const otherHost = makeTempDir("ci-shared-d-");
+  const dataDir = fixture(root);
+
+  await reconcileItem(asSharedCollection(dataDir), "t1", { workspaceRoot: root });
+  assert.deepEqual(await legacyIds(), [sharedId]);
+
+  await sweepStaleActiveEntries({ workspaceRoot: otherHost });
+  assert.deepEqual(await legacyIds(), [sharedId], "another host's sweep must not retire it");
+
+  // Nor may a sweep that resolves a DIFFERENT collection of the same name: the
+  // slug is not the identity.
+  await sweepStaleActiveEntries({});
+  assert.deepEqual(await legacyIds(), [sharedId], "a same-named local collection must not retire it either");
+  for (const entry of await listAll()) await notifierClear(entry.id);
+});
+
 test("a rootless sweep leaves a ROOTED entry alone", async () => {
   // The mirror of the case above, and the one that protects a single-workspace
   // host: it sweeps with no root and must not clear a bell belonging to a

--- a/packages/core/test/collection/test_appManifest.ts
+++ b/packages/core/test/collection/test_appManifest.ts
@@ -1,0 +1,69 @@
+// `app.json` — the repository's app declaration, and the one field a shared
+// collection needs from it.
+//
+// The parse half is tested without a filesystem; the read half only has to be
+// checked for the distinction that matters downstream, which is "no file" vs
+// "a file that says nothing usable" — discovery turns each into a different
+// line for the author.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { appManifestReason, loadAppManifest, parseAppManifest } from "../../src/collection/server/appManifest";
+
+test("parseAppManifest reads the aid and nothing else", () => {
+  // `members` / `public` belong to publish; reading them here would be a second
+  // place that could disagree with it.
+  const parsed = parseAppManifest(JSON.stringify({ aid: "app_salon_7f3a", members: { "a@b.jp": { "*": "owner" } } }));
+  assert.equal(parsed.ok, true);
+  assert.deepEqual(parsed.ok ? parsed.manifest : null, { aid: "app_salon_7f3a" });
+});
+
+test("parseAppManifest refuses an aid no downstream encoding could carry", () => {
+  // The rule is `isValidCollectionName`, the SAME predicate the CollectionKey
+  // constructors apply — not a rule of its own. An aid is re-encoded as a
+  // Firestore document id, a pubsub channel segment and a bell id, and a layer
+  // with its own rule is how those come to disagree silently.
+  for (const aid of ["app/../other", "sales:2026", "app id", "", "-leading", "trailing-"]) {
+    const parsed = parseAppManifest(JSON.stringify({ aid }));
+    assert.equal(parsed.ok, false, `must refuse ${JSON.stringify(aid)}`);
+  }
+});
+
+test("parseAppManifest distinguishes malformed shapes, and says which", () => {
+  assert.equal(parseAppManifest("{").ok, false);
+  assert.equal(parseAppManifest("[]").ok, false);
+  assert.equal(parseAppManifest("{}").ok, false);
+  const noAid = parseAppManifest(JSON.stringify({ name: "Salon" }));
+  assert.equal(noAid.ok, false);
+  assert.equal(!noAid.ok && noAid.kind, "malformed");
+  assert.match(!noAid.ok && noAid.kind === "malformed" ? noAid.detail : "", /aid/);
+});
+
+test("loadAppManifest tells a missing file apart from an unusable one", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "app-manifest-"));
+  try {
+    const missing = loadAppManifest(root);
+    assert.equal(missing.ok, false);
+    assert.equal(missing.ok ? "" : missing.kind, "missing");
+    // The reason has to name the file to create — this line is all the author
+    // sees when their collection is skipped.
+    assert.match(appManifestReason({ kind: "missing" }, root), /app\.json/);
+
+    writeFileSync(path.join(root, "app.json"), JSON.stringify({ aid: "app_7f3a" }));
+    const found = loadAppManifest(root);
+    assert.deepEqual(found.ok ? found.manifest : null, { aid: "app_7f3a" });
+
+    // A directory named app.json is neither missing nor malformed: reporting it
+    // as "missing" would send the author to create a file that is already there.
+    rmSync(path.join(root, "app.json"));
+    mkdirSync(path.join(root, "app.json"));
+    const unreadable = loadAppManifest(root);
+    assert.equal(unreadable.ok, false);
+    assert.equal(unreadable.ok ? "" : unreadable.kind, "unreadable");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
         "collection/index": "src/collection/index.ts",
         "collection/server/index": "src/collection/server/index.ts",
         "collection/paths": "src/collection/server/templatePath.ts",
+        // The only collection entry that runtime-imports the firebase SDK.
+        // Separate so the OPTIONAL `firebase` peer stays optional for every
+        // consumer of `collection/server` (see that file's export note).
+        "collection/firestore": "src/collection/firestore.ts",
         "collection/registry/index": "src/collection/registry/index.ts",
         "collection/registry/server/index": "src/collection/registry/server/index.ts",
         "wiki/index": "src/wiki/index.ts",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.5.0",
+    "@mulmoclaude/core": "^3.6.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -87,6 +87,7 @@ import { initFileChangePublisher } from "./events/file-change.js";
 // effect at module load — plans/done/feat-mulmoscript-plugin.md phase 3).
 import { initMulmoScriptGenerationPublisher } from "./plugins/mulmoscript-server.js";
 import { initCollectionChangePublisher } from "./events/collection-change.js";
+import { initFirestoreCollectionBinding } from "./workspace/collections/firestoreBinding.js";
 import { initPhotoLocationsChangePublisher } from "./events/photo-locations-change.js";
 import { getRole, loadAllRoles } from "./workspace/roles.js";
 import { discoverSkills } from "./workspace/skills/index.js";
@@ -1160,6 +1161,10 @@ function initEventPublishers(pubsub: IPubSub): void {
   // near the route mount; only the pub/sub instance is wired here.
   initAccountingEventPublisher(pubsub);
   initCollectionChangePublisher(pubsub);
+  // Shared collections → the remote-host session's Firestore. No pubsub
+  // involvement; wired here because the session, like the publisher, isn't
+  // available at host-binding time.
+  initFirestoreCollectionBinding();
   initPhotoLocationsChangePublisher(pubsub);
   // MulmoScript generation events → plugin pubsub channel (the extracted
   // presentMulmoScript View's spinner/reload signal).

--- a/server/remoteHost/session.ts
+++ b/server/remoteHost/session.ts
@@ -79,6 +79,21 @@ export const currentUid = (): string | null => handles?.auth.currentUser?.uid ??
 export const currentFirestore = (): Firestore => requireHandles().firestore;
 export const currentStorage = (): FirebaseStorage => requireHandles().storage;
 
+// Non-throwing twin of `currentFirestore`, for consumers that must treat "no
+// session" as an ordinary state rather than an exception — shared collections
+// ask on every operation, including from screens that merely LIST collections,
+// so a throw would break unrelated UI.
+//
+// It reports the signed-in EMAIL, not the uid, because that is the principal
+// the deployed Firestore rules authorize on (`apps/{aid}.members` is keyed by
+// email). A session whose user has no email is not usable for a shared
+// collection, so it is reported as no session at all rather than as a session
+// that will be refused document by document.
+export const currentFirestoreSession = (): { firestore: Firestore; email: string } | null => {
+  const email = handles?.auth.currentUser?.email;
+  return handles && email ? { firestore: handles.firestore, email } : null;
+};
+
 // The signed-in user's Firebase ID token, or null when the RemoteHost session
 // isn't open / not authenticated. web-push uses this to authenticate `sendPush`;
 // a null result (RemoteHost disconnected) makes the push a silent no-op. The

--- a/server/workspace/collections/firestoreBinding.ts
+++ b/server/workspace/collections/firestoreBinding.ts
@@ -1,0 +1,31 @@
+// Bind shared (firestore-backed) collections to the remote-host session's
+// Firestore.
+//
+// Separate from the one-shot host binding because the session is late-bound and
+// comes and goes: it doesn't exist at startup, opens when the user connects,
+// and closes on disconnect. The accessor is therefore consulted per operation
+// and answers null while there is no session — the store turns that into
+// "connect remote-host first" rather than an empty result.
+import { setFirestoreAccessor, type FirestoreDocs } from "@mulmoclaude/core/collection/server";
+// The adapter ships from its own subpath — it is the one collection module that
+// pulls the firebase SDK in at runtime, kept off the main entry so the optional
+// peer stays optional for hosts without Firestore.
+import { createFirestoreDocs } from "@mulmoclaude/core/collection/firestore";
+import type { Firestore } from "firebase/firestore";
+import { currentFirestoreSession } from "../../remoteHost/session.js";
+
+// One adapter per Firestore instance. The accessor runs on every store call,
+// and a fresh adapter each time would allocate a closure set per read.
+let cached: { firestore: Firestore; docs: FirestoreDocs } | null = null;
+
+function docsFor(firestore: Firestore): FirestoreDocs {
+  if (cached?.firestore !== firestore) cached = { firestore, docs: createFirestoreDocs(firestore) };
+  return cached.docs;
+}
+
+export function initFirestoreCollectionBinding(): void {
+  setFirestoreAccessor(() => {
+    const session = currentFirestoreSession();
+    return session === null ? null : { docs: docsFor(session.firestore), email: session.email };
+  });
+}

--- a/src/composables/collections/uiHost.ts
+++ b/src/composables/collections/uiHost.ts
@@ -82,6 +82,59 @@ let notifiedSeveritiesFn: NotifiedSeverities | null = null;
 
 /** Called once from App.vue's setup, where `useAppApi()` / `useNotifications()`
  *  resolve. Wires the capabilities that can't be set at module load. */
+// Which channel a collection's live-change events arrive on.
+//
+// A LOCAL collection publishes on `collection:<slug>`; a SHARED one publishes
+// on `collection:app/<aid>/<cid>`, because two apps may each own a `tasks` and
+// they must not refresh each other's open views. A subscriber that keys on the
+// name alone therefore hears nothing for a shared collection — the refetch this
+// capability exists to provide simply never happens.
+//
+// The app id rides in on every collections list / detail response, but a view
+// can subscribe BEFORE either has resolved (the route's slug is known first).
+// So the local subscription is made immediately (it is what a local collection
+// needs, and it is inert for a shared one, which never publishes there), and
+// the app-scoped one is added as soon as the app id is learnt — including for
+// subscriptions already open.
+type Unsubscribe = () => void;
+
+const appIdBySlug = new Map<string, string>();
+const liveSubscribers = new Map<string, Set<{ onChange: () => void; unsubscribeApp: Unsubscribe | null }>>();
+
+function subscribeToApp(slug: string, aid: string, onChange: () => void): Unsubscribe {
+  return usePubSub().subscribe(collectionChannel(slug, aid), () => onChange());
+}
+
+/** Record (or clear) a collection's app id, and bring already-open
+ *  subscriptions onto the right channel. Called from the two responses that
+ *  carry it rather than by a fetch of its own. */
+function rememberAppId(collection: { slug: string; appId?: string }): void {
+  const { slug, appId } = collection;
+  if (appIdBySlug.get(slug) === appId) return;
+  if (appId === undefined) appIdBySlug.delete(slug);
+  else appIdBySlug.set(slug, appId);
+  for (const subscriber of liveSubscribers.get(slug) ?? []) {
+    subscriber.unsubscribeApp?.();
+    subscriber.unsubscribeApp = appId === undefined ? null : subscribeToApp(slug, appId, subscriber.onChange);
+  }
+}
+
+function subscribeCollectionChanges(slug: string, onChange: () => void): Unsubscribe {
+  const unsubscribeLocal = usePubSub().subscribe(collectionChannel(slug), () => onChange());
+  const aid = appIdBySlug.get(slug);
+  const subscriber = { onChange, unsubscribeApp: aid === undefined ? null : subscribeToApp(slug, aid, onChange) };
+  const forSlug = liveSubscribers.get(slug) ?? new Set<typeof subscriber>();
+  forSlug.add(subscriber);
+  liveSubscribers.set(slug, forSlug);
+  return () => {
+    unsubscribeLocal();
+    subscriber.unsubscribeApp?.();
+    subscriber.unsubscribeApp = null;
+    forSlug.delete(subscriber);
+    if (forSlug.size === 0) liveSubscribers.delete(slug);
+  };
+}
+
 export function installCollectionAppBindings(bindings: {
   startChat: StartChat;
   startNewChatDraft: StartChatDraft;
@@ -93,7 +146,11 @@ export function installCollectionAppBindings(bindings: {
 }
 
 configureCollectionUi({
-  fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(withSlug(API_ROUTES.collections.detail, slug)),
+  fetchCollectionDetail: (slug) =>
+    apiGet<CollectionDetailResponse>(withSlug(API_ROUTES.collections.detail, slug)).then((result) => {
+      if (result.ok) rememberAppId(result.data.collection);
+      return result;
+    }),
   fileAssetUrl: (value) => (isValidFilePath(value) ? (htmlPreviewUrlFor(value) ?? svgPreviewUrlFor(value)) : null),
   fileRoutePath: (value) => (isValidFilePath(value) ? `/files/${value.split("/").map(encodeURIComponent).join("/")}` : null),
   imageSrc: (imageData) => resolveImageSrc(imageData),
@@ -171,7 +228,11 @@ configureCollectionUi({
   },
 
   // index pages
-  listCollections: () => apiGet<CollectionsListResponse>(API_ROUTES.collections.list),
+  listCollections: () =>
+    apiGet<CollectionsListResponse>(API_ROUTES.collections.list).then((result) => {
+      if (result.ok) result.data.collections.forEach(rememberAppId);
+      return result;
+    }),
   listFeeds: () => apiGet<FeedsListResponse>(API_ROUTES.feeds.list),
   fetchOntology: () => apiGet<CollectionOntologyResponse>(API_ROUTES.collections.ontology),
   listRegistry: () => apiGet<RegistryListResponse>(API_ROUTES.collectionsRegistry.list),
@@ -192,7 +253,12 @@ configureCollectionUi({
   // (module-level socket), so this works when invoked from a view's setup; the
   // view owns the returned unsubscribe (onUnmounted). The payload is ignored —
   // subscribers refetch — so the callback is parameterless.
-  subscribeChanges: (slug, onChange) => usePubSub().subscribe(collectionChannel(slug), () => onChange()),
+  //
+  // A SHARED collection publishes on `collection:app/<aid>/<cid>`, not on the
+  // local `collection:<slug>` — which channel a slug lives on is the host's
+  // question, not the view's, so it is answered here and the plugin's
+  // `(slug, cb)` capability is unchanged.
+  subscribeChanges: (slug, onChange) => subscribeCollectionChanges(slug, onChange),
 
   pinToggle: PinToggle,
 

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -19,10 +19,18 @@ import {
   CollectionSchemaZ,
   discoverCollections,
   pageFromFullRead,
+  collectionChangeKey,
   projectItemFields,
+  setCollectionChangePublisher,
+  setFirestoreAccessor,
+  sharedItemsPath,
   storeFor,
+  type CollectionChangePayload,
   type CollectionStore,
+  type FirestoreDoc,
+  type FirestoreDocs,
 } from "@mulmoclaude/core/collection/server";
+import { sharedCollectionKey } from "@mulmoclaude/core/collection";
 
 let workdir: string;
 let emptyUserDir: string;
@@ -33,6 +41,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Module-level state — leaving a fixture's fake wired would let a shared
+  // collection resolve in a later test that never set one up.
+  setFirestoreAccessor(null);
+  setCollectionChangePublisher(null);
   rmSync(workdir, { recursive: true, force: true });
   rmSync(emptyUserDir, { recursive: true, force: true });
 });
@@ -126,10 +138,96 @@ async function sqliteStoreFixture(): Promise<CollectionStore> {
   return store;
 }
 
+const APP_ID = "app_test_7f3a";
+
+const FIRESTORE_SCHEMA = {
+  title: "Notes Cloud",
+  icon: "cloud",
+  storage: { type: "firestore" },
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true },
+    title: { type: "string", label: "Title" },
+    score: { type: "number", label: "Score" },
+  },
+};
+
+/** The repository's committed app declaration — what makes `aid` a property of
+ *  the location rather than of the session. Discovery refuses a shared
+ *  collection whose root has none, so every firestore fixture writes one. */
+function writeAppManifest(aid: string = APP_ID): void {
+  writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid }));
+}
+
+/** In-memory stand-in for the Firestore SDK, satisfying the same
+ *  `FirestoreDocs` seam the real implementation does. Insertion order is
+ *  deliberately NOT the read order — `list` sorts by document id, so seeding
+ *  shuffled proves the store's documented stable order the same way the sqlite
+ *  fixture does.
+ *
+ *  Fidelity limits (why this can't fully replace a live check): it models
+ *  document storage and create-atomicity, not Firestore's consistency model,
+ *  its security rules, or listener semantics. */
+function makeFakeFirestoreDocs(): FirestoreDocs & { paths: () => string[] } {
+  const collections = new Map<string, Map<string, unknown>>();
+  const bucket = (collectionPath: string): Map<string, unknown> => {
+    const existing = collections.get(collectionPath);
+    if (existing) return existing;
+    const created = new Map<string, unknown>();
+    collections.set(collectionPath, created);
+    return created;
+  };
+  return {
+    paths: () => [...collections.keys()],
+    list: (collectionPath) => {
+      const entries: FirestoreDoc[] = [...bucket(collectionPath).entries()].map(([docId, data]) => ({ id: docId, data }));
+      entries.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+      return Promise.resolve(entries);
+    },
+    get: (collectionPath, docId) => Promise.resolve(bucket(collectionPath).has(docId) ? (bucket(collectionPath).get(docId) as unknown) : null),
+    set: (collectionPath, docId, data) => {
+      bucket(collectionPath).set(docId, data);
+      return Promise.resolve();
+    },
+    create: (collectionPath, docId, data) => {
+      if (bucket(collectionPath).has(docId)) return Promise.resolve(false);
+      bucket(collectionPath).set(docId, data);
+      return Promise.resolve(true);
+    },
+    delete: (collectionPath, docId) => Promise.resolve(bucket(collectionPath).delete(docId)),
+  };
+}
+
+/** Wire a fake session. ONE fake per fixture — the accessor is called per
+ *  operation, so building it inside the closure would hand out a fresh empty
+ *  store every time and silently lose every write. */
+function connectFakeFirestore(): FirestoreDocs & { paths: () => string[] } {
+  const docs = makeFakeFirestoreDocs();
+  setFirestoreAccessor(() => ({ docs, email: "owner@example.com" }));
+  return docs;
+}
+
+async function firestoreStoreFixture(): Promise<CollectionStore> {
+  writeSkill("notescloud", FIRESTORE_SCHEMA);
+  writeAppManifest();
+  connectFakeFirestore();
+  const [collection] = await discoverCollections(discoveryOpts());
+  assert.ok(collection);
+  const store = storeFor(collection, { workspaceRoot: workdir });
+  assert.ok(store.write, "a shared collection's store must be writable");
+  // Seed through the store's own write path, shuffled to prove id ordering.
+  for (const recordId of ["n3", "n1", "n4", "n2"]) {
+    const written = await store.write(recordId, { id: recordId, title: `T-${recordId}`, score: Number(recordId.slice(1)) });
+    assert.equal(written.kind, "ok");
+  }
+  return store;
+}
+
 const FIXTURES: { name: string; make: () => Promise<CollectionStore>; writable: boolean; nativeQuery: boolean }[] = [
   { name: "file store", make: fileStoreFixture, writable: true, nativeQuery: false },
   { name: "csv store", make: csvStoreFixture, writable: false, nativeQuery: true },
   { name: "sqlite store", make: sqliteStoreFixture, writable: true, nativeQuery: false },
+  { name: "firestore store", make: firestoreStoreFixture, writable: true, nativeQuery: false },
 ];
 
 for (const fixture of FIXTURES) {
@@ -248,6 +346,121 @@ describe("storage schema gates (sqlite)", () => {
   it("rejects a storage.path escaping the workspace", async () => {
     writeSkill("escape", { ...SQLITE_SCHEMA, storage: { type: "sqlite", path: "../outside.db" } });
     assert.equal((await discoverCollections(discoveryOpts())).length, 0);
+  });
+});
+
+describe("shared (firestore) collections", () => {
+  it("puts records at apps/{aid}/collections/{cid}/items — cid is the slug", async () => {
+    writeSkill("notescloud", FIRESTORE_SCHEMA);
+    writeAppManifest();
+    const docs = connectFakeFirestore();
+    const [collection] = await discoverCollections(discoveryOpts());
+    assert.ok(collection);
+    assert.equal(collection.appId, APP_ID, "discovery resolves the aid once, onto the collection");
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    assert.ok(store.write);
+    await store.write("n1", { id: "n1", title: "T" });
+    assert.deepEqual(docs.paths(), [`apps/${APP_ID}/collections/notescloud/items`]);
+  });
+
+  it("builds that path only through the key, which refuses a name no encoding survives", () => {
+    assert.equal(sharedItemsPath(sharedCollectionKey(APP_ID, "notescloud")), `apps/${APP_ID}/collections/notescloud/items`);
+    // A cid the completion-bell id and the pubsub channel could not carry must
+    // not be reachable by building a path out of loose strings.
+    assert.throws(() => sharedCollectionKey(APP_ID, "sales:2026"));
+    assert.throws(() => sharedCollectionKey("app/../other", "notescloud"));
+  });
+
+  it("refuses the schema when the repository declares no aid — a config error, not an empty collection", async () => {
+    writeSkill("notescloud", FIRESTORE_SCHEMA);
+    connectFakeFirestore(); // a session exists; the APP is what is missing
+    assert.equal((await discoverCollections(discoveryOpts())).length, 0);
+    // ...and equally when app.json is there but says nothing usable.
+    writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid: "not a valid id" }));
+    assert.equal((await discoverCollections(discoveryOpts())).length, 0);
+  });
+
+  it("accepts the schema and resolves NO storageFile — records aren't on disk", async () => {
+    writeSkill("notescloud", FIRESTORE_SCHEMA);
+    writeAppManifest();
+    const [collection] = await discoverCollections(discoveryOpts());
+    assert.ok(collection);
+    assert.equal(collection.storageFile, undefined);
+    assert.equal(collection.dataDir, path.resolve(workdir, "data/collections/notescloud/items"));
+    assert.equal(storeFor(collection, { workspaceRoot: workdir }).capabilities.writable, true);
+  });
+
+  it("rejects a firestore schema carrying a path or a cid — there is nothing for it to declare", () => {
+    assert.equal(CollectionSchemaZ.safeParse({ ...FIRESTORE_SCHEMA, storage: { type: "firestore", path: "data/x.db" } }).success, false);
+    assert.equal(CollectionSchemaZ.safeParse({ ...FIRESTORE_SCHEMA, storage: { type: "firestore", cid: "other" } }).success, false);
+  });
+
+  it("keeps the sqlite variant parsing unchanged (discriminated-union regression)", () => {
+    assert.equal(CollectionSchemaZ.safeParse(SQLITE_SCHEMA).success, true);
+    assert.equal(CollectionSchemaZ.safeParse({ ...SQLITE_SCHEMA, storage: { type: "sqlite" } }).success, false, "sqlite still requires its path");
+    assert.equal(CollectionSchemaZ.safeParse({ ...SQLITE_SCHEMA, storage: { type: "mongo", path: "x" } }).success, false, "unknown backend refused");
+  });
+
+  it("fails loudly when there is no session — never an empty result", async () => {
+    writeSkill("notescloud", FIRESTORE_SCHEMA);
+    writeAppManifest();
+    setFirestoreAccessor(null); // no remote-host session
+    const [collection] = await discoverCollections(discoveryOpts());
+    assert.ok(collection);
+    // The FACTORY must not throw: storeFor runs on screens that merely list
+    // collections, and one disconnected backend can't break them.
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    const { write, delete: removeItem } = store;
+    assert.ok(write);
+    assert.ok(removeItem);
+    // Every operation must reject with something the user can act on. An
+    // empty list here would read as "this collection has no records".
+    await assert.rejects(() => store.list(), /connect remote-host/i);
+    await assert.rejects(() => store.page(), /connect remote-host/i);
+    await assert.rejects(() => store.read("n1"), /connect remote-host/i);
+    await assert.rejects(() => write("n1", { id: "n1" }), /connect remote-host/i);
+    await assert.rejects(() => removeItem("n1"), /connect remote-host/i);
+  });
+
+  it("publishes a change keyed by the app, and NEVER carrying a root", async () => {
+    writeSkill("notescloud", FIRESTORE_SCHEMA);
+    writeAppManifest();
+    connectFakeFirestore();
+    const published: CollectionChangePayload[] = [];
+    setCollectionChangePublisher((payload) => published.push(payload));
+    const [collection] = await discoverCollections(discoveryOpts());
+    assert.ok(collection);
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    assert.ok(store.write);
+    assert.ok(store.delete);
+    await store.write("n1", { id: "n1", title: "T" });
+    await store.delete("n1");
+    assert.deepEqual(
+      published.map((payload) => ({ ...payload })),
+      [
+        { slug: "notescloud", ids: ["n1"], op: "upsert", aid: APP_ID },
+        { slug: "notescloud", ids: ["n1"], op: "delete", aid: APP_ID },
+      ],
+    );
+    // This payload is relayed to the browser and on into an LLM-generated
+    // custom-view iframe: a filesystem path on it would be a disclosure.
+    for (const payload of published) assert.equal("root" in payload, false);
+    assert.deepEqual(
+      published.map((payload) => collectionChangeKey(payload, workdir)),
+      [
+        { kind: "shared", aid: APP_ID, cid: "notescloud" },
+        { kind: "shared", aid: APP_ID, cid: "notescloud" },
+      ],
+    );
+  });
+
+  it("refuses create over an existing id — the atomicity the store contract requires", async () => {
+    const store = await firestoreStoreFixture();
+    assert.ok(store.write);
+    const conflicted = await store.write("n1", { id: "n1", title: "again" }, { refuseOverwrite: true });
+    assert.equal(conflicted.kind, "conflict");
+    const created = await store.write("n9", { id: "n9", title: "new" }, { refuseOverwrite: true });
+    assert.equal(created.kind, "ok");
   });
 });
 

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -454,6 +454,31 @@ describe("shared (firestore) collections", () => {
     );
   });
 
+  it("names the signed-in address when the app's roster refuses the request", async () => {
+    writeSkill("notescloud", FIRESTORE_SCHEMA);
+    writeAppManifest();
+    // What the SDK actually throws when the rules refuse: a code, and a message
+    // that says nothing about WHO was refused.
+    const denied = Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" });
+    const rejectAll = () => Promise.reject(denied);
+    setFirestoreAccessor(() => ({
+      docs: { list: rejectAll, get: rejectAll, set: rejectAll, create: rejectAll, delete: rejectAll } as unknown as FirestoreDocs,
+      email: "stranger@example.com",
+    }));
+    const [collection] = await discoverCollections(discoveryOpts());
+    assert.ok(collection);
+    const store = storeFor(collection, { workspaceRoot: workdir });
+    const { write, delete: removeItem } = store;
+    assert.ok(write);
+    assert.ok(removeItem);
+    // Every path, not just the one the user happened to be on — and the address
+    // is the fact the app's owner needs in order to fix it.
+    for (const call of [() => store.list(), () => store.page(), () => store.read("n1"), () => write("n1", { id: "n1" }), () => removeItem("n1")]) {
+      await assert.rejects(call, /stranger@example\.com/);
+      await assert.rejects(call, /roster/i);
+    }
+  });
+
   it("refuses create over an existing id — the atomicity the store contract requires", async () => {
     const store = await firestoreStoreFixture();
     assert.ok(store.write);

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -20,6 +20,7 @@ import {
   discoverCollections,
   pageFromFullRead,
   collectionChangeKey,
+  isBackendUnavailable,
   projectItemFields,
   setCollectionChangePublisher,
   setFirestoreAccessor,
@@ -474,8 +475,19 @@ describe("shared (firestore) collections", () => {
     // Every path, not just the one the user happened to be on — and the address
     // is the fact the app's owner needs in order to fix it.
     for (const call of [() => store.list(), () => store.page(), () => store.read("n1"), () => write("n1", { id: "n1" }), () => removeItem("n1")]) {
-      await assert.rejects(call, /stranger@example\.com/);
-      await assert.rejects(call, /roster/i);
+      // ONE rejection, then both assertions against it: two `assert.rejects`
+      // calls would invoke the operation twice and could be satisfied by two
+      // DIFFERENT errors, which is not what this test claims.
+      const error: unknown = await call().then(
+        () => null,
+        (err: unknown) => err,
+      );
+      assert.ok(error, "a denied request must reject");
+      assert.match(String(error), /stranger@example\.com/);
+      assert.match(String(error), /roster/i);
+      // The TYPE matters as much as the words: the layers above catch broadly,
+      // and without this a denial degrades to "no records" (see the store).
+      assert.ok(isBackendUnavailable(error));
     }
   });
 

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -580,6 +580,12 @@ describe("a watch that cannot arm is retried, not marked mounted", () => {
 
 const SHARED_APP_ID = "app_test_7f3a";
 
+// A shared collection's bell is keyed by its APP, not by the root this
+// repository happens to be checked out into — the same obligation seen from two
+// worktrees is one bell. Spelled out here rather than imported, like
+// `legacyIdFor` above: it is a cross-app on-disk format.
+const sharedLegacyIdFor = (slug: string, itemId: string): string => `collection-completion:#${SHARED_APP_ID}\u0000${slug}:${itemId}`;
+
 /** In-memory `FirestoreDocs`, keyed only by document id: these tests never
  *  exercise two collection paths at once, and the path itself is pinned in
  *  test_storeContract.ts. */
@@ -678,14 +684,14 @@ describe("shared collection — declared bells actually run", () => {
 
     await _tickTimeTriggersForTesting(undefined, workdir);
     let legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
-    assert.ok(legacyIds.includes(legacyIdFor(FSB_SLUG, "a")), "pending record must bell");
+    assert.ok(legacyIds.includes(sharedLegacyIdFor(FSB_SLUG, "a")), "pending record must bell");
 
     // The record turns done remotely. Nothing can report that (no `watch`), so
     // only the tick can clear the bell.
     await docs.set("ignored", "a", { id: "a", read: true });
     await _tickTimeTriggersForTesting(undefined, workdir);
     legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
-    assert.ok(!legacyIds.includes(legacyIdFor(FSB_SLUG, "a")), "bell must clear once done");
+    assert.ok(!legacyIds.includes(sharedLegacyIdFor(FSB_SLUG, "a")), "bell must clear once done");
   });
 
   it("survives a closed session — no throw, and it recovers once connected", async () => {
@@ -699,7 +705,7 @@ describe("shared collection — declared bells actually run", () => {
     connectFake(makeFakeDocs([{ id: "a", read: false }]));
     await _tickTimeTriggersForTesting(undefined, workdir);
     const legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
-    assert.ok(legacyIds.includes(legacyIdFor(FSB_SLUG, "a")), "must recover after reconnect");
+    assert.ok(legacyIds.includes(sharedLegacyIdFor(FSB_SLUG, "a")), "must recover after reconnect");
   });
 
   // A failed pass learns nothing, so it must change nothing — least of all
@@ -709,12 +715,12 @@ describe("shared collection — declared bells actually run", () => {
     connectFake(makeFakeDocs([{ id: "a", read: false }]));
     await startForTest();
     await _tickTimeTriggersForTesting(undefined, workdir);
-    assert.ok((await activeCompletionEntries()).map((entry) => entry.legacyId).includes(legacyIdFor(FSB_SLUG, "a")), "precondition: the bell exists");
+    assert.ok((await activeCompletionEntries()).map((entry) => entry.legacyId).includes(sharedLegacyIdFor(FSB_SLUG, "a")), "precondition: the bell exists");
 
     setFirestoreAccessor(null); // the session closes again
     await _tickTimeTriggersForTesting(undefined, workdir);
     assert.ok(
-      (await activeCompletionEntries()).map((entry) => entry.legacyId).includes(legacyIdFor(FSB_SLUG, "a")),
+      (await activeCompletionEntries()).map((entry) => entry.legacyId).includes(sharedLegacyIdFor(FSB_SLUG, "a")),
       "a disconnected tick must leave the previous pass's bells alone",
     );
   });
@@ -735,11 +741,11 @@ describe("shared collection — bells don't outlive their schema", () => {
 
     await _tickTimeTriggersForTesting(undefined, workdir);
     let legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
-    assert.ok(legacyIds.includes(legacyIdFor(FSD_SLUG, "a")), "precondition: the bell exists");
+    assert.ok(legacyIds.includes(sharedLegacyIdFor(FSD_SLUG, "a")), "precondition: the bell exists");
 
     writeSharedSchema(FSD_SLUG); // schema edited — no more completion tracking
     assert.equal(await _syncWatchersForTesting(workdir), true, "a changed schema is a real mutation");
     legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
-    assert.ok(!legacyIds.includes(legacyIdFor(FSD_SLUG, "a")), "bell must not outlive the field that declared it");
+    assert.ok(!legacyIds.includes(sharedLegacyIdFor(FSD_SLUG, "a")), "bell must not outlive the field that declared it");
   });
 });

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -36,9 +36,9 @@ import {
   startCollectionWatchers,
   stopCollectionWatchers,
 } from "../../../server/workspace/collections/watcher.js";
-import { loadCollection, storeFor } from "@mulmoclaude/core/collection/server";
+import { loadCollection, setFirestoreAccessor, storeFor } from "@mulmoclaude/core/collection/server";
 import type { CollectionSchema } from "../../../server/workspace/collections/types.js";
-import type { LoadedCollection } from "@mulmoclaude/core/collection/server";
+import type { FirestoreDoc, FirestoreDocs, LoadedCollection } from "@mulmoclaude/core/collection/server";
 
 let workdir: string;
 let userDir: string;
@@ -113,6 +113,9 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await stopCollectionWatchers();
+  // Module-level state: a fixture's fake left wired would let a shared
+  // collection resolve in a later test that never set one up.
+  setFirestoreAccessor(null);
   rmSync(workdir, { recursive: true, force: true });
   rmSync(userDir, { recursive: true, force: true });
   rmSync(notifierDir, { recursive: true, force: true });
@@ -565,5 +568,178 @@ describe("a watch that cannot arm is retried, not marked mounted", () => {
 
     const legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
     assert.deepEqual(legacyIds, [legacyIdFor(SLUG, "a")], "and its boot reconcile must bell the pending item");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared (firestore-backed) collections. Their store implements no `watch`, so
+// nothing ever reports that their records moved — the clock tick has to stand
+// in for the store-change path. These pin that it does, and that a closed
+// session stays an ordinary state rather than an error or a data loss.
+// ---------------------------------------------------------------------------
+
+const SHARED_APP_ID = "app_test_7f3a";
+
+/** In-memory `FirestoreDocs`, keyed only by document id: these tests never
+ *  exercise two collection paths at once, and the path itself is pinned in
+ *  test_storeContract.ts. */
+function makeFakeDocs(seed: Record<string, unknown>[]): FirestoreDocs {
+  const rows = new Map<string, unknown>(seed.map((record) => [record.id as string, record]));
+  return {
+    list: () => {
+      const entries: FirestoreDoc[] = [...rows.entries()].map(([docId, data]) => ({ id: docId, data }));
+      entries.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+      return Promise.resolve(entries);
+    },
+    get: (_path, docId) => Promise.resolve(rows.get(docId) ?? null),
+    set: (_path, docId, data) => {
+      rows.set(docId, data);
+      return Promise.resolve();
+    },
+    create: (_path, docId, data) => {
+      if (rows.has(docId)) return Promise.resolve(false);
+      rows.set(docId, data);
+      return Promise.resolve(true);
+    },
+    delete: (_path, docId) => Promise.resolve(rows.delete(docId)),
+  };
+}
+
+function connectFake(docs: FirestoreDocs): void {
+  setFirestoreAccessor(() => ({ docs, email: "owner@example.com" }));
+}
+
+function writeSharedSchema(slug: string, extra: Record<string, unknown> = {}): void {
+  writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid: SHARED_APP_ID }));
+  const skillDir = path.join(workdir, ".claude/skills", slug);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(path.join(skillDir, "SKILL.md"), `---\nname: ${slug}\ndescription: test\n---\nbody\n`);
+  writeFileSync(
+    path.join(skillDir, "schema.json"),
+    JSON.stringify({
+      title: "Cloud",
+      icon: "cloud",
+      storage: { type: "firestore" },
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        read: { type: "boolean", label: "Read", required: true },
+      },
+      ...extra,
+    }),
+  );
+}
+
+const BELLS = { completionField: "read", completionDoneValues: ["true"] };
+
+const startForTest = () =>
+  startCollectionWatchers({
+    discoveryOpts: { workspaceRoot: workdir, userSkillsDir: userDir },
+    rediscoveryIntervalMs: null,
+    triggerTickIntervalMs: null,
+  });
+
+describe("shared collection — the watcher set stays quiet", () => {
+  const FS_SLUG = "test-watcher-firestore";
+
+  // A collection with no file to watch is still MOUNTED (a store without
+  // `watch` registers, just without live updates). Were it not, every
+  // rediscovery poll would try to mount it again, report a mutation, and sweep
+  // — a permanent 30 s sweep loop.
+  it("does not report a mutation on repeat ticks (no permanent sweep loop)", async () => {
+    writeSharedSchema(FS_SLUG);
+    connectFake(makeFakeDocs([]));
+    await startForTest();
+    assert.equal(await _syncWatchersForTesting(workdir), false, "first quiet tick must not sweep");
+    assert.equal(await _syncWatchersForTesting(workdir), false, "second quiet tick must not sweep");
+  });
+
+  it("still reports a mutation when a watchable collection really appears", async () => {
+    writeSharedSchema(FS_SLUG);
+    connectFake(makeFakeDocs([]));
+    await startForTest();
+    assert.equal(await _syncWatchersForTesting(workdir), false);
+    writeSchema(buildSchema());
+    assert.equal(await _syncWatchersForTesting(workdir), true, "a newly mounted watcher must still sweep");
+  });
+});
+
+describe("shared collection — declared bells actually run", () => {
+  const FSB_SLUG = "test-watcher-fs-bell";
+
+  // Without `tickUnwatchedCollections`, a shared collection declaring
+  // `completionField` would validate and then silently do nothing: no change
+  // event ever arrives, so nothing re-derives its bells.
+  it("bells a pending record via the clock tick, and clears it when done", async () => {
+    writeSharedSchema(FSB_SLUG, BELLS);
+    const docs = makeFakeDocs([{ id: "a", read: false }]);
+    connectFake(docs);
+    await startForTest();
+
+    await _tickTimeTriggersForTesting(undefined, workdir);
+    let legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(legacyIds.includes(legacyIdFor(FSB_SLUG, "a")), "pending record must bell");
+
+    // The record turns done remotely. Nothing can report that (no `watch`), so
+    // only the tick can clear the bell.
+    await docs.set("ignored", "a", { id: "a", read: true });
+    await _tickTimeTriggersForTesting(undefined, workdir);
+    legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(!legacyIds.includes(legacyIdFor(FSB_SLUG, "a")), "bell must clear once done");
+  });
+
+  it("survives a closed session — no throw, and it recovers once connected", async () => {
+    writeSharedSchema(FSB_SLUG, BELLS);
+    setFirestoreAccessor(null); // no remote-host session
+    await startForTest();
+    // A disconnected session is an ordinary state: the tick must not reject.
+    await assert.doesNotReject(() => _tickTimeTriggersForTesting(undefined, workdir));
+    assert.equal((await activeCompletionEntries()).length, 0);
+
+    connectFake(makeFakeDocs([{ id: "a", read: false }]));
+    await _tickTimeTriggersForTesting(undefined, workdir);
+    const legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(legacyIds.includes(legacyIdFor(FSB_SLUG, "a")), "must recover after reconnect");
+  });
+
+  // A failed pass learns nothing, so it must change nothing — least of all
+  // clear bells a successful pass derived.
+  it("a failed pass after a successful one does not wipe what the successful one derived", async () => {
+    writeSharedSchema(FSB_SLUG, BELLS);
+    connectFake(makeFakeDocs([{ id: "a", read: false }]));
+    await startForTest();
+    await _tickTimeTriggersForTesting(undefined, workdir);
+    assert.ok((await activeCompletionEntries()).map((entry) => entry.legacyId).includes(legacyIdFor(FSB_SLUG, "a")), "precondition: the bell exists");
+
+    setFirestoreAccessor(null); // the session closes again
+    await _tickTimeTriggersForTesting(undefined, workdir);
+    assert.ok(
+      (await activeCompletionEntries()).map((entry) => entry.legacyId).includes(legacyIdFor(FSB_SLUG, "a")),
+      "a disconnected tick must leave the previous pass's bells alone",
+    );
+  });
+});
+
+describe("shared collection — bells don't outlive their schema", () => {
+  const FSD_SLUG = "test-watcher-fs-drop";
+
+  // Removing `completionField` drops the collection out of the reconcile set
+  // at once, so the bell has to be cleared by something. For a shared
+  // collection that something is the rediscovery pass — `reconcileChangedSchemas`
+  // sees the schema move and pairs it with a sweep, exactly as it does for
+  // every other backend. The clock tick deliberately does NOT duplicate it.
+  it("clears bells when completionField is removed from the schema", async () => {
+    writeSharedSchema(FSD_SLUG, BELLS);
+    connectFake(makeFakeDocs([{ id: "a", read: false }]));
+    await startForTest();
+
+    await _tickTimeTriggersForTesting(undefined, workdir);
+    let legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(legacyIds.includes(legacyIdFor(FSD_SLUG, "a")), "precondition: the bell exists");
+
+    writeSharedSchema(FSD_SLUG); // schema edited — no more completion tracking
+    assert.equal(await _syncWatchersForTesting(workdir), true, "a changed schema is a real mutation");
+    legacyIds = (await activeCompletionEntries()).map((entry) => entry.legacyId);
+    assert.ok(!legacyIds.includes(legacyIdFor(FSD_SLUG, "a")), "bell must not outlive the field that declared it");
   });
 });


### PR DESCRIPTION
## Summary

`storage: { "type": "firestore" }` を宣言したコレクションのレコードを
`apps/{aid}/collections/{cid}/items/{id}` に読み書きする `CollectionStore` を追加します。
**スキーマとビューは git のまま、レコードだけが Firestore に移ります。**

共有コレクション計画（`../mulmoterminal` `plans/feat-shareable-collections.md`）の**実装順 3**。
実装順 1（`CollectionKey`、#2855、core 3.5.0）と 2（Firestore ルール、mulmoserver#155、emulator で実行確認済み）の上に乗ります。
引き継ぎプラン: mulmoterminal#1616（未決事項 3 点の判断もそこに書き戻しました）。

ドラフト PR #2209 の機構を再利用していますが、**同一性とパスと安全論拠が別物**なので、そちらは置き換えになります。

## Items to Confirm / Review

- **守っているものが変わりました。** #2209 は `users/{uid}/…` に書き、デプロイ済みルール `users/{uid}/{document=**}` に頼っていたので「スキーマにパスを書かせない」が安全論拠でした。共有では成り立ちません — `aid` はクローンした誰でも編集できるリポジトリにコミットされます。読み書きを認可するのは**アプリの名簿**で、ルールは `request.auth.token.email` を `apps/{aid}.members` に照合します。**パスの計算は 1 行ですが、論拠の入れ替えは全ファイルに及びます**（`firestoreStore.ts` / `host.ts` / `schemaZ.ts` / `discovery.ts`）。古い論拠が 1 つでも残っていたら指摘してください
- **`FirestoreHandle` から `uid` を落として `{ docs, email }` にしました。** ルールは `uid` を 1 度も評価しません。残せば必ずパスを再導出されるので落としています。`email` は失敗文言のため — `permission-denied` は共有で最も出る失敗なのに最も情報が無く、「`a@b.jp` としてサインインしています」が言えるかどうかで質が変わります
- **`aid` は discovery が解決し、store は `app.json` を読みません。** read path で読ませると、キャッシュ・失効・ファイルが無いときの扱いをそこで決めることになり、そこでの安い答えは「何も返さない」なので、**設定ミスが「空のコレクション」としてユーザーに届きます**。無い / 不正な `aid` は discovery が理由つきでスキーマを拒否します
- **ホストの binding では渡していません。** MT の server プロセスは複数のプロジェクトルートを同時に扱うので、プロセスグローバルな `aid` はどのリポジトリのコレクションも同じアプリに向けます
- **レコードはドキュメントそのものです（`{ data }` で包みません）。** #2209 はラップしていましたが、ルールは `request.resource.data.<field>` / `resource.data[s.idField]` を直接読むので、1 段深くすると必須項目検査も状態機械も「自分の行」判定も**全部 fail closed** します。共有レコードの形は認可契約の一部です
- **未接続は空に縮退させません。** 沈黙は「レコードが無い」と区別できず、データ消失に見えます。ファクトリは throw せず（一覧画面を巻き添えにしないため）、各メソッドが実行可能な文言で失敗します
- **フェイクの忠実度。** 契約テストはインメモリのフェイクで通しています。ドキュメント保存と create の原子性はモデル化していますが、**Firestore の整合性モデル・セキュリティルール・リスナー挙動は再現していません。実接続の検証は未実施です**

## 決めたこと（プラン側に書き戻し済み）

| 未決だった点 | 判断 |
| --- | --- |
| `aid` の出所 | core の最小ローダが `<root>/app.json` から読み、**discovery が 1 回解決**して `LoadedCollection.appId` に載せる |
| `uid` | **落とす**。`FirestoreHandle` は `{ docs, email }` |
| `cid` | **常に slug**。schema にキーを持たせない（firestore バリアントは `.strict()` で `path` も `cid` も拒否） |

あわせて「**匿名申込は許さない**」というオーナー判断を記録しました。**ルールは変えていません**（3 段階を表現できる状態でデプロイ済みの凍結インフラ）— 制約は publish の事前検証（実装順 5）とリンター（18）が宣言側で拒否する形に置きます。

## 実装

| 場所 | 変更 |
| --- | --- |
| `collection/core/schemaZ.ts` | `StorageZ` を判別共用体化（firestore アームは `.strict()`、path なし） |
| `collection/server/appManifest.ts` | **新規** — `<root>/app.json` の `aid` だけ読む。名前規則は `isValidCollectionName` |
| `collection/server/discovery.ts` | `acceptStorageSchema()` を抽出。firestore は `storageFile` ではなく**同一性**を解決する |
| `collection/server/firestoreDocs.ts` | **新規** — SDK との継ぎ目。`orderBy("__name__")`、create/delete はトランザクション |
| `collection/server/firestoreStore.ts` | **新規** — `CollectionStore` 実装。`sharedItemsPath` は鍵しか受け取らない |
| `collection/server/host.ts` | `FirestoreHandle` / `setFirestoreAccessor` |
| `collection/server/delete.ts` | 共有コレクションの削除を拒否（出口はプロジェクト管理者の再帰削除） |
| `collection-watchers/watcher.ts` | `watch` を持たない store のために clock tick が全再導出 + sweep |
| `server/workspace/collections/firestoreBinding.ts` | **新規** — remote-host セッションへの配線 |

`cannotReportChanges()` は**バックエンドではなく能力**を問う形なので、実装順 6 で `watch` が生えれば watcher を触らずに特別扱いが消えます。

## テスト

**API キー無し・ネットワーク無しで走ります**（`FirestoreDocs` の継ぎ目にインメモリ fake を注入）。

| ケース | 検証 |
| --- | --- |
| store contract | 5 本目の fixture として既存の契約アサーションを全て素通し |
| パス | `apps/<aid>/collections/<cid>/items` であること。**鍵を経由しない組み立てが作れないこと**（不正な `aid` / `cid` は throw） |
| 可用性 | セッション無しで全操作が実行可能な文言で reject。**空配列を返さない**。ファクトリは throw しない |
| 変更通知 | `collectionChangeKey` が `{kind:"shared", aid, cid}` を返し、**`root` が絶対に載らない**（このペイロードはブラウザ、さらに LLM 生成の iframe に届く） |
| スキーマ受理 | `storageFile` が解決されない。`path` / `cid` は検証エラー。`aid` 無しは discovery が拒否。sqlite 回帰 |
| clock tick | ベルが立ち、done で消える。切断中は throw せず何も変えない。復帰で回復 |

## 検証

`yarn format` / `lint`(0 errors) / `typecheck` / `build` / `test`(fail 0) / `check:launcher-sync` / `check-changelog-ships.mjs` すべて green。

**実 Firestore への接続テストは未実施です。** 動作確認をお願いします。

## core の bump

`@mulmoclaude/core` を **3.6.0** に上げ、launcher の dep range と CHANGELOG の Ships 行を lockstep で更新しました。`google-plugin` の `^3.5.0` は ratchet ルール（core の bump で plugin の range を追わない）に従い据え置きです。

Refs #2196, #2197, receptron/mulmoserver#155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Add Firestore-backed shared collection storage and bind it to the remote-host session, including discovery, store, and watcher support, plus core version bump.

New Features:
- Introduce a Firestore-based CollectionStore that persists shared collection records as documents under apps/{aid}/collections/{cid}/items.
- Add app manifest support so repositories declare an app id in app.json, used to identify shared collections.
- Expose a Firestore adapter subpath and server binding that connects shared collections to the current remote-host Firestore session.

Enhancements:
- Extend collection discovery, schema validation, and LoadedCollection metadata to support discriminated storage backends and shared (firestore) collections.
- Update collection watchers to handle stores without watch capabilities by reconciling shared collections on clock ticks and sweeping stale completion entries.
- Improve delete workflows and restore documentation to recognize and explicitly refuse deletion of shared collections while documenting their record location.
- Augment collection help and error recovery documentation with guidance for configuring and troubleshooting firestore-backed shared collections.

Build:
- Add a dedicated collection/firestore entry point and build target that encapsulates the Firestore SDK-dependent adapter while keeping the main server entry Firebase-optional.

Documentation:
- Update collection skills and error recovery docs to describe firestore-based shared storage, app.json requirements, remote-host connectivity expectations, and authorization behavior.

Tests:
- Add comprehensive tests for Firestore-backed shared collections, app manifest parsing, store contract behavior, watcher behavior, and clock-tick reconciliation using in-memory Firestore fakes.

Chores:
- Bump @mulmoclaude/core to version 3.6.0 and align MulmoClaude dependencies and changelog Ships line with the new core release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Firestore-backed shared collections with authenticated remote storage.
  * Added app configuration, collection discovery, document operations, and remote change reconciliation.
  * Added a dedicated Firestore integration entry point and app-scoped change notifications.
* **Bug Fixes**
  * Improved handling of disconnected sessions, invalid configuration, authorization failures, watcher recovery, and unsupported shared-collection deletion.
* **Documentation**
  * Added setup, storage, lifecycle, authorization, troubleshooting, and recovery guidance for Firestore collections.
* **Chores**
  * Updated the core package to version 3.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->