### PR TITLE
feat(collections): app.json が URL 名（slug）を宣言できるようにする

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,31 @@ identity belongs to the id the rules can pin, not to a field they cannot.
 
 ### Added
 
+#### `app.json` may declare the URL name an app is handed out under
+
+`AuthoredAppZ` accepts an optional `slug` — the name in `https://<host>/{slug}`,
+kept separate from the `aid` for the reason the aid is a UUID: `apps/{aid}` is a
+shelf every user of a deployment shares, its `allow create` asks only that you
+name yourself owner, and availability cannot be checked because the app document
+is unreadable until you are on its roster. A memorable id there is
+first-come-first-served; a memorable NAME costs nothing to change, so that is
+where the fightable one belongs.
+
+It lives in the declaration rather than beside it because a reservation has to
+travel with the repository. `appSlugs/{slug}` is unreadable until the app is
+published (`allow read: if resource.data.published == true`), so nothing can ask
+Firestore which slug an app holds — and a second file to keep in step with
+`app.json` is the kind of pair that goes out of step silently. The host reserves
+a slug and writes back the one it got (a wanted name can be taken), which a
+strict schema would have made unwriteable.
+
+Nothing in this package reads the key: reserving and publishing a slug is the
+host's operation. The shape is stricter than a collection name — lowercase
+alphanumerics separated by single hyphens — because it is BOTH a URL path
+segment people retype and a Firestore document id, and a case rule would make
+one name for a person and two reservations for Firestore.
+
+
 #### Publishing a shared app: `manageCollection` action `publishApp`
 
 A repository that declares a shared app (`app.json` + collections with
@@ -173,7 +198,7 @@ is people.
 
 ### Package releases
 
-Ships `@mulmoclaude/core@3.10.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.11.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/publishManifest.ts
+++ b/packages/core/src/collection/server/publishManifest.ts
@@ -150,6 +150,43 @@ const PublicZ = z
   })
   .strict();
 
+/** The URL name an app is handed out under: `https://<host>/{slug}`.
+ *
+ *  A SEPARATE name from the `aid`, and that separation is the point (design
+ *  D2b). `apps/{aid}` is a shelf every user of the deployment shares and the
+ *  rules' `allow create` asks only that you name yourself owner — so a
+ *  memorable aid is first-come-first-served, cannot be checked for
+ *  availability, and frees up again when an app is deleted. The aid is
+ *  therefore a UUID, and the thing people can fight over is moved to the name
+ *  that costs nothing to change.
+ *
+ *  Declared here rather than kept beside `app.json` because a RESERVATION has
+ *  to travel with the repository: `appSlugs/{slug}` is unreadable until the app
+ *  is published (`allow read: if resource.data.published == true`), so nothing
+ *  can recover which slug an app holds by asking Firestore. A second file to
+ *  keep in step with the declaration is the alternative, and it is the kind of
+ *  pair that goes out of step silently.
+ *
+ *  The shape is stricter than `NameZ` on purpose: it is BOTH a URL path
+ *  segment people read aloud and a Firestore document id. Lowercase
+ *  alphanumerics separated by single hyphens covers both without a case rule
+ *  that would make two slugs collide in one place and not the other.
+ *
+ *  Which slug an app ended up with is the HOST's business — a wanted slug can
+ *  be taken, and the host writes the one it reserved back here. Nothing in this
+ *  package reads the key; it is declared so that writing it back does not make
+ *  the file unparseable. */
+const SLUG_SHAPE = "must be lowercase letters, digits and single hyphens, and must not start or end with one (e.g. sakura-hair)";
+
+const SlugZ = z
+  .string()
+  .trim()
+  .max(64)
+  // Two checks rather than the obvious `^[a-z0-9]+(?:-[a-z0-9]+)*$`: that one nests a quantifier
+  // inside a quantifier, which the ReDoS lint rejects. Split, neither part backtracks.
+  .regex(/^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/, SLUG_SHAPE)
+  .refine((slug) => !slug.includes("--"), SLUG_SHAPE);
+
 /** The whole authored declaration.
  *
  *  `owner` is accepted but is NOT the published value — publish stamps the
@@ -162,6 +199,8 @@ export const AuthoredAppZ = z
   .object({
     aid: NameZ,
     name: z.string().trim().min(1).optional(),
+    /** The wanted (or reserved) URL name — see {@link SlugZ}. */
+    slug: SlugZ.optional(),
     /** Per-worktree app id (design D6, implementation order 7). Accepted so a
      *  repository already carrying it parses; nothing reads it yet. */
     aidEnv: z.string().trim().min(1).optional(),

--- a/packages/core/test/collection/test_authoredSlug.ts
+++ b/packages/core/test/collection/test_authoredSlug.ts
@@ -1,0 +1,52 @@
+// The URL name, and why the declaration carries it at all.
+//
+// `aid` is the identity and `slug` is the name people are handed
+// (`https://<host>/{slug}`). They are separate because a shelf every user
+// shares cannot hold memorable ids fairly, and the SLUG is where the
+// fightable name was moved — so this file pins the two properties a host
+// depends on: the key parses, and it parses only in a shape that is safe in
+// both places it is used.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseAuthoredApp } from "../../src/collection/server/publishManifest";
+
+const withSlug = (slug: unknown): ReturnType<typeof parseAuthoredApp> =>
+  parseAuthoredApp(JSON.stringify({ aid: "3f2b8c1a", name: "Sakura Hair", slug, members: { "owner@example.com": { "*": "owner" } } }));
+
+test("a declaration may carry the wanted URL name", () => {
+  const parsed = withSlug("sakura-hair");
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.ok ? parsed.app.slug : null, "sakura-hair");
+});
+
+test("the key is optional — an app reachable only at /staging/{aid} never needs one", () => {
+  const parsed = parseAuthoredApp(JSON.stringify({ aid: "3f2b8c1a", members: { "owner@example.com": { "*": "owner" } } }));
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.ok ? parsed.app.slug : "unset", undefined);
+});
+
+test("a host may write back the slug it actually reserved", () => {
+  // The wanted one can be taken, and the reservation is unreadable until the
+  // app is published — so the host's write-back is the ONLY record of which
+  // slug an app holds. A declaration that refused it would make that record
+  // impossible to keep.
+  assert.equal(withSlug("sakura-hair-2").ok, true);
+});
+
+test("it refuses a shape that is not safe in both a URL and a document id", () => {
+  // Uppercase is the one worth naming: a URL path is compared case-sensitively
+  // and readers retype it in either case, so `Sakura` and `sakura` would be one
+  // name to a person and two reservations to Firestore.
+  for (const slug of ["Sakura", "sakura hair", "sakura_hair", "sakura/hair", "-sakura", "sakura-", "sakura--hair", "", "a".repeat(65)]) {
+    assert.equal(withSlug(slug).ok, false, `expected ${JSON.stringify(slug)} to be refused`);
+  }
+});
+
+test("it says what a rejected slug should look like", () => {
+  const parsed = withSlug("Sakura Hair");
+  assert.equal(parsed.ok, false);
+  // The author is holding the file open; a reason without an example is a
+  // second round trip.
+  assert.match(parsed.ok ? "" : parsed.problems.join("\n"), /sakura-hair/);
+});

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.10.0",
+    "@mulmoclaude/core": "^3.11.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",


