### PR TITLE
fix(test): collection root の fixture をプラットフォーム依存でなくする (#2864)

### DIFF
--- a/packages/core/test/collection-watchers/test_completionIdShared.ts
+++ b/packages/core/test/collection-watchers/test_completionIdShared.ts
@@ -4,8 +4,15 @@
 // added — the two that already existed byte-for-byte, and the new one.
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import path from "node:path";
 
 import { completionLegacyId, parseCompletionLegacyId } from "../../src/collection-watchers/reconciler.ts";
+import { testRoot } from "../helpers/testRoot.ts";
+
+// The root inside an id is whatever `canonicalRoot` produced, which is
+// platform-shaped — so the fixtures are too. Everything else about the format
+// is pinned byte-for-byte below.
+const PROJ = testRoot("work", "proj");
 
 test("with no root the id is the pre-multi-root format, byte for byte", () => {
   // A single-workspace host's existing entries must keep matching, or every
@@ -14,10 +21,10 @@ test("with no root the id is the pre-multi-root format, byte for byte", () => {
 });
 
 test("a root is included only when one was supplied", () => {
-  assert.equal(completionLegacyId("tasks", "t1", "/work/proj"), "collection-completion:@/work/proj\u0000tasks:t1");
+  assert.equal(completionLegacyId("tasks", "t1", PROJ), `collection-completion:@${PROJ}\u0000tasks:t1`);
   // Canonicalised here as well as at the watcher's claim: `/proj/` reaching
   // reconcileItem directly would otherwise publish a second, uncleardable bell.
-  assert.equal(completionLegacyId("tasks", "t1", "/work/proj/"), completionLegacyId("tasks", "t1", "/work/proj"));
+  assert.equal(completionLegacyId("tasks", "t1", `${PROJ}${path.sep}`), completionLegacyId("tasks", "t1", PROJ));
 });
 
 test("a shared collection gets a mark of its own, not the rootless form", () => {
@@ -26,7 +33,7 @@ test("a shared collection gets a mark of its own, not the rootless form", () => 
   const shared = completionLegacyId("tasks", "t1", undefined, "salon");
   assert.equal(shared, "collection-completion:#salon\u0000tasks:t1");
   assert.notEqual(shared, completionLegacyId("tasks", "t1"));
-  assert.notEqual(shared, completionLegacyId("tasks", "t1", "/work/proj"));
+  assert.notEqual(shared, completionLegacyId("tasks", "t1", PROJ));
 });
 
 test("two apps owning the same cid hold two bells", () => {
@@ -36,7 +43,7 @@ test("two apps owning the same cid hold two bells", () => {
 test("an id cannot carry both a root and an app", () => {
   // Preferring one silently would put a LOCAL bell in the shared namespace,
   // where every root's sweep skips it and nobody can ever clear it.
-  assert.throws(() => completionLegacyId("tasks", "t1", "/work/proj", "salon"), /both a root/);
+  assert.throws(() => completionLegacyId("tasks", "t1", PROJ, "salon"), /both a root/);
 });
 
 test("a collection name carrying a colon is refused, not mis-parsed", () => {
@@ -67,7 +74,7 @@ test("an itemId may still carry colons", () => {
 
 test("all three forms parse", () => {
   assert.deepEqual(parseCompletionLegacyId("collection-completion:tasks:t1"), { slug: "tasks", itemId: "t1" });
-  assert.deepEqual(parseCompletionLegacyId("collection-completion:@/work/proj\u0000tasks:t1"), { root: "/work/proj", slug: "tasks", itemId: "t1" });
+  assert.deepEqual(parseCompletionLegacyId(`collection-completion:@${PROJ}\u0000tasks:t1`), { root: PROJ, slug: "tasks", itemId: "t1" });
   assert.deepEqual(parseCompletionLegacyId("collection-completion:#salon\u0000tasks:t1"), { aid: "salon", slug: "tasks", itemId: "t1" });
 });
 
@@ -81,7 +88,7 @@ test("a rooted id read back from disk is canonicalised on the way out too", () =
   // written by hand or by an older build with a trailing separator would
   // otherwise never match: the verdict would be "another root's, skip" and
   // nobody could ever clear that bell.
-  assert.deepEqual(parseCompletionLegacyId("collection-completion:@/work/proj/\u0000tasks:t1"), { root: "/work/proj", slug: "tasks", itemId: "t1" });
+  assert.deepEqual(parseCompletionLegacyId(`collection-completion:@${PROJ}${path.sep}\u0000tasks:t1`), { root: PROJ, slug: "tasks", itemId: "t1" });
 });
 
 test("a string from somewhere else parses to null", () => {

--- a/packages/core/test/collection/test_changeKey.ts
+++ b/packages/core/test/collection/test_changeKey.ts
@@ -6,6 +6,7 @@
 // nothing about roots at all.
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import path from "node:path";
 
 import {
   collectionChangeKey,
@@ -15,8 +16,12 @@ import {
   type SharedCollectionChange,
 } from "../../src/collection/server/host.ts";
 import { collectionKeyId } from "../../src/collection/core/collectionKey.ts";
+import { testRoot } from "../helpers/testRoot.ts";
 
-const HOST_ROOT = "/work/host";
+// Platform-shaped, because `collectionChangeKey` canonicalises through
+// `path.resolve` — a POSIX literal is not a fixed point of that on Windows.
+const HOST_ROOT = testRoot("work", "host");
+const PROJ = testRoot("work", "proj");
 
 test("a payload with no root resolves against the host's root", () => {
   const payload = collectionChangePayload({ slug: "tasks", ids: ["t1"], op: "upsert" }, undefined);
@@ -24,10 +29,10 @@ test("a payload with no root resolves against the host's root", () => {
 });
 
 test("a payload with an explicit root resolves against that one", () => {
-  const payload = collectionChangePayload({ slug: "tasks" }, "/work/proj/");
-  // Canonical on both sides: a direct write against `/work/proj/` and the
-  // watcher's own publish for `/work/proj` must land on ONE channel.
-  assert.deepEqual(collectionChangeKey(payload, HOST_ROOT), { kind: "local", root: "/work/proj", slug: "tasks" });
+  const payload = collectionChangePayload({ slug: "tasks" }, `${PROJ}${path.sep}`);
+  // Canonical on both sides: a direct write against a root with a trailing
+  // separator and the watcher's own publish without one must land on ONE channel.
+  assert.deepEqual(collectionChangeKey(payload, HOST_ROOT), { kind: "local", root: PROJ, slug: "tasks" });
 });
 
 test("a shared payload carries the app, never a root", () => {
@@ -39,8 +44,8 @@ test("a shared payload carries the app, never a root", () => {
 test("the fan-out cannot cross a project or an app", () => {
   // The failure this exists to prevent: two projects each owning `tasks`
   // refreshing each other's open views, and a shared `tasks` refreshing both.
-  const projA = collectionChangeKey(collectionChangePayload({ slug: "tasks" }, "/work/a"), HOST_ROOT);
-  const projB = collectionChangeKey(collectionChangePayload({ slug: "tasks" }, "/work/b"), HOST_ROOT);
+  const projA = collectionChangeKey(collectionChangePayload({ slug: "tasks" }, testRoot("work", "a")), HOST_ROOT);
+  const projB = collectionChangeKey(collectionChangePayload({ slug: "tasks" }, testRoot("work", "b")), HOST_ROOT);
   const shared = collectionChangeKey(sharedCollectionChangePayload({ slug: "tasks" }, "salon"), HOST_ROOT);
   const ids = new Set([projA, projB, shared].map(collectionKeyId));
   assert.equal(ids.size, 3);
@@ -60,7 +65,7 @@ test("a payload cannot carry both a root and an app", () => {
   // something off a wire -- it throws rather than being guessed into one
   // channel or the other, because a misrouted fan-out is invisible.
   // @ts-expect-error - the base of a local payload has no aid
-  const built = collectionChangePayload({ slug: "tasks", aid: "salon" }, "/work/a");
+  const built = collectionChangePayload({ slug: "tasks", aid: "salon" }, testRoot("work", "a"));
   assert.throws(() => collectionChangeKey(built, HOST_ROOT), /both an app/);
 });
 

--- a/packages/core/test/helpers/testRoot.ts
+++ b/packages/core/test/helpers/testRoot.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+
+// A notional workspace root, in the shape `canonicalRoot` produces ON THIS
+// PLATFORM.
+//
+// `canonicalRoot` is `path.resolve`, so a POSIX literal is not a fixed point of
+// it everywhere: on Windows `path.resolve("/work/proj")` is `C:\work\proj`
+// (the CWD's drive), never `/work/proj`. A test that hardcodes the POSIX
+// spelling therefore asserts against a root the code cannot produce there, and
+// only Windows sees it — `lint_test_windows` runs on a schedule and on push to
+// main, so it lands after the merge (#2864).
+export const testRoot = (...segments: string[]): string => path.resolve("/", ...segments);

--- a/plans/fix-2864-windows-root-fixtures.md
+++ b/plans/fix-2864-windows-root-fixtures.md
@@ -1,0 +1,61 @@
+# Windows CI の collection root テスト失敗を直す（#2864）
+
+## 現状
+
+`lint_test_windows` が 4 コミット連続で赤（`3abf85a90` / `2bc38f5d7` / `946245f2f` / `173fba0d6`）。
+ubuntu / macOS は緑なので Windows 限定。`yarn run test:coverage` の 5 件が失敗している。
+
+## 原因
+
+本番コードのバグではなく、テスト fixture がプラットフォーム依存。
+
+`canonicalRoot` は `path.resolve` そのもの。POSIX 絶対パスを直書きした fixture は Windows で
+別の文字列に解決される:
+
+```
+"/work/proj"   win32 = "\work\proj"   posix = "/work/proj"
+"/work/proj/"  win32 = "\work\proj"   posix = "/work/proj"
+```
+
+（実機の Windows ではカレントドライブが付いて `C:\work\proj`。どちらにせよ `/work/proj` ではない。）
+
+`test_collectionKey.ts` が同じ POSIX パスで緑なのは、`isCanonicalRootShape` が isomorphic ゆえに
+`node:path` を使えず **POSIX 形と Windows ドライブ形の両方を正準と認める**ため。canonicalise を
+するのは `canonicalRoot` の側だけ。本番の Windows ではルートが常に Windows 形なので両者は一致し、
+食い違うのは POSIX 直書き fixture だけ。
+
+## やること
+
+### 1. テスト用ヘルパー `packages/core/test/helpers/testRoot.ts` を足す
+
+```ts
+export const testRoot = (...segments: string[]): string => path.resolve("/", ...segments);
+```
+
+POSIX で `/work/proj`、Windows で `C:\work\proj`。つまり「動作中のプラットフォームで
+`canonicalRoot` が生成する形」の notional root。WHY をここに 1 回だけ書く。
+
+### 2. 失敗している 2 ファイルの fixture を差し替える
+
+- `test_completionIdShared.ts` — 期待する id 文字列も同じ root から組み立てる。
+  末尾セパレータのケースは `path.sep` を使う
+- `test_changeKey.ts` — `HOST_ROOT` とプロジェクトルートを `testRoot()` 由来にする
+
+構造（`collection-completion:@<root>\0<slug>:<itemId>`）と正準化（末尾セパレータの吸収）を
+pin する目的は維持する。変えるのはルート文字列がプラットフォーム依存でない、という点だけ。
+
+## 検証
+
+- macOS でテストが緑のままであること（既存の pin を壊していないこと）
+- **`path.win32` で Windows の解決を再現し、修正後の期待値が win32 でも成立することを確認**
+- **`lint_test_windows` を `workflow_dispatch` でこのブランチに対して実行し、実機 Windows で 5 件が
+  緑になることを確認**（このワークフローの `pull_request` トリガーは path 限定で、
+  `packages/core/test/**` では起動しないため、dispatch が唯一の実機確認手段）
+
+推論で「直ったはず」と言わない。実機 Windows の結果を根拠にする。
+
+## やらないこと
+
+- `canonicalRoot` / `isCanonicalRootShape` の仕様変更。本番の挙動は正しい
+- `lint_test_windows` のトリガー変更（毎 PR で Windows を回すのはコストが大きい。
+  ただし「マージ後にしか気付けない」構造そのものは #2864 に観測として残す）


### PR DESCRIPTION
## Summary

`lint_test_windows` が **4 コミット連続で赤**だったのを直します。ubuntu / macOS は緑なので Windows 限定でした。

**本番コードのバグではなく、テストの fixture がプラットフォーム依存**だったのが原因です。
POSIX 絶対パスの直書きをやめ、動作中のプラットフォームで `canonicalRoot` が生成する形の
notional root を返すヘルパーに置き換えました。

**実機 Windows で検証済み**: `workflow_dispatch` で `lint_test_windows` をこのブランチに対して実行し、
22.x / 24.x 両方 success、失敗していた 5 件すべてが `✔`、failing tests セクション 0 を確認しました
（[run 31466426319](https://github.com/receptron/mulmoclaude/actions/runs/31466426319)）。

## Items to Confirm / Review

1. **id の構造の pin は維持しています。** `collection-completion:@<root>\0<slug>:<itemId>` という
   形と、末尾セパレータが吸収されることは従来どおり assert しています。
   プラットフォーム依存でなくしたのは**ルート文字列だけ**です。
   ルートなしの形（`collection-completion:tasks:t1`）は今も byte-for-byte で pin されています。
2. **`lint_test_windows` は `packages/core/test/**` では PR 上で起動しません。**
   `pull_request` トリガーの path が `server/utils/launcher/**` / `test/utils/launcher/**` /
   自分自身の workflow ファイルに限定されているためです。この PR の CI にも Windows は出ません。
   上記の dispatch 実行が唯一の実機確認で、リンクを貼ってあります。
   トリガーを広げるべきかは別途ご判断ください（毎 PR で Windows を回すとコストが大きいので、
   この PR では変更していません）。
3. **観測（今回は直していません）**: Windows 上では `CollectionKey` が `/work/proj` を「正準」と
   認める一方、`canonicalRoot` は `C:\work\proj` を生成します。canonicalise を通さないルートから
   鍵を作る経路が Windows にできると、この 2 つの同一性が黙って割れます。現状そういう経路は
   ありません（watcher の claim で canonicalise される）。#2864 に記録済みです。

## User Prompt

> （直前のセッションで報告した「残っている宿題」のうち 2 番を指定）
>
> 2. **main の Windows テスト失敗** — collection root 正規化の 5 件が 4 コミット連続で赤（#2858 でも解消せず）。
>    `lint_test_windows` は schedule と push:main でしか走らないため気付きにくい構造です

## 原因

`canonicalRoot`（`packages/core/src/files/root.ts`）は `path.resolve` そのものです:

```ts
export function canonicalRoot(root: string): string {
  return path.resolve(root);
}
```

対してテストは POSIX 絶対パスを直書きし、その文字列がそのまま返る前提で assert していました:

```ts
assert.equal(completionLegacyId("tasks", "t1", "/work/proj"), "collection-completion:@/work/proj\u0000tasks:t1");
const HOST_ROOT = "/work/host";
```

**POSIX リテラルは `path.resolve` の不動点ではありません。** 実測:

```
"/work/proj"   win32 = "\work\proj"   posix = "/work/proj"
"/work/proj/"  win32 = "\work\proj"   posix = "/work/proj"
```

（実機 Windows ではカレントドライブが付いて `C:\work\proj`。いずれにせよ `/work/proj` ではない。）

### なぜ `test_collectionKey.ts` は同じ POSIX パスなのに緑だったか

`CollectionKey` 側の検証 `isCanonicalRootShape` は isomorphic で `node:path` を使えないため、
**POSIX 形と Windows ドライブ形の両方を「正準」と認めます**。canonicalise するのは
`canonicalRoot` の側だけです。本番の Windows ではルートが常に Windows 形なので両者は一致し、
食い違うのはテストの POSIX 直書き fixture だけ、という切り分けになります。

## 変更内容

**`packages/core/test/helpers/testRoot.ts`（新規）**

```ts
export const testRoot = (...segments: string[]): string => path.resolve("/", ...segments);
```

POSIX で `/work/proj`、Windows で `C:\work\proj` を返します。WHY はこのファイルに 1 回だけ書いてあります。

**`test_completionIdShared.ts` / `test_changeKey.ts`** — 直書きしていたルートと期待値の
文字列を、この root から組み立てる形に差し替え。末尾セパレータのケースは `path.sep` を使用。

## 検証

- **実機 Windows（workflow_dispatch, run 31466426319）で 22.x / 24.x とも success。**
  以前失敗していた 5 件すべて `✔`、failing tests 0
- macOS で当該 2 ファイル 19 件すべて緑（既存の pin を壊していないこと）
- **`path.win32` セマンティクスでも `testRoot` が `canonicalRoot` の不動点であり、
  末尾セパレータが吸収されることを確認**（推論ではなく実行して確認）:

  ```
  posix  testRoot = "/work/proj"    | 不動点: true | 末尾セパレータ吸収: true
  win32  testRoot = "\work\proj"    | 不動点: true | 末尾セパレータ吸収: true
  ```
- `yarn typecheck` exit 0 / 型エラー 0、`eslint` exit 0、`prettier` 変更なし

Closes #2864

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Make collection root fixtures in tests platform-agnostic so Windows CI passes consistently.

Enhancements:
- Introduce a shared test helper to generate a platform-shaped canonical workspace root for fixtures.
- Update collection change and completion ID tests to build expected roots and IDs from the platform-shaped test root instead of hardcoded POSIX paths.

Documentation:
- Add a plan document describing the Windows CI failures around collection roots and the chosen fix approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection root and completion ID handling across operating systems.
  * Ensured trailing separators are canonicalized consistently.
  * Preserved distinct project keys and existing shared/root ID behavior.

* **Tests**
  * Expanded coverage for Windows, macOS, and platform-specific path formats.
  * Added reusable test coverage for workspace root resolution.

* **Documentation**
  * Added a plan documenting the Windows root fixture compatibility work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->