### PR TITLE
feat(collections): 招待されたコレクションを discovery の第 2 ソースにする

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### Collections you were invited to now show up (implementation order 4, first half)
+
+Discovery has always answered one question — "what is on this disk?" — and for a
+shared app that is the wrong question. A member of an app has never cloned its
+repository and may never: the invitation is an entry in `apps/{aid}.members`,
+and the schema is a document `publish` wrote. Discovery now unions a second
+source, the apps whose roster carries your address, asked as `apps` where
+`memberEmails` contains it.
+
+- **Firestore is the source of truth for a subscribed collection, and the disk
+  is at most a display copy.** Not a preference: `acceptParsedSchema` resolves a
+  firestore schema's `aid` from the WORKSPACE's `app.json`, so a subscribed
+  schema written into a skills directory would be re-discovered as belonging to
+  whichever repository the server happens to be serving — somebody else's
+  records, read and written under your app id. A subscribed collection's `aid`
+  comes from the subscription and from nowhere else.
+- **Anything on this disk wins a slug collision.** A repository's own copy is
+  the one its author is editing; serving the published projection instead would
+  make local edits look ineffective.
+- **A host with no session, or a query that fails, is left with its local
+  collections** rather than an empty screen. This is deliberately a different
+  judgement from the store's, which refuses loudly — there someone is reading
+  data, and "no records" must stay distinguishable from "not connected".
+- The subscription list is memoised for 30s: discovery runs several times per
+  interaction, and a membership list changes when somebody edits a roster.
+
+`FirestoreDocs` gains one query, `listWhereArrayContains` — one shape, not a
+query builder, so a fake can satisfy the seam honestly. It exists for the single
+question the sharing model turns on, and it is answerable only because publish
+derives `memberEmails` (Firestore cannot index the keys of a map).
+
+Materialising a subscribed skill to disk, so Claude Code can read it, is the
+second half and lands separately.
+
 #### Publishing a shared app: `manageCollection` action `publishApp`
 
 A repository that declares a shared app (`app.json` + collections with
@@ -63,7 +97,7 @@ is people.
 
 ### Package releases
 
-Ships `@mulmoclaude/core@3.7.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.8.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/core/schema.ts
+++ b/packages/core/src/collection/core/schema.ts
@@ -88,7 +88,13 @@ export type FeedSchedule = (typeof FEED_SCHEDULES)[number];
 // "feed" collections live in the non-skill `<workspace>/feeds/` registry
 // and carry an `ingest` block; they reuse the same storage + rendering
 // as skill-backed collections but are never loaded into the agent prompt.
-export type CollectionSource = "user" | "project" | "feed";
+/** Where a collection came from.
+ *
+ *  The first three are DIRECTORIES this machine can scan. `subscribed` is not:
+ *  it is an app whose roster carries your address, discovered from Firestore,
+ *  and it is the one source whose `appId` does NOT come from the workspace's
+ *  `app.json` (see `server/subscribedCollections.ts`). */
+export type CollectionSource = "user" | "project" | "feed" | "subscribed";
 
 /** One field of a record — a discriminated union on `type`; see the variant
  *  docs in `./schemaZ` (`FieldSpecZ`). */

--- a/packages/core/src/collection/registry/server/performExport.ts
+++ b/packages/core/src/collection/registry/server/performExport.ts
@@ -35,6 +35,12 @@ export async function performExport(
   if (collection.schema.dataSource !== undefined) {
     return { ok: false, status: STATUS_UNPROCESSABLE, error: `collection '${slug}' is backed by an external dataSource and cannot be exported to a registry` };
   }
+  // A subscribed collection has no directory of ours to export: its schema is
+  // a document in another app, and its records are that app's. Refused for the
+  // same reason a `dataSource` collection is — a bundle cannot carry it.
+  if (collection.skillDir === null) {
+    return { ok: false, status: STATUS_UNPROCESSABLE, error: `collection '${slug}' is subscribed from another app and cannot be exported to a registry` };
+  }
   const skillMd = await readFile(path.join(collection.skillDir, "SKILL.md"), "utf-8").catch(() => "");
   const existingMeta = await readJsonObject(path.join(collection.skillDir, "meta.json"));
   const meta: ExportMeta = {

--- a/packages/core/src/collection/server/delete.ts
+++ b/packages/core/src/collection/server/delete.ts
@@ -89,7 +89,9 @@ function deleteTargets(collection: LoadedCollection, workspaceRoot: string): str
   const staging = stagingSkillDir(workspaceRoot, collection.slug);
   return [
     ...(staging === null ? [] : [staging]),
-    collection.skillDir,
+    // Absent for a subscribed collection: there is no directory of ours to
+    // remove, and the records belong to another app.
+    ...(collection.skillDir === null ? [] : [collection.skillDir]),
     collection.dataDir,
     ingestStatePath(collection.slug, workspaceRoot),
     ...(collection.storageFile !== undefined ? [collection.storageFile] : []),
@@ -218,7 +220,9 @@ async function writeArchive(collection: LoadedCollection, archiveDir: string, wo
   // for a project collection that was created without the bridge.
   const staging = stagingSkillDir(workspaceRoot, collection.slug);
   const skillSrc = staging !== null && (await pathExists(staging)) ? staging : collection.skillDir;
-  await cp(skillSrc, path.join(archiveDir, "skill"), { recursive: true });
+  // Nothing to archive for a subscribed collection: the schema is a document
+  // in another app and no skill of ours was ever written here.
+  if (skillSrc !== null) await cp(skillSrc, path.join(archiveDir, "skill"), { recursive: true });
   if (await pathExists(collection.dataDir)) {
     await cp(collection.dataDir, path.join(archiveDir, "records"), { recursive: true });
   }
@@ -252,7 +256,7 @@ async function removeLocations(collection: LoadedCollection, workspaceRoot: stri
   // under the name "staging" — see the `skillsStagingDir` contract.
   const staging = stagingSkillDir(workspaceRoot, collection.slug);
   if (staging !== null) await rm(staging, { recursive: true, force: true });
-  await rm(collection.skillDir, { recursive: true, force: true });
+  if (collection.skillDir !== null) await rm(collection.skillDir, { recursive: true, force: true });
   await rm(collection.dataDir, { recursive: true, force: true });
   await rmdir(path.dirname(collection.dataDir)).catch(() => undefined);
   // The retrieval cursor lives in a SHARED dir (`data/ingest-state/<slug>.json`),

--- a/packages/core/src/collection/server/discoveredCollection.ts
+++ b/packages/core/src/collection/server/discoveredCollection.ts
@@ -36,6 +36,16 @@ export interface LoadedCollection {
    *  REFUSED at discovery, so this is present whenever the backend needs it. */
   appId?: string;
   /** Absolute path to the skill directory this collection was loaded from
-   *  (`<skillsRoot>/<slug>/`). Action templates are read from here, path-safely. */
-  skillDir: string;
+   *  (`<skillsRoot>/<slug>/`). Action templates are read from here, path-safely.
+   *
+   *  **null for a SUBSCRIBED collection**: nothing was cloned, so there is no
+   *  directory. It is null rather than `""` because an empty string does not
+   *  fail closed — `path.join("", "views/x.html")` is a RELATIVE path, which
+   *  resolves against the server's working directory, so a template or a
+   *  custom view would be read from wherever the process happens to be
+   *  running. Making it null moves that from an accident to a decision each
+   *  consumer states: a subscribed collection's schema cannot be edited here
+   *  (it belongs to another app's repository), and it has no view files until
+   *  it is materialised. */
+  skillDir: string | null;
 }

--- a/packages/core/src/collection/server/discovery.ts
+++ b/packages/core/src/collection/server/discovery.ts
@@ -18,6 +18,7 @@ import { log, getWorkspaceRoot, userSkillsDir, projectSkillsDir, feedsRoot } fro
 import { CollectionSchemaZ } from "../core/schemaZ";
 import { SCHEMA_FILE, resolveDataDir, safeSlugName } from "./paths";
 import { appManifestReason, loadAppManifest } from "./appManifest";
+import { subscribedCollections } from "./subscribedCollections";
 import type { LoadedCollection } from "./discoveredCollection";
 import type { CollectionDetail, CollectionSchema, CollectionSource, CollectionSummary } from "../core/schema";
 import { isErrorWithCode, isRecord } from "@mulmoclaude/common";
@@ -58,7 +59,7 @@ export type SchemaAcceptance = { ok: true; dataDir: string; dataSourceFile?: str
  *  `dataSource` / `storage`; a schema with none of the three is REJECTED, not
  *  quietly pointed here. Handing a per-file collection this path would silently
  *  relocate its records away from the folder the user (and its SKILL.md) sees. */
-function conventionalDataPath(slug: string): string {
+export function conventionalDataPath(slug: string): string {
   return `data/collections/${slug}/items`;
 }
 
@@ -269,11 +270,17 @@ export async function discoverCollections(opts: DiscoveryOptions = {}): Promise<
   // project) always overrides a feed on slug collision — a feed must
   // never shadow a genuine skill-backed collection.
   const feedCollections = await collectFromDir(feedsRoot(workspaceRoot), "feed", workspaceRoot);
+  // The second source: apps whose roster carries this address. Merged FIRST,
+  // so anything on this disk wins a slug collision — a repository's own copy
+  // of a collection is the one its author is editing, and silently serving the
+  // published projection instead would make local edits look ineffective.
+  const subscribed = await subscribedCollections(workspaceRoot);
   // A root with no user scope skips the pass entirely (not an empty dir scan)
   // — see the `userSkillsDir` contract in `host.ts`.
   const userCollections = userDir === null ? [] : await collectFromDir(userDir, "user", workspaceRoot);
   const projectCollections = await collectFromDir(projectDir, "project", workspaceRoot);
   const merged = new Map<string, LoadedCollection>();
+  for (const entry of subscribed) merged.set(entry.slug, entry);
   for (const entry of feedCollections) merged.set(entry.slug, entry);
   for (const entry of userCollections) merged.set(entry.slug, entry);
   for (const entry of projectCollections) merged.set(entry.slug, entry);
@@ -297,7 +304,13 @@ export async function loadCollection(slug: string, opts: DiscoveryOptions = {}):
   // ONLY in user scope is a MISS rather than a quiet hop into another world.
   const userCollection = userDir === null ? null : await loadOneCollection(userDir, safeName, "user", workspaceRoot);
   if (userCollection) return userCollection;
-  return loadOneCollection(feedsRoot(workspaceRoot), safeName, "feed", workspaceRoot);
+  const feedCollection = await loadOneCollection(feedsRoot(workspaceRoot), safeName, "feed", workspaceRoot);
+  if (feedCollection) return feedCollection;
+  // Last, and only by slug: a subscribed collection is not on this disk, so a
+  // name that resolves nowhere locally may still be an app you belong to.
+  // Same precedence as the union above — disk first, always.
+  const subscribed = await subscribedCollections(workspaceRoot);
+  return subscribed.find((entry: LoadedCollection) => entry.slug === safeName) ?? null;
 }
 
 export function toSummary(collection: LoadedCollection): CollectionSummary {

--- a/packages/core/src/collection/server/firestoreDocs.ts
+++ b/packages/core/src/collection/server/firestoreDocs.ts
@@ -25,6 +25,7 @@ import {
   query as firestoreQuery,
   runTransaction,
   setDoc,
+  where,
   type Firestore,
 } from "firebase/firestore";
 
@@ -40,6 +41,20 @@ export interface FirestoreDoc {
 export interface FirestoreDocs {
   /** Every document under `collectionPath`, ordered by document id. */
   list: (collectionPath: string) => Promise<FirestoreDoc[]>;
+  /** The documents whose ARRAY field `field` contains `value`, ordered by
+   *  document id.
+   *
+   *  One query shape, not a query builder — the seam stays a list of the
+   *  operations the engine actually performs, so a fake can satisfy it
+   *  honestly. This one exists for exactly one question, and it is the
+   *  question the whole sharing model turns on: "which apps am I a member
+   *  of?", asked as `apps` where `memberEmails` contains my address.
+   *
+   *  It is answerable at all because publish DERIVES `memberEmails` from the
+   *  roster — Firestore cannot index the keys of a map, which is why the
+   *  denormalised array exists and why the rules refuse a write where the two
+   *  disagree. */
+  listWhereArrayContains: (collectionPath: string, field: string, value: string) => Promise<FirestoreDoc[]>;
   /** One document's fields, or null when it doesn't exist. */
   get: (collectionPath: string, docId: string) => Promise<unknown | null>;
   /** Create or replace. */
@@ -71,6 +86,10 @@ export function createFirestoreDocs(database: Firestore): FirestoreDocs {
   return {
     list: async (collectionPath) => {
       const snapshot = await getDocs(firestoreQuery(firestoreCollection(database, collectionPath), orderBy("__name__")));
+      return snapshot.docs.map((entry) => ({ id: entry.id, data: entry.data() }));
+    },
+    listWhereArrayContains: async (collectionPath, field, value) => {
+      const snapshot = await getDocs(firestoreQuery(firestoreCollection(database, collectionPath), where(field, "array-contains", value), orderBy("__name__")));
       return snapshot.docs.map((entry) => ({ id: entry.id, data: entry.data() }));
     },
     get: async (collectionPath, docId) => {

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -91,6 +91,7 @@ export {
 } from "./publishProject";
 export { publishProblems, bindsSubmitterIdentity, type PublishableCollection } from "./publishChecks";
 export { publishApp, type PublishOptions, type PublishResult } from "./publish";
+export { subscribedCollections, forgetSubscribedCollections } from "./subscribedCollections";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";
 export * from "./templatePath";

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -528,7 +528,11 @@ async function handleGetSchema(slug: string, deps: ManageCollectionDeps): Promis
   if (!collection) return unknownCollection(slug);
   // Path from the discovered (sanitized) slug, never the raw arg.
   const { stagingDir } = authoringTarget(deps, collection.slug);
-  const candidates = [...(stagingDir === null ? [] : [path.join(stagingDir, SCHEMA_FILE)]), path.join(collection.skillDir, SCHEMA_FILE)];
+  // A subscribed collection contributes no candidate: its schema is a document
+  // in ANOTHER app, published from a repository this machine may not even have
+  // a clone of. Reading it out of `publishedSchema` and handing it back would
+  // invite an edit that `putSchema` then has nowhere to write.
+  const candidates = [stagingDir, collection.skillDir].filter((base): base is string => base !== null).map((base) => path.join(base, SCHEMA_FILE));
   for (const candidate of candidates) {
     try {
       return await readFile(candidate, "utf-8");
@@ -631,6 +635,13 @@ async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCol
   const gate = schemaDiscoveryGate(parsed.data, resolveBase(deps));
   if (gate) {
     return `manageCollection: schema rejected — ${gate} (call schemaDocs for the field reference). It passes basic validation but discovery would skip it, hiding the collection.`;
+  }
+  // A subscribed collection has nowhere here to write: its schema belongs to
+  // another app's repository, and publish is what changes it. Refusing by name
+  // beats writing a file discovery would then ignore — the author would edit,
+  // see "written: true", and watch nothing change.
+  if (collection.skillDir === null) {
+    return `manageCollection: '${defangForPrompt(slug)}' is subscribed from another app — its schema is published by that app's repository and cannot be edited here.`;
   }
   // Path from the discovered (sanitized) slug, never the raw arg.
   await writeAndMirrorSchema(collection.slug, collection.skillDir, parsed.data, deps);

