### PR TITLE
chore(deps): @mulmoclaude/core をホスト供給の peer に統一し ^3.6.0 に揃える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,32 @@ npm view <pkg> version --registry https://registry.npmjs.org/
 
 A range update reaches users only through that consumer's own next release, so it does not force an immediate republish of all 50 packages — but it MUST be in the tree before the consumer is published next.
 
+### A plugin declares host-provided packages as `peer` + `dev` — never `dependencies`
+
+A `packages/plugins/*-plugin` is always installed **alongside a host** — `mulmoclaude` or
+`mulmoterminal` — and both hosts declare `@mulmoclaude/core` themselves. So core is supplied by
+the host, and a plugin MUST declare it as:
+
+```jsonc
+"peerDependencies":  { "@mulmoclaude/core": "^<latest>" },  // the host must provide it
+"devDependencies":   { "@mulmoclaude/core": "^<latest>" }   // so the plugin builds/tests standalone
+```
+
+and MUST NOT list it under `dependencies`. Same for anything else the host owns
+(`gui-chat-protocol`, `vue`, `echarts` — see the existing `peerDependencies` blocks).
+
+Rationale: `dependencies` makes npm install a **second copy of core nested under the plugin**,
+so the plugin and the host each get their own module instance. Anything core keeps in module
+state (registries, watchers, caches) then silently exists twice, and the plugin talks to the
+copy the host never sees. A peer range instead *fails loudly* when the host is too old, which is
+the behaviour you want. `check:launcher-sync` verifies the launcher satisfies these peers
+("no peer-dep violations"); nothing catches a wrongly-placed `dependencies` entry, so it is on
+you at review time.
+
+`collection-plugin` is the reference shape. When a plugin imports core, moving the entry out of
+`dependencies` means **adding** it to `peerDependencies` and `devDependencies` — deleting it
+outright leaves an imported package undeclared.
+
 ### Tag every publish — no untagged releases
 
 Every `npm publish` of a workspace package MUST be accompanied by a git tag `@scope/name@X.Y.Z` (no `v` prefix) on the published commit, plus a GH release (`--latest=false`). The `/publish` skill does this — do NOT publish by hand and skip the tag.

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.1.0"
+    "@mulmoclaude/core": "^3.6.0"
   },
   "peerDependencies": {
     "express": "^5.2.1",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -37,10 +37,10 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.6.0"
+    "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
+    "@mulmoclaude/core": "^3.6.0",
     "express": "^5.2.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
@@ -61,6 +61,7 @@
     }
   },
   "devDependencies": {
+    "@mulmoclaude/core": "^3.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/express": "^5.0.6",
     "@types/node": "^26.1.2",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -34,16 +34,15 @@
     "lint": "eslint .",
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
-  "dependencies": {
-    "@mulmoclaude/core": "^3.6.0"
-  },
   "peerDependencies": {
+    "@mulmoclaude/core": "^3.6.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@mulmoclaude/core": "^3.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,7 +35,7 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^3.1.0"
+    "@mulmoclaude/core": "^3.6.0"
   },
   "peerDependencies": {
     "echarts": "^6.0.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^3.2.0",
+    "@mulmoclaude/core": "^3.6.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^3.2.0",
+    "@mulmoclaude/core": "^3.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -30,14 +30,13 @@
     "test": "tsx --test test/test_*.ts",
     "lint": "eslint src test"
   },
-  "dependencies": {
-    "@mulmoclaude/core": "^3.6.0"
-  },
   "peerDependencies": {
+    "@mulmoclaude/core": "^3.6.0",
     "gui-chat-protocol": "^2.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@mulmoclaude/core": "^3.6.0",
     "@types/node": "^26.1.2",
     "tsx": "^4.23.5",
     "typescript": "^6.0.3",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint src test"
   },
   "dependencies": {
-    "@mulmoclaude/core": "^3.5.0"
+    "@mulmoclaude/core": "^3.6.0"
   },
   "peerDependencies": {
     "gui-chat-protocol": "^2.0.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -35,8 +35,7 @@
     "test": "tsx --test test/test_*.ts"
   },
   "dependencies": {
-    "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.6.0"
+    "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
     "@mulmoclaude/core": "^3.6.0",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -36,17 +36,17 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.1.0"
+    "@mulmoclaude/core": "^3.6.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^3.1.0",
+    "@mulmoclaude/core": "^3.6.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.1.0",
+    "@mulmoclaude/core": "^3.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.6.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
     "js-yaml": "^5.2.3",
     "marked": "^18.0.7",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -37,20 +37,20 @@
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.1.0",
+    "@mulmoclaude/core": "^3.6.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
     "js-yaml": "^5.2.3",
     "marked": "^18.0.7",
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^3.1.0",
+    "@mulmoclaude/core": "^3.6.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^3.1.0",
+    "@mulmoclaude/core": "^3.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -41,12 +41,12 @@
     "test": "tsx --test test/test_*.ts"
   },
   "dependencies": {
-    "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.6.0"
+    "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
+    "@mulmoclaude/core": "^3.6.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "mulmocast": "^2.9.0",
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@mulmoclaude/core": "^3.6.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.1.0"
+    "@mulmoclaude/core": "^3.6.0"
   },
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",


### PR DESCRIPTION
## Summary

`@mulmoclaude/core` の宣言を **7 プラグイン全部で同じ形**に揃えました。

1. **レンジを ^3.6.0 に統一** — ^3.1.0 / ^3.2.0 / ^3.5.0 が残っていた（npm 最新 = workspace = 3.6.0）
2. **`dependencies` から削除し、`peerDependencies` + `devDependencies` に移設** —
   プラグインはホスト（`mulmoclaude` / `mulmoterminal`）と一緒に入り、**ホスト側が core を宣言している**ため
3. **CLAUDE.md にルールとして追記**

`collection-plugin` が既に `peer` + `dev` の形だったので、残り 6 つをそれに合わせた形です。

## Items to Confirm / Review

1. **リリース監査の decision が 33 → 34 に増えます（意図的）。** マージベース 946245f2f と比較すると:
   - `@mulmoclaude/accounting-plugin` が **新規に** `manifest drift` に入る
   - `chart` / `google` / `mulmoscript` は drift の理由が `dependencies` → `dependencies, peerDependencies` に拡大
   - `collection` / `html` / `markdown` は変更前から drift 済み

   マニフェストを変えたので当然の結果で、次回それぞれを publish したときに利用者へ届きます。
   （**当初この PR に「監査出力は変更前後で同一」と書いていましたが誤りでした。** 詳細は下記「検証」参照）
2. **`dependencies` は単純削除ではなく「移設」しています。** 7 プラグインとも `src` で core を
   import しているため（accounting 5 / chart 1 / collection 41 / google 4 / html 2 / markdown 3 /
   mulmoscript 3 ファイル）、削除だけでは import している依存が未宣言になります。
3. **mulmoterminal 側は `@mulmoclaude/core: ^3.3.0` です。** peer を ^3.6.0 に上げたプラグインを
   mulmoterminal が次に取り込むと、Yarn 1 は peer を自動インストールしないので
   「unmet peer dependency」警告のまま core 3.3.0 で解決されます。**別リポで追従が必要**です。
4. **各プラグインの再公開は行っていません。** CLAUDE.md のとおり、この変更は「そのコンシューマ自身の
   次のリリース」で初めて npm 利用者に届きます。
5. `@mulmoclaude/core` 以外（`@mulmoclaude/common`、`gui-chat-protocol` 等）は今回の範囲外です。
   `@mulmoclaude/common` は accounting / html / markdown / mulmoscript の `dependencies` に
   残っています — 同じ理屈で peer にすべきかは別途ご判断ください。

## User Prompt

> - @mulmoclaude/core をimportしているのは、ぜんぶ最新のバージョンに依存するようにpackage.jsonをすべてかきかえて
> - peerDependenciesはあげる / dependenciesはさくじょ / devDependenciesもあげる
> - plugin って実際には mulmoterminal か mulmoclaude といっしょにつかうんだ
> - CLAUDE.md にもかいておいてね（このレポの）

## 変更後の形（全プラグイン共通）

```jsonc
"peerDependencies": { "@mulmoclaude/core": "^3.6.0" },  // ホストが供給する
"devDependencies":  { "@mulmoclaude/core": "^3.6.0" }   // 単体でビルド/テストするため
// dependencies には置かない
```

| プラグイン | 変更前 | 変更後 |
|---|---|---|
| accounting | deps ^3.1.0 | peer ^3.6.0 + dev ^3.6.0 |
| chart | deps ^3.1.0 | peer ^3.6.0 + dev ^3.6.0 |
| collection | dev+peer ^3.2.0 | dev+peer ^3.6.0 |
| google | deps ^3.5.0 | peer ^3.6.0 + dev ^3.6.0 |
| html | deps+dev+peer ^3.1.0 | dev+peer ^3.6.0（deps 削除） |
| markdown | deps+dev+peer ^3.1.0 | dev+peer ^3.6.0（deps 削除） |
| mulmoscript | deps ^3.1.0 | peer ^3.6.0 + dev ^3.6.0 |

`packages/mulmoclaude`（launcher）は既に ^3.6.0 で、ホストなので `dependencies` のまま（変更なし）。

## なぜ `dependencies` ではだめか

`dependencies` に置くと npm が**プラグイン配下に core をもう一部インストール**します。
その結果プラグインとホストがそれぞれ別の core インスタンスを持ち、core がモジュール状態として
持っているもの（レジストリ・watcher・キャッシュ）が二重に存在して、プラグインはホストから
見えない方のコピーに話しかけることになります。peer なら、ホストが古いときに**大きな音を立てて失敗**します。

## 検証

- **`yarn install` 成功、`yarn.lock` は変化なし**（`@mulmoclaude/core` は workspace リンク解決のため lock に載らない）
- **解決結果を実物で確認**: `node_modules/@mulmoclaude/core -> ../../packages/core`
- **`check:launcher-sync` OK** — `root ↔ launcher deps in sync, no peer-dep violations`
- **`yarn build:packages` エラー 0**（core を deps から外してもプラグインのビルド解決は壊れていない）
- **`yarn typecheck` exit 0 / 型エラー 0**
- `prettier --check` 通過（package.json のフォーマット維持）

### 訂正: `audit:releases` の検証は最初やり方が間違っていました

当初この PR には「`audit:releases --code-only` の出力は変更前後で完全に同一」と書いていましたが、
**誤りでした。** `git stash` で作業ツリーを戻して前後比較したのですが、このスクリプトは
**リリースタグと HEAD コミットを比較する**ので、コミットされていない作業ツリーの変更は
そもそも見ていません。つまり「差分なし」は何も検証できていませんでした。

マージベース 946245f2f を別 worktree にチェックアウトして取り直した正しい比較:

```
< @mulmoclaude/chart-plugin        manifest drift  published fields changed: dependencies
---
> @mulmoclaude/accounting-plugin   manifest drift  published fields changed: dependencies, peerDependencies
> @mulmoclaude/chart-plugin        manifest drift  published fields changed: dependencies, peerDependencies
...
< 53 publishable workspaces · 33 need a decision
---
> 53 publishable workspaces · 34 need a decision
```

Codex の指摘（CHANGES REQUESTED）が正しく、drift は増えます。内容は意図どおり
（マニフェストを変えたのだから当然）ですが、記述が事実と違っていたので訂正します。

## CLAUDE.md への追記

`### Internal dep ranges` の直後に
`### A plugin declares host-provided packages as peer + dev — never dependencies` を追加。
理由（モジュール状態の二重化）、参照実装（collection-plugin）、
「import しているなら削除ではなく peer + dev へ移設」という落とし穴まで明記しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude
