### PR TITLE
fix(collections): 共有レコードの同一性はドキュメント ID であって、投稿できるフィールドではない

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Fixed
+
+#### A shared record's identity is its document id, not a field a submitter can name
+
+The security rules can pin the DOCUMENT ID of a submission — `idFrom` ties it to
+the submitter's uid, or to uid plus a field — and they cannot pin the VALUE of a
+field: `validateOk` checks which keys are present and `keyFieldsOk` checks a
+declared enum, but nothing compares `request.resource.data[primaryKey]` with the
+path being written.
+
+The firestore store returned a document's fields verbatim, so whatever the
+writer put in the primary-key field became the record's identity to every
+reader. A public submitter writing at their one permitted document id could
+therefore claim a duplicate — or another member's record id — and be believed.
+
+`firestoreStore` now takes the identity from the document id and overwrites the
+field on read. For a record written through the store the two already agree
+(`firestoreWrite` writes at the id it was given), so nothing changes for an
+honest write; the spoof simply becomes unreachable.
+
+`publish` refuses the declaration that made it reachable: a `public.submit[cid]`
+whose `createFields` names the schema's `primaryKey`. There is nothing for that
+field to do now — a submitted value is either equal to the id or a lie that is
+discarded — and publishing a form field whose value is thrown away is worse than
+not having it, because the author will believe submitters choose their ids.
+
+This reverses a check added earlier in this release, which required the primary
+key in `createFields` for the opposite reason (a record without one was rejected
+by every reader). That was right about the symptom and wrong about the cure: the
+identity belongs to the id the rules can pin, not to a field they cannot.
+
 ### Added
 
 #### Publishing a shared app: `manageCollection` action `publishApp`
@@ -63,7 +94,7 @@ is people.
 
 ### Package releases
 
