### PR TITLE
feat(collections): 共有アプリの publish（git → Firestore）

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,9 +8,62 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Added
+
+#### Publishing a shared app: `manageCollection` action `publishApp`
+
+A repository that declares a shared app (`app.json` + collections with
+`storage.type: "firestore"`) can now publish it — the member roster, the public
+read/submit configuration, and every shared collection's schema — to
+`apps/{aid}` in Firestore, where the deployed security rules read it.
+
+Publishing is the one operation in the collection surface that changes what
+every member sees the moment it runs, so the action is built as a gate rather
+than an upload:
+
+- **The declaration is compiled, not copied.** `app.json` is what a human
+  writes; the Firestore document is what the rules read, and the differences
+  are stated in one place (`publishProject.ts`). The load-bearing one is the
+  submit window: authored as ISO strings, published as epoch millis, because
+  the rules do not coerce a string to a timestamp — comparing one with
+  `request.time` is a type error, which denies, so an ISO string that reached
+  Firestore would present as "nobody can submit" with nothing saying why.
+  `memberEmails` is likewise derived from `members`, never authored.
+- **It refuses declarations that are silently permissive** — chiefly a
+  submission bound to its submitter (`idFrom: "auth.uid"`, `emailField`,
+  `audience: "participant"`) in a collection that does not declare
+  `submitOnly`, which is the difference between "the submitter said this" and
+  "someone with a writer role said this on their behalf".
+- **It refuses declarations that would silently deny everyone** — an
+  `initialStatus` with no `statusField`, a required field outside
+  `createFields`, a mail transition the state machine forbids. Each of these
+  produces a permission denial that carries no explanation to the person
+  hitting it.
+- **It refuses to publish over live records the new schemas would break**,
+  listing them, until the caller passes `confirm`.
+- **It signs what it writes** (`publishedBy` / `publishedCommit` /
+  `publishedAt`, plus `publishedDirty` when the working tree was modified) and
+  keeps the previous app document in `previousPublished` for rollback.
+
+CI publishing is deliberately not included: an owner-role service account is a
+new kind of principal in a permission model that currently assumes the roster
+is people.
+
+### Changed
+
+- **`FirestoreHandle` now carries `uid`** alongside `email`
+  (`@mulmoclaude/core/collection/server`). The roster is keyed by email and
+  every record operation resolves a role from it, but the app document's
+  `owner` is a uid — the rules require `owner == request.auth.uid` when an app
+  is created — so a session that can read and write records still could not
+  create an app. Required rather than optional so the gap is a compile error
+  instead of a permission denial that says nothing about identity. **Breaking
+  for a host that calls `setFirestoreAccessor`**; MulmoClaude's binding is
+  updated here, and MulmoTerminal binds no accessor.
+
 ### Package releases
 
-Ships `@mulmoclaude/core@3.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.7.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/host.ts
+++ b/packages/core/src/collection/server/host.ts
@@ -141,6 +141,17 @@ export interface CollectionHost {
 export interface FirestoreHandle {
   docs: FirestoreDocs;
   email: string;
+  /** The signed-in Firebase uid.
+   *
+   *  The EMAIL is the principal the roster is keyed by, and it is what every
+   *  record operation needs. The uid is needed by exactly one caller —
+   *  `publish` — because the app document's `owner` is a uid: the rules
+   *  require `owner == request.auth.uid` when the app is created and require
+   *  it unchanged afterwards. Required rather than optional so a host cannot
+   *  wire a session that can read and write records but silently cannot
+   *  create an app; the failure would surface as a permission denial with
+   *  nothing in it about identity. */
+  uid: string;
 }
 
 /** A collection's records changed on disk. Carries the `slug` so the host can

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -66,6 +66,31 @@ export {
 export type { FirestoreDoc, FirestoreDocs } from "./firestoreDocs";
 export { sharedItemsPath } from "./firestoreStore";
 export { loadAppManifest, parseAppManifest, appManifestReason, APP_MANIFEST_FILE, type AppManifest, type AppManifestResult } from "./appManifest";
+// publish (git -> Firestore). `publishManifest` reads the parts of `app.json`
+// that `appManifest` deliberately does not; `publishProject` is the whole
+// authored -> published conversion; `publishChecks` is what publish refuses.
+export {
+  AuthoredAppZ,
+  parseAuthoredApp,
+  APP_ROLES,
+  type AuthoredApp,
+  type AuthoredCollectionConfig,
+  type AuthoredMail,
+  type AuthoredSubmit,
+} from "./publishManifest";
+export {
+  projectApp,
+  APPS_COLLECTION,
+  PUBLIC_CONFIG_DOC,
+  appConfigPath,
+  appSchemasPath,
+  type PublishStamp,
+  type PublishedApp,
+  type PublishedConfigDoc,
+  type PublishedSchemaDoc,
+} from "./publishProject";
+export { publishProblems, bindsSubmitterIdentity } from "./publishChecks";
+export { publishApp, type PublishOptions, type PublishResult } from "./publish";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";
 export * from "./templatePath";

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -89,7 +89,7 @@ export {
   type PublishedConfigDoc,
   type PublishedSchemaDoc,
 } from "./publishProject";
-export { publishProblems, bindsSubmitterIdentity } from "./publishChecks";
+export { publishProblems, bindsSubmitterIdentity, type PublishableCollection } from "./publishChecks";
 export { publishApp, type PublishOptions, type PublishResult } from "./publish";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -471,7 +471,13 @@ async function handlePublishApp(deps: ManageCollectionDeps, confirm: boolean): P
   const result = await publishApp({ ...deps, confirm });
   if (!result.ok) {
     const bullets = result.problems.map((problem) => `- ${problem}`).join("\n");
-    return `publish refused — nothing was written:\n${bullets}`;
+    // "nothing was written" is true of nearly every failure, and it is most of
+    // what a refusal is worth saying. It is NOT true of a write that failed
+    // part-way, and printing it there would tell the caller the app is
+    // untouched while its roster is already live — the one case where being
+    // wrong sends someone to look at the wrong thing.
+    const headline = result.partial ? "publish FAILED PART-WAY — some documents are already live:" : "publish refused — nothing was written:";
+    return `${headline}\n${bullets}`;
   }
   const dirtyNote = result.dirty ? " (WORKING TREE DIRTY — the commit does not describe what was published)" : "";
   const stamp = result.commit ? `commit ${result.commit.slice(0, 12)}${dirtyNote}` : "no commit (not a git repository, or no HEAD)";

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -475,10 +475,13 @@ async function handlePublishApp(deps: ManageCollectionDeps, confirm: boolean): P
   }
   const dirtyNote = result.dirty ? " (WORKING TREE DIRTY — the commit does not describe what was published)" : "";
   const stamp = result.commit ? `commit ${result.commit.slice(0, 12)}${dirtyNote}` : "no commit (not a git repository, or no HEAD)";
+  // "at least" when the scan hit its per-collection cap. The refusal path
+  // already says so, and the confirmed path is the one where saying otherwise
+  // costs something: the records are published over, and an understated count
+  // is an understated repair.
+  const brokenCount = result.recordIssuesCapped ? `at least ${result.recordIssues}` : `${result.recordIssues}`;
   const forced =
-    result.recordIssues > 0
-      ? ` Published over ${result.recordIssues} record(s) that do not satisfy the new schema — repair them now; members are reading them.`
-      : "";
+    result.recordIssues > 0 ? ` Published over ${brokenCount} record(s) that do not satisfy the new schema — repair them now; members are reading them.` : "";
   return (
     `${result.created ? "Created" : "Updated"} app '${result.aid}' and published ${result.cids.length} collection(s): ${result.cids.join(", ")}. ` +
     `Signed ${stamp}. The previous app document is kept in \`previousPublished\` for rollback.${forced}`

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -59,6 +59,7 @@ import { isBackendUnavailable } from "./backendAvailability";
 import { runCollectionQuery } from "./queryRunner";
 import { enrichItems } from "./derive";
 import { validateCollectionRecords, validateRecordObject } from "./validate";
+import { publishApp } from "./publish";
 import { buildWorkspaceOntology } from "./ontology";
 import { resolveDataDir } from "./paths";
 import { getWorkspaceRoot, stagingSkillDir } from "./host";
@@ -455,6 +456,35 @@ async function handleGetOntology(deps: ManageCollectionDeps): Promise<string> {
   return JSON.stringify({ count: collections.length, collections });
 }
 
+/** Publish this repository's `app.json` + shared schemas to its Firestore app.
+ *
+ *  Named as a whole-app action because it IS one: publish takes the repository
+ *  as its unit (one roster, one public config, every shared collection), so it
+ *  carries no `slug` and refusing one is not a limitation to work around.
+ *
+ *  The reply is prose rather than a status code on purpose. This is the one
+ *  operation in the collection surface that changes what every member sees the
+ *  moment it lands, and the two things the caller has to relay — what will
+ *  break, and that `confirm` is how it proceeds anyway — are sentences, not
+ *  fields. */
+async function handlePublishApp(deps: ManageCollectionDeps, confirm: boolean): Promise<string> {
+  const result = await publishApp({ ...deps, confirm });
+  if (!result.ok) {
+    const bullets = result.problems.map((problem) => `- ${problem}`).join("\n");
+    return `publish refused — nothing was written:\n${bullets}`;
+  }
+  const dirtyNote = result.dirty ? " (WORKING TREE DIRTY — the commit does not describe what was published)" : "";
+  const stamp = result.commit ? `commit ${result.commit.slice(0, 12)}${dirtyNote}` : "no commit (not a git repository, or no HEAD)";
+  const forced =
+    result.recordIssues > 0
+      ? ` Published over ${result.recordIssues} record(s) that do not satisfy the new schema — repair them now; members are reading them.`
+      : "";
+  return (
+    `${result.created ? "Created" : "Updated"} app '${result.aid}' and published ${result.cids.length} collection(s): ${result.cids.join(", ")}. ` +
+    `Signed ${stamp}. The previous app document is kept in \`previousPublished\` for rollback.${forced}`
+  );
+}
+
 /** Return the collection-authoring reference (`collection-skills.md`),
  *  rendered by `renderSchemaDocs` — the full doc overflows the agent's
  *  per-result limit, so the default reply is the core guide + a table of
@@ -606,6 +636,7 @@ const MANAGE_COLLECTION_PROMPT =
   "`putItems` validates every row against the schema before writing (required fields, enum values, primaryKey = record id) and returns `{ written, rejected }`; fix each rejected row using its `problem` text and retry just those rows. Never include computed fields in a row you write. " +
   'To update a few fields of an existing record, use `mode: "merge"` with a partial row ({ id, <changed fields> }) — the default upsert replaces the WHOLE record, so a partial upsert would silently erase every optional field it omits. ' +
   "`deleteItems` removes records by id and returns `{ deleted, rejected }`; an id that doesn't exist comes back rejected rather than counted as deleted, so check `rejected` before reporting a deletion as done. " +
+  "`publishApp` publishes the whole repository — its `app.json` (member roster, public read/submit configuration) and every shared collection's schema — to the app's Firestore. It is the ONE operation here that changes what every member sees the moment it runs, and it cannot be undone by reverting a commit: publishing again is the only undo (the previous app document is kept as `previousPublished`). Call it when the user asks to publish, invite, or open an app; never as a follow-up to an edit the user did not ask you to ship. Its refusals are the product, not an obstacle — relay them verbatim, and do not work around one by rewriting `app.json` until the user has said what they actually want. If it reports live records the new schemas would break, show the user that list and ask before re-running with `confirm`. " +
   "Answer aggregation questions (counts, sums, averages, group-bys) with `queryItems` on ANY collection — on a dataSource (CSV) collection it scans the whole file (getItems is row-capped, so aggregates computed from its output can be silently wrong on large files); on a file-backed collection it aggregates the enriched records, so computed fields (derived/rollup/toggle) are queryable columns.";
 
 /** Validate getItems' optional `ids`/`fields` args, then delegate. */