### PR DESCRIPTION
共有コレクションのために **MulmoClaude に入れる最後の変更**です（MT 側からの依頼。
これ以降、共有アプリの機能追加は MulmoTerminal だけで完結します）。

`AuthoredAppZ` に任意の **`slug`** を足します。`https://<host>/{slug}` で配る名前で、
`aid` とは別物です。

## なぜ別の名前なのか

`aid` を UUID にしたのと同じ理由です。`apps/{aid}` は全ユーザー共通の棚で、
`allow create` が要求するのは「自分をオーナーと名乗る」ことだけ。空きを調べることも
できません（名簿に載るまでアプリ文書は読めない）。つまり**覚えやすい aid は早い者勝ち**で、
削除で窓が開き直します。覚えやすい**名前**なら捨てても痛くないので、取り合いの対象は
そちらへ移します。

## なぜ宣言の中なのか

**予約がリポジトリと一緒に travel しなければならない**からです。`appSlugs/{slug}` は
publish されるまで読めません（`allow read: if resource.data.published == true`）。
つまりオーナー自身も、自分がどの slug を握っているかを Firestore に問い合わせて復元
できません。`app.json` の隣に別ファイルを置く案は、黙って食い違う類のペアになります。

またホストは**予約できた方を書き戻します**（希望の名前は取られていることがある）。
strict なスキーマだと、その書き戻しで `app.json` が丸ごとパースできなくなっていました。

## 何を読むか

**このパッケージは `slug` を読みません。** 予約（deploy）と公開（publish）はホストの操作です。
形だけはコレクション名より厳しくしてあります — 小文字英数とハイフン 1 つずつ。URL の
パスセグメントであると同時に Firestore のドキュメント id でもあるので、大文字を許すと
**人には 1 つの名前、Firestore には 2 つの予約**になります。

## テスト

`packages/core/test/collection/test_authoredSlug.ts`（5 件）。任意であること、書き戻せること、
両方の場所で安全でない形は断ること、断るときに例を出すこと。

`@mulmoclaude/core` 3.10.0 → **3.11.0**（launcher の依存と CHANGELOG の Ships 行も更新）。
lint 0 errors / typecheck 0 / `yarn test` 9293 pass・0 fail。

work in mulmoterminal

## Summary by Sourcery

Allow authored apps to optionally declare a URL slug in app.json, with validation that keeps host write-backs parseable and safe for both URL paths and Firestore document IDs.

New Features:
- Support an optional slug field in AuthoredApp declarations to specify the app’s public URL name.

Enhancements:
- Define and enforce a stricter slug shape for authored apps to avoid unsafe or ambiguous names across URL and Firestore contexts.

Build:
- Bump @mulmoclaude/core to version 3.11.0 and update dependent package versions and changelog release entry.

Documentation:
- Document the new optional slug field in app.json and its reasoning in the changelog, including constraints and host responsibilities.

Tests:
- Add collection tests covering optionality, host write-back, validation failures, and error messaging for invalid slugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional URL slugs for apps, supporting lowercase letters, numbers, and hyphens.
  * Host-managed slug reservation and publication are now supported.
  * Added validation for slug format and length, with clear guidance when invalid values are used.

* **Documentation**
  * Updated the unreleased changelog with publishing, visibility, provenance, and API changes.

* **Chores**
  * Released `@mulmoclaude/core` version 3.11.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->