-Ships `@mulmoclaude/core@3.7.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.8.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/firestoreStore.ts
+++ b/packages/core/src/collection/server/firestoreStore.ts
@@ -125,8 +125,29 @@ async function guarded<T>(key: SharedCollectionKey, email: string, run: () => Pr
  *  older version) can hold anything, so a non-object is dropped rather than
  *  surfaced as a broken record — the same fail-soft the file store applies to
  *  an unparseable `.json`. */
-function toItem(data: unknown): CollectionItem | null {
-  return isRecord(data) ? data : null;
+/** A stored document as a record — with its identity taken from the DOCUMENT
+ *  ID, never from the document's own fields.
+ *
+ *  This is the one place a shared record's identity is decided, and it is
+ *  decided against the field the writer supplied on purpose.
+ *
+ *  The rules can constrain the document id (`idFrom` pins it to the
+ *  submitter's uid, or to uid+field) and they CANNOT constrain the value of a
+ *  field: `validateOk` checks which keys are present, `keyFieldsOk` checks a
+ *  declared enum, and nothing compares `request.resource.data[primaryKey]`
+ *  with the path being written. So a public submitter writing at their one
+ *  permitted document id could put ANY value in the primary-key field —
+ *  another member's record id, or a duplicate — and every reader would take it
+ *  as the record's identity. Overwriting it here makes that unreachable rather
+ *  than merely discouraged, and it costs nothing: for a record written through
+ *  this store the two already agree, because `firestoreWrite` writes at the id
+ *  it was given.
+ *
+ *  It also removes the reason a submit path would have had to accept the
+ *  primary key as a `createField` at all — a submission that cannot name its
+ *  own id is exactly right when the id is the thing being assigned. */
+function toItem(data: unknown, docId: string, primaryKey: string): CollectionItem | null {
+  return isRecord(data) ? { ...data, [primaryKey]: docId } : null;
 }
 
 /** Record ids are validated with the SAME helper every other backend uses.
@@ -139,10 +160,10 @@ function withSafeId<T>(itemId: string, onInvalid: () => T, run: (safeId: string,
   return run(safeId, requireHandle());
 }
 
-async function firestoreList(key: SharedCollectionKey): Promise<CollectionItem[]> {
+async function firestoreList(key: SharedCollectionKey, primaryKey: string): Promise<CollectionItem[]> {
   const { docs, email } = requireHandle();
   const entries = await guarded(key, email, () => docs.list(sharedItemsPath(key)));
-  return entries.map((entry) => toItem(entry.data)).filter((item): item is CollectionItem => item !== null);
+  return entries.map((entry) => toItem(entry.data, entry.id, primaryKey)).filter((item): item is CollectionItem => item !== null);
 }
 
 /** Paging is emulated over a full ordered read rather than pushed into
@@ -151,17 +172,17 @@ async function firestoreList(key: SharedCollectionKey): Promise<CollectionItem[]
  *  `total` needs the full count anyway. Hence `nativePaging: false` — the
  *  capability is honest about the cost. */
 async function firestorePage(key: SharedCollectionKey, primaryKey: string, opts: ListOptions): Promise<ListPage> {
-  const items = await firestoreList(key);
+  const items = await firestoreList(key, primaryKey);
   const offset = Math.max(0, opts.offset ?? 0);
   const sliced = opts.limit === undefined ? items.slice(offset) : items.slice(offset, offset + Math.max(0, opts.limit));
   return { items: projectItemFields(sliced, opts.fields, primaryKey), total: items.length, truncated: false };
 }
 
-async function firestoreRead(key: SharedCollectionKey, itemId: string): Promise<CollectionItem | null> {
+async function firestoreRead(key: SharedCollectionKey, itemId: string, primaryKey: string): Promise<CollectionItem | null> {
   return withSafeId(
     itemId,
     () => Promise.resolve(null),
-    async (safeId, { docs, email }) => toItem(await guarded(key, email, () => docs.get(sharedItemsPath(key), safeId))),
+    async (safeId, { docs, email }) => toItem(await guarded(key, email, () => docs.get(sharedItemsPath(key), safeId)), safeId, primaryKey),
   );
 }
 
@@ -222,9 +243,9 @@ export function firestoreStoreFor(collection: LoadedCollection, opts: IoOptions)
   // collections; one that throws there takes an unrelated screen down with it.
   return {
     capabilities: { writable: true, nativeQuery: false, nativePaging: false },
-    list: async () => firestoreList(keyOf(collection)),
+    list: async () => firestoreList(keyOf(collection), primaryKey),
     page: async (pageOpts = {}) => firestorePage(keyOf(collection), primaryKey, pageOpts),
-    read: async (itemId: string) => firestoreRead(keyOf(collection), itemId),
+    read: async (itemId: string) => firestoreRead(keyOf(collection), itemId, primaryKey),
     write: async (itemId: string, item: CollectionItem, writeOpts: WriteOptions = {}) =>
       firestoreWrite(keyOf(collection), itemId, item, { ...ioOpts, refuseOverwrite: writeOpts.refuseOverwrite }),
     delete: async (itemId: string) => firestoreDelete(keyOf(collection), itemId, ioOpts),

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -360,31 +360,34 @@ export function publishProblems(app: AuthoredApp, collections: readonly Publisha
   ];
 }
 
-/** A public submission must be able to produce a record the HOST can read.
+/** A public submission must NOT be allowed to name its own primary key.
  *
- *  The rules and the engine disagree about what identifies a record, and the
- *  gap is invisible from either side alone. The rules bind the DOCUMENT ID
- *  (`idFrom`) and let a submission carry only `createFields`; the engine
- *  identifies a record by its schema's `primaryKey` FIELD, and the firestore
- *  store hands back the document's fields verbatim — `toItem` does not
- *  synthesize the key from the document id. So a submit path whose
- *  `createFields` omits the primary key writes rows that Firestore accepts and
- *  every reader rejects: `validateRecordObject` fails them, the collection
- *  renders empty-ish, and the next publish's own pre-check reports them as
- *  broken records the publisher never wrote.
+ *  The rules constrain the DOCUMENT ID (`idFrom`) and cannot constrain the
+ *  value of a field — nothing compares `request.resource.data[primaryKey]`
+ *  with the path being written. So a submit path that accepts the primary key
+ *  as a `createField` lets a submitter write at their one permitted document
+ *  id while CLAIMING another record's identity, or a duplicate.
  *
- *  Not checkable by the rules (they have never heard of a schema) and not
- *  catchable at write time (nothing is wrong with the write). Publish is the
- *  only place that holds both halves. */
+ *  It is refused rather than tolerated because there is nothing for the field
+ *  to do: `firestoreStore` takes a shared record's identity from the document
+ *  id and overwrites the field on read, so a submitted value is either equal
+ *  to the id (noise) or a lie (silently discarded). Publishing a form field
+ *  whose value is thrown away is worse than not having it — the author will
+ *  believe submitters choose their ids.
+ *
+ *  This is the second answer to the same question. The first was the reverse —
+ *  REQUIRE the key, because a record without one was rejected by every reader
+ *  — and it was right about the symptom and wrong about the cure: the identity
+ *  belongs to the id the rules can pin, not to a field they cannot. */
 function primaryKeyProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
   const primaryKeyOf = new Map(collections.map((collection) => [collection.cid, collection.primaryKey]));
   return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
     const primaryKey = primaryKeyOf.get(cid);
-    if (primaryKey === undefined || submit.createFields.includes(primaryKey)) return [];
+    if (primaryKey === undefined || !submit.createFields.includes(primaryKey)) return [];
     return [
-      `public.submit.${cid}.createFields must include "${primaryKey}", the schema's primaryKey: a submission may carry only the createFields, ` +
-        "and a shared record is stored as exactly the fields it was written with — the document id is not copied into the record. " +
-        "Without it every submission is accepted by the rules and then rejected by every reader.",
+      `public.submit.${cid}.createFields must NOT include "${primaryKey}", the schema's primaryKey: the rules can pin the document id but not the value of a field, ` +
+        "so a submitter could write at their own id while claiming another record's. A shared record's identity is its document id — the store fills the field from it, " +
+        "and a submitted value is either the same thing or a lie that is thrown away.",
     ];
   });
 }