@@ -653,12 +684,13 @@ async function dispatchManageCollection(deps: ManageCollectionDeps, args: Record
   const action = typeof args.action === "string" ? args.action : "";
   if (action === "schemaDocs") return handleSchemaDocs(deps, typeof args.topic === "string" ? args.topic : undefined);
   if (action === "getOntology") return handleGetOntology(deps);
+  if (action === "publishApp") return handlePublishApp(deps, args.confirm === true);
   const slug = typeof args.slug === "string" ? args.slug.trim() : "";
   if (!slug) return "manageCollection: `slug` is required (the collection's slug).";
   if (action === "getSchema") return handleGetSchema(slug, deps);
   if (action === "putSchema") return handlePutSchema(slug, args.schema, deps);
   if (!RECORD_ACTIONS.has(action)) {
-    return 'manageCollection: `action` must be "getItems", "putItems", "deleteItems", "queryItems", "getOntology", "schemaDocs", "getSchema", or "putSchema".';
+    return 'manageCollection: `action` must be "getItems", "putItems", "deleteItems", "queryItems", "getOntology", "schemaDocs", "getSchema", "putSchema", or "publishApp".';
   }
   const collection = await loadCollection(slug, deps);
   if (!collection) return unknownCollection(slug);
@@ -670,13 +702,13 @@ async function dispatchManageCollection(deps: ManageCollectionDeps, args: Record
 const MANAGE_COLLECTION_DEFINITION = {
   name: "manageCollection",
   description:
-    "Read and write a schema-driven collection through the host — both its records and its structure. getItems returns records WITH computed values (derived formulas, toggles, embeds) the stored JSON files don't contain; putItems validates each row against the schema before writing; deleteItems removes records by id. getOntology maps the whole workspace: every collection with its record count and outbound ref/embed relations — call it first for cross-collection questions. schemaDocs returns the collection-authoring reference — the core guide plus a table of contents by default; pass `topic` for a specific section. getSchema/putSchema read and validate-then-write the collection's schema.json. Prefer it over raw file I/O on collections.",
+    "Read and write a schema-driven collection through the host — both its records and its structure. getItems returns records WITH computed values (derived formulas, toggles, embeds) the stored JSON files don't contain; putItems validates each row against the schema before writing; deleteItems removes records by id. getOntology maps the whole workspace: every collection with its record count and outbound ref/embed relations — call it first for cross-collection questions. schemaDocs returns the collection-authoring reference — the core guide plus a table of contents by default; pass `topic` for a specific section. getSchema/putSchema read and validate-then-write the collection's schema.json. publishApp publishes the repository's app.json + shared schemas to Firestore, where every member sees them immediately -- it refuses declarations that would be silently permissive or silently deny everyone, and refuses to publish over records the new schemas would break unless `confirm` is set. Prefer it over raw file I/O on collections.",
   inputSchema: {
     type: "object",
     properties: {
       action: {
         type: "string",
-        enum: ["getItems", "putItems", "deleteItems", "queryItems", "getOntology", "schemaDocs", "getSchema", "putSchema"],
+        enum: ["getItems", "putItems", "deleteItems", "queryItems", "getOntology", "schemaDocs", "getSchema", "putSchema", "publishApp"],
         description: "What to do.",
       },
       slug: {
@@ -709,6 +741,11 @@ const MANAGE_COLLECTION_DEFINITION = {
         type: "object",
         description:
           "putSchema: the full collection schema object (same shape as schema.json — title, icon, dataPath, primaryKey, fields, …). Call getSchema first for the current one, and schemaDocs for the field DSL.",
+      },
+      confirm: {
+        type: "boolean",
+        description:
+          "publishApp: publish even though existing records fail the schemas being published. Omit it first — the refusal lists what would break, and that list is the thing to show the user before asking.",
       },
       topic: {
         type: "string",

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -293,7 +293,27 @@ async function writePublished(
   issues: { records: number; capped: boolean },
 ): Promise<PublishResult> {
   const { aid } = authored;
-  const existing = await handle.docs.get(APPS_COLLECTION, aid);
+  // The preflight read is a backend call like any other, and it decides two
+  // things the rules care about: whether `owner` is stamped or carried
+  // forward, and what `previousPublished` holds. A rejection here — permission,
+  // network, quota — must become the documented result rather than escape as a
+  // raw exception: `manageCollectionHandler` only translates
+  // `BackendUnavailableError`, so anything else reaches the agent as a tool
+  // crash. It happens before any write, which is the one thing the caller most
+  // needs told.
+  let existing: unknown;
+  try {
+    existing = await handle.docs.get(APPS_COLLECTION, aid);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      problems: [
+        `publish failed while reading the current app document (apps/${aid}): ${reason}`,
+        "Nothing was written. Publishing again is safe — this read only decides whether the app is created or updated.",
+      ],
+    };
+  }
   const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
   const stamp: PublishStamp = {
     uid: handle.uid,

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -231,40 +231,62 @@ function declarationProblems(app: AuthoredApp, collections: LoadedCollection[], 
  *
  *  Returns null when everything was written; a failure result otherwise.
  *
- *  A raw rejection here would reach the agent as a tool crash rather than as
- *  the actionable text this tool promises — and it would do so having possibly
- *  written the app document already, which is the one fact the caller most
- *  needs. So the step is named in the message: a publish that stopped after
- *  the app document is a live roster with last publish's schemas, and the fix
- *  is to publish again rather than to guess. */
+ *  A raw rejection here would reach the agent as a tool crash rather than the
+ *  actionable text this tool promises. But "actionable" is a strong claim for
+ *  a half-finished publish, so the message ENUMERATES what landed rather than
+ *  summarising it: the order is app → every schema → config, and a summary
+ *  written for one failure point is wrong at the others. Saying "the roster
+ *  and configuration are live" after a SCHEMA write failed names a config
+ *  document this publish never wrote — which still holds whatever the last
+ *  publish left, and is exactly the state the caller is trying to repair. */
 async function writeDocuments(handle: NonNullable<ReturnType<typeof firestoreHandle>>, aid: string, published: PublishedApp): Promise<PublishResult | null> {
   const steps: { what: string; run: () => Promise<void> }[] = [
     { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, published.app) },
     ...published.schemas.map(({ cid, doc }) => ({ what: `the published schema for '${cid}'`, run: () => handle.docs.set(appSchemasPath(aid), cid, doc) })),
-    { what: "the public config document", run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, published.config) },
+    {
+      what: `the public config document (apps/${aid}/config/${PUBLIC_CONFIG_DOC})`,
+      run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, published.config),
+    },
   ];
+  const landed: string[] = [];
   for (const [index, step] of steps.entries()) {
     try {
       await step.run();
+      landed.push(step.what);
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
-      const already =
-        index === 0
-          ? "Nothing was written."
-          : `Everything before it WAS written — the app's roster and configuration are already live while ${index === steps.length - 1 ? "the public config is" : "the remaining documents are"} one publish behind.`;
       return {
         ok: false,
         // The whole reason the flag exists: this is the one failure where
         // documents ARE live.
         partial: index > 0,
+        // The failed step belongs to "not written" — it is the first thing
+        // that did not land, and leaving it out of the list left the sentence
+        // empty when the LAST step failed.
         problems: [
           `publish failed while writing ${step.what}: ${reason}`,
-          `${already} Publishing again is the repair: the write is idempotent, and it re-does the steps that did not land.`,
+          ...partialState(landed, [step.what, ...steps.slice(index + 1).map((rest) => rest.what)]),
         ],
       };
     }
   }
   return null;
+}
+
+/** What is live and what is not, listed rather than summarised.
+ *
+ *  Two facts, and both matter for the repair: a document this publish wrote is
+ *  live NOW, and a document it did not write still holds what the LAST publish
+ *  left — which is not the same as being absent, and not the same as matching
+ *  the declaration that was just half-applied. */
+function partialState(landed: readonly string[], notWritten: readonly string[]): string[] {
+  const repair = "Publishing again is the repair: the write is idempotent, and it re-does every step, including the ones that did land.";
+  if (landed.length === 0) return [`Nothing was written. ${repair}`];
+  return [
+    `Written by this publish, and live now: ${landed.join("; ")}.`,
+    `NOT written: ${notWritten.join("; ")} — ${notWritten.length === 1 ? "it still holds" : "they still hold"} whatever the previous publish left.`,
+    repair,
+  ];
 }
 
 /** Publish this repository's declaration to its app.

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -70,7 +70,16 @@ export type PublishResult =
       created: boolean;
       commit?: string | undefined;
       dirty: boolean;
+      /** How many live records the pre-check found that the published schemas
+       *  reject — and whether that number is a FLOOR.
+       *
+       *  `validateCollectionRecords` stops at its own cap per collection, so a
+       *  full batch means "at least this many". The count and the cap travel
+       *  together because they are read together: a caller that reports the
+       *  number without the flag understates how much repair is owed, on the
+       *  one path (a confirmed publish) where the damage is already done. */
       recordIssues: number;
+      recordIssuesCapped: boolean;
       published: PublishedApp;
     };
 
@@ -107,9 +116,10 @@ async function sharedCollections(opts: DiscoveryOptions): Promise<LoadedCollecti
  *  a refusal the publisher can override, because a breaking change is
  *  sometimes exactly what is intended and the point is that it is a decision
  *  rather than a discovery. */
-async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOptions): Promise<{ lines: string[]; records: number }> {
+async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOptions): Promise<{ lines: string[]; records: number; capped: boolean }> {
   const lines: string[] = [];
   let records = 0;
+  let cappedAnywhere = false;
   for (const collection of collections) {
     const issues = await validateCollectionRecords(collection, opts);
     if (issues.length === 0) continue;
@@ -118,6 +128,7 @@ async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOp
     // a full batch means "at least this many" and saying otherwise would read
     // as a complete count of the damage.
     const capped = issues.length >= MAX_RECORD_ISSUES;
+    cappedAnywhere = cappedAnywhere || capped;
     const count = capped ? `at least ${issues.length}` : String(issues.length);
     const plural = issues.length === 1 ? "" : "s";
     const note = capped ? " (the scan stops there)" : "";
@@ -125,7 +136,7 @@ async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOp
     for (const issue of issues.slice(0, MAX_LISTED_ISSUES)) lines.push(`  - ${issue.file}: ${issue.problem}`);
     if (issues.length > MAX_LISTED_ISSUES) lines.push(`  - … and ${issues.length - MAX_LISTED_ISSUES} more`);
   }
-  return { lines, records };
+  return { lines, records, capped: cappedAnywhere };
 }
 
 function schemasOf(collections: LoadedCollection[]): { cid: string; schema: CollectionSchema }[] {
@@ -200,7 +211,7 @@ export async function publishApp(opts: PublishOptions = {}): Promise<PublishResu
     };
   }
 
-  return writePublished(authored.app, collections, handle, opts, root, issues.records);
+  return writePublished(authored.app, collections, handle, opts, root, issues);
 }
 
 /** The write half: stamp, project, and put the documents in the order the
@@ -212,7 +223,7 @@ async function writePublished(
   handle: NonNullable<ReturnType<typeof firestoreHandle>>,
   opts: PublishOptions,
   root: string,
-  recordIssues: number,
+  issues: { records: number; capped: boolean },
 ): Promise<PublishResult> {
   const { aid } = authored;
   const existing = await handle.docs.get(APPS_COLLECTION, aid);
@@ -237,7 +248,8 @@ async function writePublished(
     created: existing === null,
     commit: stamp.commit,
     dirty: stampSource.dirty === true,
-    recordIssues,
+    recordIssues: issues.records,
+    recordIssuesCapped: issues.capped,
     published,
   };
 }

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -62,7 +62,20 @@ export interface PublishOptions extends DiscoveryOptions {
 }
 
 export type PublishResult =
-  | { ok: false; problems: string[] }
+  | {
+      ok: false;
+      problems: string[];
+      /** Did any document reach Firestore before this failed?
+       *
+       *  Almost every refusal happens before the first write, and saying so is
+       *  most of the value of refusing. But a write that fails part-way is a
+       *  DIFFERENT state — the roster and configuration are live while the
+       *  schemas are one publish behind — and it is the state a caller most
+       *  needs to hear about. Carried as a field rather than left for the
+       *  caller to infer from prose, because a caller that guesses will guess
+       *  "nothing was written": that is what every other failure means. */
+      partial: boolean;
+    }
   | {
       ok: true;
       aid: string;
@@ -222,6 +235,9 @@ async function writeDocuments(handle: NonNullable<ReturnType<typeof firestoreHan
           : `Everything before it WAS written — the app's roster and configuration are already live while ${index === steps.length - 1 ? "the public config is" : "the remaining documents are"} one publish behind.`;
       return {
         ok: false,
+        // The whole reason the flag exists: this is the one failure where
+        // documents ARE live.
+        partial: index > 0,
         problems: [
           `publish failed while writing ${step.what}: ${reason}`,
           `${already} Publishing again is the repair: the write is idempotent, and it re-does the steps that did not land.`,
@@ -244,6 +260,7 @@ export async function publishApp(opts: PublishOptions = {}): Promise<PublishResu
   if (!handle) {
     return {
       ok: false,
+      partial: false,
       problems: [
         "publish needs a signed-in Firestore session: connect remote-host first. Publishing writes the app's roster and configuration as the app's owner, which is an authenticated write.",
       ],
@@ -251,16 +268,17 @@ export async function publishApp(opts: PublishOptions = {}): Promise<PublishResu
   }
 
   const authored = await readAuthored(root);
-  if (!authored.ok) return authored;
+  if (!authored.ok) return { ...authored, partial: false };
 
   const collections = await sharedCollections({ ...opts, workspaceRoot: root });
   const problems = declarationProblems(authored.app, collections, handle);
-  if (problems.length > 0) return { ok: false, problems };
+  if (problems.length > 0) return { ok: false, partial: false, problems };
 
   const issues = await recordProblems(collections, { ...opts, workspaceRoot: root });
   if (issues.unreadable.length > 0) {
     return {
       ok: false,
+      partial: false,
       problems: [
         ...issues.unreadable,
         "publish stopped: the live records could not be read, so nothing checked whether the schemas about to be published still fit them. " +
@@ -271,6 +289,7 @@ export async function publishApp(opts: PublishOptions = {}): Promise<PublishResu
   if (issues.records > 0 && opts.confirm !== true) {
     return {
       ok: false,
+      partial: false,
       problems: [
         ...issues.lines,
         "publish stopped: these records are live and members are reading them. Migrate them first, or re-run with confirm to publish the schema anyway and repair the records afterwards.",
@@ -308,6 +327,7 @@ async function writePublished(
     const reason = err instanceof Error ? err.message : String(err);
     return {
       ok: false,
+      partial: false,
       problems: [
         `publish failed while reading the current app document (apps/${aid}): ${reason}`,
         "Nothing was written. Publishing again is safe — this read only decides whether the app is created or updated.",

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -115,9 +115,28 @@ async function gitStamp(root: string): Promise<{ commit?: string | undefined; di
   }
 }
 
-/** The shared collections of this repository, by cid. */
-async function sharedCollections(opts: DiscoveryOptions): Promise<LoadedCollection[]> {
-  const all = await discoverCollections(opts);
+/** The shared collections of THIS REPOSITORY, by cid.
+ *
+ *  `userSkillsDir: null` — not a test convenience, a boundary. Discovery
+ *  resolves every schema it finds against the WORKSPACE root, user-scope
+ *  included, so a globally installed skill under `~/.claude/skills` carrying
+ *  `storage.type: "firestore"` picks up whichever repository's `aid` it
+ *  happens to be discovered from. Left in, publish would write that schema
+ *  into this app — and into every other app the same user publishes, since the
+ *  skill is installed once per machine and the repositories are not.
+ *
+ *  An app is a REPOSITORY (design D1): its collections are the ones committed
+ *  beside its `app.json`, which is what makes a clone resolve the same
+ *  collections and an invitation a matter of authorization rather than
+ *  discovery. A schema that is not in the repository has no claim on a cid
+ *  there. And because a view is HTML, publishing one is not a tidiness
+ *  question: it is the machine's own skills reaching every member's browser.
+ *
+ *  The consequence is deliberate: a cid named in `app.json` that exists only
+ *  in user scope is now an unknown cid, and publish says so by name instead of
+ *  quietly publishing a schema from outside the repository. */
+async function sharedCollections(opts: DiscoveryOptions, root: string): Promise<LoadedCollection[]> {
+  const all = await discoverCollections({ ...opts, workspaceRoot: root, userSkillsDir: null });
   return all.filter((collection) => collection.appId !== undefined);
 }
 
@@ -270,7 +289,7 @@ export async function publishApp(opts: PublishOptions = {}): Promise<PublishResu
   const authored = await readAuthored(root);
   if (!authored.ok) return { ...authored, partial: false };
 
-  const collections = await sharedCollections({ ...opts, workspaceRoot: root });
+  const collections = await sharedCollections(opts, root);
   const problems = declarationProblems(authored.app, collections, handle);
   if (problems.length > 0) return { ok: false, partial: false, problems };
 

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -1,0 +1,243 @@
+// publish — the one dangerous operation in a shared app.
+//
+// Merging a pull request changes nobody's screen. Publishing changes
+// everyone's, immediately, and in two ways at once: a breaking schema change
+// leaves live records inconsistent with the schema that is now supposed to
+// describe them, and — because a view is HTML — the right to publish is in
+// practice the right to run JavaScript in every member's browser. So this
+// module is deliberately not a convenience. It refuses more than it accepts,
+// it reports what it is about to break before it breaks it, and it signs what
+// it writes.
+//
+// The order of operations is load → CHECK → pre-validate live records →
+// project → write, and each stage's failure is returned as text rather than
+// thrown, because the caller is an agent tool whose whole contract is
+// actionable prose.
+//
+// WRITE ORDER is not arbitrary. The app document authorizes the other two
+// (`allow write: if role(app(aid), '*') == "owner"` reads the app document to
+// decide), so it goes first. A publish that failed halfway leaves an app whose
+// roster and configuration are new and whose published schemas are one publish
+// behind — recoverable by publishing again, and strictly better than the
+// reverse, where a schema the rules have not been told about is already live.
+//
+// NO CI. The design note defers automated publishing on purpose: a service
+// account holding the owner role is a new kind of principal in the permission
+// model, and the model is currently "the roster is people". Manual, signed
+// with the commit, is where this starts.
+
+import { isRecord } from "@mulmoclaude/common";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { CollectionSchema } from "../core/schema";
+import { APP_MANIFEST_FILE } from "./appManifest";
+import { discoverCollections, type DiscoveryOptions } from "./discovery";
+import type { LoadedCollection } from "./discoveredCollection";
+import { firestoreHandle, getWorkspaceRoot } from "./host";
+import { parseAuthoredApp, type AuthoredApp } from "./publishManifest";
+import { publishProblems } from "./publishChecks";
+import { APPS_COLLECTION, PUBLIC_CONFIG_DOC, appConfigPath, appSchemasPath, projectApp, type PublishStamp, type PublishedApp } from "./publishProject";
+import { MAX_RECORD_ISSUES, validateCollectionRecords } from "./validate";
+
+const execFileAsync = promisify(execFile);
+
+/** How many broken records to name before summarising. A publish that would
+ *  break a thousand rows is answered by the count and a sample; dumping all of
+ *  them buries the number, which is the part the decision turns on. */
+const MAX_LISTED_ISSUES = 10;
+
+export interface PublishOptions extends DiscoveryOptions {
+  /** Proceed even though existing records fail the schemas about to be
+   *  published. Never a default: the pre-check is the migration gate, and a
+   *  gate that opens itself is a log line. */
+  confirm?: boolean | undefined;
+  /** Wall clock, injectable so a test can assert an exact document. */
+  now?: (() => number) | undefined;
+  /** Resolve the commit the declaration is being published from. Injectable
+   *  for the same reason, and because a repository without git is a normal
+   *  state rather than a failure. */
+  resolveCommit?: ((root: string) => Promise<{ commit?: string | undefined; dirty?: boolean | undefined }>) | undefined;
+}
+
+export type PublishResult =
+  | { ok: false; problems: string[] }
+  | {
+      ok: true;
+      aid: string;
+      cids: string[];
+      created: boolean;
+      commit?: string | undefined;
+      dirty: boolean;
+      recordIssues: number;
+      published: PublishedApp;
+    };
+
+/** `git rev-parse HEAD` plus a dirty check, or nothing.
+ *
+ *  A missing git, a repository with no commits and a non-repository are all
+ *  the same answer here — no commit — because the stamp is attribution, not a
+ *  requirement. What is NOT acceptable is a stamp that lies, which is why the
+ *  dirty flag exists: publishing from a modified tree records a commit that
+ *  does not describe what was published, and the flag is the only thing that
+ *  would ever tell a reader so. */
+async function gitStamp(root: string): Promise<{ commit?: string | undefined; dirty?: boolean | undefined }> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", root, "rev-parse", "HEAD"]);
+    const commit = stdout.trim();
+    const { stdout: status } = await execFileAsync("git", ["-C", root, "status", "--porcelain"]);
+    return { commit: commit.length > 0 ? commit : undefined, dirty: status.trim().length > 0 };
+  } catch {
+    return {};
+  }
+}
+
+/** The shared collections of this repository, by cid. */
+async function sharedCollections(opts: DiscoveryOptions): Promise<LoadedCollection[]> {
+  const all = await discoverCollections(opts);
+  return all.filter((collection) => collection.appId !== undefined);
+}
+
+/** Existing records that would not satisfy the schema about to be published.
+ *
+ *  Read from FIRESTORE, not from disk: a shared collection's records live in
+ *  the app, and the question this answers is "what does the live data look
+ *  like under the new schema" — which is the migration question. Reported as
+ *  a refusal the publisher can override, because a breaking change is
+ *  sometimes exactly what is intended and the point is that it is a decision
+ *  rather than a discovery. */
+async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOptions): Promise<{ lines: string[]; records: number }> {
+  const lines: string[] = [];
+  let records = 0;
+  for (const collection of collections) {
+    const issues = await validateCollectionRecords(collection, opts);
+    if (issues.length === 0) continue;
+    records += issues.length;
+    // `validateCollectionRecords` stops at its own cap (25 per collection), so
+    // a full batch means "at least this many" and saying otherwise would read
+    // as a complete count of the damage.
+    const capped = issues.length >= MAX_RECORD_ISSUES;
+    const count = capped ? `at least ${issues.length}` : String(issues.length);
+    const plural = issues.length === 1 ? "" : "s";
+    const note = capped ? " (the scan stops there)" : "";
+    lines.push(`${collection.slug}: ${count} existing record${plural} would not satisfy the schema about to be published${note}`);
+    for (const issue of issues.slice(0, MAX_LISTED_ISSUES)) lines.push(`  - ${issue.file}: ${issue.problem}`);
+    if (issues.length > MAX_LISTED_ISSUES) lines.push(`  - … and ${issues.length - MAX_LISTED_ISSUES} more`);
+  }
+  return { lines, records };
+}
+
+function schemasOf(collections: LoadedCollection[]): { cid: string; schema: CollectionSchema }[] {
+  return collections
+    .map((collection) => ({ cid: collection.slug, schema: collection.schema }))
+    .sort((left, right) => (left.cid < right.cid ? -1 : left.cid > right.cid ? 1 : 0));
+}
+
+/** Read and parse `<root>/app.json`'s full declaration. */
+async function readAuthored(root: string): Promise<{ ok: true; app: AuthoredApp } | { ok: false; problems: string[] }> {
+  let raw: string;
+  try {
+    raw = await readFile(path.join(root, APP_MANIFEST_FILE), "utf-8");
+  } catch (err) {
+    return { ok: false, problems: [`cannot read ${path.join(root, APP_MANIFEST_FILE)}: ${String(err)}`] };
+  }
+  return parseAuthoredApp(raw);
+}
+
+/** Everything wrong with the declaration itself, publisher included. */
+function declarationProblems(app: AuthoredApp, collections: LoadedCollection[], handle: { uid: string; email: string }): string[] {
+  const problems = publishProblems(
+    app,
+    collections.map((collection) => collection.slug),
+    handle.email,
+  );
+  if (app.owner !== undefined && app.owner !== handle.uid) {
+    // Not fatal on its own — the rules pin `owner` to the EXISTING document on
+    // update — but a declaration naming somebody else's uid is either the
+    // sample's `<uid>` placeholder or a misunderstanding of what the key is.
+    problems.push(
+      `app.json declares owner "${app.owner}", which is not your uid (${handle.uid}). ` +
+        "`owner` is stamped by publish and carried forward unchanged afterwards — remove it from app.json rather than maintaining it by hand.",
+    );
+  }
+  return problems;
+}
+
+/** Publish this repository's declaration to its app.
+ *
+ *  Everything variable is a parameter or comes from the host binding, so the
+ *  whole path is exercisable against an in-memory `FirestoreDocs` with no
+ *  network and no API key — which is the only way the conversion table gets
+ *  tested as a table. */
+export async function publishApp(opts: PublishOptions = {}): Promise<PublishResult> {
+  const root = opts.workspaceRoot ?? getWorkspaceRoot();
+  const handle = firestoreHandle();
+  if (!handle) {
+    return {
+      ok: false,
+      problems: [
+        "publish needs a signed-in Firestore session: connect remote-host first. Publishing writes the app's roster and configuration as the app's owner, which is an authenticated write.",
+      ],
+    };
+  }
+
+  const authored = await readAuthored(root);
+  if (!authored.ok) return authored;
+
+  const collections = await sharedCollections({ ...opts, workspaceRoot: root });
+  const problems = declarationProblems(authored.app, collections, handle);
+  if (problems.length > 0) return { ok: false, problems };
+
+  const issues = await recordProblems(collections, { ...opts, workspaceRoot: root });
+  if (issues.records > 0 && opts.confirm !== true) {
+    return {
+      ok: false,
+      problems: [
+        ...issues.lines,
+        "publish stopped: these records are live and members are reading them. Migrate them first, or re-run with confirm to publish the schema anyway and repair the records afterwards.",
+      ],
+    };
+  }
+
+  return writePublished(authored.app, collections, handle, opts, root, issues.records);
+}
+
+/** The write half: stamp, project, and put the documents in the order the
+ *  rules require. Split from the gate above so neither half hides the other —
+ *  everything up to here can refuse, and nothing from here on does. */
+async function writePublished(
+  authored: AuthoredApp,
+  collections: LoadedCollection[],
+  handle: NonNullable<ReturnType<typeof firestoreHandle>>,
+  opts: PublishOptions,
+  root: string,
+  recordIssues: number,
+): Promise<PublishResult> {
+  const { aid } = authored;
+  const existing = await handle.docs.get(APPS_COLLECTION, aid);
+  const stampSource = await (opts.resolveCommit ?? gitStamp)(root);
+  const stamp: PublishStamp = {
+    uid: handle.uid,
+    email: handle.email,
+    publishedAt: (opts.now ?? Date.now)(),
+    commit: stampSource.commit,
+  };
+  const published = projectApp(authored, schemasOf(collections), stamp, isRecord(existing) ? existing : null);
+  if (stampSource.dirty === true) published.app.publishedDirty = true;
+
+  await handle.docs.set(APPS_COLLECTION, aid, published.app);
+  for (const { cid, doc } of published.schemas) await handle.docs.set(appSchemasPath(aid), cid, doc);
+  await handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, published.config);
+
+  return {
+    ok: true,
+    aid,
+    cids: published.schemas.map((entry) => entry.cid),
+    created: existing === null,
+    commit: stamp.commit,
+    dirty: stampSource.dirty === true,
+    recordIssues,
+    published,
+  };
+}

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -39,7 +39,7 @@ import { firestoreHandle, getWorkspaceRoot } from "./host";
 import { parseAuthoredApp, type AuthoredApp } from "./publishManifest";
 import { publishProblems } from "./publishChecks";
 import { APPS_COLLECTION, PUBLIC_CONFIG_DOC, appConfigPath, appSchemasPath, projectApp, type PublishStamp, type PublishedApp } from "./publishProject";
-import { MAX_RECORD_ISSUES, validateCollectionRecords } from "./validate";
+import { MAX_RECORD_ISSUES, STORE_UNREADABLE, validateCollectionRecords } from "./validate";
 
 const execFileAsync = promisify(execFile);
 
@@ -108,6 +108,15 @@ async function sharedCollections(opts: DiscoveryOptions): Promise<LoadedCollecti
   return all.filter((collection) => collection.appId !== undefined);
 }
 
+interface RecordScan {
+  lines: string[];
+  records: number;
+  capped: boolean;
+  /** Collections whose records could not be READ at all. Kept apart from
+   *  `lines` because `confirm` may not override them. */
+  unreadable: string[];
+}
+
 /** Existing records that would not satisfy the schema about to be published.
  *
  *  Read from FIRESTORE, not from disk: a shared collection's records live in
@@ -116,13 +125,23 @@ async function sharedCollections(opts: DiscoveryOptions): Promise<LoadedCollecti
  *  a refusal the publisher can override, because a breaking change is
  *  sometimes exactly what is intended and the point is that it is a decision
  *  rather than a discovery. */
-async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOptions): Promise<{ lines: string[]; records: number; capped: boolean }> {
+async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOptions): Promise<RecordScan> {
   const lines: string[] = [];
+  const unreadable: string[] = [];
   let records = 0;
   let cappedAnywhere = false;
   for (const collection of collections) {
     const issues = await validateCollectionRecords(collection, opts);
     if (issues.length === 0) continue;
+    // "the backend could not be read" is not a broken record, and must not be
+    // overridable the way a broken record is: `confirm` means "I know these
+    // rows will not fit the new schema", and here nobody knows anything —
+    // the migration gate did not run. Overriding it would publish blind.
+    const unread = issues.filter((issue) => issue.file === STORE_UNREADABLE);
+    if (unread.length > 0) {
+      unreadable.push(`${collection.slug}: ${unread.map((issue) => issue.problem).join("; ")}`);
+      continue;
+    }
     records += issues.length;
     // `validateCollectionRecords` stops at its own cap (25 per collection), so
     // a full batch means "at least this many" and saying otherwise would read
@@ -136,7 +155,7 @@ async function recordProblems(collections: LoadedCollection[], opts: DiscoveryOp
     for (const issue of issues.slice(0, MAX_LISTED_ISSUES)) lines.push(`  - ${issue.file}: ${issue.problem}`);
     if (issues.length > MAX_LISTED_ISSUES) lines.push(`  - … and ${issues.length - MAX_LISTED_ISSUES} more`);
   }
-  return { lines, records, capped: cappedAnywhere };
+  return { lines, records, capped: cappedAnywhere, unreadable };
 }
 
 function schemasOf(collections: LoadedCollection[]): { cid: string; schema: CollectionSchema }[] {
@@ -160,7 +179,7 @@ async function readAuthored(root: string): Promise<{ ok: true; app: AuthoredApp 
 function declarationProblems(app: AuthoredApp, collections: LoadedCollection[], handle: { uid: string; email: string }): string[] {
   const problems = publishProblems(
     app,
-    collections.map((collection) => collection.slug),
+    collections.map((collection) => ({ cid: collection.slug, primaryKey: collection.schema.primaryKey })),
     handle.email,
   );
   if (app.owner !== undefined && app.owner !== handle.uid) {
@@ -173,6 +192,44 @@ function declarationProblems(app: AuthoredApp, collections: LoadedCollection[], 
     );
   }
   return problems;
+}
+
+/** Put the three kinds of document, in the order the rules require, and turn a
+ *  rejected write into the result type instead of letting it escape.
+ *
+ *  Returns null when everything was written; a failure result otherwise.
+ *
+ *  A raw rejection here would reach the agent as a tool crash rather than as
+ *  the actionable text this tool promises — and it would do so having possibly
+ *  written the app document already, which is the one fact the caller most
+ *  needs. So the step is named in the message: a publish that stopped after
+ *  the app document is a live roster with last publish's schemas, and the fix
+ *  is to publish again rather than to guess. */
+async function writeDocuments(handle: NonNullable<ReturnType<typeof firestoreHandle>>, aid: string, published: PublishedApp): Promise<PublishResult | null> {
+  const steps: { what: string; run: () => Promise<void> }[] = [
+    { what: `the app document (apps/${aid})`, run: () => handle.docs.set(APPS_COLLECTION, aid, published.app) },
+    ...published.schemas.map(({ cid, doc }) => ({ what: `the published schema for '${cid}'`, run: () => handle.docs.set(appSchemasPath(aid), cid, doc) })),
+    { what: "the public config document", run: () => handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, published.config) },
+  ];
+  for (const [index, step] of steps.entries()) {
+    try {
+      await step.run();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      const already =
+        index === 0
+          ? "Nothing was written."
+          : `Everything before it WAS written — the app's roster and configuration are already live while ${index === steps.length - 1 ? "the public config is" : "the remaining documents are"} one publish behind.`;
+      return {
+        ok: false,
+        problems: [
+          `publish failed while writing ${step.what}: ${reason}`,
+          `${already} Publishing again is the repair: the write is idempotent, and it re-does the steps that did not land.`,
+        ],
+      };
+    }
+  }
+  return null;
 }
 
 /** Publish this repository's declaration to its app.
@@ -201,6 +258,16 @@ export async function publishApp(opts: PublishOptions = {}): Promise<PublishResu
   if (problems.length > 0) return { ok: false, problems };
 
   const issues = await recordProblems(collections, { ...opts, workspaceRoot: root });
+  if (issues.unreadable.length > 0) {
+    return {
+      ok: false,
+      problems: [
+        ...issues.unreadable,
+        "publish stopped: the live records could not be read, so nothing checked whether the schemas about to be published still fit them. " +
+          "This is not something `confirm` overrides — confirming means accepting a known breakage, and here there is no reading at all. Fix the access (or the connection) and publish again.",
+      ],
+    };
+  }
   if (issues.records > 0 && opts.confirm !== true) {
     return {
       ok: false,
@@ -234,18 +301,23 @@ async function writePublished(
     publishedAt: (opts.now ?? Date.now)(),
     commit: stampSource.commit,
   };
-  const published = projectApp(authored, schemasOf(collections), stamp, isRecord(existing) ? existing : null);
+  // ONE normalization of "was there an app document?", used by the projection
+  // and by the report. Two spellings of the same question (`isRecord` here,
+  // `=== null` there) disagree the moment `get` resolves to anything that is
+  // neither a record nor null: the projection stamps a fresh `owner` while the
+  // reply says "Updated".
+  const existingApp = isRecord(existing) ? existing : null;
+  const published = projectApp(authored, schemasOf(collections), stamp, existingApp);
   if (stampSource.dirty === true) published.app.publishedDirty = true;
 
-  await handle.docs.set(APPS_COLLECTION, aid, published.app);
-  for (const { cid, doc } of published.schemas) await handle.docs.set(appSchemasPath(aid), cid, doc);
-  await handle.docs.set(appConfigPath(aid), PUBLIC_CONFIG_DOC, published.config);
+  const written = await writeDocuments(handle, aid, published);
+  if (written !== null) return written;
 
   return {
     ok: true,
     aid,
     cids: published.schemas.map((entry) => entry.cid),
-    created: existing === null,
+    created: existingApp === null,
     commit: stamp.commit,
     dirty: stampSource.dirty === true,
     recordIssues: issues.records,

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -28,6 +28,16 @@
 
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
 
+/** What publish knows about a shared collection in this repository, as far as
+ *  these checks are concerned: its cid and the schema key its records are
+ *  identified by. The whole schema is deliberately not threaded in — these
+ *  checks are about the DECLARATION, and the primary key is the one part of
+ *  the schema the declaration can contradict. */
+export interface PublishableCollection {
+  cid: string;
+  primaryKey: string;
+}
+
 /** Does this submit declaration bind a record to the submitter's identity?
  *
  *  The condition for requiring `submitOnly`, and deliberately NOT "declares an
@@ -213,10 +223,38 @@ function statusCoherenceProblems(cid: string, submit: AuthoredSubmit, collection
   ];
 }
 
+/** Every field a RULE reads off a submitted record, other than the status
+ *  field (which `statusCoherenceProblems` words for itself).
+ *
+ *  `emailField` and `idField` belong here for exactly the reason `required`
+ *  and `keyFields` do, and forgetting them was the same oversight twice: the
+ *  rules read `request.resource.data[s.emailField]` and rebuild the document
+ *  id from `s.idField`, while `hasOnly(createFields)` decides what a
+ *  submission may carry at all. A field in one list and not the other is a
+ *  contradiction the submitter cannot resolve — including it is refused,
+ *  omitting it fails the check. */
+function ruleReadFields(submit: AuthoredSubmit): { field: string; why: string }[] {
+  const fields: { field: string; why: string }[] = [];
+  if (submit.emailField !== undefined) {
+    fields.push({ field: submit.emailField, why: `public.submit.<cid>.emailField — the rules compare it to the submitter's verified address` });
+  }
+  if (submit.idFrom === "auth.uid+field" && submit.idField !== undefined) {
+    fields.push({ field: submit.idField, why: `public.submit.<cid>.idField — the rules rebuild the document id from it` });
+  }
+  return fields;
+}
+
 /** A checked field a submission is not allowed to carry can never be
  *  satisfied: carrying it fails `hasOnly`, omitting it fails the check. */
 function createFieldProblems(cid: string, submit: AuthoredSubmit): string[] {
   const createFields = new Set(submit.createFields);
+  const ruleRead = ruleReadFields(submit)
+    .filter((entry) => !createFields.has(entry.field))
+    .map(
+      (entry) =>
+        `public.submit.${cid}.createFields must include "${entry.field}" (${entry.why.replace("<cid>", cid)}): ` +
+        "a submission may carry only the createFields, so as written every submission is refused whether or not it carries the field.",
+    );
   const required = (submit.validate?.required ?? [])
     .filter((field) => !createFields.has(field))
     .map(
@@ -229,7 +267,7 @@ function createFieldProblems(cid: string, submit: AuthoredSubmit): string[] {
       (keyField) =>
         `public.submit.${cid}.validate.keyFields checks "${keyField.field}", which is not in createFields: a submission carrying it is refused, and one omitting it fails the check.`,
     );
-  return [...required, ...keyFields];
+  return [...ruleRead, ...required, ...keyFields];
 }
 
 function submitCoherenceProblems(app: AuthoredApp, cid: string, submit: AuthoredSubmit): string[] {
@@ -285,8 +323,8 @@ function publisherProblems(app: AuthoredApp, publisherEmail: string): string[] {
  *  a configuration for a collection nobody publishes, and the collection the
  *  author meant is published with no configuration at all — i.e. with the
  *  status machine and the submit path silently absent. */
-function unknownCidProblems(app: AuthoredApp, knownCids: readonly string[]): string[] {
-  const known = new Set(knownCids);
+function unknownCidProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const known = new Set(collections.map((collection) => collection.cid));
   const mentions: [string, string[]][] = [
     ["collections", Object.keys(app.collections ?? {})],
     ["public.read", app.public?.read ?? []],
@@ -308,9 +346,9 @@ function unknownCidProblems(app: AuthoredApp, knownCids: readonly string[]): str
  *
  *  All of them, every time. Publish is a manual step with a human waiting on
  *  it; stopping at the first problem turns one review into five. */
-export function publishProblems(app: AuthoredApp, knownCids: readonly string[], publisherEmail: string): string[] {
+export function publishProblems(app: AuthoredApp, collections: readonly PublishableCollection[], publisherEmail: string): string[] {
   return [
-    ...unknownCidProblems(app, knownCids),
+    ...unknownCidProblems(app, collections),
     ...publisherProblems(app, publisherEmail),
     ...submitOnlyProblems(app),
     ...aggregateProblems(app),
@@ -318,5 +356,35 @@ export function publishProblems(app: AuthoredApp, knownCids: readonly string[], 
     ...mailProblems(app),
     ...submitShapeProblems(app),
     ...coherenceProblems(app),
+    ...primaryKeyProblems(app, collections),
   ];
+}
+
+/** A public submission must be able to produce a record the HOST can read.
+ *
+ *  The rules and the engine disagree about what identifies a record, and the
+ *  gap is invisible from either side alone. The rules bind the DOCUMENT ID
+ *  (`idFrom`) and let a submission carry only `createFields`; the engine
+ *  identifies a record by its schema's `primaryKey` FIELD, and the firestore
+ *  store hands back the document's fields verbatim — `toItem` does not
+ *  synthesize the key from the document id. So a submit path whose
+ *  `createFields` omits the primary key writes rows that Firestore accepts and
+ *  every reader rejects: `validateRecordObject` fails them, the collection
+ *  renders empty-ish, and the next publish's own pre-check reports them as
+ *  broken records the publisher never wrote.
+ *
+ *  Not checkable by the rules (they have never heard of a schema) and not
+ *  catchable at write time (nothing is wrong with the write). Publish is the
+ *  only place that holds both halves. */
+function primaryKeyProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const primaryKeyOf = new Map(collections.map((collection) => [collection.cid, collection.primaryKey]));
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
+    const primaryKey = primaryKeyOf.get(cid);
+    if (primaryKey === undefined || submit.createFields.includes(primaryKey)) return [];
+    return [
+      `public.submit.${cid}.createFields must include "${primaryKey}", the schema's primaryKey: a submission may carry only the createFields, ` +
+        "and a shared record is stored as exactly the fields it was written with — the document id is not copied into the record. " +
+        "Without it every submission is accepted by the rules and then rejected by every reader.",
+    ];
+  });
 }

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -1,0 +1,322 @@
+// What publish REFUSES, and why the refusal lives here rather than in a linter.
+//
+// A linter runs on the author's machine, when the author remembers to run it.
+// Publish is the only gate every published byte passes through, so the
+// guarantees are put here — the same argument the rules make for themselves
+// against `require` in an action ("a linter is not a substitute for a rule").
+//
+// Two kinds of refusal, and the difference matters when reading this file:
+//
+//   SECURITY invariants — the declaration is internally consistent and the
+//   rules will happily enforce it, but what it permits is not what the author
+//   meant. `submitOnly` is the archetype: without it the rules do exactly as
+//   told, and the owner can fabricate records in a collection whose entire
+//   meaning is "the submitter said this".
+//
+//   FAIL-CLOSED traps — the rules will refuse EVERY write the declaration was
+//   written to allow, and refuse it silently. `initialStatus` without a
+//   `statusField` is not a weaker app, it is an app where nobody can submit
+//   and nothing says why. These are worth as much as the security ones,
+//   because a permission denial carries no explanation to the person hitting
+//   it, and the author is not the person hitting it.
+//
+// Every check returns a LINE the author can act on, and every check has a test
+// for the refusal AND a test for the neighbouring declaration that must still
+// pass. A refusal test on its own is satisfied by a function that refuses
+// everything, which is the one bug this file could have that would look like
+// safety.
+
+import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
+
+/** Does this submit declaration bind a record to the submitter's identity?
+ *
+ *  The condition for requiring `submitOnly`, and deliberately NOT "declares an
+ *  `audience`": `audience` appears only in the rules' public-create branch, so
+ *  an owner or editor never meets it and can add records freely. `immutable`
+ *  is the wrong condition too — a survey's responses are not immutable and
+ *  can be padded exactly the same way.
+ *
+ *  What these four have in common is that each one makes the record MEAN "the
+ *  person who submitted it said this": a per-uid id, a per-uid+field id, a
+ *  row stamped with the submitter's verified address, or a submission
+ *  restricted to a named participant. A record created through the writer
+ *  branch carries the same shape and none of that meaning. */
+export function bindsSubmitterIdentity(submit: AuthoredSubmit): boolean {
+  return submit.idFrom === "auth.uid" || submit.idFrom === "auth.uid+field" || submit.emailField !== undefined || submit.audience === "participant";
+}
+
+/** The fields a rule actually CHECKS the value of, for one collection.
+ *
+ *  `keyFields` pins a value against a declared set, `gateOn.match` pins it
+ *  against the session's current question, and the status field is pinned by
+ *  the transition machine. An aggregation grouped by anything else is grouped
+ *  by a field any submitter may write anything into — so the published
+ *  aggregate is whatever the noisiest respondent decided it should be. */
+function checkedFields(collection: AuthoredCollectionConfig | undefined, submit: AuthoredSubmit | undefined): Set<string> {
+  const fields = new Set<string>();
+  for (const keyField of submit?.validate?.keyFields ?? []) fields.add(keyField.field);
+  if (submit?.gateOn) fields.add(submit.gateOn.match);
+  if (collection?.statusField) fields.add(collection.statusField);
+  return fields;
+}
+
+/** INVARIANT 1 — a submission bound to its submitter needs `submitOnly`. */
+function submitOnlyProblems(app: AuthoredApp): string[] {
+  const problems: string[] = [];
+  for (const [cid, submit] of Object.entries(app.public?.submit ?? {})) {
+    if (!bindsSubmitterIdentity(submit)) continue;
+    if (app.collections?.[cid]?.submitOnly === true) continue;
+    problems.push(
+      `collections.${cid}.submitOnly must be true: public.submit.${cid} binds each record to its submitter ` +
+        `(${identityBindings(submit).join(", ")}), so a record created any other way would carry that meaning without having earned it. ` +
+        `Without submitOnly the rules let an owner or editor write rows directly into ${cid}.`,
+    );
+  }
+  return problems;
+}
+
+function identityBindings(submit: AuthoredSubmit): string[] {
+  const bindings: string[] = [];
+  if (submit.idFrom === "auth.uid" || submit.idFrom === "auth.uid+field") bindings.push(`idFrom: "${submit.idFrom}"`);
+  if (submit.emailField !== undefined) bindings.push(`emailField: "${submit.emailField}"`);
+  if (submit.audience === "participant") bindings.push(`audience: "participant"`);
+  return bindings;
+}
+
+/** INVARIANT 2 — every aggregation key is a field some rule checks. */
+function aggregateProblems(app: AuthoredApp): string[] {
+  const problems: string[] = [];
+  for (const [cid, collection] of Object.entries(app.collections ?? {})) {
+    const keys = collection.aggregate?.by;
+    if (!keys) continue;
+    const checked = checkedFields(collection, app.public?.submit?.[cid]);
+    const loose = keys.filter((field) => !checked.has(field));
+    const spelled = loose.map((field) => `'${field}'`).join(", ");
+    if (loose.length > 0) {
+      problems.push(
+        `collections.${cid}.aggregate.by names ${spelled}, which no rule checks the value of. ` +
+          `An aggregation key must appear in public.submit.${cid}.validate.keyFields, in gateOn.match, or be the statusField — ` +
+          `otherwise a submitter chooses their own bucket and the published aggregate is not a count of anything.`,
+      );
+    }
+  }
+  return problems;
+}
+
+/** INVARIANT 3 — `auth: "verifiedEmail"` only.
+ *
+ *  A product decision, not a rules limitation: the rules keep all three stages
+ *  and the emulator tests keep exercising them, because deleting a stage from
+ *  the rules turns a change of mind into a cross-repo deploy. Publish is where
+ *  the current decision is expressed, and it is one line to move. */
+function authProblems(app: AuthoredApp): string[] {
+  return Object.entries(app.public?.submit ?? {})
+    .filter(([, submit]) => submit.auth !== "verifiedEmail")
+    .map(
+      ([cid, submit]) =>
+        `public.submit.${cid}.auth is "${submit.auth}": only "verifiedEmail" may be published. ` +
+        `The rules still implement "none" and "anonymous" — this is a product decision, and lifting it is a change here, not a rules deploy.`,
+    );
+}
+
+/** INVARIANT 5 — a mail transition's origins and destination must be disjoint.
+ *
+ *  Overlap means the same write can satisfy the same template twice over, and
+ *  the deterministic mail id is the only other thing stopping a duplicate
+ *  send. The rules also require the status to have CHANGED, so an overlapping
+ *  declaration is not merely redundant: `from` containing `to` is a transition
+ *  that can never fire, which is a mail nobody ever receives. */
+function mailProblems(app: AuthoredApp): string[] {
+  return Object.entries(app.collections ?? {}).flatMap(([cid, collection]) => collectionMailProblems(cid, collection));
+}
+
+function collectionMailProblems(cid: string, collection: AuthoredCollectionConfig): string[] {
+  const { mail } = collection;
+  if (!mail) return [];
+  const problems: string[] = [];
+  if (!collection.statusField) {
+    problems.push(
+      `collections.${cid}.mail needs collections.${cid}.statusField: the rules read the status before and after the write to decide the mail is warranted.`,
+    );
+  }
+  for (const [template, transition] of Object.entries(mail.on)) {
+    problems.push(...templateMailProblems(cid, collection, template, transition));
+  }
+  return problems;
+}
+
+function templateMailProblems(cid: string, collection: AuthoredCollectionConfig, template: string, transition: { from: string[]; to: string }): string[] {
+  const problems: string[] = [];
+  if (transition.from.includes(transition.to)) {
+    problems.push(
+      `collections.${cid}.mail.on.${template} lists "${transition.to}" in both \`from\` and \`to\`. ` +
+        "The rules require the status to CHANGE in the same write, so this template can never send.",
+    );
+  }
+  const allowed = collection.transitions;
+  if (allowed) {
+    const unreachable = transition.from.filter((from) => !(allowed[from] ?? []).includes(transition.to));
+    const spelled = unreachable.map((from) => `'${from}' -> '${transition.to}'`).join(", ");
+    if (unreachable.length > 0) {
+      problems.push(
+        `collections.${cid}.mail.on.${template} sends on ${spelled}, ` +
+          `which collections.${cid}.transitions does not allow. The record write is refused first, so the mail never fires.`,
+      );
+    }
+  }
+  return problems;
+}
+
+/** INVARIANTS 6 and 7 — the window is a real interval, and `keyFields` fits
+ *  the unrolled check in the rules. */
+function submitShapeProblems(app: AuthoredApp): string[] {
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => [...windowProblems(cid, submit), ...keyFieldCountProblems(cid, submit)]);
+}
+
+function windowProblems(cid: string, submit: AuthoredSubmit): string[] {
+  const { window } = submit;
+  if (window?.from === undefined || window.until === undefined) return [];
+  if (Date.parse(window.until) > Date.parse(window.from)) return [];
+  return [`public.submit.${cid}.window closes at or before it opens (${window.from} -> ${window.until}): nothing could ever be submitted.`];
+}
+
+function keyFieldCountProblems(cid: string, submit: AuthoredSubmit): string[] {
+  const keyFields = submit.validate?.keyFields ?? [];
+  if (keyFields.length <= 2) return [];
+  return [
+    `public.submit.${cid}.validate.keyFields declares ${keyFields.length}; the rules check at most 2. ` +
+      "Rules have no iteration, so the check is unrolled — a third would be published and never enforced.",
+  ];
+}
+
+/** The fail-closed traps: declarations the rules read together, where the
+ *  missing half denies every write instead of loosening one. */
+function coherenceProblems(app: AuthoredApp): string[] {
+  const fromSubmits = Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => submitCoherenceProblems(app, cid, submit));
+  const fromCollections = Object.entries(app.collections ?? {}).flatMap(([cid, collection]) => gateCoherenceProblems(cid, collection));
+  return [...fromSubmits, ...fromCollections];
+}
+
+/** `initialStatus` is read together with the collection's `statusField` and
+ *  with `createFields`; miss either and every submission is refused. */
+function statusCoherenceProblems(cid: string, submit: AuthoredSubmit, collection: AuthoredCollectionConfig | undefined): string[] {
+  if (submit.initialStatus === undefined) return [];
+  if (!collection?.statusField) {
+    return [
+      `public.submit.${cid}.initialStatus needs collections.${cid}.statusField: the rules look the status up by that name, and refuse every submission without it.`,
+    ];
+  }
+  if (new Set(submit.createFields).has(collection.statusField)) return [];
+  return [
+    `public.submit.${cid}.createFields must include "${collection.statusField}": a submission may carry ONLY the createFields, ` +
+      "and the rules also require the status field to be present and equal to initialStatus. As written, every submission is refused.",
+  ];
+}
+
+/** A checked field a submission is not allowed to carry can never be
+ *  satisfied: carrying it fails `hasOnly`, omitting it fails the check. */
+function createFieldProblems(cid: string, submit: AuthoredSubmit): string[] {
+  const createFields = new Set(submit.createFields);
+  const required = (submit.validate?.required ?? [])
+    .filter((field) => !createFields.has(field))
+    .map(
+      (field) =>
+        `public.submit.${cid}.validate.required names "${field}", which is not in createFields: a submission may carry only the createFields, so the requirement can never be met.`,
+    );
+  const keyFields = (submit.validate?.keyFields ?? [])
+    .filter((keyField) => !createFields.has(keyField.field))
+    .map(
+      (keyField) =>
+        `public.submit.${cid}.validate.keyFields checks "${keyField.field}", which is not in createFields: a submission carrying it is refused, and one omitting it fails the check.`,
+    );
+  return [...required, ...keyFields];
+}
+
+function submitCoherenceProblems(app: AuthoredApp, cid: string, submit: AuthoredSubmit): string[] {
+  const collection = app.collections?.[cid];
+  const problems = [...statusCoherenceProblems(cid, submit, collection), ...createFieldProblems(cid, submit)];
+  if (submit.idFrom === "auth.uid+field" && submit.idField === undefined) {
+    problems.push(
+      `public.submit.${cid}.idFrom is "auth.uid+field" but no idField is declared: the rules rebuild the document id from that field and refuse every create.`,
+    );
+  }
+  if ((submit.selfUpdate !== undefined || submit.selfTransitions !== undefined) && !collection?.statusField) {
+    problems.push(
+      `public.submit.${cid}.selfUpdate / selfTransitions are declared per CURRENT STATUS, but collections.${cid} declares no statusField: ` +
+        "the rules read the current status first and refuse every self-edit without it.",
+    );
+  }
+  if (submit.audience === "participant" && Object.keys(app.members).length === 0) {
+    problems.push(
+      `public.submit.${cid}.audience is "participant" but the roster is empty: the rules resolve the submitter's role from members, so every submission is refused.`,
+    );
+  }
+  return problems;
+}
+
+/** The staged reveal reads its flag off the PARENT record, so the path to that
+ *  parent is not optional decoration — without it the gate never opens. */
+function gateCoherenceProblems(cid: string, collection: AuthoredCollectionConfig): string[] {
+  if (collection.revealGated !== true) return [];
+  if (collection.gatedFrom !== undefined && collection.revealBy !== undefined) return [];
+  return [
+    `collections.${cid}.revealGated needs both gatedFrom and revealBy: the flag is read off the PARENT record, and without the path the gate never opens.`,
+  ];
+}
+
+/** The publisher must be able to write what they are about to write.
+ *
+ *  On a first publish the rules require the creator to name themselves owner,
+ *  in the roster, under `'*'`. Getting this wrong produces a bare permission
+ *  error from Firestore with nothing in it about rosters — worth one line
+ *  here instead. */
+function publisherProblems(app: AuthoredApp, publisherEmail: string): string[] {
+  const roles = app.members[publisherEmail];
+  if (roles?.["*"] === "owner") return [];
+  return [
+    `members must give you app-wide owner: add "${publisherEmail}": { "*": "owner" }. ` +
+      `The rules require the publisher to hold that role (and to name themselves owner when the app is first created); otherwise the write is refused with no explanation.`,
+  ];
+}
+
+/** Every cid the declaration mentions must be a collection that exists.
+ *
+ *  A typo'd cid is not an error anywhere else: the app document simply carries
+ *  a configuration for a collection nobody publishes, and the collection the
+ *  author meant is published with no configuration at all — i.e. with the
+ *  status machine and the submit path silently absent. */
+function unknownCidProblems(app: AuthoredApp, knownCids: readonly string[]): string[] {
+  const known = new Set(knownCids);
+  const mentions: [string, string[]][] = [
+    ["collections", Object.keys(app.collections ?? {})],
+    ["public.read", app.public?.read ?? []],
+    ["public.submit", Object.keys(app.public?.submit ?? {})],
+    ["participantRead", app.participantRead ?? []],
+  ];
+  return mentions.flatMap(([where, cids]) =>
+    cids
+      .filter((cid) => !known.has(cid))
+      .map(
+        (cid) =>
+          `${where} names '${cid}', which is not a shared collection in this repository. ` +
+          `Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : '(none - a schema needs storage.type "firestore")'}.`,
+      ),
+  );
+}
+
+/** Everything publish refuses, as lines the author can act on.
+ *
+ *  All of them, every time. Publish is a manual step with a human waiting on
+ *  it; stopping at the first problem turns one review into five. */
+export function publishProblems(app: AuthoredApp, knownCids: readonly string[], publisherEmail: string): string[] {
+  return [
+    ...unknownCidProblems(app, knownCids),
+    ...publisherProblems(app, publisherEmail),
+    ...submitOnlyProblems(app),
+    ...aggregateProblems(app),
+    ...authProblems(app),
+    ...mailProblems(app),
+    ...submitShapeProblems(app),
+    ...coherenceProblems(app),
+  ];
+}

--- a/packages/core/src/collection/server/publishManifest.ts
+++ b/packages/core/src/collection/server/publishManifest.ts
@@ -1,0 +1,206 @@
+// The AUTHORED app declaration — everything in `<root>/app.json` that is not
+// `aid`.
+//
+// WHY THIS IS NOT IN `appManifest.ts`. That module reads ONE field, and its
+// header says why: every key added there is a key `publish` and the discovery
+// loader could disagree about. Discovery needs to know which app a collection
+// belongs to; it has no business knowing who is on the roster. So the roster
+// and the public config are read HERE, by the only thing that consumes them.
+// `aid` is still read through `parseAppManifest` — one parse of one field, not
+// a second opinion about it.
+//
+// AUTHORED, NOT PUBLISHED. What this module produces is the shape a human
+// wrote. The Firestore document is derived from it by `publishProject.ts`
+// (epoch-millis windows, a derived `memberEmails`, publisher stamps). The two
+// are deliberately different and the difference is written down in exactly one
+// place — see that module's header.
+//
+// WHERE `collections[cid]` COMES FROM. From this file, authored by hand, as the
+// samples in `mulmoterminal plans/feat-shareable-collections.md` (S1-S4) write
+// it. The design note also describes deriving it from each collection's
+// `schema.json` (`actions[].then.email` → `mail`, `require`/`set` →
+// `transitions`), and that remains the intent — but the schema keys it would
+// read DO NOT EXIST yet: `schemaZ.ts` has `require` and `set` and no `then`,
+// no `immutable`, no `peerVisibility`, no `submitOnly`. Adding them is
+// blocked behind the `.strict()` decision (implementation order 10), because
+// today an unknown key is stripped per-variant and would vanish silently.
+// Deriving from a source that cannot hold the declaration would mean inventing
+// the source first. So: authored here, projected and CHECKED by publish, and
+// when the schema can hold it the derivation replaces this arm rather than
+// joining it.
+//
+// STRICT ON PURPOSE. Unlike `schemaZ`, this parser refuses unknown keys. The
+// failure mode it prevents is the one the design note keeps warning about: a
+// misspelled declaration key is not a broken app, it is a SILENTLY PERMISSIVE
+// one — `submitOnl: true` publishes a collection anyone may write to, with
+// nothing red anywhere. A schema key that vanishes costs a feature; a
+// declaration key that vanishes costs the guarantee.
+
+import { z } from "zod";
+import { isValidCollectionName } from "../core/collectionKey";
+import { parseAppManifest, type AppManifestResult } from "./appManifest";
+
+/** A collection id / app id, held to the one name rule (`SAFE_SLUG_PATTERN`)
+ *  that `sharedCollectionKey` applies. Stated once so a path built later
+ *  cannot be a way around it. */
+const NameZ = z.string().refine(isValidCollectionName, { message: "is not a valid id (letters, digits, '-' and '_' only)" });
+
+/** An address on the roster. Not validated as an email beyond "has an @":
+ *  the rules compare it to `request.auth.token.email` verbatim, so any
+ *  narrowing here would refuse addresses Firebase itself accepts. */
+const EmailZ = z.string().trim().min(3).includes("@");
+
+/** The four roles the deployed rules understand. `participant` is the layer
+ *  that is NAMED but reads only its own rows — see `readerOf` vs `listedIn`. */
+export const APP_ROLES = ["owner", "editor", "viewer", "participant"] as const;
+const RoleZ = z.enum(APP_ROLES);
+
+/** `{ email: { "*" | cid: role } }`. The `"*"` key is the app-wide role; a
+ *  member may hold per-collection roles only (the stylist who is editor of
+ *  bookings and viewer of everything else). */
+const MembersZ = z.record(EmailZ, z.record(z.union([z.literal("*"), NameZ]), RoleZ));
+
+/** The declarative mail queue, as the rules re-derive it: a transition of the
+ *  status field, a recipient read off the RECORD, and a fixed template. */
+const MailZ = z
+  .object({
+    toField: z.string().trim().min(1),
+    on: z.record(z.string().trim().min(1), z.object({ from: z.array(z.string().trim().min(1)).min(1), to: z.string().trim().min(1) }).strict()),
+    dataFields: z.array(z.string().trim().min(1)).optional(),
+  })
+  .strict();
+
+/** What the rules read out of `collections[cid]`. NOT the schema — the schema
+ *  is published beside it, untouched, for clients to render from. */
+const CollectionConfigZ = z
+  .object({
+    statusField: z.string().trim().min(1).optional(),
+    /** `{ initial: [...], <status>: [<status>...] }`. Binds writers too, and
+     *  binds `create` — that is the point of publishing it. */
+    transitions: z.record(z.string().trim().min(1), z.array(z.string().trim().min(1))).optional(),
+    immutable: z.boolean().optional(),
+    submitOnly: z.boolean().optional(),
+    peerVisibility: z.enum(["public", "hidden"]).optional(),
+    revealGated: z.boolean().optional(),
+    gatedFrom: NameZ.optional(),
+    revealBy: z.string().trim().min(1).optional(),
+    mail: MailZ.optional(),
+    /** Which fields an aggregate groups by. Declared here rather than in the
+     *  schema for the same reason as everything else in this file — the schema
+     *  has no `aggregate` key yet — and it is here at all because the
+     *  invariant that guards it ("every aggregation key is a CHECKED field")
+     *  is about `public.submit`, which is an app-level declaration. Published
+     *  as-is; the rules never read it. */
+    aggregate: z
+      .object({ by: z.array(z.string().trim().min(1)).min(1) })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+/** An authored submit window. ISO strings, because `app.json` is JSON and a
+ *  Firestore `Timestamp` has no JSON form. Publish lowers it to epoch millis —
+ *  the rules do not coerce strings, so an ISO string reaching Firestore is a
+ *  type error that fails CLOSED (`inWindow` refuses every submission and the
+ *  author sees "nobody can submit", not an error). */
+const WindowZ = z.object({ from: z.iso.datetime().optional(), until: z.iso.datetime().optional() }).strict();
+
+const ValidateZ = z
+  .object({
+    required: z.array(z.string().trim().min(1)).optional(),
+    /** Capped at two by the rules themselves: rules have no iteration, so
+     *  `keyFieldsOk` is unrolled. A third would be accepted here and silently
+     *  unchecked there. */
+    keyFields: z
+      .array(z.object({ field: z.string().trim().min(1), values: z.array(z.union([z.string(), z.number(), z.boolean()])).min(1) }).strict())
+      .optional(),
+  })
+  .strict();
+
+const SubmitZ = z
+  .object({
+    auth: z.enum(["none", "anonymous", "verifiedEmail"]),
+    emailField: z.string().trim().min(1).optional(),
+    createFields: z.array(z.string().trim().min(1)).min(1),
+    initialStatus: z.string().trim().min(1).optional(),
+    idFrom: z.enum(["auto", "auth.uid", "auth.uid+field"]).optional(),
+    idField: z.string().trim().min(1).optional(),
+    validate: ValidateZ.optional(),
+    window: WindowZ.optional(),
+    /** Per CURRENT STATUS, never a flat list: a flat list lets a customer move
+     *  an approved booking's `startAt` without anyone re-approving it. */
+    selfUpdate: z.record(z.string().trim().min(1), z.array(z.string().trim().min(1))).optional(),
+    selfTransitions: z.record(z.string().trim().min(1), z.array(z.string().trim().min(1))).optional(),
+    finalize: z.boolean().optional(),
+    audience: z.literal("participant").optional(),
+    gateOn: z
+      .object({ phase: z.string().trim().min(1), match: z.string().trim().min(1) })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+const PublicZ = z
+  .object({
+    /** The master switch. Anonymous submission (`auth: "none"`) needs it as
+     *  well as its own declaration. */
+    enabled: z.boolean().optional(),
+    read: z.array(NameZ).optional(),
+    submit: z.record(NameZ, SubmitZ).optional(),
+  })
+  .strict();
+
+/** The whole authored declaration.
+ *
+ *  `owner` is accepted but is NOT the published value — publish stamps the
+ *  publisher's uid (or carries the existing one forward, which is what the
+ *  rules require on update) and refuses a declaration that disagrees. It is
+ *  accepted rather than banned because the sample app.json in the design note
+ *  shows it, and a hard refusal on a key the samples contain would be a worse
+ *  first experience than a message naming the mismatch. */
+export const AuthoredAppZ = z
+  .object({
+    aid: NameZ,
+    name: z.string().trim().min(1).optional(),
+    /** Per-worktree app id (design D6, implementation order 7). Accepted so a
+     *  repository already carrying it parses; nothing reads it yet. */
+    aidEnv: z.string().trim().min(1).optional(),
+    owner: z.string().trim().min(1).optional(),
+    members: MembersZ,
+    collections: z.record(NameZ, CollectionConfigZ).optional(),
+    participantRead: z.array(NameZ).optional(),
+    public: PublicZ.optional(),
+  })
+  .strict();
+
+export type AuthoredApp = z.infer<typeof AuthoredAppZ>;
+export type AuthoredCollectionConfig = z.infer<typeof CollectionConfigZ>;
+export type AuthoredSubmit = z.infer<typeof SubmitZ>;
+export type AuthoredMail = z.infer<typeof MailZ>;
+
+export type AuthoredAppResult = { ok: true; app: AuthoredApp } | { ok: false; problems: string[] };
+
+/** Parse the authored declaration out of `app.json`'s text.
+ *
+ *  Returns a LIST of problems rather than throwing, for the same reason
+ *  `loadAppManifest` returns a failure: the caller is a gate whose entire job
+ *  is to hand the author something to act on. Every problem is reported at
+ *  once — publish is a manual step, and a parser that stops at the first key
+ *  makes it N round trips. */
+export function parseAuthoredApp(raw: string): AuthoredAppResult {
+  // Reuse the one-field parse so `aid`'s rule has a single statement, and so a
+  // file that is not even JSON says so in the same words discovery uses.
+  const manifest: AppManifestResult = parseAppManifest(raw);
+  if (!manifest.ok) return { ok: false, problems: [manifest.kind === "missing" ? "app.json is missing" : manifest.detail] };
+  const parsed = AuthoredAppZ.safeParse(JSON.parse(raw));
+  if (!parsed.success) return { ok: false, problems: authoredProblems(parsed.error) };
+  return { ok: true, app: parsed.data };
+}
+
+/** zod issues as one actionable line each: `public.submit.responses.auth: …`. */
+export function authoredProblems(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const where = issue.path.length > 0 ? issue.path.join(".") : "app.json";
+    return `${where}: ${issue.message}`;
+  });
+}

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -1,0 +1,230 @@
+// authored (`app.json`) → published (`apps/{aid}`). The compilation step.
+//
+// THE WHOLE CONVERSION LIVES HERE. That is the point of the module, not a
+// tidiness claim: the design note's D4 calls publish a compiler, and the
+// failure it is guarding against is "I wrote what the sample shows and the
+// rules refuse it". Every difference between what a human writes and what the
+// rules read is either in this file or is a bug.
+//
+// What actually differs, and why:
+//
+//   window.from / window.until (ISO strings)  →  window.fromMs / untilMs (numbers)
+//     The rules do not coerce a string to a timestamp. Comparing an ISO string
+//     with `request.time` is a TYPE ERROR, and a rules type error denies. The
+//     symptom is not an error message, it is "nobody can submit".
+//
+//   members                                   →  members + memberEmails
+//     Denormalised so a client can ask "which apps am I in?" with
+//     `array-contains`. It is DERIVED, never authored: `membersConsistent()`
+//     refuses any write where the two disagree, so a hand-written value cannot
+//     survive anyway — it can only make the whole publish fail with a
+//     permission error that says nothing about the cause.
+//
+//   —                                         →  owner / publishedAt / publishedBy /
+//                                                publishedCommit / previousPublished
+//     Attribution and rollback. `owner` is a uid and the publisher's identity;
+//     see `projectApp`'s parameter for why it is threaded in rather than read
+//     from the declaration.
+//
+// WHAT DOES *NOT* CHANGE, and the temptation to make it change:
+// `public.read` and `participantRead` stay ARRAYS. The rules test them with
+// `cid in a.public.read`, which in the rules language means "is an element of"
+// for a list and "is a key of" for a map — so a `{cid: true}` map would work
+// equally well, and an earlier draft of the handoff note specified one. Two
+// spellings that both work is exactly the kind of silent divergence this
+// module exists to prevent, so the published form is the authored form and
+// the emulator round-trip test (`../mulmoserver test/rules/rules_publish.ts`)
+// pins that the rules accept it.
+
+import type { CollectionSchema } from "../core/schema";
+import type { AuthoredApp, AuthoredSubmit } from "./publishManifest";
+
+/** Who and when. Threaded in rather than read from a clock inside the
+ *  projection so the projection stays pure and the tests can assert on an
+ *  exact document. */
+export interface PublishStamp {
+  /** The publisher's Firebase uid. The rules require `owner ==
+   *  request.auth.uid` on CREATE and `owner` unchanged on UPDATE, so this is
+   *  used only when the app document does not exist yet. */
+  uid: string;
+  /** The publisher's verified email — the principal the roster is keyed by. */
+  email: string;
+  /** Wall-clock millis of this publish. */
+  publishedAt: number;
+  /** The git commit the declaration was read from, when the host could
+   *  resolve one. Absent is a normal state (a dirty tree, a repository
+   *  without git), and absent is more honest than a fabricated value. */
+  commit?: string | undefined;
+}
+
+/** One collection's published schema document (`apps/{aid}/collections/{cid}`).
+ *
+ *  The rules never read `publishedSchema` — `schemaRead` gates the whole
+ *  document and stops there. It is here for the CLIENTS: a member's host
+ *  renders from it, and a public webview has no other way to know the fields.
+ *  The whole schema is published rather than a projection of it, because
+ *  every attempt to guess "the part a view needs" is a guess about a view
+ *  that has not been written yet. */
+export interface PublishedSchemaDoc extends Record<string, unknown> {
+  publishedSchema: CollectionSchema;
+  publishedAt: number;
+  publishedBy: string;
+  publishedCommit?: string;
+}
+
+/** The public settings document (`apps/{aid}/config/public`).
+ *
+ *  `allow read: if true` — this is the one document an anonymous visitor can
+ *  read, and it is the reason `apps/{aid}` itself is reader-only: a
+ *  participant reading the app document would see their classmates'
+ *  addresses. So the roster is NOT here, and neither is `owner`. What is here
+ *  is what a public form needs in order to render itself and to tell a visitor
+ *  "this closed yesterday" instead of failing a write with no explanation. */
+export interface PublishedConfigDoc extends Record<string, unknown> {
+  name?: string;
+  enabled: boolean;
+  read: string[];
+  submit: Record<string, Record<string, unknown>>;
+  publishedAt: number;
+}
+
+/** Everything one publish writes. Separate documents because they live at
+ *  separate paths with separate rules — and in the order given: the app
+ *  document authorizes the other two, so it goes first. */
+export interface PublishedApp {
+  app: Record<string, unknown>;
+  schemas: { cid: string; doc: PublishedSchemaDoc }[];
+  config: PublishedConfigDoc;
+}
+
+/** The document id under `apps/{aid}/config`. One document, named, rather than
+ *  a spread of them: a second public document is a second thing to keep in
+ *  step, and nothing yet needs one. */
+export const PUBLIC_CONFIG_DOC = "public";
+
+/** Drop keys whose value is `undefined`. Firestore rejects an undefined field
+ *  value outright, and `"k" in c` — which every optional key in the rules is
+ *  read through — must mean "the author declared it". */
+function compact(entries: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(entries).filter(([, value]) => value !== undefined));
+}
+
+/** ISO → epoch millis, the one conversion the rules cannot do for themselves.
+ *  The caller has already refused an unparseable string (the authored parser
+ *  requires `z.iso.datetime()`), so a NaN here would be a programming error;
+ *  it is still checked, because a NaN written to Firestore fails closed in the
+ *  same silent way an ISO string does. */
+function windowMillis(window: { from?: string | undefined; until?: string | undefined } | undefined): Record<string, number> | undefined {
+  if (!window) return undefined;
+  const out: Record<string, number> = {};
+  if (window.from !== undefined) out.fromMs = Date.parse(window.from);
+  if (window.until !== undefined) out.untilMs = Date.parse(window.until);
+  if (Object.values(out).some((value) => !Number.isFinite(value))) {
+    throw new Error(`publish: window bound is not a parseable timestamp (${JSON.stringify(window)})`);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** One `public.submit[cid]`, with its window lowered. Everything else passes
+ *  through: the rules read these keys by the names the author wrote. */
+function projectSubmit(submit: AuthoredSubmit): Record<string, unknown> {
+  const { window, ...rest } = submit;
+  return compact({ ...rest, window: windowMillis(window) });
+}
+
+/** The roster's addresses as a set, in a stable order.
+ *
+ *  Sorted so two publishes of the same declaration produce the same document
+ *  — idempotence is a property this step is tested for, and Firestore compares
+ *  arrays by ORDER. `membersConsistent()` compares as sets and would accept
+ *  any order; the test that would notice is the one asserting a second publish
+ *  changes nothing but `publishedAt`. */
+function memberEmailsOf(members: AuthoredApp["members"]): string[] {
+  return Object.keys(members).sort();
+}
+
+/** The previous document, kept for rollback, with its OWN `previousPublished`
+ *  stripped.
+ *
+ *  One level, deliberately. Chaining would make every publish carry the entire
+ *  history of the app inside a single document, which grows without bound and
+ *  meets Firestore's 1 MiB document limit as a permission-shaped failure at
+ *  some unpredictable publish. One level answers the question rollback
+ *  actually asks — "put back what was there before I broke it" — and the
+ *  further history is in git, which is where the declaration came from. */
+function previousOf(existing: Record<string, unknown> | null): Record<string, unknown> | undefined {
+  if (!existing) return undefined;
+  const { previousPublished: __dropped, ...rest } = existing;
+  return rest;
+}
+
+/** Project the authored declaration into the documents publish writes.
+ *
+ *  `existing` is the app document as it is in Firestore right now, or null on
+ *  a first publish. Two things need it, both required by the rules:
+ *    - `owner` must be UNCHANGED on update. Re-stamping the publisher's uid
+ *      would be refused for any app whose owner ever signed in as a different
+ *      account, and would silently transfer ownership if it were not.
+ *    - `previousPublished` is that document, so a rollback has something to
+ *      put back.
+ *
+ *  Pure: no clock, no filesystem, no Firestore. Everything variable arrives as
+ *  a parameter, which is what makes the conversion table testable as a table. */
+export function projectApp(
+  authored: AuthoredApp,
+  schemas: { cid: string; schema: CollectionSchema }[],
+  stamp: PublishStamp,
+  existing: Record<string, unknown> | null,
+): PublishedApp {
+  const owner = typeof existing?.owner === "string" ? existing.owner : stamp.uid;
+  const submit = Object.fromEntries(Object.entries(authored.public?.submit ?? {}).map(([cid, spec]) => [cid, projectSubmit(spec)]));
+  const publicBlock = authored.public
+    ? compact({
+        enabled: authored.public.enabled,
+        read: authored.public.read,
+        submit: Object.keys(submit).length > 0 ? submit : undefined,
+      })
+    : undefined;
+
+  const app = compact({
+    aid: authored.aid,
+    name: authored.name,
+    owner,
+    members: authored.members,
+    memberEmails: memberEmailsOf(authored.members),
+    collections: authored.collections,
+    participantRead: authored.participantRead,
+    public: publicBlock,
+    publishedAt: stamp.publishedAt,
+    publishedBy: stamp.email,
+    publishedCommit: stamp.commit,
+    previousPublished: previousOf(existing),
+  });
+
+  const config: PublishedConfigDoc = {
+    enabled: authored.public?.enabled === true,
+    read: authored.public?.read ?? [],
+    submit,
+    publishedAt: stamp.publishedAt,
+  };
+  if (authored.name !== undefined) config.name = authored.name;
+
+  return { app, schemas: schemas.map(({ cid, schema }) => ({ cid, doc: schemaDoc(schema, stamp) })), config };
+}
+
+/** One published schema document. Written key by key rather than through
+ *  `compact`, so the declared type is the type — an optional commit is the
+ *  only variable part. */
+function schemaDoc(schema: CollectionSchema, stamp: PublishStamp): PublishedSchemaDoc {
+  const doc: PublishedSchemaDoc = { publishedSchema: schema, publishedAt: stamp.publishedAt, publishedBy: stamp.email };
+  if (stamp.commit !== undefined) doc.publishedCommit = stamp.commit;
+  return doc;
+}
+
+/** The app documents' parent path — the `FirestoreDocs` seam takes a
+ *  collection path plus a document id, and the app document's id is the aid. */
+export const APPS_COLLECTION = "apps";
+/** The collection (schema) documents' parent path. */
+export const appSchemasPath = (aid: string): string => `apps/${aid}/collections`;
+/** The public-config documents' parent path. */
+export const appConfigPath = (aid: string): string => `apps/${aid}/config`;

--- a/packages/core/src/collection/server/validate.ts
+++ b/packages/core/src/collection/server/validate.ts
@@ -35,6 +35,15 @@ export interface RecordIssue {
  *  because a caller that REPORTS a count has to know the count is a floor —
  *  `publish` presents a full batch as "at least N" rather than as a total. */
 export const MAX_RECORD_ISSUES = 25;
+
+/** The `file` of the pseudo-issue reported when the backend could not be read
+ *  at all.
+ *
+ *  Exported because it is a DIFFERENT KIND of answer from "this record is
+ *  invalid", and a caller that treats the two alike gets it wrong in the
+ *  direction that matters: `publish` lets the user override invalid records,
+ *  and overriding this one would mean publishing without ever having looked. */
+export const STORE_UNREADABLE = "(store)";
 const MAX_ISSUES = MAX_RECORD_ISSUES;
 
 /** Read every `<id>.json` under the collection's dataDir and report the
@@ -88,7 +97,7 @@ async function validateStoreRecords(collection: LoadedCollection, opts: { worksp
     items = await storeFor(collection, { workspaceRoot: opts.workspaceRoot }).list();
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
-    return [{ file: "(store)", problem: `records could not be read from the storage backend: ${reason}` }];
+    return [{ file: STORE_UNREADABLE, problem: `records could not be read from the storage backend: ${reason}` }];
   }
   const issues: RecordIssue[] = [];
   for (const item of items) {

--- a/packages/core/src/collection/server/validate.ts
+++ b/packages/core/src/collection/server/validate.ts
@@ -31,8 +31,11 @@ export interface RecordIssue {
   problem: string;
 }
 
-// Don't flood the result; the first batch is enough to act on.
-const MAX_ISSUES = 25;
+/** Don't flood the result; the first batch is enough to act on. Exported
+ *  because a caller that REPORTS a count has to know the count is a floor —
+ *  `publish` presents a full batch as "at least N" rather than as a total. */
+export const MAX_RECORD_ISSUES = 25;
+const MAX_ISSUES = MAX_RECORD_ISSUES;
 
 /** Read every `<id>.json` under the collection's dataDir and report the
  *  ones that won't load or violate the schema. An empty list means every

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -373,6 +373,44 @@ test("a first-step failure says nothing was written, because nothing was", async
   assert.equal(!result.ok && result.partial, false, "a first-step failure wrote nothing, and must not claim otherwise");
 });
 
+test("a user-scope skill is NOT published into this repository's app", async () => {
+  // `~/.claude/skills` is installed once per machine; a repository is not. And
+  // discovery resolves every schema it finds — user scope included — against
+  // the WORKSPACE root, so a globally installed firestore skill would pick up
+  // whichever repository's aid it was discovered from and be written into that
+  // app, and into every other app the same user publishes.
+  //
+  // A view is HTML, so this is not a tidiness question: it is the machine's
+  // own skills reaching every member's browser.
+  const userSkillDir = path.join(emptyUserDir, "globalnotes");
+  mkdirSync(userSkillDir, { recursive: true });
+  writeFileSync(path.join(userSkillDir, "SKILL.md"), "---\nname: globalnotes\ndescription: installed once per machine\n---\nbody\n");
+  writeFileSync(path.join(userSkillDir, "schema.json"), JSON.stringify({ ...BOOKINGS_SCHEMA, title: "Global Notes" }));
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, true, result.ok ? "" : result.problems.join("\n"));
+  assert.deepEqual(result.ok && result.cids, ["bookings"], "only the repository's own collections may be published");
+  assert.equal(await docs.get(`apps/${AID}/collections`, "globalnotes"), null);
+});
+
+test("naming a user-scope-only collection in app.json is refused, not silently published", async () => {
+  // The paired case, and the reason the boundary is safe to draw: a cid that
+  // exists only outside the repository becomes an unknown cid — said by name —
+  // rather than a schema from off the repository going live.
+  const userSkillDir = path.join(emptyUserDir, "globalnotes");
+  mkdirSync(userSkillDir, { recursive: true });
+  writeFileSync(path.join(userSkillDir, "SKILL.md"), "---\nname: globalnotes\ndescription: installed once per machine\n---\nbody\n");
+  writeFileSync(path.join(userSkillDir, "schema.json"), JSON.stringify({ ...BOOKINGS_SCHEMA, title: "Global Notes" }));
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp({ participantRead: ["globalnotes"] });
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("participantRead names 'globalnotes'")));
+});
+
 test("publish without a session refuses instead of failing document by document", async () => {
   writeSkill("bookings", BOOKINGS_SCHEMA);
   writeApp();

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -135,7 +135,10 @@ function writeApp(overrides: Record<string, unknown> = {}): void {
         submit: {
           bookings: {
             auth: "verifiedEmail",
-            createFields: ["customerEmail", "status"],
+            // `id` is the schema's primaryKey, and a submission may carry only
+            // the createFields — without it, every submitted row would be
+            // stored with no primary key and rejected by every reader.
+            createFields: ["id", "customerEmail", "status"],
             initialStatus: "pending",
             window: { until: "2026-12-31T23:59:59Z" },
           },
@@ -198,7 +201,7 @@ test("a refused declaration writes NOTHING", async () => {
   // rules enforcing one declaration while members read another.
   writeSkill("bookings", BOOKINGS_SCHEMA);
   writeApp({
-    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerEmail"], idFrom: "auth.uid" } } },
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerEmail"], idFrom: "auth.uid" } } },
   });
 
   const result = await publishApp(opts());
@@ -286,6 +289,63 @@ test("a dirty working tree is recorded, because the commit no longer describes t
   assert.equal(result.ok, true);
   const app = (await docs.get("apps", AID)) as Record<string, unknown>;
   assert.equal(app.publishedDirty, true);
+});
+
+test("an unreadable backend stops publish, and confirm does NOT override it", async () => {
+  // `confirm` means "I know these rows will not fit the new schema". Here
+  // nobody knows anything — the records were never read, so the migration gate
+  // did not run. Letting confirm through would publish blind, which is the one
+  // thing the gate exists to prevent.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const denied = Object.assign(new Error("Missing or insufficient permissions."), { code: "permission-denied" });
+  const unreadable: FirestoreDocs = { ...docs, list: () => Promise.reject(denied) };
+  setFirestoreAccessor(() => ({ docs: unreadable, email: OWNER_EMAIL, uid: OWNER_UID }));
+
+  for (const confirm of [false, true]) {
+    const result = await publishApp(opts({ confirm }));
+    assert.equal(result.ok, false, `confirm: ${confirm} must not publish`);
+    assert.ok(!result.ok && result.problems.some((problem) => problem.includes("could not be read")));
+    assert.ok(!result.ok && result.problems.some((problem) => problem.includes("not something `confirm` overrides")));
+  }
+  assert.equal(await docs.get("apps", AID), null);
+});
+
+test("a failed write becomes a result naming the step, not a thrown call", async () => {
+  // The tool's whole contract is actionable text. A raw rejection reaches the
+  // agent as a crash — and does so having possibly written the app document,
+  // which is exactly the fact the caller needs to hear.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const failOnSchemas: FirestoreDocs = {
+    ...docs,
+    set: (collectionPath, docId, data) =>
+      collectionPath === `apps/${AID}/collections` ? Promise.reject(new Error("network is unreachable")) : docs.set(collectionPath, docId, data),
+  };
+  setFirestoreAccessor(() => ({ docs: failOnSchemas, email: OWNER_EMAIL, uid: OWNER_UID }));
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems[0]?.includes("the published schema for 'bookings'"));
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("Everything before it WAS written")));
+  // …and it says so truthfully: the app document really is live.
+  assert.notEqual(await docs.get("apps", AID), null);
+});
+
+test("a first-step failure says nothing was written, because nothing was", async () => {
+  // The paired case. "Everything before it was written" on the FIRST step
+  // would send the user looking for a half-published app that does not exist.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const failOnApp: FirestoreDocs = {
+    ...docs,
+    set: (collectionPath, docId, data) => (collectionPath === "apps" ? Promise.reject(new Error("permission denied")) : docs.set(collectionPath, docId, data)),
+  };
+  setFirestoreAccessor(() => ({ docs: failOnApp, email: OWNER_EMAIL, uid: OWNER_UID }));
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("Nothing was written.")));
 });
 
 test("publish without a session refuses instead of failing document by document", async () => {

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -207,6 +207,7 @@ test("a refused declaration writes NOTHING", async () => {
   const result = await publishApp(opts());
   assert.equal(result.ok, false);
   assert.ok(!result.ok && result.problems.some((problem) => problem.includes("submitOnly must be true")));
+  assert.equal(!result.ok && result.partial, false);
   assert.equal(await docs.get("apps", AID), null);
 });
 
@@ -328,6 +329,9 @@ test("a failed write becomes a result naming the step, not a thrown call", async
   assert.equal(result.ok, false);
   assert.ok(!result.ok && result.problems[0]?.includes("the published schema for 'bookings'"));
   assert.ok(!result.ok && result.problems.some((problem) => problem.includes("Everything before it WAS written")));
+  // The flag the caller words its headline from. Inferring it from the prose
+  // is what produced "nothing was written" over a live roster.
+  assert.equal(!result.ok && result.partial, true);
   // …and it says so truthfully: the app document really is live.
   assert.notEqual(await docs.get("apps", AID), null);
 });
@@ -366,6 +370,7 @@ test("a first-step failure says nothing was written, because nothing was", async
   const result = await publishApp(opts());
   assert.equal(result.ok, false);
   assert.ok(!result.ok && result.problems.some((problem) => problem.includes("Nothing was written.")));
+  assert.equal(!result.ok && result.partial, false, "a first-step failure wrote nothing, and must not claim otherwise");
 });
 
 test("publish without a session refuses instead of failing document by document", async () => {

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -1,0 +1,273 @@
+// publish, end to end, against an in-memory Firestore.
+//
+// No API key, no network, no emulator: the `FirestoreDocs` seam takes the same
+// in-memory stand-in the store contract uses, so the whole path — read
+// app.json, refuse, pre-validate the LIVE records, write three kinds of
+// document in the order the rules require — is exercisable here.
+//
+// What this file cannot tell you is whether the rules ACCEPT what publish
+// wrote. Nothing that reads the rules can: implementation order 2 put four
+// rounds of static review through rules that then failed to execute at all.
+// That is `../mulmoserver test/rules/rules_publish.ts`, which feeds these
+// exact documents to the real rules under the emulator.
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { configureCollectionHost, setFirestoreAccessor } from "../../src/collection/server/host";
+import type { FirestoreDoc, FirestoreDocs } from "../../src/collection/server/firestoreDocs";
+import { publishApp } from "../../src/collection/server/publish";
+import { sharedItemsPath } from "../../src/collection/server/firestoreStore";
+import { sharedCollectionKey } from "../../src/collection/core/collectionKey";
+
+// Explicit-root mode (`workspaceRoot: null`): every call here passes its own
+// root, and a call that read an ambient one would throw rather than quietly
+// reach into a real workspace. That is the multi-root contract MulmoTerminal
+// depends on — one process, N project roots.
+configureCollectionHost({
+  workspaceRoot: null,
+  log: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  paths: {
+    userSkillsDir: () => null,
+    projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+    feedsRoot: (root) => path.join(root, "data", "feeds"),
+    skillsStagingDir: () => null,
+    archiveDir: "data/archive",
+    collectionsRegistriesConfig: (root) => path.join(root, "config", "collections-registries.json"),
+  },
+  isPresetSlug: () => false,
+});
+
+const AID = "app_salon_7f3a";
+const OWNER_EMAIL = "owner@salon.jp";
+const OWNER_UID = "uid_owner";
+
+let workdir: string;
+let emptyUserDir: string;
+let docs: FirestoreDocs;
+
+/** The same in-memory stand-in the store-contract suite uses: document
+ *  storage and create-atomicity, not consistency, listeners or rules. */
+function makeFakeFirestoreDocs(): FirestoreDocs {
+  const collections = new Map<string, Map<string, unknown>>();
+  const bucket = (collectionPath: string): Map<string, unknown> => {
+    const existing = collections.get(collectionPath);
+    if (existing) return existing;
+    const created = new Map<string, unknown>();
+    collections.set(collectionPath, created);
+    return created;
+  };
+  return {
+    list: (collectionPath) => {
+      const entries: FirestoreDoc[] = [...bucket(collectionPath).entries()].map(([docId, data]) => ({ id: docId, data }));
+      entries.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+      return Promise.resolve(entries);
+    },
+    get: (collectionPath, docId) => Promise.resolve(bucket(collectionPath).has(docId) ? (bucket(collectionPath).get(docId) as unknown) : null),
+    set: (collectionPath, docId, data) => {
+      bucket(collectionPath).set(docId, data);
+      return Promise.resolve();
+    },
+    create: (collectionPath, docId, data) => {
+      if (bucket(collectionPath).has(docId)) return Promise.resolve(false);
+      bucket(collectionPath).set(docId, data);
+      return Promise.resolve(true);
+    },
+    delete: (collectionPath, docId) => Promise.resolve(bucket(collectionPath).delete(docId)),
+  };
+}
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "publish-"));
+  emptyUserDir = mkdtempSync(path.join(tmpdir(), "publish-user-"));
+  docs = makeFakeFirestoreDocs();
+  setFirestoreAccessor(() => ({ docs, email: OWNER_EMAIL, uid: OWNER_UID }));
+});
+
+afterEach(() => {
+  // Module-level state: a fixture's fake left wired would resolve in a later
+  // test that never set one up.
+  setFirestoreAccessor(null);
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(emptyUserDir, { recursive: true, force: true });
+});
+
+const BOOKINGS_SCHEMA = {
+  title: "Bookings",
+  icon: "event",
+  storage: { type: "firestore" },
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true },
+    customerEmail: { type: "email", label: "Email" },
+    // `enum`, not `status`: the design note's vocabulary table lists a
+    // `status` field type and `schemaZ`'s discriminated union has no such
+    // member. A schema declaring one is not an error anywhere — discovery
+    // simply skips the collection, and publish then reports the cid as
+    // unknown.
+    status: { type: "enum", label: "Status", values: ["pending", "approved", "cancelled"] },
+  },
+};
+
+function writeSkill(slug: string, schema: object): void {
+  const dir = path.join(workdir, ".claude/skills", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${slug}\ndescription: test fixture\n---\nbody\n`);
+  writeFileSync(path.join(dir, "schema.json"), JSON.stringify(schema));
+}
+
+/** An `app.json` that passes every check, so a test can break exactly one
+ *  thing and know which check answered. */
+function writeApp(overrides: Record<string, unknown> = {}): void {
+  writeFileSync(
+    path.join(workdir, "app.json"),
+    JSON.stringify({
+      aid: AID,
+      name: "Sakura Hair",
+      members: { [OWNER_EMAIL]: { "*": "owner" } },
+      collections: { bookings: { statusField: "status", transitions: { initial: ["pending"], pending: ["approved", "cancelled"] } } },
+      public: {
+        enabled: true,
+        read: ["bookings"],
+        submit: {
+          bookings: {
+            auth: "verifiedEmail",
+            createFields: ["customerEmail", "status"],
+            initialStatus: "pending",
+            window: { until: "2026-12-31T23:59:59Z" },
+          },
+        },
+      },
+      ...overrides,
+    }),
+  );
+}
+
+/** Deterministic stamps, so an assertion can be about the document rather
+ *  than about "something that looks like a timestamp". */
+const opts = (extra: Record<string, unknown> = {}) => ({
+  workspaceRoot: workdir,
+  userSkillsDir: emptyUserDir,
+  now: () => 1_760_000_000_000,
+  resolveCommit: () => Promise.resolve({ commit: "abc123def456", dirty: false }),
+  ...extra,
+});
+
+test("publish writes the app, each collection's schema, and the public config", async () => {
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, true, result.ok ? "" : result.problems.join("\n"));
+  assert.equal(result.ok && result.created, true);
+
+  const app = (await docs.get("apps", AID)) as Record<string, unknown>;
+  assert.equal(app.owner, OWNER_UID);
+  assert.deepEqual(app.memberEmails, [OWNER_EMAIL]);
+  assert.equal(app.publishedBy, OWNER_EMAIL);
+  assert.equal(app.publishedCommit, "abc123def456");
+  assert.equal("publishedDirty" in app, false);
+
+  const schema = (await docs.get(`apps/${AID}/collections`, "bookings")) as Record<string, unknown>;
+  assert.equal((schema.publishedSchema as Record<string, unknown>).title, "Bookings");
+
+  const config = (await docs.get(`apps/${AID}/config`, "public")) as Record<string, unknown>;
+  assert.equal(config.enabled, true);
+  assert.equal("members" in config, false);
+});
+
+test("the app document goes out before the documents it authorizes", async () => {
+  // `allow write` on `collections/{cid}` and `config/{docId}` both resolve the
+  // role from the APP document, so a publish that wrote a schema first would
+  // be refused by the real rules on a first publish.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const order: string[] = [];
+  const recording: FirestoreDocs = { ...docs, set: (collectionPath, docId, data) => (order.push(collectionPath), docs.set(collectionPath, docId, data)) };
+  setFirestoreAccessor(() => ({ docs: recording, email: OWNER_EMAIL, uid: OWNER_UID }));
+
+  await publishApp(opts());
+  assert.deepEqual(order, ["apps", `apps/${AID}/collections`, `apps/${AID}/config`]);
+});
+
+test("a refused declaration writes NOTHING", async () => {
+  // The refusal has to be a gate, not a warning: a partial publish leaves the
+  // rules enforcing one declaration while members read another.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp({
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerEmail"], idFrom: "auth.uid" } } },
+  });
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("submitOnly must be true")));
+  assert.equal(await docs.get("apps", AID), null);
+});
+
+test("publish stops on live records the new schema would break, and confirm proceeds", async () => {
+  // The pre-check reads the LIVE records — the ones members are looking at —
+  // through the same store the app uses, which is what makes publish the
+  // migration gate rather than a schema upload.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const items = sharedItemsPath(sharedCollectionKey(AID, "bookings"));
+  await docs.set(items, "b1", { id: "b1", status: "nonsense" });
+
+  const stopped = await publishApp(opts());
+  assert.equal(stopped.ok, false);
+  assert.ok(!stopped.ok && stopped.problems.some((problem) => problem.includes("b1")));
+  assert.equal(await docs.get("apps", AID), null, "nothing may be written while the gate is closed");
+
+  const forced = await publishApp(opts({ confirm: true }));
+  assert.equal(forced.ok, true, forced.ok ? "" : forced.problems.join("\n"));
+  assert.equal(forced.ok && forced.recordIssues, 1);
+});
+
+test("republishing keeps the previous document and changes nothing else", async () => {
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  await publishApp(opts());
+  const first = (await docs.get("apps", AID)) as Record<string, unknown>;
+
+  const second = await publishApp(opts({ now: () => 1_760_000_009_999 }));
+  assert.equal(second.ok, true);
+  assert.equal(second.ok && second.created, false, "the second publish is an update");
+
+  const app = (await docs.get("apps", AID)) as Record<string, unknown>;
+  assert.equal((app.previousPublished as Record<string, unknown>).publishedAt, first.publishedAt);
+  assert.equal(app.owner, OWNER_UID);
+  const { publishedAt: __secondAt, previousPublished: __secondPrev, ...rest } = app;
+  const { publishedAt: __firstAt, previousPublished: __firstPrev, ...firstRest } = first;
+  assert.deepEqual(rest, firstRest);
+});
+
+test("a dirty working tree is recorded, because the commit no longer describes the publish", async () => {
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const result = await publishApp(opts({ resolveCommit: () => Promise.resolve({ commit: "abc123def456", dirty: true }) }));
+  assert.equal(result.ok, true);
+  const app = (await docs.get("apps", AID)) as Record<string, unknown>;
+  assert.equal(app.publishedDirty, true);
+});
+
+test("publish without a session refuses instead of failing document by document", async () => {
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  setFirestoreAccessor(() => null);
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("connect remote-host first")));
+});
+
+test("an app.json declaring someone else's owner uid is refused, not quietly ignored", async () => {
+  // The sample in the design note carries `"owner": "<uid>"`. Publishing over
+  // it silently would leave the author believing the key does something.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp({ owner: "<uid>" });
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("remove it from app.json")));
+});

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -226,6 +226,41 @@ test("publish stops on live records the new schema would break, and confirm proc
   assert.equal(forced.ok && forced.recordIssues, 1);
 });
 
+test("a capped record scan reports a FLOOR, on the confirmed path as well as the refusal", async () => {
+  // `validateCollectionRecords` stops at 25 per collection. Reporting that as
+  // an exact total understates the repair owed — and it understates it on the
+  // path where the records have already been published over, which is the one
+  // place the number is acted on rather than reconsidered.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const items = sharedItemsPath(sharedCollectionKey(AID, "bookings"));
+  for (let index = 0; index < 30; index += 1) {
+    await docs.set(items, `b${index}`, { id: `b${index}`, status: "nonsense" });
+  }
+
+  const stopped = await publishApp(opts());
+  assert.equal(stopped.ok, false);
+  assert.ok(!stopped.ok && stopped.problems.some((problem) => problem.includes("at least 25")));
+
+  const forced = await publishApp(opts({ confirm: true }));
+  assert.equal(forced.ok, true, forced.ok ? "" : forced.problems.join("\n"));
+  assert.equal(forced.ok && forced.recordIssues, 25);
+  assert.equal(forced.ok && forced.recordIssuesCapped, true, "a full batch is a floor, and the caller has to be able to tell");
+});
+
+test("an uncapped record scan is reported as the exact count it is", async () => {
+  // The paired case: without it, `recordIssuesCapped: true` always would pass
+  // the assertion above and turn every count into a hedge.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const items = sharedItemsPath(sharedCollectionKey(AID, "bookings"));
+  await docs.set(items, "b1", { id: "b1", status: "nonsense" });
+
+  const forced = await publishApp(opts({ confirm: true }));
+  assert.equal(forced.ok && forced.recordIssues, 1);
+  assert.equal(forced.ok && forced.recordIssuesCapped, false);
+});
+
 test("republishing keeps the previous document and changes nothing else", async () => {
   writeSkill("bookings", BOOKINGS_SCHEMA);
   writeApp();

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -332,6 +332,26 @@ test("a failed write becomes a result naming the step, not a thrown call", async
   assert.notEqual(await docs.get("apps", AID), null);
 });
 
+test("a rejecting preflight read becomes a result too, and says nothing was written", async () => {
+  // The read that decides create-vs-update is a backend call like any other.
+  // Left unguarded it escaped as a raw exception while the neighbouring read
+  // and write paths both returned actionable results — and it happens before
+  // any write, so the answer is unambiguous.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const failOnGet: FirestoreDocs = {
+    ...docs,
+    get: (collectionPath, docId) => (collectionPath === "apps" ? Promise.reject(new Error("quota exceeded")) : docs.get(collectionPath, docId)),
+  };
+  setFirestoreAccessor(() => ({ docs: failOnGet, email: OWNER_EMAIL, uid: OWNER_UID }));
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok && result.problems[0]?.includes(`reading the current app document (apps/${AID})`));
+  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("Nothing was written.")));
+  assert.equal(await docs.get("apps", AID), null);
+});
+
 test("a first-step failure says nothing was written, because nothing was", async () => {
   // The paired case. "Everything before it was written" on the FIRST step
   // would send the user looking for a half-published app that does not exist.

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -328,12 +328,43 @@ test("a failed write becomes a result naming the step, not a thrown call", async
   const result = await publishApp(opts());
   assert.equal(result.ok, false);
   assert.ok(!result.ok && result.problems[0]?.includes("the published schema for 'bookings'"));
-  assert.ok(!result.ok && result.problems.some((problem) => problem.includes("Everything before it WAS written")));
   // The flag the caller words its headline from. Inferring it from the prose
   // is what produced "nothing was written" over a live roster.
   assert.equal(!result.ok && result.partial, true);
-  // …and it says so truthfully: the app document really is live.
+
+  const said = !result.ok ? result.problems.join("\n") : "";
+  // What landed is ENUMERATED, not summarised. The order is app → schemas →
+  // config, so a summary written for one failure point is wrong at the others:
+  // saying "the roster and configuration are live" here would name a config
+  // document this publish never wrote.
+  assert.match(said, /Written by this publish, and live now: the app document/);
+  assert.match(said, /NOT written:.*public config document/s);
+  assert.doesNotMatch(said, /configuration are already live/);
+  // …and the enumeration is true on both sides.
   assert.notEqual(await docs.get("apps", AID), null);
+  assert.equal(await docs.get(`apps/${AID}/config`, "public"), null);
+});
+
+test("a config-write failure names the schemas that DID land", async () => {
+  // The other end of the same order. Here the app document and every schema
+  // are live and only the public config is missing — the opposite of the case
+  // above, and a message that summarised would be wrong at one of the two.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const failOnConfig: FirestoreDocs = {
+    ...docs,
+    set: (collectionPath, docId, data) =>
+      collectionPath === `apps/${AID}/config` ? Promise.reject(new Error("quota exceeded")) : docs.set(collectionPath, docId, data),
+  };
+  setFirestoreAccessor(() => ({ docs: failOnConfig, email: OWNER_EMAIL, uid: OWNER_UID }));
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, false);
+  assert.equal(!result.ok && result.partial, true);
+  const said = !result.ok ? result.problems.join("\n") : "";
+  assert.match(said, /Written by this publish, and live now:.*the published schema for 'bookings'/s);
+  assert.match(said, /NOT written: the public config document/);
+  assert.notEqual(await docs.get(`apps/${AID}/collections`, "bookings"), null);
 });
 
 test("a rejecting preflight read becomes a result too, and says nothing was written", async () => {

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -1,0 +1,302 @@
+// What publish refuses — and, for every refusal, the neighbouring declaration
+// it must still accept.
+//
+// The pairing is the point. A file of refusal assertions is satisfied by
+// `publishProblems = () => ["no"]`, and an implementation that refuses
+// everything looks exactly like a safe one from inside its own test suite. So
+// each case below states the accepted form first or immediately after.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { AuthoredAppZ } from "../../src/collection/server/publishManifest";
+import { publishProblems } from "../../src/collection/server/publishChecks";
+
+const OWNER = "owner@salon.jp";
+const CIDS = ["bookings", "responses", "services", "answers"];
+
+/** Build + parse a declaration through the real zod schema, so no fixture can
+ *  assert about a shape publish would have rejected before it got this far. */
+function app(overrides: Record<string, unknown>) {
+  return AuthoredAppZ.parse({ aid: "app_test", members: { [OWNER]: { "*": "owner" } }, ...overrides });
+}
+
+const problemsFor = (overrides: Record<string, unknown>, cids: readonly string[] = CIDS) => publishProblems(app(overrides), cids, OWNER);
+
+/** Assert exactly which check fired, by a distinctive fragment of its line —
+ *  not merely that SOMETHING was refused, which would pass on an unrelated
+ *  failure and hide the check under test being dead. */
+function listed(fragment: string, problems: string[]): string {
+  const bullets = problems.map((problem) => `  - ${problem}`).join("\n");
+  return `expected a problem mentioning ${JSON.stringify(fragment)}, got:\n${bullets || "  (none)"}`;
+}
+
+function refuses(problems: string[], fragment: string): void {
+  assert.ok(
+    problems.some((problem) => problem.includes(fragment)),
+    listed(fragment, problems),
+  );
+}
+
+// --- invariant 1: submitOnly ------------------------------------------------
+
+const IDENTITY_BOUND: Record<string, unknown>[] = [
+  { auth: "verifiedEmail", createFields: ["a"], idFrom: "auth.uid" },
+  { auth: "verifiedEmail", createFields: ["a", "who"], idFrom: "auth.uid+field", idField: "who" },
+  { auth: "verifiedEmail", createFields: ["a", "email"], emailField: "email" },
+  { auth: "verifiedEmail", createFields: ["a"], audience: "participant" },
+];
+
+test("a submission bound to its submitter must declare submitOnly", () => {
+  // Each of the four bindings makes the record MEAN "the submitter said this".
+  // The writer branch of `allow create` never meets any of them, so without
+  // submitOnly an owner or editor can manufacture the same rows.
+  for (const submit of IDENTITY_BOUND) {
+    const problems = problemsFor({ public: { submit: { responses: submit } }, collections: { responses: {} } });
+    refuses(problems, "collections.responses.submitOnly must be true");
+  }
+});
+
+test("declaring submitOnly satisfies it", () => {
+  for (const submit of IDENTITY_BOUND) {
+    const problems = problemsFor({ public: { submit: { responses: submit } }, collections: { responses: { submitOnly: true } } });
+    assert.deepEqual(problems, [], `must accept ${JSON.stringify(submit)}`);
+  }
+});
+
+test("a submission NOT bound to its submitter must not be forced to submitOnly", () => {
+  // The counter-case that keeps the rule from being "always require it": S1's
+  // ledger-style booking form, where staff enter records on a customer's
+  // behalf. Requiring submitOnly there would break the feature.
+  const problems = problemsFor({
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"], idFrom: "auto" } } },
+    collections: { bookings: {} },
+  });
+  assert.deepEqual(problems, []);
+});
+
+test("immutable is not the condition — a mutable survey is padded the same way", () => {
+  // `immutable` was the tempting condition and it is wrong: S2's responses are
+  // not immutable and can be inflated exactly as a vote can.
+  const problems = problemsFor({
+    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid" } } },
+    collections: { responses: { immutable: false } },
+  });
+  refuses(problems, "submitOnly must be true");
+});
+
+// --- invariant 2: aggregation keys -----------------------------------------
+
+test("an aggregation key no rule checks is refused, and a checked one is not", () => {
+  const loose = problemsFor({
+    collections: { responses: { submitOnly: true, aggregate: { by: ["q1"] } } },
+    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid" } } },
+  });
+  refuses(loose, "aggregate.by names 'q1'");
+
+  const checked = problemsFor({
+    collections: { responses: { submitOnly: true, aggregate: { by: ["q1"] } } },
+    public: {
+      submit: {
+        responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid", validate: { keyFields: [{ field: "q1", values: ["a", "b"] }] } },
+      },
+    },
+  });
+  assert.deepEqual(checked, []);
+});
+
+test("the status field and gateOn.match also count as checked", () => {
+  // The transition machine pins the status; the session gate pins the match
+  // field. Both are checked by a rule, so both are legitimate group-by keys.
+  const byStatus = problemsFor({ collections: { responses: { statusField: "status", aggregate: { by: ["status"] } } } });
+  assert.deepEqual(byStatus, []);
+
+  const byGate = problemsFor({
+    collections: { answers: { submitOnly: true, aggregate: { by: ["questionId"] } } },
+    public: {
+      submit: { answers: { auth: "verifiedEmail", createFields: ["questionId"], idFrom: "auth.uid", gateOn: { phase: "open", match: "questionId" } } },
+    },
+  });
+  assert.deepEqual(byGate, []);
+});
+
+// --- invariant 3: auth stage ------------------------------------------------
+
+test("only verifiedEmail may be published, and the rules keep the other two", () => {
+  for (const auth of ["none", "anonymous"]) {
+    refuses(problemsFor({ public: { submit: { bookings: { auth, createFields: ["a"] } } } }), `public.submit.bookings.auth is "${auth}"`);
+  }
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"] } } } }), []);
+});
+
+// --- invariant 4: names -----------------------------------------------------
+
+test("a cid the repository does not have is refused rather than published as dead config", () => {
+  // Nothing else notices this: the app document simply configures a collection
+  // nobody publishes, and the collection that WAS meant goes out with no
+  // status machine and no submit path.
+  refuses(problemsFor({ collections: { bookingz: {} } }), "collections names 'bookingz'");
+  refuses(problemsFor({ public: { read: ["servicez"] } }), "public.read names 'servicez'");
+  refuses(problemsFor({ participantRead: ["nope"] }), "participantRead names 'nope'");
+  assert.deepEqual(problemsFor({ collections: { bookings: {} }, public: { read: ["services"] }, participantRead: ["services"] }), []);
+});
+
+test("a name that no downstream encoding could carry is refused by the parser itself", () => {
+  // The rule is `isValidCollectionName`, stated once. A second rule here is how
+  // the layers come to disagree.
+  assert.throws(() => app({ collections: { "book/ings": {} } }));
+});
+
+// --- invariant 5: mail ------------------------------------------------------
+
+const MAIL_BASE = {
+  statusField: "status",
+  transitions: { initial: ["pending"], pending: ["approved", "rejected"], approved: [], rejected: [] },
+};
+
+test("a mail transition whose from includes its to can never send", () => {
+  refuses(
+    problemsFor({
+      collections: {
+        bookings: { ...MAIL_BASE, mail: { toField: "customerEmail", on: { "booking-approved": { from: ["pending", "approved"], to: "approved" } } } },
+      },
+    }),
+    'lists "approved" in both',
+  );
+  assert.deepEqual(
+    problemsFor({
+      collections: { bookings: { ...MAIL_BASE, mail: { toField: "customerEmail", on: { "booking-approved": { from: ["pending"], to: "approved" } } } } },
+    }),
+    [],
+  );
+});
+
+test("a mail transition the state machine forbids is refused", () => {
+  // The record write is denied first, so the mail simply never fires — a
+  // feature that is silently absent rather than broken.
+  refuses(
+    problemsFor({
+      collections: { bookings: { ...MAIL_BASE, mail: { toField: "e", on: { t: { from: ["approved"], to: "rejected" } } } } },
+    }),
+    "which collections.bookings.transitions does not allow",
+  );
+});
+
+test("mail needs a statusField, because the rules read the status either side of the write", () => {
+  refuses(
+    problemsFor({ collections: { bookings: { mail: { toField: "e", on: { t: { from: ["a"], to: "b" } } } } } }),
+    "mail needs collections.bookings.statusField",
+  );
+});
+
+// --- invariants 6 and 7: window and keyFields -------------------------------
+
+test("a window that closes before it opens is refused; a real interval is not", () => {
+  refuses(
+    problemsFor({
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], window: { from: "2026-09-30T00:00:00Z", until: "2026-09-01T00:00:00Z" } } } },
+    }),
+    "closes at or before it opens",
+  );
+  assert.deepEqual(
+    problemsFor({
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], window: { from: "2026-09-01T00:00:00Z", until: "2026-09-30T00:00:00Z" } } } },
+    }),
+    [],
+  );
+});
+
+test("keyFields is capped at two, because the rules unroll the check", () => {
+  const keyFields = (count: number) => Array.from({ length: count }, (_unused, index) => ({ field: `f${index}`, values: ["x"] }));
+  const submitWith = (count: number) => ({
+    auth: "verifiedEmail",
+    createFields: keyFields(count).map((keyField) => keyField.field),
+    validate: { keyFields: keyFields(count) },
+  });
+  refuses(problemsFor({ public: { submit: { bookings: submitWith(3) } } }), "the rules check at most 2");
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: submitWith(2) } } }), []);
+});
+
+// --- the fail-closed traps --------------------------------------------------
+
+test("initialStatus without a statusField would deny every submission", () => {
+  refuses(
+    problemsFor({ collections: { bookings: {} }, public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], initialStatus: "pending" } } } }),
+    "initialStatus needs collections.bookings.statusField",
+  );
+});
+
+test("the status field must be one of the createFields a submission may carry", () => {
+  // `hasOnly(createFields)` and "the status must equal initialStatus" are both
+  // required by the same rule. Omit the field from createFields and the two
+  // cannot be satisfied at once — every submission is refused, silently.
+  refuses(
+    problemsFor({
+      collections: { bookings: { statusField: "status" } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], initialStatus: "pending" } } },
+    }),
+    'createFields must include "status"',
+  );
+  assert.deepEqual(
+    problemsFor({
+      collections: { bookings: { statusField: "status" } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a", "status"], initialStatus: "pending" } } },
+    }),
+    [],
+  );
+});
+
+test("a required or key-checked field outside createFields can never be satisfied", () => {
+  refuses(
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], validate: { required: ["b"] } } } } }),
+    'validate.required names "b"',
+  );
+  refuses(
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], validate: { keyFields: [{ field: "b", values: ["x"] }] } } } } }),
+    'validate.keyFields checks "b"',
+  );
+});
+
+test("auth.uid+field without an idField denies every create", () => {
+  refuses(
+    problemsFor({
+      collections: { responses: { submitOnly: true } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["a"], idFrom: "auth.uid+field" } } },
+    }),
+    "no idField is declared",
+  );
+});
+
+test("selfUpdate without a statusField denies every self-edit", () => {
+  // `selfUpdate` is declared per CURRENT STATUS; with no status field the
+  // rules read null and refuse before looking at the field list.
+  refuses(
+    problemsFor({
+      collections: { bookings: {} },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], selfUpdate: { pending: ["a"] } } } },
+    }),
+    "declares no statusField",
+  );
+});
+
+test("revealGated needs the parent it reads the flag off", () => {
+  refuses(problemsFor({ collections: { answers: { revealGated: true } } }), "revealGated needs both gatedFrom and revealBy");
+  assert.deepEqual(problemsFor({ collections: { answers: { revealGated: true, gatedFrom: "responses", revealBy: "revealed" } } }), []);
+});
+
+// --- the publisher ----------------------------------------------------------
+
+test("the publisher must hold app-wide owner in the roster they are publishing", () => {
+  // Otherwise Firestore answers with a permission error that says nothing
+  // about rosters, on a write the author believes they are entitled to make.
+  const problems = publishProblems(app({}), CIDS, "someone-else@salon.jp");
+  refuses(problems, 'add "someone-else@salon.jp": { "*": "owner" }');
+  assert.deepEqual(publishProblems(app({}), CIDS, OWNER), []);
+});
+
+test("a per-collection role is not app-wide owner", () => {
+  // `role(a, '*')` falls back to the '*' entry only; a member holding
+  // `{ bookings: "owner" }` cannot write the app document.
+  const problems = publishProblems(AuthoredAppZ.parse({ aid: "app_test", members: { [OWNER]: { bookings: "owner" } } }), CIDS, OWNER);
+  refuses(problems, "members must give you app-wide owner");
+});

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -13,7 +13,16 @@ import { AuthoredAppZ } from "../../src/collection/server/publishManifest";
 import { publishProblems } from "../../src/collection/server/publishChecks";
 
 const OWNER = "owner@salon.jp";
-const CIDS = ["bookings", "responses", "services", "answers"];
+/** The repository's shared collections, as publish sees them: a cid and the
+ *  schema key its records are identified by. `id` throughout, which is why
+ *  every submit fixture below carries `id` in its createFields — a submission
+ *  that cannot produce the primary key writes rows no reader accepts. */
+const CIDS = [
+  { cid: "bookings", primaryKey: "id" },
+  { cid: "responses", primaryKey: "id" },
+  { cid: "services", primaryKey: "id" },
+  { cid: "answers", primaryKey: "id" },
+];
 
 /** Build + parse a declaration through the real zod schema, so no fixture can
  *  assert about a shape publish would have rejected before it got this far. */
@@ -21,7 +30,8 @@ function app(overrides: Record<string, unknown>) {
   return AuthoredAppZ.parse({ aid: "app_test", members: { [OWNER]: { "*": "owner" } }, ...overrides });
 }
 
-const problemsFor = (overrides: Record<string, unknown>, cids: readonly string[] = CIDS) => publishProblems(app(overrides), cids, OWNER);
+const problemsFor = (overrides: Record<string, unknown>, cids: readonly { cid: string; primaryKey: string }[] = CIDS) =>
+  publishProblems(app(overrides), cids, OWNER);
 
 /** Assert exactly which check fired, by a distinctive fragment of its line —
  *  not merely that SOMETHING was refused, which would pass on an unrelated
@@ -41,10 +51,10 @@ function refuses(problems: string[], fragment: string): void {
 // --- invariant 1: submitOnly ------------------------------------------------
 
 const IDENTITY_BOUND: Record<string, unknown>[] = [
-  { auth: "verifiedEmail", createFields: ["a"], idFrom: "auth.uid" },
-  { auth: "verifiedEmail", createFields: ["a", "who"], idFrom: "auth.uid+field", idField: "who" },
-  { auth: "verifiedEmail", createFields: ["a", "email"], emailField: "email" },
-  { auth: "verifiedEmail", createFields: ["a"], audience: "participant" },
+  { auth: "verifiedEmail", createFields: ["id", "a"], idFrom: "auth.uid" },
+  { auth: "verifiedEmail", createFields: ["id", "a", "who"], idFrom: "auth.uid+field", idField: "who" },
+  { auth: "verifiedEmail", createFields: ["id", "a", "email"], emailField: "email" },
+  { auth: "verifiedEmail", createFields: ["id", "a"], audience: "participant" },
 ];
 
 test("a submission bound to its submitter must declare submitOnly", () => {
@@ -69,7 +79,7 @@ test("a submission NOT bound to its submitter must not be forced to submitOnly",
   // ledger-style booking form, where staff enter records on a customer's
   // behalf. Requiring submitOnly there would break the feature.
   const problems = problemsFor({
-    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"], idFrom: "auto" } } },
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerName"], idFrom: "auto" } } },
     collections: { bookings: {} },
   });
   assert.deepEqual(problems, []);
@@ -79,7 +89,7 @@ test("immutable is not the condition — a mutable survey is padded the same way
   // `immutable` was the tempting condition and it is wrong: S2's responses are
   // not immutable and can be inflated exactly as a vote can.
   const problems = problemsFor({
-    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid" } } },
+    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "q1"], idFrom: "auth.uid" } } },
     collections: { responses: { immutable: false } },
   });
   refuses(problems, "submitOnly must be true");
@@ -90,7 +100,7 @@ test("immutable is not the condition — a mutable survey is padded the same way
 test("an aggregation key no rule checks is refused, and a checked one is not", () => {
   const loose = problemsFor({
     collections: { responses: { submitOnly: true, aggregate: { by: ["q1"] } } },
-    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid" } } },
+    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "q1"], idFrom: "auth.uid" } } },
   });
   refuses(loose, "aggregate.by names 'q1'");
 
@@ -98,7 +108,7 @@ test("an aggregation key no rule checks is refused, and a checked one is not", (
     collections: { responses: { submitOnly: true, aggregate: { by: ["q1"] } } },
     public: {
       submit: {
-        responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid", validate: { keyFields: [{ field: "q1", values: ["a", "b"] }] } },
+        responses: { auth: "verifiedEmail", createFields: ["id", "q1"], idFrom: "auth.uid", validate: { keyFields: [{ field: "q1", values: ["a", "b"] }] } },
       },
     },
   });
@@ -114,7 +124,7 @@ test("the status field and gateOn.match also count as checked", () => {
   const byGate = problemsFor({
     collections: { answers: { submitOnly: true, aggregate: { by: ["questionId"] } } },
     public: {
-      submit: { answers: { auth: "verifiedEmail", createFields: ["questionId"], idFrom: "auth.uid", gateOn: { phase: "open", match: "questionId" } } },
+      submit: { answers: { auth: "verifiedEmail", createFields: ["id", "questionId"], idFrom: "auth.uid", gateOn: { phase: "open", match: "questionId" } } },
     },
   });
   assert.deepEqual(byGate, []);
@@ -124,9 +134,9 @@ test("the status field and gateOn.match also count as checked", () => {
 
 test("only verifiedEmail may be published, and the rules keep the other two", () => {
   for (const auth of ["none", "anonymous"]) {
-    refuses(problemsFor({ public: { submit: { bookings: { auth, createFields: ["a"] } } } }), `public.submit.bookings.auth is "${auth}"`);
+    refuses(problemsFor({ public: { submit: { bookings: { auth, createFields: ["id", "a"] } } } }), `public.submit.bookings.auth is "${auth}"`);
   }
-  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"] } } } }), []);
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"] } } } }), []);
 });
 
 // --- invariant 4: names -----------------------------------------------------
@@ -194,13 +204,17 @@ test("mail needs a statusField, because the rules read the status either side of
 test("a window that closes before it opens is refused; a real interval is not", () => {
   refuses(
     problemsFor({
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], window: { from: "2026-09-30T00:00:00Z", until: "2026-09-01T00:00:00Z" } } } },
+      public: {
+        submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], window: { from: "2026-09-30T00:00:00Z", until: "2026-09-01T00:00:00Z" } } },
+      },
     }),
     "closes at or before it opens",
   );
   assert.deepEqual(
     problemsFor({
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], window: { from: "2026-09-01T00:00:00Z", until: "2026-09-30T00:00:00Z" } } } },
+      public: {
+        submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], window: { from: "2026-09-01T00:00:00Z", until: "2026-09-30T00:00:00Z" } } },
+      },
     }),
     [],
   );
@@ -210,7 +224,7 @@ test("keyFields is capped at two, because the rules unroll the check", () => {
   const keyFields = (count: number) => Array.from({ length: count }, (_unused, index) => ({ field: `f${index}`, values: ["x"] }));
   const submitWith = (count: number) => ({
     auth: "verifiedEmail",
-    createFields: keyFields(count).map((keyField) => keyField.field),
+    createFields: ["id", ...keyFields(count).map((keyField) => keyField.field)],
     validate: { keyFields: keyFields(count) },
   });
   refuses(problemsFor({ public: { submit: { bookings: submitWith(3) } } }), "the rules check at most 2");
@@ -221,7 +235,10 @@ test("keyFields is capped at two, because the rules unroll the check", () => {
 
 test("initialStatus without a statusField would deny every submission", () => {
   refuses(
-    problemsFor({ collections: { bookings: {} }, public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], initialStatus: "pending" } } } }),
+    problemsFor({
+      collections: { bookings: {} },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], initialStatus: "pending" } } },
+    }),
     "initialStatus needs collections.bookings.statusField",
   );
 });
@@ -233,14 +250,14 @@ test("the status field must be one of the createFields a submission may carry", 
   refuses(
     problemsFor({
       collections: { bookings: { statusField: "status" } },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], initialStatus: "pending" } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], initialStatus: "pending" } } },
     }),
     'createFields must include "status"',
   );
   assert.deepEqual(
     problemsFor({
       collections: { bookings: { statusField: "status" } },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a", "status"], initialStatus: "pending" } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a", "status"], initialStatus: "pending" } } },
     }),
     [],
   );
@@ -248,11 +265,13 @@ test("the status field must be one of the createFields a submission may carry", 
 
 test("a required or key-checked field outside createFields can never be satisfied", () => {
   refuses(
-    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], validate: { required: ["b"] } } } } }),
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], validate: { required: ["b"] } } } } }),
     'validate.required names "b"',
   );
   refuses(
-    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], validate: { keyFields: [{ field: "b", values: ["x"] }] } } } } }),
+    problemsFor({
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], validate: { keyFields: [{ field: "b", values: ["x"] }] } } } },
+    }),
     'validate.keyFields checks "b"',
   );
 });
@@ -261,7 +280,7 @@ test("auth.uid+field without an idField denies every create", () => {
   refuses(
     problemsFor({
       collections: { responses: { submitOnly: true } },
-      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["a"], idFrom: "auth.uid+field" } } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "a"], idFrom: "auth.uid+field" } } },
     }),
     "no idField is declared",
   );
@@ -273,7 +292,7 @@ test("selfUpdate without a statusField denies every self-edit", () => {
   refuses(
     problemsFor({
       collections: { bookings: {} },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], selfUpdate: { pending: ["a"] } } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], selfUpdate: { pending: ["a"] } } } },
     }),
     "declares no statusField",
   );
@@ -282,6 +301,55 @@ test("selfUpdate without a statusField denies every self-edit", () => {
 test("revealGated needs the parent it reads the flag off", () => {
   refuses(problemsFor({ collections: { answers: { revealGated: true } } }), "revealGated needs both gatedFrom and revealBy");
   assert.deepEqual(problemsFor({ collections: { answers: { revealGated: true, gatedFrom: "responses", revealBy: "revealed" } } }), []);
+});
+
+test("a submit path that cannot produce the schema's primaryKey is refused", () => {
+  // The rules bind the DOCUMENT ID; the engine identifies a record by its
+  // primaryKey FIELD, and the firestore store stores exactly the fields it was
+  // given — the document id is not copied in. So without the key in
+  // createFields, Firestore accepts every submission and every reader rejects
+  // it. Neither side can see this alone.
+  refuses(
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"] } } } }),
+    'createFields must include "id", the schema\'s primaryKey',
+  );
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerName"] } } } }), []);
+});
+
+test("the primaryKey check follows the schema, not the name 'id'", () => {
+  // A collection keyed by `name` (S1's services) must be held to `name`.
+  // Hard-coding "id" would pass this file and fail the first real schema.
+  const keyedByName = [{ cid: "bookings", primaryKey: "name" }];
+  refuses(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id"] } } } }, keyedByName), 'createFields must include "name"');
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["name"] } } } }, keyedByName), []);
+});
+
+test("emailField and idField must be in createFields — the rules read them off the record", () => {
+  // The same contradiction `required` and `keyFields` have: the rules read
+  // `resource.data[emailField]`, and `hasOnly(createFields)` decides what may
+  // be there at all. Declared in one and not the other, every submission is
+  // refused whether or not it carries the field.
+  refuses(
+    problemsFor({
+      collections: { responses: { submitOnly: true } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "answer"], emailField: "email" } } },
+    }),
+    'createFields must include "email"',
+  );
+  refuses(
+    problemsFor({
+      collections: { responses: { submitOnly: true } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "answer"], idFrom: "auth.uid+field", idField: "who" } } },
+    }),
+    'createFields must include "who"',
+  );
+  assert.deepEqual(
+    problemsFor({
+      collections: { responses: { submitOnly: true } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "answer", "email"], emailField: "email" } } },
+    }),
+    [],
+  );
 });
 
 // --- the publisher ----------------------------------------------------------

--- a/packages/core/test/collection/test_publishProject.ts
+++ b/packages/core/test/collection/test_publishProject.ts
@@ -1,0 +1,183 @@
+// The authored → published conversion, tested AS A TABLE.
+//
+// Every row of the design note's conversion table gets an assertion here, and
+// the reason it is worth this much attention is that each conversion's failure
+// mode is silence. An ISO string that reaches Firestore does not error: it
+// makes `inWindow` a type error, which denies, so the app's symptom is "nobody
+// can submit" with nothing anywhere saying why. Same for `memberEmails` — a
+// stale one is refused by `membersConsistent()` as a bare permission error.
+//
+// The projection is pure, so this file needs no filesystem, no Firestore and
+// no clock: the stamp is a parameter.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { AuthoredAppZ, type AuthoredApp } from "../../src/collection/server/publishManifest";
+import { projectApp, type PublishStamp } from "../../src/collection/server/publishProject";
+import type { CollectionSchema } from "../../src/collection/core/schema";
+
+const STAMP: PublishStamp = { uid: "uid_owner", email: "owner@salon.jp", publishedAt: 1_760_000_000_000, commit: "abc123def456" };
+
+const SCHEMA = { title: "Bookings", icon: "event", primaryKey: "id", fields: { id: { type: "string", primary: true } } } as unknown as CollectionSchema;
+
+/** The S1 declaration, trimmed to the keys under test. Parsed through the real
+ *  zod schema rather than cast, so a fixture cannot drift from what publish
+ *  would actually accept. */
+function authored(overrides: Record<string, unknown> = {}): AuthoredApp {
+  return AuthoredAppZ.parse({
+    aid: "app_salon_7f3a",
+    name: "Sakura Hair",
+    members: {
+      "owner@salon.jp": { "*": "owner" },
+      "stylist-a@salon.jp": { bookings: "editor" },
+    },
+    collections: {
+      bookings: {
+        statusField: "status",
+        submitOnly: true,
+        transitions: { initial: ["pending"], pending: ["approved", "cancelled"], approved: [], cancelled: [] },
+      },
+    },
+    public: {
+      enabled: true,
+      read: ["services"],
+      submit: {
+        bookings: {
+          auth: "verifiedEmail",
+          emailField: "customerEmail",
+          createFields: ["customerEmail", "status"],
+          initialStatus: "pending",
+          window: { from: "2026-09-01T00:00:00Z", until: "2026-09-30T23:59:59Z" },
+        },
+      },
+    },
+    ...overrides,
+  });
+}
+
+/** The published `public.submit[cid]` block, or a failure naming what was
+ *  missing — an assertion on `undefined.window` says nothing about which half
+ *  of the projection broke. */
+function publishedSubmit(app: Record<string, unknown>, cid: string): Record<string, unknown> {
+  const publicBlock = app.public;
+  assert.ok(publicBlock !== null && typeof publicBlock === "object", "the app document has no `public` block");
+  const submits = (publicBlock as { submit?: Record<string, Record<string, unknown>> }).submit;
+  const submit = submits?.[cid];
+  assert.ok(submit, `the app document has no public.submit.${cid}`);
+  return submit;
+}
+
+test("the submit window is lowered to epoch millis", () => {
+  // THE conversion. The rules do not coerce a string to a timestamp; comparing
+  // an ISO string with request.time is a type error, and a rules type error
+  // denies. A published `window.from` is the bug, not a stylistic difference.
+  const { app } = projectApp(authored(), [], STAMP, null);
+  const submit = publishedSubmit(app, "bookings");
+  assert.deepEqual(submit.window, { fromMs: Date.parse("2026-09-01T00:00:00Z"), untilMs: Date.parse("2026-09-30T23:59:59Z") });
+  assert.deepEqual(Object.keys(submit.window as object).sort(), ["fromMs", "untilMs"], "the ISO form must not survive alongside the millis");
+});
+
+test("a one-sided window publishes only the bound that was declared", () => {
+  // `inWindow` defaults the missing bound (0 / MAX_SAFE_INTEGER). Publishing a
+  // zero for an undeclared `from` would work by accident today and break the
+  // moment the default changes.
+  const app = authored({
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerEmail"], window: { until: "2026-12-31T23:59:59Z" } } } },
+  });
+  const projected = projectApp(app, [], STAMP, null);
+  const submit = publishedSubmit(projected.app, "bookings");
+  assert.deepEqual(submit.window, { untilMs: Date.parse("2026-12-31T23:59:59Z") });
+});
+
+test("memberEmails is derived from members, and a hand-written one is overwritten", () => {
+  // `membersConsistent()` refuses any write where the two disagree, so an
+  // authored value could only ever turn publish into a bare permission error.
+  const { app } = projectApp(authored(), [], STAMP, null);
+  assert.deepEqual(app.memberEmails, ["owner@salon.jp", "stylist-a@salon.jp"]);
+  assert.deepEqual(Object.keys(app.members as object).sort(), app.memberEmails);
+});
+
+test("public.read stays a list — the shape the rules were tested against", () => {
+  // `cid in list` and `cid in map` both work in the rules language. Two
+  // spellings that both work is how the two repositories drift, so the
+  // published form is the authored form, and the emulator test pins it.
+  const { app } = projectApp(authored(), [], STAMP, null);
+  assert.deepEqual((app.public as Record<string, unknown>).read, ["services"]);
+});
+
+test("owner is stamped on create and carried forward on update", () => {
+  // The rules require `owner == request.auth.uid` on create and `owner`
+  // UNCHANGED on update. Re-stamping the publisher would make every publish by
+  // a second owner-role account fail, and would silently transfer ownership if
+  // it did not.
+  const created = projectApp(authored(), [], STAMP, null);
+  assert.equal(created.app.owner, "uid_owner");
+
+  const updated = projectApp(authored(), [], { ...STAMP, uid: "uid_someone_else" }, { owner: "uid_owner", members: {} });
+  assert.equal(updated.app.owner, "uid_owner");
+});
+
+test("the previous document is kept for rollback, one level deep", () => {
+  // Chaining would carry the app's whole history inside one document and meet
+  // Firestore's 1 MiB limit as an unexplained failure at some later publish.
+  const first = projectApp(authored(), [], STAMP, null);
+  const second = projectApp(authored(), [], { ...STAMP, publishedAt: STAMP.publishedAt + 1000 }, first.app);
+  const previous = second.app.previousPublished as Record<string, unknown>;
+  assert.equal(previous.publishedAt, STAMP.publishedAt);
+  assert.equal("previousPublished" in previous, false);
+
+  const third = projectApp(authored(), [], { ...STAMP, publishedAt: STAMP.publishedAt + 2000 }, second.app);
+  const thirdPrevious = third.app.previousPublished as Record<string, unknown>;
+  assert.equal("previousPublished" in thirdPrevious, false, "the chain must not grow");
+});
+
+test("publishing the same declaration twice changes only the timestamp", () => {
+  // Idempotence. If this fails, `previousPublished` grows, or a map/array
+  // ordering is unstable, and every publish is a diff for readers watching the
+  // document.
+  const first = projectApp(authored(), [{ cid: "bookings", schema: SCHEMA }], STAMP, null);
+  const second = projectApp(authored(), [{ cid: "bookings", schema: SCHEMA }], { ...STAMP, publishedAt: STAMP.publishedAt + 5 }, first.app);
+  const { publishedAt: __firstAt, previousPublished: __firstPrev, ...firstRest } = first.app;
+  const { publishedAt: __secondAt, previousPublished: __secondPrev, ...secondRest } = second.app;
+  assert.deepEqual(secondRest, firstRest);
+});
+
+test("undeclared keys are absent, not present-and-undefined", () => {
+  // Every optional key in the rules is read through `"k" in c`, so a key
+  // written with an undefined value would flip a check the author never made.
+  // Firestore rejects undefined outright as well.
+  const bare = AuthoredAppZ.parse({ aid: "app_bare", members: { "owner@salon.jp": { "*": "owner" } } });
+  const { app } = projectApp(bare, [], { ...STAMP, commit: undefined }, null);
+  for (const key of ["name", "collections", "participantRead", "public", "publishedCommit", "previousPublished"]) {
+    assert.equal(key in app, false, `${key} must be absent`);
+  }
+});
+
+test("the schema is published whole, beside the config the rules read", () => {
+  // The rules never read `publishedSchema` — clients do, and a public webview
+  // has no other way to learn the fields.
+  const { schemas } = projectApp(authored(), [{ cid: "bookings", schema: SCHEMA }], STAMP, null);
+  assert.equal(schemas.length, 1);
+  const [only] = schemas;
+  assert.ok(only);
+  assert.equal(only.cid, "bookings");
+  assert.deepEqual(only.doc.publishedSchema, SCHEMA);
+  assert.equal(only.doc.publishedBy, "owner@salon.jp");
+});
+
+test("the public config document carries no roster", () => {
+  // `apps/{aid}/config/{docId}` is `allow read: if true`. It exists so a
+  // public form can render itself; the roster is the reason `apps/{aid}`
+  // itself is reader-only.
+  const { config } = projectApp(authored(), [], STAMP, null);
+  assert.equal("members" in config, false);
+  assert.equal("memberEmails" in config, false);
+  assert.equal("owner" in config, false);
+  assert.equal(config.enabled, true);
+  assert.deepEqual(config.read, ["services"]);
+  // The window a visitor's form needs is the lowered one, same as the app doc.
+  const { bookings } = config.submit;
+  assert.ok(bookings);
+  assert.deepEqual(bookings.window, { fromMs: Date.parse("2026-09-01T00:00:00Z"), untilMs: Date.parse("2026-09-30T23:59:59Z") });
+});

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.6.0",
+    "@mulmoclaude/core": "^3.7.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/server/remoteHost/session.ts
+++ b/server/remoteHost/session.ts
@@ -84,14 +84,21 @@ export const currentStorage = (): FirebaseStorage => requireHandles().storage;
 // ask on every operation, including from screens that merely LIST collections,
 // so a throw would break unrelated UI.
 //
-// It reports the signed-in EMAIL, not the uid, because that is the principal
-// the deployed Firestore rules authorize on (`apps/{aid}.members` is keyed by
-// email). A session whose user has no email is not usable for a shared
-// collection, so it is reported as no session at all rather than as a session
-// that will be refused document by document.
-export const currentFirestoreSession = (): { firestore: Firestore; email: string } | null => {
+// The EMAIL is the principal the deployed Firestore rules authorize on
+// (`apps/{aid}.members` is keyed by email), and it is what every record
+// operation resolves a role with. A session whose user has no email is not
+// usable for a shared collection, so it is reported as no session at all
+// rather than as a session that will be refused document by document.
+//
+// The uid rides along for `publish` alone: the app document's `owner` is a uid
+// (`owner == request.auth.uid` on create, unchanged thereafter), so creating
+// an app needs an identity the roster never mentions. Both are required — a
+// session missing either cannot do the whole job, and reporting a half-usable
+// session would move the failure to a permission denial that says nothing.
+export const currentFirestoreSession = (): { firestore: Firestore; email: string; uid: string } | null => {
   const email = handles?.auth.currentUser?.email;
-  return handles && email ? { firestore: handles.firestore, email } : null;
+  const uid = handles?.auth.currentUser?.uid;
+  return handles && email && uid ? { firestore: handles.firestore, email, uid } : null;
 };
 
 // The signed-in user's Firebase ID token, or null when the RemoteHost session

--- a/server/workspace/collections/firestoreBinding.ts
+++ b/server/workspace/collections/firestoreBinding.ts
@@ -26,6 +26,6 @@ function docsFor(firestore: Firestore): FirestoreDocs {
 export function initFirestoreCollectionBinding(): void {
   setFirestoreAccessor(() => {
     const session = currentFirestoreSession();
-    return session === null ? null : { docs: docsFor(session.firestore), email: session.email };
+    return session === null ? null : { docs: docsFor(session.firestore), email: session.email, uid: session.uid };
   });
 }

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -204,7 +204,7 @@ function makeFakeFirestoreDocs(): FirestoreDocs & { paths: () => string[] } {
  *  store every time and silently lose every write. */
 function connectFakeFirestore(): FirestoreDocs & { paths: () => string[] } {
   const docs = makeFakeFirestoreDocs();
-  setFirestoreAccessor(() => ({ docs, email: "owner@example.com" }));
+  setFirestoreAccessor(() => ({ docs, email: "owner@example.com", uid: "uid_owner" }));
   return docs;
 }
 
@@ -465,6 +465,7 @@ describe("shared (firestore) collections", () => {
     setFirestoreAccessor(() => ({
       docs: { list: rejectAll, get: rejectAll, set: rejectAll, create: rejectAll, delete: rejectAll } as unknown as FirestoreDocs,
       email: "stranger@example.com",
+      uid: "uid_stranger",
     }));
     const [collection] = await discoverCollections(discoveryOpts());
     assert.ok(collection);

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -612,7 +612,7 @@ function makeFakeDocs(seed: Record<string, unknown>[]): FirestoreDocs {
 }
 
 function connectFake(docs: FirestoreDocs): void {
-  setFirestoreAccessor(() => ({ docs, email: "owner@example.com" }));
+  setFirestoreAccessor(() => ({ docs, email: "owner@example.com", uid: "uid_owner" }));
 }
 
 function writeSharedSchema(slug: string, extra: Record<string, unknown> = {}): void {


### PR DESCRIPTION
実装順 5。リポジトリの宣言（`app.json` + `storage.type: "firestore"` の `schema.json`）を、デプロイ済みの Firestore ルールが読める形に落として `apps/{aid}` に書く。`manageCollection` の **`publishApp`** アクションから起動する。

対: receptron/mulmoserver#156（ルールは変更せず、publish が出す実物を emulator に流す往復テスト）

## publish は転送ではなく「コンパイル段階」

authored（人が書く `app.json`）と published（ルールが読む `apps/{aid}`）は別物で、差分は **`publishProject.ts` に全部**書いてある。効くのは主に 2 つ:

- **`window` の ISO 文字列 → epoch millis。** ルールは文字列を timestamp に変換しないので、ISO のまま載ると `inWindow` が型エラーになって fail closed する。症状はエラーではなく「**なぜか誰も投稿できない**」
- **`memberEmails` は `members` からの導出。** `membersConsistent()` がずれを拒否するので、手で書いた値は書き込み自体を失敗させるしかない（しかもメッセージは原因を何も言わない）

`public.read` / `participantRead` は **authored のままリスト**で出す。ルールは `in` で見るのでマップでも通るが、「どちらでも通る 2 つの綴り」は 2 リポジトリが緑のまま離れる経路なので、片方に決めて mulmoserver#156 で実行確認した。

## publish が拒否するもの

リンターではなく publish に置く理由はルール本体と同じ — **リンターは作者の手元でしか走らない**。

**黙って緩い宣言**（ルールは言われたとおり動くが、意味が違う）
- レコードを投稿者の身元に束縛しているのに（`idFrom: "auth.uid"` / `"auth.uid+field"` / `emailField` / `audience: "participant"`）`submitOnly` を宣言していないコレクション。writer 経路の create は束縛を一度も通らないので、owner / editor が誰の名前でも同じ形のレコードを作れる。**`audience` の有無でも `immutable` でもなく、この 4 つが条件**
- 未検査のフィールドで集計している（`aggregate.by ⊆ keyFields ∪ gateOn.match ∪ statusField`）
- `auth` が `"verifiedEmail"` 以外（**ルールは 3 段階すべて保持**。商売判断が変わっても cross-repo デプロイにならないよう、決定はここに置く）

**黙って全部を拒否する宣言**（fail-closed の罠 — permission denial は当たった人に何も説明しない）
- `statusField` の無い `initialStatus` / `createFields` に status が無い
- `createFields` の外にある `validate.required` / `keyFields`
- `idField` の無い `idFrom: "auth.uid+field"`、`statusField` の無い `selfUpdate`、`gatedFrom`/`revealBy` の無い `revealGated`
- 状態機械が許さない mail 遷移、`from` が `to` を含む mail 遷移
- リポジトリに存在しない cid（黙って死んだ設定として載るだけになる）
- **publish 実行者が名簿で app-wide owner でない**（Firestore は名簿について何も言わない権限エラーを返すだけ）

**壊れるライブレコード** — 新スキーマで壊れる既存レコードを列挙して止まり、`confirm` で通す。件数はスキャン上限に達したら「at least N」と出す（過少な数を総数として出すのは、この事前検査が防ごうとしている失敗そのもの）。

## 記名と rollback

`publishedBy` / `publishedCommit` / `publishedAt`、作業ツリーが汚れていれば `publishedDirty`（コミットが publish の中身を説明しなくなるため）。前版は `previousPublished` に **1 段だけ** — 連鎖させるとアプリの全履歴を 1 ドキュメントに抱え、いつかの publish で 1 MiB 上限に説明の無い失敗として当たる。

CI からの publish は入れていない（owner ロールのサービスアカウントは、いまの「名簿は人である」という権限モデルに無い種類の principal）。

## 設計上の判断（オーナー確認済み）

**published な `collections[cid]` は `app.json` に authored する。** プランは `schema.json` からの導出（`actions[].then.email` → `mail` など）も書いているが、**読むべき schema キーが存在しない** — `schemaZ` に `require` と `set` はあるが `then` は無く、`immutable` / `peerVisibility` / `submitOnly` も無い。追加は実装順 10（`.strict()` 化）の決着待ちで、いま導出すると出所を先に発明することになる。schema がその宣言を持てるようになったら、この腕は**置き換わる**（並存ではなく）。

`publishManifest.ts` は `schemaZ` と違い**未知キーを拒否する**。schema のキーが消えると機能が 1 つ消えるが、宣言のキーが消えると保証が消える。

## 破壊的変更

**`FirestoreHandle` に `uid` を追加（必須）。** 名簿は email で引き、レコード操作はそれで足りるが、app ドキュメントの `owner` は uid で、ルールは作成時に `owner == request.auth.uid` を要求する。つまり「レコードは読み書きできるがアプリは作れない」セッションが成立してしまう。任意ではなく必須にしたのは、その穴を**コンパイルエラー**にするため（さもなければ、身元について何も言わない permission denial になる）。

影響は `setFirestoreAccessor` を呼ぶホストだけ。MulmoClaude 側は本 PR で更新済み、**MulmoTerminal はアクセサを bind していない**。

`@mulmoclaude/core` 3.6.0 → **3.7.0**（`packages/mulmoclaude` のレンジも追随、`check:launcher-sync` OK）。

## 検証

API キー無し・ネットワーク無しで走る（`FirestoreDocs` の継ぎ目にインメモリ fake）。**拒否のテストには必ず対になる成功ケース**を書いている — 拒否だけ書くと「全部拒否する」実装が安全に見える。

```
packages/core   915 pass / 0 fail（publish 関連 40 本）、typecheck・lint クリーン
mulmoclaude     yarn test 全スイート 0 fail、typecheck 0、lint 0 errors
                yarn test:coverage 0 fail
                check:launcher-sync / check-changelog-ships OK
mulmoserver     yarn test:rules 93 pass（往復テスト 10 本を含む、#156）
```

ルールが実際に受け取るかは**読んで確かめていない** — 実装順 2 で、4 巡の静的レビューを通ったルールが 1 つも実行できなかったため。mulmoserver#156 が emulator で実行して確かめている。

## ついでに見つかった、設計ノートの誤り

語彙表が「既存のフィールド型」に **`status` を挙げているが、`schemaZ` の判別共用体に `status` は無い**（`enum` を使う）。宣言してもエラーは出ず、discovery がそのコレクションを黙って飛ばすだけなので、テストのフィクスチャを書いていて初めて分かった。

設計: mulmoterminal `plans/feat-shareable-collections-step5-publish.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a managed publish pipeline from shared app repositories to Firestore, and tighten Firestore session handling for shared collections.

New Features:
- Introduce a `manageCollection` action `publishApp` that publishes a repository's shared app declaration and collection schemas from git to its Firestore app, with human-readable responses.
- Add publish-specific parsing, projection, and validation for authored app declarations, ensuring security invariants and fail-closed traps are enforced before writing to Firestore.

Enhancements:
- Export publish-related types and helpers from the core collection server module for host and test integration.
- Track publish attribution and rollback metadata on app documents, including publisher identity, commit, timestamp, dirty state, and previous version.
- Cap and expose record validation issue counts so publish can report live records that would be broken by new schemas.

Documentation:
- Document the new `publishApp` action and shared app publishing flow in the changelog, including its safety guarantees and usage guidance.

Tests:
- Add unit tests for publish declaration checks, authored-to-published projection, and end-to-end publishing against an in-memory FirestoreDocs implementation.
- Update shared collection tests and Firestore binding tests to account for the new Firestore uid requirement.

Chores:
- Bump `@mulmoclaude/core` to 3.7.0 and update `@mulmoclaude/core` dependency ranges in the MulmoClaude package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared-app publishing with configuration and schema validation.
  * Added live-data compatibility checks and confirmation for breaking schema changes.
  * Publication results now include metadata, ownership, rollback state, and actionable validation messages.

* **Breaking Changes**
  * Firestore access now requires an authenticated user ID.

* **Documentation**
  * Added publishing guidance, release notes, and publishing limitations.

* **Chores**
  * Updated package versions to 3.7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->