--- a/packages/core/src/collection/server/publish.ts
+++ b/packages/core/src/collection/server/publish.ts
@@ -137,7 +137,15 @@ async function gitStamp(root: string): Promise<{ commit?: string | undefined; di
  *  quietly publishing a schema from outside the repository. */
 async function sharedCollections(opts: DiscoveryOptions, root: string): Promise<LoadedCollection[]> {
   const all = await discoverCollections({ ...opts, workspaceRoot: root, userSkillsDir: null });
-  return all.filter((collection) => collection.appId !== undefined);
+  // `appId !== undefined` is NOT the test. Discovery's second source hands back
+  // the collections of apps this address was INVITED to, and those carry an
+  // appId too — somebody else's. Publishing one would write another app's
+  // schema into THIS repository's app, under this repository's aid: the same
+  // shape as the user-scope hole above, arriving through a different door.
+  //
+  // An app is a repository, and what it publishes is what is committed beside
+  // its own `app.json`. So the test is where the collection CAME FROM.
+  return all.filter((collection) => collection.appId !== undefined && collection.source !== "subscribed");
 }
 
 interface RecordScan {

--- a/packages/core/src/collection/server/publishManifest.ts
+++ b/packages/core/src/collection/server/publishManifest.ts
@@ -121,7 +121,19 @@ const SubmitZ = z
   .object({
     auth: z.enum(["none", "anonymous", "verifiedEmail"]),
     emailField: z.string().trim().min(1).optional(),
-    createFields: z.array(z.string().trim().min(1)).min(1),
+    /** The fields a submission may carry — and it may carry NONE.
+     *
+     *  An empty list is the identity-only submission: a record whose whole
+     *  content is the fact that it exists at its id ("I attended", "I voted",
+     *  a per-uid marker). The rules read it as `keys().hasOnly([])`, which
+     *  admits exactly the empty document.
+     *
+     *  It is expressible only because the primary key is NOT a create field:
+     *  the identity is the document id, which `idFrom` pins and the store
+     *  fills in on read. Requiring at least one field here would have made
+     *  that shape undeclarable — the only field it wants is the one publish
+     *  refuses. */
+    createFields: z.array(z.string().trim().min(1)),
     initialStatus: z.string().trim().min(1).optional(),
     idFrom: z.enum(["auto", "auth.uid", "auth.uid+field"]).optional(),
     idField: z.string().trim().min(1).optional(),

--- a/packages/core/src/collection/server/skillAssets.ts
+++ b/packages/core/src/collection/server/skillAssets.ts
@@ -58,7 +58,10 @@ async function readSourceAwareFile(collection: SourceAwareReadTarget, relPath: s
   // followed the staged authoring instructions would SHADOW the committed
   // `.claude/skills/<slug>/views/x.html` on every read.
   const staging = collection.source === "project" ? stagingSkillDir(workspaceRoot, safeSlug) : null;
-  const bases = staging === null ? [collection.skillDir] : [staging, collection.skillDir];
+  // A subscribed collection contributes no base: it has no directory here, and
+  // an absent base must read NOTHING rather than fall through to a relative
+  // path resolved against the process's working directory.
+  const bases = [staging, collection.skillDir].filter((base): base is string => base !== null);
   for (const base of bases) {
     const resolved = resolveTemplatePath(base, relPath);
     if (resolved === null) continue;
@@ -139,7 +142,12 @@ export async function readCustomViewI18n(
 /** Read an action's template file from `skillDir`, path-safely. Returns
  *  the file contents, or null when the path escapes the skill dir, the
  *  resolved target isn't a regular file, or the read fails. */
-export async function readSkillTemplate(skillDir: string, templateRelPath: string): Promise<string | null> {
+export async function readSkillTemplate(skillDir: string | null, templateRelPath: string): Promise<string | null> {
+  // No directory (a subscribed collection) reads NOTHING. Taking `null` here
+  // rather than at every call site is what keeps an absent base from becoming
+  // a relative path resolved against the server's working directory — the
+  // shape `""` would have had.
+  if (skillDir === null) return null;
   const resolved = resolveTemplatePath(skillDir, templateRelPath);
   if (resolved === null) return null;
   if (!(await isRegularFile(resolved))) return null;
@@ -200,7 +208,10 @@ function sanitizeDeep(value: unknown): unknown {
 export interface CollectionPromptPaths {
   slug: string;
   dataPath: string;
-  skillDir: string;
+  /** null for a subscribed collection: there is no directory on this machine,
+   *  and a prompt that named one would send the agent to a path that does not
+   *  exist — or, worse, to a relative one resolved against the process's cwd. */
+  skillDir: string | null;
 }
 
 /** Build the paths block from a discovered collection. `skillDir` is
@@ -210,9 +221,19 @@ export interface CollectionPromptPaths {
  *  absolute path is emitted so the agent can still address it. `dataPath` is
  *  read straight from the schema — post-R3-normalization for imported
  *  collections, so it reflects what the host actually reads/writes. */
+/** The skill dir as the agent should see it: workspace-relative when it is
+ *  inside the workspace, absolute when it is not (a user-scope skill), and
+ *  null when there is no directory at all. */
+function relativeSkillDir(skillDir: string | null, workspaceRoot: string): string | null {
+  if (skillDir === null) return null;
+  const rel = path.relative(workspaceRoot, skillDir);
+  return rel === "" || rel.startsWith("..") ? skillDir : rel;
+}
+
 export function promptPathsFor(collection: Pick<LoadedCollection, "slug" | "schema" | "skillDir">, workspaceRoot: string): CollectionPromptPaths {
-  const rel = path.relative(workspaceRoot, collection.skillDir);
-  const raw = rel === "" || rel.startsWith("..") ? collection.skillDir : rel;
+  // Absent for a subscribed collection: nothing of it is on this machine, and a
+  // prompt naming a directory that does not exist is worse than naming none.
+  const raw = relativeSkillDir(collection.skillDir, workspaceRoot);
   // POSIX separators unconditionally — the value goes into `<collection_paths>`
   // and the prompt tells the agent to substitute it verbatim into shell / script
   // invocations (`python3 {{skillDir}}/fetch.py ...`). On Windows `path.relative`
@@ -220,7 +241,7 @@ export function promptPathsFor(collection: Pick<LoadedCollection, "slug" | "sche
   // escape sequences and break the invocation. Every legitimate consumer (bash
   // inside the sandbox, cross-platform CLIs) accepts forward slashes on both
   // platforms, so the normalization is one-way safe. Codex review on #1897.
-  const skillDir = toPosixRelPath(raw);
+  const skillDir = raw === null ? null : toPosixRelPath(raw);
   // A `dataSource` collection has no record dir — its data location IS the
   // external file, so that path is the honest value for scripts/templates.
   return { slug: collection.slug, dataPath: collection.schema.dataPath ?? collection.schema.dataSource?.path ?? "", skillDir };

--- a/packages/core/src/collection/server/subscribedCollections.ts
+++ b/packages/core/src/collection/server/subscribedCollections.ts
@@ -1,0 +1,152 @@
+// The collections you can reach because someone put you on a roster.
+//
+// Discovery has always answered one question — "what is on this disk?" — and
+// for a shared app that is the wrong question. A member of an app has never
+// cloned its repository and may never; the invitation is an entry in
+// `apps/{aid}.members`, and the schema is a document publish wrote. So this is
+// discovery's SECOND source, and the two are unioned (design: implementation
+// order 4).
+//
+// FIRESTORE IS THE SOURCE OF TRUTH HERE, and the disk is at most a display
+// copy. That is not a preference, it is what keeps the read path from
+// re-opening the hole publish just closed: `acceptParsedSchema` resolves a
+// firestore schema's `aid` from the WORKSPACE's `app.json`, so any subscribed
+// schema written into a skills directory would be re-discovered as if it
+// belonged to whichever repository the server happens to be serving. A
+// subscribed collection's `aid` comes from the SUBSCRIPTION and from nowhere
+// else, which is only expressible by building the collection here rather than
+// leaving a file for the directory scan to find.
+//
+// WHY `memberEmails` AND NOT `members`. Firestore cannot index the keys of a
+// map, so "which apps am I in?" is unanswerable against the roster itself.
+// That is the entire reason publish derives the denormalised array, and the
+// reason the rules refuse a write where the two disagree — a stale
+// `memberEmails` is not a cosmetic drift, it is a member who cannot find the
+// app they were invited to.
+
+import { isRecord } from "@mulmoclaude/common";
+import type { CollectionSchema } from "../core/schema";
+import { CollectionSchemaZ } from "../core/schemaZ";
+import { resolveDataDir } from "./paths";
+// `conventionalDataPath` lives with the acceptance gate that first needed it;
+// importing it keeps one definition of "where a slug's data dir would be".
+import { conventionalDataPath } from "./discovery";
+import type { LoadedCollection } from "./discoveredCollection";
+import { firestoreHandle, log, type FirestoreHandle } from "./host";
+import { appSchemasPath, APPS_COLLECTION } from "./publishProject";
+
+/** The field publish derives so this query is possible at all. */
+const MEMBER_EMAILS = "memberEmails";
+
+/** How long a resolved subscription list is reused.
+ *
+ *  `discoverCollections` is called from ontology, validation, routes and the
+ *  agent tool — several times per interaction — and a Firestore round trip on
+ *  each would make every one of those paths pay for a membership list that
+ *  changes when somebody edits a roster, i.e. almost never. Short enough that
+ *  an invitation shows up without a restart; long enough that a screen listing
+ *  collections does not issue a query per widget. */
+const CACHE_TTL_MS = 30_000;
+
+interface CacheEntry {
+  email: string;
+  at: number;
+  collections: LoadedCollection[];
+}
+
+let cache: CacheEntry | null = null;
+
+/** Drop the memoised subscription list.
+ *
+ *  Exported because two events invalidate it and neither is a clock: signing
+ *  out (the next caller must not see the previous account's apps) and
+ *  publishing (an app whose roster just changed). Tests call it between cases
+ *  for the same reason they reset the accessor. */
+export function forgetSubscribedCollections(): void {
+  cache = null;
+}
+
+/** One published collection document → a collection the engine can serve.
+ *
+ *  Returns null rather than throwing, and says why in the log: a subscribed
+ *  app is written by SOMEONE ELSE, so a document that fails validation is a
+ *  normal state of the world, not a bug here. Refusing the one collection and
+ *  keeping the rest is the behaviour that matches — the alternative is that a
+ *  stranger's malformed publish empties your workspace. */
+function toSubscribedCollection(aid: string, cid: string, data: unknown, workspaceRoot: string): LoadedCollection | null {
+  if (!isRecord(data)) return null;
+  const parsed = CollectionSchemaZ.safeParse(data.publishedSchema);
+  if (!parsed.success) {
+    log.warn("collections", "subscribed collection has an unusable published schema, skipping", { aid, cid, issues: parsed.error.issues });
+    return null;
+  }
+  const schema: CollectionSchema = parsed.data;
+  if (schema.storage?.type !== "firestore") {
+    // Publish only ever emits firestore-backed schemas into an app, so this is
+    // a document written by hand or by an older publisher. Serving it would
+    // point the store at this machine's disk for records that live in the app.
+    log.warn("collections", "subscribed collection does not declare firestore storage, skipping", { aid, cid });
+    return null;
+  }
+  // The records live in Firestore, so this directory holds nothing — but the
+  // engine's delete/archive paths need it to be well-defined and inside the
+  // workspace, exactly as it is for a locally declared firestore collection.
+  const dataDir = resolveDataDir(conventionalDataPath(cid), workspaceRoot);
+  if (dataDir === null) return null;
+  return {
+    slug: cid,
+    source: "subscribed",
+    schema,
+    dataDir,
+    appId: aid,
+    // No skill directory: nothing was cloned. Action templates and custom-view
+    // files are read from a skill dir, and a subscribed collection has none
+    // until it is materialised (implementation order 4, second half) — the
+    // empty string keeps the field's shape while making any path built from it
+    // fail closed rather than resolve to the workspace root.
+    skillDir: "",
+  };
+}
+
+/** Every collection of every app whose roster carries this address. */
+async function loadFor(handle: FirestoreHandle, workspaceRoot: string): Promise<LoadedCollection[]> {
+  const apps = await handle.docs.listWhereArrayContains(APPS_COLLECTION, MEMBER_EMAILS, handle.email);
+  const collections: LoadedCollection[] = [];
+  for (const app of apps) {
+    const schemas = await handle.docs.list(appSchemasPath(app.id));
+    for (const schema of schemas) {
+      const loaded = toSubscribedCollection(app.id, schema.id, schema.data, workspaceRoot);
+      if (loaded) collections.push(loaded);
+    }
+  }
+  return collections;
+}
+
+/** The subscribed source, memoised, and silent when there is nothing to ask.
+ *
+ *  Returns an empty list — never throws — when there is no session, because
+ *  every caller of `discoverCollections` is a screen or a tool that must keep
+ *  working without one. That is a different judgement from the STORE's, which
+ *  refuses loudly: there, "no records" and "not connected" must stay
+ *  distinguishable because someone is reading data. Here the question is which
+ *  collections exist, and a host with no Firestore has exactly the ones on its
+ *  disk.
+ *
+ *  A query failure is logged and treated the same way, for the same reason: a
+ *  network blip must not empty the collection list a user is looking at — it
+ *  must leave them with their local collections, which is what they had a
+ *  moment ago. */
+export async function subscribedCollections(workspaceRoot: string): Promise<LoadedCollection[]> {
+  const handle = firestoreHandle();
+  if (!handle) return [];
+  const now = Date.now();
+  if (cache && cache.email === handle.email && now - cache.at < CACHE_TTL_MS) return cache.collections;
+  try {
+    const collections = await loadFor(handle, workspaceRoot);
+    cache = { email: handle.email, at: now, collections };
+    return collections;
+  } catch (err) {
+    log.warn("collections", "could not list subscribed apps, falling back to local collections only", { error: String(err) });
+    return [];
+  }
+}

--- a/packages/core/src/collection/server/subscribedCollections.ts
+++ b/packages/core/src/collection/server/subscribedCollections.ts
@@ -50,6 +50,16 @@ const CACHE_TTL_MS = 30_000;
 
 interface CacheEntry {
   email: string;
+  /** The root the cached collections were RESOLVED AGAINST.
+   *
+   *  Part of the key, not decoration. A cached `LoadedCollection` carries a
+   *  `dataDir` built from the workspace root that produced it, and
+   *  MulmoTerminal serves N project roots from ONE process — so a cache keyed
+   *  by address alone would hand the second root the first root's paths, with
+   *  types and tests green and nothing to see. This is the same multi-root
+   *  contract the engine's entry points are held to; a memo is just another
+   *  place to break it. */
+  workspaceRoot: string;
   at: number;
   collections: LoadedCollection[];
 }
@@ -100,11 +110,11 @@ function toSubscribedCollection(aid: string, cid: string, data: unknown, workspa
     dataDir,
     appId: aid,
     // No skill directory: nothing was cloned. Action templates and custom-view
-    // files are read from a skill dir, and a subscribed collection has none
-    // until it is materialised (implementation order 4, second half) — the
-    // empty string keeps the field's shape while making any path built from it
-    // fail closed rather than resolve to the workspace root.
-    skillDir: "",
+    // files are read from one, and a subscribed collection has none until it is
+    // materialised (implementation order 4, second half). NULL, not "" — an
+    // empty base does not fail closed, it makes every path RELATIVE and so
+    // reads from the server's working directory.
+    skillDir: null,
   };
 }
 
@@ -140,10 +150,10 @@ export async function subscribedCollections(workspaceRoot: string): Promise<Load
   const handle = firestoreHandle();
   if (!handle) return [];
   const now = Date.now();
-  if (cache && cache.email === handle.email && now - cache.at < CACHE_TTL_MS) return cache.collections;
+  if (cache && cache.email === handle.email && cache.workspaceRoot === workspaceRoot && now - cache.at < CACHE_TTL_MS) return cache.collections;
   try {
     const collections = await loadFor(handle, workspaceRoot);
-    cache = { email: handle.email, at: now, collections };
+    cache = { email: handle.email, workspaceRoot, at: now, collections };
     return collections;
   } catch (err) {
     log.warn("collections", "could not list subscribed apps, falling back to local collections only", { error: String(err) });

--- a/packages/core/src/collection/server/views.ts
+++ b/packages/core/src/collection/server/views.ts
@@ -52,7 +52,7 @@ async function fileExists(target: string): Promise<boolean> {
  *  (imported layout — staging never materialised). For feed / user, it's
  *  always the discovered skillDir. Matches `readCustomViewHtml` so reads and
  *  deletes agree on both layouts. */
-async function canonicalBase(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): Promise<string> {
+async function canonicalBase(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): Promise<string | null> {
   if (collection.source !== "project") return collection.skillDir;
   const staging = stagingSkillDir(workspaceRoot, safeSlug);
   if (staging !== null && (await fileExists(path.join(staging, SCHEMA_FILE)))) return staging;
@@ -65,6 +65,10 @@ async function canonicalBase(collection: Pick<LoadedCollection, "source" | "skil
  *  project collection (no staging mirror) doesn't have an empty staging tree
  *  materialised by a side effect of the delete. */
 async function schemaWriteTargets(collection: Pick<LoadedCollection, "source" | "skillDir">, workspaceRoot: string, safeSlug: string): Promise<string[]> {
+  // A subscribed collection has no schema.json on this machine — its schema is
+  // a document in another app. Nothing to rewrite, and nothing to refuse
+  // loudly about: the caller's own gate decides whether the operation applies.
+  if (collection.skillDir === null) return [];
   const active = path.join(collection.skillDir, SCHEMA_FILE);
   if (collection.source !== "project") return [active];
   const staging = stagingSkillDir(workspaceRoot, safeSlug);
@@ -90,6 +94,10 @@ async function unlinkIfPresent(target: string): Promise<void> {
  *  preserved verbatim. */
 async function removeViewFromSchemas(collection: LoadedCollection, viewId: string, workspaceRoot: string, safeSlug: string): Promise<void> {
   const base = await canonicalBase(collection, workspaceRoot, safeSlug);
+  // A subscribed collection has no schema file here — `deleteCustomView`
+  // refuses before reaching this, so an absent base is a no-op rather than a
+  // second refusal in a function whose job is the rewrite.
+  if (base === null) return;
   const canonical = path.join(base, SCHEMA_FILE);
   const parsed: unknown = JSON.parse(await readFile(canonical, "utf-8"));
   // Anything that isn't an object with a `views` array is written back
@@ -115,7 +123,11 @@ export async function deleteCustomView(collection: LoadedCollection, viewId: str
   const view = views.find((entry) => entry.id === viewId);
   if (!view) return { kind: "not-found", viewId };
   const workspaceRoot = opts.workspaceRoot ?? getWorkspaceRoot();
-  const htmlPath = resolveTemplatePath(await canonicalBase(collection, workspaceRoot, safeSlug), view.file);
+  // Nothing of this collection is on this machine: its views live in another
+  // app's repository and its schema is changed by that app's publish.
+  const base = await canonicalBase(collection, workspaceRoot, safeSlug);
+  if (base === null) return { kind: "not-found", viewId };
+  const htmlPath = resolveTemplatePath(base, view.file);
   if (htmlPath === null) return { kind: "unsafe-path", viewId };
   // Rewrite the schema BEFORE unlinking: if the write fails the request errors
   // out, but the HTML stays put and the still-registered view keeps working —

--- a/packages/core/src/google/collectionSync.ts
+++ b/packages/core/src/google/collectionSync.ts
@@ -694,7 +694,9 @@ export async function anySyncedCollectionSurvives(
   collections: readonly Pick<LoadedCollection, "skillDir">[],
   exists: (absPath: string) => Promise<boolean> = pathExists,
 ): Promise<boolean> {
-  const alive = await Promise.all(collections.map((collection) => exists(collection.skillDir)));
+  // A subscribed collection has no directory on this machine, so it can never
+  // be the thing keeping a sync alive — it is not a skill this host installed.
+  const alive = await Promise.all(collections.map((collection) => (collection.skillDir === null ? Promise.resolve(false) : exists(collection.skillDir))));
   return alive.some(Boolean);
 }
 

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -61,6 +61,14 @@ function makeFakeFirestoreDocs(): FirestoreDocs {
     return created;
   };
   return {
+    listWhereArrayContains: (collectionPath, field, value) =>
+      Promise.resolve(
+        [...bucket(collectionPath).entries()]
+          .filter(
+            ([, data]) => Array.isArray((data as Record<string, unknown>)[field]) && ((data as Record<string, unknown>)[field] as unknown[]).includes(value),
+          )
+          .map(([docId, data]) => ({ id: docId, data })),
+      ),
     list: (collectionPath) => {
       const entries: FirestoreDoc[] = [...bucket(collectionPath).entries()].map(([docId, data]) => ({ id: docId, data }));
       entries.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -417,6 +417,30 @@ test("a first-step failure says nothing was written, because nothing was", async
   assert.equal(!result.ok && result.partial, false, "a first-step failure wrote nothing, and must not claim otherwise");
 });
 
+test("a SUBSCRIBED collection is NOT published into this repository's app", async () => {
+  // Discovery's second source hands back the collections of apps this address
+  // was invited to, and those carry an appId too — somebody else's. Filtering
+  // on `appId !== undefined` alone would publish another app's schema into
+  // THIS app, under this repository's aid: the same shape as the user-scope
+  // hole, arriving through a different door.
+  writeSkill("bookings", BOOKINGS_SCHEMA);
+  writeApp();
+  const invitedApp = "app_someone_else";
+  await docs.set("apps", invitedApp, { owner: "uid_them", members: {}, memberEmails: [OWNER_EMAIL] });
+  await docs.set(`apps/${invitedApp}/collections`, "theirnotes", {
+    publishedSchema: { ...BOOKINGS_SCHEMA, title: "Their Notes" },
+    publishedAt: 1,
+    publishedBy: "them@example.com",
+  });
+
+  const result = await publishApp(opts());
+  assert.equal(result.ok, true, result.ok ? "" : result.problems.join("\n"));
+  assert.deepEqual(result.ok && result.cids, ["bookings"], "only this repository's own collections may be published");
+  assert.equal(await docs.get(`apps/${AID}/collections`, "theirnotes"), null);
+  // …and the invited app is untouched: publish writes to its own app alone.
+  assert.notEqual(await docs.get(`apps/${invitedApp}/collections`, "theirnotes"), null);
+});
+
 test("a user-scope skill is NOT published into this repository's app", async () => {
   // `~/.claude/skills` is installed once per machine; a repository is not. And
   // discovery resolves every schema it finds — user scope included — against

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -315,6 +315,20 @@ test("a submit path that lets the submitter name its own primaryKey is refused",
   assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"] } } } }), []);
 });
 
+test("an identity-only submission is expressible — createFields may be empty", () => {
+  // "I attended", "I voted": a record whose whole content is that it exists at
+  // its id. The rules read `keys().hasOnly([])`, which admits exactly the
+  // empty document. Requiring one field would have made the shape undeclarable
+  // — the only field it wants is the primary key, which publish refuses.
+  assert.deepEqual(
+    problemsFor({
+      collections: { responses: { submitOnly: true } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: [], idFrom: "auth.uid" } } },
+    }),
+    [],
+  );
+});
+
 test("the primaryKey check follows the schema, not the name 'id'", () => {
   // A collection keyed by `name` (S1's services) must be held to `name`.
   // Hard-coding "id" would pass this file and fail the first real schema.

--- a/packages/core/test/collection/test_subscribedCollections.ts
+++ b/packages/core/test/collection/test_subscribedCollections.ts
@@ -1,0 +1,263 @@
+// Discovery's second source: apps whose roster carries your address.
+//
+// The behaviour under test is not "a query runs". It is that a collection you
+// were INVITED to shows up with the app it actually belongs to, that a
+// collection on this disk still wins its own name, and that a host with no
+// session — or a Firestore that answers with an error — is left with exactly
+// the collections it had before rather than an empty screen.
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { configureCollectionHost, setFirestoreAccessor } from "../../src/collection/server/host";
+import type { FirestoreDoc, FirestoreDocs } from "../../src/collection/server/firestoreDocs";
+import { discoverCollections, loadCollection } from "../../src/collection/server/discovery";
+import { forgetSubscribedCollections } from "../../src/collection/server/subscribedCollections";
+
+configureCollectionHost({
+  workspaceRoot: null,
+  log: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} },
+  paths: {
+    userSkillsDir: () => null,
+    projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+    feedsRoot: (root) => path.join(root, "data", "feeds"),
+    skillsStagingDir: () => null,
+    archiveDir: "data/archive",
+    collectionsRegistriesConfig: (root) => path.join(root, "config", "collections-registries.json"),
+  },
+  isPresetSlug: () => false,
+});
+
+const MY_EMAIL = "member@school.jp";
+const OTHER_APP = "app_teacher_class";
+const MY_APP = "app_my_repo";
+
+let workdir: string;
+let emptyUserDir: string;
+
+/** A plain, disk-backed collection — the thing a subscribed source must never
+ *  displace or take down with it. */
+const LOCAL_SCHEMA = {
+  title: "Notes",
+  icon: "note",
+  dataPath: "data/notes",
+  primaryKey: "id",
+  fields: { id: { type: "string", label: "ID", primary: true } },
+};
+
+const SHARED_SCHEMA = {
+  title: "Answers",
+  icon: "quiz",
+  storage: { type: "firestore" },
+  primaryKey: "id",
+  fields: { id: { type: "string", label: "ID", primary: true }, choice: { type: "string", label: "Choice" } },
+};
+
+/** Documents keyed by collection path, driven straight from the test. */
+function fakeDocs(seed: Record<string, Record<string, unknown>>): FirestoreDocs {
+  const listOf = (collectionPath: string): FirestoreDoc[] => Object.entries(seed[collectionPath] ?? {}).map(([docId, data]) => ({ id: docId, data }));
+  return {
+    list: (collectionPath) => Promise.resolve(listOf(collectionPath)),
+    listWhereArrayContains: (collectionPath, field, value) =>
+      Promise.resolve(
+        listOf(collectionPath).filter((entry) => {
+          const field_ = (entry.data as Record<string, unknown>)[field];
+          return Array.isArray(field_) && field_.includes(value);
+        }),
+      ),
+    get: (collectionPath, docId) => Promise.resolve(seed[collectionPath]?.[docId] ?? null),
+    set: () => Promise.resolve(),
+    create: () => Promise.resolve(true),
+    delete: () => Promise.resolve(true),
+  };
+}
+
+/** A teacher's app, with me on its roster. */
+const rosteredApp = (emails: string[]): Record<string, Record<string, unknown>> => ({
+  [`apps`]: {
+    [OTHER_APP]: { owner: "uid_teacher", members: {}, memberEmails: emails },
+  },
+  [`apps/${OTHER_APP}/collections`]: {
+    answers: { publishedSchema: SHARED_SCHEMA, publishedAt: 1, publishedBy: "teacher@school.jp" },
+  },
+});
+
+/** Add one more published-collection document to a seeded app. */
+function withPublished(seed: Record<string, Record<string, unknown>>, cid: string, doc: Record<string, unknown>): Record<string, Record<string, unknown>> {
+  const collections = seed[`apps/${OTHER_APP}/collections`] ?? {};
+  return { ...seed, [`apps/${OTHER_APP}/collections`]: { ...collections, [cid]: doc } };
+}
+
+function connect(seed: Record<string, Record<string, unknown>>): void {
+  setFirestoreAccessor(() => ({ docs: fakeDocs(seed), email: MY_EMAIL, uid: "uid_me" }));
+}
+
+function writeSkill(slug: string, schema: object): void {
+  const dir = path.join(workdir, ".claude/skills", slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), `---\nname: ${slug}\ndescription: test fixture\n---\nbody\n`);
+  writeFileSync(path.join(dir, "schema.json"), JSON.stringify(schema));
+}
+
+const opts = () => ({ workspaceRoot: workdir, userSkillsDir: emptyUserDir });
+
+beforeEach(() => {
+  workdir = mkdtempSync(path.join(tmpdir(), "subscribed-"));
+  emptyUserDir = mkdtempSync(path.join(tmpdir(), "subscribed-user-"));
+});
+
+afterEach(() => {
+  // Both are module-level state: an accessor left wired resolves in a later
+  // test that never set one up, and the memoised subscription list would carry
+  // one case's apps into the next.
+  setFirestoreAccessor(null);
+  forgetSubscribedCollections();
+  rmSync(workdir, { recursive: true, force: true });
+  rmSync(emptyUserDir, { recursive: true, force: true });
+});
+
+test("a collection from an app I was invited to is discovered", async () => {
+  connect(rosteredApp([MY_EMAIL]));
+  const found = await discoverCollections(opts());
+  assert.deepEqual(
+    found.map((entry) => entry.slug),
+    ["answers"],
+  );
+});
+
+test("its appId comes from the SUBSCRIPTION, not from this repository's app.json", async () => {
+  // The whole reason this source exists rather than a file the directory scan
+  // could find. `acceptParsedSchema` resolves a firestore schema's aid from
+  // the workspace's app.json, so a subscribed schema written to disk would be
+  // served under whichever repository the server happens to be serving — the
+  // records of somebody else's app, read and written under my app id.
+  writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid: MY_APP }));
+  connect(rosteredApp([MY_EMAIL]));
+  const [answers] = await discoverCollections(opts());
+  assert.ok(answers);
+  assert.equal(answers.appId, OTHER_APP);
+  assert.notEqual(answers.appId, MY_APP);
+  assert.equal(answers.source, "subscribed");
+});
+
+test("an app whose roster does NOT carry my address is invisible", async () => {
+  // The paired case. Without it, a query that returned everything would pass
+  // every assertion above.
+  connect(rosteredApp(["someone-else@school.jp"]));
+  assert.deepEqual(await discoverCollections(opts()), []);
+});
+
+test("a collection on this disk wins its own name", async () => {
+  // A repository's own copy is the one its author is editing. Serving the
+  // published projection instead would make local edits look ineffective —
+  // the schema in the editor and the schema in use would differ with nothing
+  // saying so.
+  writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid: MY_APP }));
+  writeSkill("answers", { ...SHARED_SCHEMA, title: "My Local Answers" });
+  connect(rosteredApp([MY_EMAIL]));
+
+  const [answers] = await discoverCollections(opts());
+  assert.ok(answers);
+  assert.equal(answers.schema.title, "My Local Answers");
+  assert.equal(answers.source, "project");
+  assert.equal(answers.appId, MY_APP);
+});
+
+test("loadCollection finds a subscribed slug, and prefers the local one", async () => {
+  connect(rosteredApp([MY_EMAIL]));
+  const subscribed = await loadCollection("answers", opts());
+  assert.equal(subscribed?.source, "subscribed");
+
+  writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid: MY_APP }));
+  writeSkill("answers", { ...SHARED_SCHEMA, title: "My Local Answers" });
+  const local = await loadCollection("answers", opts());
+  assert.equal(local?.source, "project");
+});
+
+test("no session means the local collections, not an empty list", async () => {
+  // Every caller of discoverCollections is a screen or a tool that has to keep
+  // working without Firestore. This is deliberately a different judgement from
+  // the STORE's, which refuses loudly — there someone is reading data, and
+  // "no records" must stay distinguishable from "not connected".
+  writeFileSync(path.join(workdir, "app.json"), JSON.stringify({ aid: MY_APP }));
+  writeSkill("notes", LOCAL_SCHEMA);
+  setFirestoreAccessor(null);
+
+  const found = await discoverCollections(opts());
+  assert.deepEqual(
+    found.map((entry) => entry.slug),
+    ["notes"],
+  );
+});
+
+test("a failing query leaves the local collections alone", async () => {
+  // A network blip must not empty the list someone is looking at. It leaves
+  // them with what they had a moment ago.
+  writeSkill("notes", LOCAL_SCHEMA);
+  const failing: FirestoreDocs = {
+    ...fakeDocs({}),
+    listWhereArrayContains: () => Promise.reject(new Error("permission-denied")),
+  };
+  setFirestoreAccessor(() => ({ docs: failing, email: MY_EMAIL, uid: "uid_me" }));
+
+  const found = await discoverCollections(opts());
+  assert.deepEqual(
+    found.map((entry) => entry.slug),
+    ["notes"],
+  );
+});
+
+test("a published document that is not a usable schema is skipped, not fatal", async () => {
+  // A subscribed app is written by SOMEONE ELSE. One unusable document must
+  // not take the rest of their app — or this workspace — down with it.
+  const seed = withPublished(rosteredApp([MY_EMAIL]), "broken", { publishedSchema: { title: "no fields here" } });
+  connect(seed);
+
+  const found = await discoverCollections(opts());
+  assert.deepEqual(
+    found.map((entry) => entry.slug),
+    ["answers"],
+  );
+});
+
+test("a published schema that is not firestore-backed is skipped", async () => {
+  // Publish only ever emits firestore schemas into an app, so this is a
+  // hand-written document. Serving it would point the store at THIS machine's
+  // disk for records that live in someone else's app.
+  const seed = withPublished(rosteredApp([MY_EMAIL]), "local", {
+    publishedSchema: { title: "Local", icon: "note", dataPath: "data/local", primaryKey: "id", fields: { id: { type: "string", label: "ID", primary: true } } },
+  });
+  connect(seed);
+
+  const found = await discoverCollections(opts());
+  assert.deepEqual(
+    found.map((entry) => entry.slug),
+    ["answers"],
+  );
+});
+
+test("the subscription list is memoised, and forgotten on demand", async () => {
+  // Discovery runs several times per interaction; a round trip on each would
+  // make every screen pay for a membership list that changes when somebody
+  // edits a roster.
+  let queries = 0;
+  const counting: FirestoreDocs = {
+    ...fakeDocs(rosteredApp([MY_EMAIL])),
+    listWhereArrayContains: (collectionPath, field, value) => {
+      queries += 1;
+      return fakeDocs(rosteredApp([MY_EMAIL])).listWhereArrayContains(collectionPath, field, value);
+    },
+  };
+  setFirestoreAccessor(() => ({ docs: counting, email: MY_EMAIL, uid: "uid_me" }));
+
+  await discoverCollections(opts());
+  await discoverCollections(opts());
+  assert.equal(queries, 1, "the second discovery must reuse the first answer");
+
+  forgetSubscribedCollections();
+  await discoverCollections(opts());
+  assert.equal(queries, 2, "and forgetting it must ask again");
+});

--- a/packages/core/test/collection/test_subscribedCollections.ts
+++ b/packages/core/test/collection/test_subscribedCollections.ts
@@ -239,6 +239,36 @@ test("a published schema that is not firestore-backed is skipped", async () => {
   );
 });
 
+test("a subscribed collection has NO skill directory — null, not an empty string", async () => {
+  // `""` does not fail closed. `path.join("", "views/x.html")` is a RELATIVE
+  // path, so a custom view or an action template would be read from wherever
+  // the server process happens to be running. null makes every consumer state
+  // what it does instead — refuse, or contribute no base at all.
+  connect(rosteredApp([MY_EMAIL]));
+  const [answers] = await discoverCollections(opts());
+  assert.ok(answers);
+  assert.equal(answers.skillDir, null);
+  assert.notEqual(answers.skillDir, "");
+});
+
+test("the memo is keyed by WORKSPACE ROOT as well as address", async () => {
+  // A cached LoadedCollection carries a dataDir built from the root that
+  // produced it, and MulmoTerminal serves N roots from ONE process. Keyed by
+  // address alone, the second root would be handed the first root's paths —
+  // green types, green tests, wrong workspace.
+  connect(rosteredApp([MY_EMAIL]));
+  const otherRoot = mkdtempSync(path.join(tmpdir(), "subscribed-other-"));
+  try {
+    const [here] = await discoverCollections(opts());
+    const [there] = await discoverCollections({ workspaceRoot: otherRoot, userSkillsDir: emptyUserDir });
+    assert.ok(here && there);
+    assert.ok(here.dataDir.startsWith(workdir), "the first root's dataDir belongs to the first root");
+    assert.ok(there.dataDir.startsWith(otherRoot), "and the second root's to the second — not a memoised copy of the first");
+  } finally {
+    rmSync(otherRoot, { recursive: true, force: true });
+  }
+});
+
 test("the subscription list is memoised, and forgotten on demand", async () => {
   // Discovery runs several times per interaction; a round trip on each would
   // make every screen pay for a membership list that changes when somebody

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.7.0",
+    "@mulmoclaude/core": "^3.8.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/test/workspace/collections/test_io.ts
+++ b/test/workspace/collections/test_io.ts
@@ -464,6 +464,10 @@ describe("prompt paths block — #1891 ingest-dataPath gap", () => {
       skillDir: path.join("/w", ".claude", "skills", "jma-weather"),
     };
     const built = promptPathsFor(collection, "/w");
+    // Non-null here by construction: this collection HAS a skill dir. (A
+    // subscribed collection has none, and `promptPathsFor` answers null rather
+    // than a relative path the agent would resolve against its own cwd.)
+    assert.ok(built.skillDir);
     assert.equal(built.skillDir.includes("\\"), false, "no backslash may reach the prompt output");
     assert.equal(built.skillDir.includes("//"), false, "no double-slash from a botched normalize");
     assert.equal(built.skillDir, ".claude/skills/jma-weather", "canonical POSIX form regardless of host");

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -180,6 +180,19 @@ function makeFakeFirestoreDocs(): FirestoreDocs & { paths: () => string[] } {
   };
   return {
     paths: () => [...collections.keys()],
+    // The subscription query. This fixture never exercises it — a store test
+    // is about one known collection path, not about finding apps — but the
+    // seam is what a fake has to satisfy WHOLE, or it stops standing in for
+    // the real backend.
+    listWhereArrayContains: (collectionPath, field, value) =>
+      Promise.resolve(
+        [...bucket(collectionPath).entries()]
+          .filter(([, data]) => {
+            const held = (data as Record<string, unknown>)[field];
+            return Array.isArray(held) && held.includes(value);
+          })
+          .map(([docId, data]) => ({ id: docId, data })),
+      ),
     list: (collectionPath) => {
       const entries: FirestoreDoc[] = [...bucket(collectionPath).entries()].map(([docId, data]) => ({ id: docId, data }));
       entries.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -374,7 +374,14 @@ describe("shared (firestore) collections", () => {
     const store = storeFor(collection, { workspaceRoot: workdir });
     assert.ok(store.write);
     await store.write("n1", { id: "n1", title: "T" });
-    assert.deepEqual(docs.paths(), [`apps/${APP_ID}/collections/notescloud/items`]);
+    // `apps` is touched too, by discovery's subscribed pass ("which apps is
+    // this address on?"). What this case pins is where RECORDS land, so it
+    // asserts on the item paths alone — a second one here would mean the store
+    // wrote somebody else's collection.
+    assert.deepEqual(
+      docs.paths().filter((touched) => touched.includes("/items")),
+      [`apps/${APP_ID}/collections/notescloud/items`],
+    );
   });
 
   it("builds that path only through the key, which refuses a name no encoding survives", () => {

--- a/test/workspace/collections/test_watcher.ts
+++ b/test/workspace/collections/test_watcher.ts
@@ -592,6 +592,9 @@ const sharedLegacyIdFor = (slug: string, itemId: string): string => `collection-
 function makeFakeDocs(seed: Record<string, unknown>[]): FirestoreDocs {
   const rows = new Map<string, unknown>(seed.map((record) => [record.id as string, record]));
   return {
+    // Not exercised here (the watcher watches one collection), but the seam
+    // has to be satisfied whole or the fake stops standing in for the backend.
+    listWhereArrayContains: () => Promise.resolve([]),
     list: () => {
       const entries: FirestoreDoc[] = [...rows.entries()].map(([docId, data]) => ({ id: docId, data }));
       entries.sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));


### PR DESCRIPTION
実装順 4 の**前半**。discovery はこれまで「このディスクに何があるか」しか答えておらず、共有アプリにとってそれは間違った問いでした。アプリのメンバーはリポジトリを clone していないし、する必要もありません — 招待は `apps/{aid}.members` のエントリであり、スキーマは publish が書いたドキュメントです。

`apps` を `memberEmails array-contains 自分` で引き、ディスクと union します。

設計: mulmoterminal `plans/feat-shareable-collections.md`（実装順 4）
前提: #2860（publish）、`@mulmoclaude/core` 3.7.0

## 購読の真実の出所は Firestore で、ディスクは表示用

**これは好みではなく、publish で塞いだ穴が読み取り側に開くのを防ぐためです。**

`acceptParsedSchema` は firestore スキーマの `aid` を**ワークスペースの** `app.json` から解決します。したがって購読したスキーマをスキルディレクトリに書き出すと、**サーバがたまたま serve しているリポジトリのもの**として再発見されます — 他人のアプリのレコードを、自分の app id で読み書きすることになります。#2860 でユーザースコープのスキルについて塞いだのと同じ形の穴です。

購読したコレクションの `aid` は**購読から**来ます。これはディレクトリ走査が拾えるファイルを置くのではなく、ここでコレクションを組み立てて初めて表現できます。テストで名指しで固定しました（`appId` が `app.json` の aid ではないこと）。

## 固定した挙動

- **ディスクにあるものが同じ slug では勝つ** — リポジトリ自身の写しは作者が編集している当のものなので、published な射影を代わりに出すと「ローカルの編集が効いていない」ように見えます（エディタの中のスキーマと使われているスキーマが、何も言わずに食い違う）
- **セッションが無い / クエリが失敗した場合は、ローカルのコレクションが残る** — `discoverCollections` の呼び出し元は全て「Firestore が無くても動き続けなければならない画面かツール」です。これは store の判断（大声で拒否）と**意図的に別**で、あちらはデータを読んでいる人がいて「レコードが無い」と「繋がっていない」を混ぜてはいけない
- **他人の壊れた publish が巻き添えにしない** — 購読アプリは**他人が書いた**ものなので、使えないドキュメントは正常な世界の状態です。その 1 つを飛ばして残りは出します
- **firestore バックエンドでないスキーマは飛ばす** — publish はそれしか出さないので手書きの文書であり、serve すると他人のアプリのレコードについて**このマシンのディスク**を見に行きます
- 購読リストは **30 秒 memo 化**（discovery は 1 操作で何度も走る）。`forgetSubscribedCollections()` で明示的に捨てられます

## 継ぎ目の拡張

`FirestoreDocs` に `listWhereArrayContains` を 1 つ。**クエリビルダにはしません** — 継ぎ目は「エンジンが実際に行う操作の一覧」であり、その形だからこそ fake が正直に満たせます。

これが答えられるのは publish が `memberEmails` を導出しているからで、**Firestore はマップのキーを索引できません**。それが非正規化された配列が存在する理由であり、ルールが両者の食い違いを拒否する理由でもあります — ずれた `memberEmails` は見た目の問題ではなく、**招待されたのにアプリを見つけられないメンバー**です。

## 検証

```
core         897 pass / 0 fail（購読の新規テスト 10 本）
mulmoclaude  9284 pass / 0 fail、yarn typecheck 0、yarn lint 0 errors
check:launcher-sync / check-changelog-ships  OK
```

新規テストは、拒否側だけでなく**対になるケース**を書いています（名簿に載っていないアプリは見えない、ディスクが勝つ、memo 化と破棄の両方）。

`@mulmoclaude/core` 3.7.0 → **3.8.0**。

## この PR に入っていないもの

- **skill の materialize**（Claude Code がディスクのスキルしか読めない件）— 実装順 4 の後半、別 PR
- 実装順 6（onSnapshot）は #2861 で進行中のため触っていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface Firestore-backed collections from apps that have invited the current user as a second discovery source, while keeping disk-backed collections authoritative on slug collisions and resilient to missing or failing Firestore sessions.

New Features:
- Include collections from apps whose roster contains the current user in discovery and collection loading as a new `subscribed` source.
- Expose subscription discovery utilities `subscribedCollections` and `forgetSubscribedCollections` for hosts to list and invalidate subscribed collections.

Enhancements:
- Add a memoised Firestore query path that lists apps by `memberEmails` array membership and derives their published collection schemas into loaded collections.
- Extend collection discovery precedence so disk-backed user, project, and feed collections continue to override subscribed collections on slug collisions, and ensure subscribed collections use the app id from Firestore rather than the local workspace.

Build:
- Bump `@mulmoclaude/core` to version 3.8.0 and update the MulmoClaude host dependency accordingly.

Documentation:
- Document the new subscribed-collections discovery behaviour and its Firestore source-of-truth model in the changelog, including cache semantics and the separation of materialisation into a later implementation step.

Tests:
- Add comprehensive tests covering subscribed collection discovery, precedence against local collections, behaviour when Firestore is unavailable or returns errors, skipping unusable or non-firestore schemas, and cache invalidation semantics.
- Update existing Firestore fakes in store and watcher tests to satisfy the new array-contains query seam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Discover collections shared with signed-in users through membership-based subscriptions.
  - Local collections take precedence over subscribed collections, with offline or unauthenticated fallback behavior.
  - Subscribed collections are cached briefly for faster discovery.

- **Bug Fixes**
  - Prevented subscribed, read-only collections from being edited, exported, published, or treated as local files.
  - Improved deletion and custom-view handling for collections without local files.

- **Documentation**
  - Added guidance covering subscription discovery, caching, fallback behavior, and publishing rules.

- **Enhancements**
  - Identity-only submissions are now supported when no additional fields are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->