--- a/packages/core/test/collection/test_publish.ts
+++ b/packages/core/test/collection/test_publish.ts
@@ -135,10 +135,11 @@ function writeApp(overrides: Record<string, unknown> = {}): void {
         submit: {
           bookings: {
             auth: "verifiedEmail",
-            // `id` is the schema's primaryKey, and a submission may carry only
-            // the createFields — without it, every submitted row would be
-            // stored with no primary key and rejected by every reader.
-            createFields: ["id", "customerEmail", "status"],
+            // `id` — the schema's primaryKey — is deliberately ABSENT: a
+            // shared record's identity is its document id, which the rules can
+            // pin, and the store fills the field from it. A submitter that
+            // could name its own would be claiming an identity nothing checks.
+            createFields: ["customerEmail", "status"],
             initialStatus: "pending",
             window: { until: "2026-12-31T23:59:59Z" },
           },
@@ -201,7 +202,7 @@ test("a refused declaration writes NOTHING", async () => {
   // rules enforcing one declaration while members read another.
   writeSkill("bookings", BOOKINGS_SCHEMA);
   writeApp({
-    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerEmail"], idFrom: "auth.uid" } } },
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerEmail"], idFrom: "auth.uid" } } },
   });
 
   const result = await publishApp(opts());

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -15,8 +15,9 @@ import { publishProblems } from "../../src/collection/server/publishChecks";
 const OWNER = "owner@salon.jp";
 /** The repository's shared collections, as publish sees them: a cid and the
  *  schema key its records are identified by. `id` throughout, which is why
- *  every submit fixture below carries `id` in its createFields — a submission
- *  that cannot produce the primary key writes rows no reader accepts. */
+ *  `id` throughout, and NO submit fixture below names it in createFields: a
+ *  shared record's identity is its document id, and a submitter that could
+ *  name its own would be claiming an identity the rules cannot check. */
 const CIDS = [
   { cid: "bookings", primaryKey: "id" },
   { cid: "responses", primaryKey: "id" },
@@ -51,10 +52,10 @@ function refuses(problems: string[], fragment: string): void {
 // --- invariant 1: submitOnly ------------------------------------------------
 
 const IDENTITY_BOUND: Record<string, unknown>[] = [
-  { auth: "verifiedEmail", createFields: ["id", "a"], idFrom: "auth.uid" },
-  { auth: "verifiedEmail", createFields: ["id", "a", "who"], idFrom: "auth.uid+field", idField: "who" },
-  { auth: "verifiedEmail", createFields: ["id", "a", "email"], emailField: "email" },
-  { auth: "verifiedEmail", createFields: ["id", "a"], audience: "participant" },
+  { auth: "verifiedEmail", createFields: ["a"], idFrom: "auth.uid" },
+  { auth: "verifiedEmail", createFields: ["a", "who"], idFrom: "auth.uid+field", idField: "who" },
+  { auth: "verifiedEmail", createFields: ["a", "email"], emailField: "email" },
+  { auth: "verifiedEmail", createFields: ["a"], audience: "participant" },
 ];
 
 test("a submission bound to its submitter must declare submitOnly", () => {
@@ -79,7 +80,7 @@ test("a submission NOT bound to its submitter must not be forced to submitOnly",
   // ledger-style booking form, where staff enter records on a customer's
   // behalf. Requiring submitOnly there would break the feature.
   const problems = problemsFor({
-    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerName"], idFrom: "auto" } } },
+    public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"], idFrom: "auto" } } },
     collections: { bookings: {} },
   });
   assert.deepEqual(problems, []);
@@ -89,7 +90,7 @@ test("immutable is not the condition — a mutable survey is padded the same way
   // `immutable` was the tempting condition and it is wrong: S2's responses are
   // not immutable and can be inflated exactly as a vote can.
   const problems = problemsFor({
-    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "q1"], idFrom: "auth.uid" } } },
+    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid" } } },
     collections: { responses: { immutable: false } },
   });
   refuses(problems, "submitOnly must be true");
@@ -100,7 +101,7 @@ test("immutable is not the condition — a mutable survey is padded the same way
 test("an aggregation key no rule checks is refused, and a checked one is not", () => {
   const loose = problemsFor({
     collections: { responses: { submitOnly: true, aggregate: { by: ["q1"] } } },
-    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "q1"], idFrom: "auth.uid" } } },
+    public: { submit: { responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid" } } },
   });
   refuses(loose, "aggregate.by names 'q1'");
 
@@ -108,7 +109,7 @@ test("an aggregation key no rule checks is refused, and a checked one is not", (
     collections: { responses: { submitOnly: true, aggregate: { by: ["q1"] } } },
     public: {
       submit: {
-        responses: { auth: "verifiedEmail", createFields: ["id", "q1"], idFrom: "auth.uid", validate: { keyFields: [{ field: "q1", values: ["a", "b"] }] } },
+        responses: { auth: "verifiedEmail", createFields: ["q1"], idFrom: "auth.uid", validate: { keyFields: [{ field: "q1", values: ["a", "b"] }] } },
       },
     },
   });
@@ -124,7 +125,7 @@ test("the status field and gateOn.match also count as checked", () => {
   const byGate = problemsFor({
     collections: { answers: { submitOnly: true, aggregate: { by: ["questionId"] } } },
     public: {
-      submit: { answers: { auth: "verifiedEmail", createFields: ["id", "questionId"], idFrom: "auth.uid", gateOn: { phase: "open", match: "questionId" } } },
+      submit: { answers: { auth: "verifiedEmail", createFields: ["questionId"], idFrom: "auth.uid", gateOn: { phase: "open", match: "questionId" } } },
     },
   });
   assert.deepEqual(byGate, []);
@@ -134,9 +135,9 @@ test("the status field and gateOn.match also count as checked", () => {
 
 test("only verifiedEmail may be published, and the rules keep the other two", () => {
   for (const auth of ["none", "anonymous"]) {
-    refuses(problemsFor({ public: { submit: { bookings: { auth, createFields: ["id", "a"] } } } }), `public.submit.bookings.auth is "${auth}"`);
+    refuses(problemsFor({ public: { submit: { bookings: { auth, createFields: ["a"] } } } }), `public.submit.bookings.auth is "${auth}"`);
   }
-  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"] } } } }), []);
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"] } } } }), []);
 });
 
 // --- invariant 4: names -----------------------------------------------------
@@ -205,7 +206,7 @@ test("a window that closes before it opens is refused; a real interval is not", 
   refuses(
     problemsFor({
       public: {
-        submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], window: { from: "2026-09-30T00:00:00Z", until: "2026-09-01T00:00:00Z" } } },
+        submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], window: { from: "2026-09-30T00:00:00Z", until: "2026-09-01T00:00:00Z" } } },
       },
     }),
     "closes at or before it opens",
@@ -213,7 +214,7 @@ test("a window that closes before it opens is refused; a real interval is not", 
   assert.deepEqual(
     problemsFor({
       public: {
-        submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], window: { from: "2026-09-01T00:00:00Z", until: "2026-09-30T00:00:00Z" } } },
+        submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], window: { from: "2026-09-01T00:00:00Z", until: "2026-09-30T00:00:00Z" } } },
       },
     }),
     [],
@@ -224,7 +225,7 @@ test("keyFields is capped at two, because the rules unroll the check", () => {
   const keyFields = (count: number) => Array.from({ length: count }, (_unused, index) => ({ field: `f${index}`, values: ["x"] }));
   const submitWith = (count: number) => ({
     auth: "verifiedEmail",
-    createFields: ["id", ...keyFields(count).map((keyField) => keyField.field)],
+    createFields: [...keyFields(count).map((keyField) => keyField.field)],
     validate: { keyFields: keyFields(count) },
   });
   refuses(problemsFor({ public: { submit: { bookings: submitWith(3) } } }), "the rules check at most 2");
@@ -237,7 +238,7 @@ test("initialStatus without a statusField would deny every submission", () => {
   refuses(
     problemsFor({
       collections: { bookings: {} },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], initialStatus: "pending" } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], initialStatus: "pending" } } },
     }),
     "initialStatus needs collections.bookings.statusField",
   );
@@ -250,14 +251,14 @@ test("the status field must be one of the createFields a submission may carry", 
   refuses(
     problemsFor({
       collections: { bookings: { statusField: "status" } },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], initialStatus: "pending" } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], initialStatus: "pending" } } },
     }),
     'createFields must include "status"',
   );
   assert.deepEqual(
     problemsFor({
       collections: { bookings: { statusField: "status" } },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a", "status"], initialStatus: "pending" } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a", "status"], initialStatus: "pending" } } },
     }),
     [],
   );
@@ -265,12 +266,12 @@ test("the status field must be one of the createFields a submission may carry", 
 
 test("a required or key-checked field outside createFields can never be satisfied", () => {
   refuses(
-    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], validate: { required: ["b"] } } } } }),
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], validate: { required: ["b"] } } } } }),
     'validate.required names "b"',
   );
   refuses(
     problemsFor({
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], validate: { keyFields: [{ field: "b", values: ["x"] }] } } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], validate: { keyFields: [{ field: "b", values: ["x"] }] } } } },
     }),
     'validate.keyFields checks "b"',
   );
@@ -280,7 +281,7 @@ test("auth.uid+field without an idField denies every create", () => {
   refuses(
     problemsFor({
       collections: { responses: { submitOnly: true } },
-      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "a"], idFrom: "auth.uid+field" } } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["a"], idFrom: "auth.uid+field" } } },
     }),
     "no idField is declared",
   );
@@ -292,7 +293,7 @@ test("selfUpdate without a statusField denies every self-edit", () => {
   refuses(
     problemsFor({
       collections: { bookings: {} },
-      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "a"], selfUpdate: { pending: ["a"] } } } },
+      public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["a"], selfUpdate: { pending: ["a"] } } } },
     }),
     "declares no statusField",
   );
@@ -303,25 +304,26 @@ test("revealGated needs the parent it reads the flag off", () => {
   assert.deepEqual(problemsFor({ collections: { answers: { revealGated: true, gatedFrom: "responses", revealBy: "revealed" } } }), []);
 });
 
-test("a submit path that cannot produce the schema's primaryKey is refused", () => {
-  // The rules bind the DOCUMENT ID; the engine identifies a record by its
-  // primaryKey FIELD, and the firestore store stores exactly the fields it was
-  // given — the document id is not copied in. So without the key in
-  // createFields, Firestore accepts every submission and every reader rejects
-  // it. Neither side can see this alone.
+test("a submit path that lets the submitter name its own primaryKey is refused", () => {
+  // The rules pin the DOCUMENT ID (`idFrom`) and cannot pin the value of a
+  // field. Accept the primary key as a createField and a submitter can write
+  // at their one permitted id while claiming another record's identity.
   refuses(
-    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"] } } } }),
-    'createFields must include "id", the schema\'s primaryKey',
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerName"] } } } }),
+    'createFields must NOT include "id", the schema\'s primaryKey',
   );
-  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id", "customerName"] } } } }), []);
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["customerName"] } } } }), []);
 });
 
 test("the primaryKey check follows the schema, not the name 'id'", () => {
   // A collection keyed by `name` (S1's services) must be held to `name`.
   // Hard-coding "id" would pass this file and fail the first real schema.
   const keyedByName = [{ cid: "bookings", primaryKey: "name" }];
-  refuses(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id"] } } } }, keyedByName), 'createFields must include "name"');
-  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["name"] } } } }, keyedByName), []);
+  refuses(
+    problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["name"] } } } }, keyedByName),
+    'createFields must NOT include "name"',
+  );
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: { auth: "verifiedEmail", createFields: ["id"] } } } }, keyedByName), []);
 });
 
 test("emailField and idField must be in createFields — the rules read them off the record", () => {
@@ -332,21 +334,21 @@ test("emailField and idField must be in createFields — the rules read them off
   refuses(
     problemsFor({
       collections: { responses: { submitOnly: true } },
-      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "answer"], emailField: "email" } } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["answer"], emailField: "email" } } },
     }),
     'createFields must include "email"',
   );
   refuses(
     problemsFor({
       collections: { responses: { submitOnly: true } },
-      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "answer"], idFrom: "auth.uid+field", idField: "who" } } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["answer"], idFrom: "auth.uid+field", idField: "who" } } },
     }),
     'createFields must include "who"',
   );
   assert.deepEqual(
     problemsFor({
       collections: { responses: { submitOnly: true } },
-      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["id", "answer", "email"], emailField: "email" } } },
+      public: { submit: { responses: { auth: "verifiedEmail", createFields: ["answer", "email"], emailField: "email" } } },
     }),
     [],
   );

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.7.0",
+    "@mulmoclaude/core": "^3.8.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",

--- a/test/workspace/collections/test_storeContract.ts
+++ b/test/workspace/collections/test_storeContract.ts
@@ -202,8 +202,13 @@ function makeFakeFirestoreDocs(): FirestoreDocs & { paths: () => string[] } {
 /** Wire a fake session. ONE fake per fixture — the accessor is called per
  *  operation, so building it inside the closure would hand out a fresh empty
  *  store every time and silently lose every write. */
+/** The fake most recently wired, so a test can seed a document the store's own
+ *  write path would never produce. */
+let connectedDocs: FirestoreDocs | null = null;
+
 function connectFakeFirestore(): FirestoreDocs & { paths: () => string[] } {
   const docs = makeFakeFirestoreDocs();
+  connectedDocs = docs;
   setFirestoreAccessor(() => ({ docs, email: "owner@example.com", uid: "uid_owner" }));
   return docs;
 }
@@ -490,6 +495,28 @@ describe("shared (firestore) collections", () => {
       // and without this a denial degrades to "no records" (see the store).
       assert.ok(isBackendUnavailable(error));
     }
+  });
+
+  it("takes a record's identity from the DOCUMENT ID, not from the stored field", async () => {
+    // The rules can pin the document id (`idFrom`) and cannot pin the value of
+    // a field: nothing compares `request.resource.data[primaryKey]` with the
+    // path being written. So a public submitter writing at their one permitted
+    // id could claim another record's identity — unless the store decides it.
+    //
+    // Seeded THROUGH THE FAKE rather than through `store.write`, because the
+    // write path is exactly what an attacker does not use.
+    const store = await firestoreStoreFixture();
+    const docs = connectedDocs;
+    assert.ok(docs);
+    await docs.set(sharedItemsPath(sharedCollectionKey(APP_ID, "notescloud")), "n7", { id: "n1", title: "spoofed" });
+
+    const read = await store.read("n7");
+    assert.equal(read?.id, "n7", "the document id wins");
+    const listed = (await store.list()).filter((item) => item.title === "spoofed");
+    assert.deepEqual(
+      listed.map((item) => item.id),
+      ["n7"],
+    );
   });
 
   it("refuses create over an existing id — the atomicity the store contract requires", async () => {


### PR DESCRIPTION
receptron/mulmoterminal#1629 のレビューで codex が出した P1。**#2860 でマージ済みの挙動の穴**で、しかも #2860 のレビュー中に私が入れた修正が到達可能にしたものです。

## 何が可能だったか

ルールは投稿の**ドキュメント ID** を縛れます（`idFrom` が投稿者の uid に固定する）が、**フィールドの値**は縛れません:

```
idOk(s, itemId)    → itemId（パス）だけを見る
validateOk(s)      → キーの有無と、宣言された enum だけを見る
```

`request.resource.data[primaryKey]` と書き込み先のパスを比較するものは**どこにもありません**。そして `firestoreStore` の `toItem` はドキュメントのフィールドをそのまま返していたので、**書き手が主キーのフィールドに入れた値が、全ての読み手にとってのレコードの同一性**でした。

公開の投稿者は、自分に許された 1 つのドキュメント ID に書きながら、**重複や他人のレコード ID を名乗れます**。エンジンはそれを信じます。

## 直し方

`toItem` が読み出し時に**ドキュメント ID から主キーを埋めます**。同一性が、ルールが固定できる唯一の場所に移ります。

正直な書き込みでは両者は元から一致している（`firestoreWrite` は与えられた ID に書く）ので**挙動は変わりません**。詐称だけが到達不能になります。

publish はそれを可能にしていた宣言を拒否します — `createFields` が schema の `primaryKey` を含む `public.submit[cid]`。いまやそのフィールドには仕事がなく（投稿された値は ID と同じか、捨てられる嘘）、**値が捨てられるフォーム項目を publish するのは無いより悪い**からです。作者は投稿者が ID を選べると信じてしまいます。

## これは同じリリースで足した検査を逆にしています

#2860 のレビューで「`createFields` が primaryKey を含まないと、投稿は Firestore に受け入れられて全ての読み手に拒否される」と指摘され、publish は primaryKey を**要求**するようにしました。

**症状の見立ては正しく、処方が誤っていました。** 同一性はルールが固定できる ID に属し、固定できないフィールドには属しません。要求をやめて store 側で決めれば、元の症状（主キーの無いレコード）も同時に消えます。

## テスト

詐称テストは **fake に直接 seed** します — `store.write` は与えられた ID に書くので、攻撃者が通らない経路で確かめても意味がないためです:

```ts
await docs.set(itemsPath, "n7", { id: "n1", title: "spoofed" });
assert.equal((await store.read("n7"))?.id, "n7");   // ドキュメント ID が勝つ
```

publish 側は拒否と対になる成功ケース（primaryKey 以外の createFields、`id` 以外の主キー名）を書いています。

```
core         887 pass / 0 fail
mulmoclaude  9285 pass / 0 fail、yarn typecheck 0、yarn lint 0 errors
```

`@mulmoclaude/core` 3.7.0 → **3.8.0**。

> **マージ順の注意**: #2867（discovery の第 2 ソース化）も 3.8.0 を取っています。どちらか一方をマージしたら、もう一方は rebase して 3.9.0 に上げる必要があります。この PR は挙動の穴なので先に出しています。

対: receptron/mulmoterminal#1629（計画側の記述もこの形に直してあります）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce shared record identity via Firestore document IDs and prevent public submitters from naming primary-key fields, updating store behavior, publish-time validation, tests, documentation, and package versions accordingly.

Bug Fixes:
- Fix shared collection identity spoofing by deriving primary-key field values from Firestore document IDs instead of trusting stored field values.
- Disallow public submit configurations that include the collection primary key in createFields to avoid uncheckable identity claims.

Enhancements:
- Align publish checks, fixtures, and tests with the new rule that shared record identity is bound to document IDs rather than user-supplied primary-key fields.

Build:
- Bump @mulmoclaude/core to 3.8.0 and update the mulmoclaude package dependency to match.

Documentation:
- Document the change in shared record identity semantics, the associated security implications, and bump the documented @mulmoclaude/core version to 3.8.0.

Tests:
- Add and update tests to cover document-ID-based identity, rejection of primary-key createFields, and the revised publish behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Record identity is now derived from the database document ID, preventing conflicting stored primary-key values.
  - Public submissions can no longer declare the primary key as a creation field.

- **Publishing**
  - Added documentation for shared-app publishing, including validation, compatibility checks, signing metadata, and rollback retention.

- **Breaking Changes**
  - Hosts configuring Firestore access must now provide a `uid` value.

- **Release**
  - Updated `@mulmoclaude/core` to version 3.8.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->