### PR TITLE
feat(collections): 行スコープの assignee ロールと、先着枠のための宣言を追加

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,46 @@ segment people retype and a Firestore document id, and a case rule would make
 one name for a person and two reservations for Firestore.
 
 
+#### A row-scoped writer (`assignee`), and the two keys a first-come queue needs
+
+Three additions to the shared-app declaration, all of them paired with rules in
+`mulmoserver`.
+
+**`assignee`**, a fifth role, plus `collections.<cid>.assigneeField`. It reads
+every row and writes only the ones assigned to it — the stylist who approves
+their own bookings and not a colleague's. The four-role split could not express
+that: `writerOf` does not look at the row, and `ownRow` identifies the SUBMITTER
+(the customer), not the person the work belongs to. Putting the scope on the
+collection instead would have made the receptionist inexpressible, so it goes on
+the roster. Reads stay unscoped deliberately — a stylist who cannot see the
+day's schedule cannot work. The field holds an ADDRESS, because that is the only
+thing the rules can compare a member against; a `ref` to a staff collection
+stores that record's primary key and matches nobody.
+
+**`public.submit.<cid>.stampField`** pins a field to the server clock on create
+and freezes it afterwards. A first-come app takes its capacity from RANK rather
+than from a count — the rules cannot count documents, so "the first 8" can only
+ever be a reading of the rows — and a rank is exactly as honest as the field it
+sorts by. `idFrom` stops one person holding two places; nothing else stopped
+them writing yesterday into the field that decides who was first.
+
+**`public.submit.<cid>.window.fromField`** is an opening time that lives on
+another record: `{ ref, collection, field }`, where the target carries epoch
+millis. `window.from` is one instant for the whole collection, which is enough
+for a survey and useless for anything recurring. The bound is not computed in
+the rules — they have no usable date arithmetic and `request.time` is UTC, which
+is the wrong answer for "08:00" — it is computed by whoever schedules the class
+and merely compared. Not spelled `in`: that is an operator in the rules
+language, and `w.fromField.in` does not parse there.
+
+Publish refuses three new fail-closed traps: an `assignee` with no
+`assigneeField` (which fails closed for that ONE member while the app keeps
+working for everybody else), a `stampField` outside `createFields` (which
+refuses every submission), and a `fromField` naming an unknown collection or a
+field the submission never writes (which shuts the window for good). A member's
+per-collection keys also joined the unknown-cid sweep.
+
+
 #### Publishing a shared app: `manageCollection` action `publishApp`
 
 A repository that declares a shared app (`app.json` + collections with
@@ -198,7 +238,7 @@ is people.
 
 ### Package releases
 
-Ships `@mulmoclaude/core@3.11.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.12.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -102,7 +102,7 @@ export {
   type PublishedSchemaDoc,
   type StagedSchemaDoc,
 } from "./publishProject";
-export { publishProblems, bindsSubmitterIdentity, type PublishableCollection } from "./publishChecks";
+export { publishProblems, promotedRoleProblems, bindsSubmitterIdentity, type PublishableCollection } from "./publishChecks";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";
 export * from "./templatePath";

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -27,6 +27,7 @@
 // safety.
 
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
+import { stagedRuleConfig, type StagedSchemaDoc } from "./publishProject";
 
 /** What publish knows about a shared collection in this repository, as far as
  *  these checks are concerned: its cid and the schema key its records are
@@ -490,4 +491,48 @@ function windowRefProblems(app: AuthoredApp, collections: readonly PublishableCo
     }
     return problems;
   });
+}
+
+/** What publish will actually promote, checked as the PAIR it becomes.
+ *
+ *  `publishProblems` reads the manifest, where `members` and `collections` sit
+ *  side by side and agree. Publish does not write that pair. It writes the
+ *  roster from the manifest and the collection configuration from what DEPLOY
+ *  staged, so the app that lands is one half of each — and no check has ever
+ *  looked at that combination.
+ *
+ *  The sequence that gets through: deploy revision A with no `assigneeField`,
+ *  add the field AND the member in revision B, publish without redeploying.
+ *  Every manifest-level check passes on a declaration that is internally sound,
+ *  while what lands is A's field-less configuration beside B's roster — an
+ *  assignee with nothing to be compared against, refused every write, in an app
+ *  that keeps working for everybody else. That is the precise trap
+ *  `assigneeProblems` exists to prevent, reached by the one route it cannot
+ *  see.
+ *
+ *  Separate from `publishProblems` because it needs what deploy staged, which
+ *  is a Firestore read the host makes and this package does not. It is checked
+ *  against `stagedRuleConfig` — the same function the projection uses — rather
+ *  than against a re-derivation, so the value validated is the value written.
+ *
+ *  Only the staged half can be stale, so only that half is named and the fix is
+ *  "deploy again" rather than "fix the declaration". */
+export function promotedRoleProblems(app: AuthoredApp, staged: { cid: string; doc: StagedSchemaDoc }[]): string[] {
+  const promoted = stagedRuleConfig(staged).collections ?? {};
+  const stagedCids = new Set(staged.map((entry) => entry.cid));
+  return Object.entries(app.members).flatMap(([email, roles]) =>
+    Object.entries(roles).flatMap(([cid, role]) => {
+      // A cid with nothing staged at all is the host's "not staged, so there is
+      // no reviewed version to promote" refusal, which names every missing
+      // collection at once. Repeating it per member would bury it.
+      if (role !== "assignee" || cid === "*" || !stagedCids.has(cid)) return [];
+      if (promoted[cid]?.assigneeField !== undefined) return [];
+      return [
+        `members["${email}"] holds "assignee" on '${cid}', and the STAGED version of '${cid}' — the one publish promotes — carries no assigneeField, even if ` +
+          `app.json declares one now. Publish writes the roster from app.json and the collection configuration from the deploy, so that member would land with ` +
+          `nothing to be compared against: refused every write, while the app keeps working for everybody else. ` +
+          "Run deploy again, so the version being published is the one the declaration describes.",
+      ];
+    }),
+  );
 }

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -330,6 +330,11 @@ function unknownCidProblems(app: AuthoredApp, collections: readonly PublishableC
     ["public.read", app.public?.read ?? []],
     ["public.submit", Object.keys(app.public?.submit ?? {})],
     ["participantRead", app.participantRead ?? []],
+    // A member's per-collection keys are cids too, and a typo there is the
+    // quietest of the lot: the member holds the role on a collection that does
+    // not exist, and on the one they were meant to hold it on they fall back
+    // to their `'*'` role — or, holding none, to nothing at all.
+    ["members", [...new Set(Object.values(app.members).flatMap((roles) => Object.keys(roles)))].filter((key) => key !== "*")],
   ];
   return mentions.flatMap(([where, cids]) =>
     cids
@@ -357,6 +362,9 @@ export function publishProblems(app: AuthoredApp, collections: readonly Publisha
     ...submitShapeProblems(app),
     ...coherenceProblems(app),
     ...primaryKeyProblems(app, collections),
+    ...assigneeProblems(app),
+    ...stampProblems(app),
+    ...windowRefProblems(app, collections),
   ];
 }
 
@@ -389,5 +397,97 @@ function primaryKeyProblems(app: AuthoredApp, collections: readonly PublishableC
         "so a submitter could write at their own id while claiming another record's. A shared record's identity is its document id — the store fills the field from it, " +
         "and a submitted value is either the same thing or a lie that is thrown away.",
     ];
+  });
+}
+
+/** `assignee` without the field that says which rows are theirs.
+ *
+ *  A FAIL-CLOSED trap of the worst kind, because it fails closed for one
+ *  person and nobody else: the rules ask `collections[cid].assigneeField` for
+ *  the field to compare, find nothing, and refuse every write that member
+ *  makes. The app works for the owner who set it up, and the member it was set
+ *  up for is told only "permission denied".
+ *
+ *  `'*': "assignee"` is refused outright rather than checked against every
+ *  collection. The role means "the rows assigned to you", and what counts as
+ *  assigned is per collection — an app-wide one would need the same field name
+ *  to be right everywhere, and where it is missing it silently means "no
+ *  access to this collection" rather than "no scoping here".
+ */
+function assigneeProblems(app: AuthoredApp): string[] {
+  return Object.entries(app.members).flatMap(([email, roles]) =>
+    Object.entries(roles).flatMap(([cid, role]) => {
+      if (role !== "assignee") return [];
+      if (cid === "*") {
+        return [
+          `members["${email}"] holds "assignee" under "*", and the role cannot be app-wide: which rows are yours is declared per collection ` +
+            '(`collections.<cid>.assigneeField`). Name the collections instead — { "bookings": "assignee" }.',
+        ];
+      }
+      if (app.collections?.[cid]?.assigneeField !== undefined) return [];
+      return [
+        `members["${email}"] holds "assignee" on '${cid}', but collections.${cid}.assigneeField does not say which field names the member a row belongs to. ` +
+          `Add it (assigneeField: "<a field holding an address>"), or give a role that is not row-scoped. Without it the rules have nothing to compare and refuse ` +
+          "every write that member makes, while the app keeps working for everybody else.",
+      ];
+    }),
+  );
+}
+
+/** A server-stamped field the submitter cannot write, or can rewrite later.
+ *
+ *  Both failures are silent in opposite directions. Left out of
+ *  `createFields`, the rules refuse every submission (`hasOnly(createFields)`
+ *  rejects the key the stamp check requires) — an app nobody can use. Left IN
+ *  a `selfUpdate` list, the field the queue is ordered by becomes editable by
+ *  the person standing in the queue. */
+function stampProblems(app: AuthoredApp): string[] {
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
+    const stamp = submit.stampField;
+    if (stamp === undefined) return [];
+    const problems: string[] = [];
+    if (!submit.createFields.includes(stamp)) {
+      problems.push(
+        `public.submit.${cid}.stampField names '${stamp}', which is not in createFields. The rules require the record to CARRY the server time in that field, ` +
+          "and refuse any key outside createFields — so every submission is denied. Add it to createFields; the page fills it in, not the person.",
+      );
+    }
+    for (const [status, fields] of Object.entries(submit.selfUpdate ?? {})) {
+      if (!fields.includes(stamp)) continue;
+      problems.push(
+        `public.submit.${cid}.selfUpdate.${status} lets the submitter write '${stamp}', which is the field stampField pins to the server clock. ` +
+          "Whatever that field orders — a first-come queue, an audit trail — could then be rewritten by the person it ranks. Remove it from selfUpdate.",
+      );
+    }
+    return problems;
+  });
+}
+
+/** A per-record window bound pointing at a collection or a field the submitter
+ *  never writes.
+ *
+ *  `fromField` makes the rules read another record, and every part of that
+ *  read is fail-closed: an unknown collection, or a `ref` the submission does
+ *  not carry, means the bound can never be satisfied and the form is shut for
+ *  good. */
+function windowRefProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const known = new Set(collections.map((collection) => collection.cid));
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
+    const ref = submit.window?.fromField;
+    if (ref === undefined) return [];
+    const problems: string[] = [];
+    if (!known.has(ref.collection)) {
+      problems.push(
+        `public.submit.${cid}.window.fromField.collection names '${ref.collection}', which is not a shared collection in this repository. ` +
+          `The rules read the opening time off a record there, so nothing can ever be submitted. Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : "(none)"}.`,
+      );
+    }
+    if (!submit.createFields.includes(ref.ref)) {
+      problems.push(
+        `public.submit.${cid}.window.fromField.ref names '${ref.ref}', which is not in createFields. The rules take the target record's id from that field ON THE ` +
+          "SUBMISSION — if the submitter never writes it, there is nothing to look up and every submission is refused.",
+      );
+    }
+    return problems;
   });
 }

--- a/packages/core/src/collection/server/publishManifest.ts
+++ b/packages/core/src/collection/server/publishManifest.ts
@@ -50,9 +50,25 @@ const NameZ = z.string().refine(isValidCollectionName, { message: "is not a vali
  *  narrowing here would refuse addresses Firebase itself accepts. */
 const EmailZ = z.string().trim().min(3).includes("@");
 
-/** The four roles the deployed rules understand. `participant` is the layer
- *  that is NAMED but reads only its own rows — see `readerOf` vs `listedIn`. */
-export const APP_ROLES = ["owner", "editor", "viewer", "participant"] as const;
+/** The roles the deployed rules understand.
+ *
+ *  Two of them are row-scoped, in opposite directions, and the pair is what
+ *  the four-way split could not express:
+ *
+ *    `participant` — the layer that is NAMED but reads only its OWN rows (the
+ *    rows it submitted). See `readerOf` vs `listedIn`.
+ *
+ *    `assignee` — reads EVERY row and writes only the rows ASSIGNED to it. The
+ *    stylist who approves their own bookings and not a colleague's; the marker
+ *    who grades their own students. Which rows are theirs is
+ *    `collections[cid].assigneeField`, a field on the record holding the
+ *    member's address. Reads are deliberately unscoped: a stylist needs the
+ *    whole day's schedule, and scoping the read makes the app unusable.
+ *
+ *  The names are permanent. The deployed rules compare these strings directly
+ *  and they are written into `app.json` files people commit, so a rename is a
+ *  migration over published apps rather than an edit. */
+export const APP_ROLES = ["owner", "editor", "viewer", "participant", "assignee"] as const;
 const RoleZ = z.enum(APP_ROLES);
 
 /** `{ email: { "*" | cid: role } }`. The `"*"` key is the app-wide role; a
@@ -80,6 +96,21 @@ const CollectionConfigZ = z
     transitions: z.record(z.string().trim().min(1), z.array(z.string().trim().min(1))).optional(),
     immutable: z.boolean().optional(),
     submitOnly: z.boolean().optional(),
+    /** The field naming the member a row belongs to, for the `assignee` role.
+     *
+     *  Holds an ADDRESS, because that is the only thing the rules can compare
+     *  a member against (`request.auth.token.email`). A `ref` to a staff
+     *  collection stores the target's primary-key slug, not an address, so it
+     *  cannot be this field — declare a plain field beside the ref and let the
+     *  ref stay the thing the UI renders. The alternative, having the rules
+     *  `get()` the staff record to read an address off it, costs a document
+     *  access on every write and puts a second document between an
+     *  authorization decision and its answer.
+     *
+     *  Only meaningful with a member holding `assignee` on this cid; a
+     *  declaration with the role and no field is refused (`assigneeProblems`),
+     *  because that member would silently hold nothing. */
+    assigneeField: z.string().trim().min(1).optional(),
     peerVisibility: z.enum(["public", "hidden"]).optional(),
     revealGated: z.boolean().optional(),
     gatedFrom: NameZ.optional(),
@@ -103,7 +134,26 @@ const CollectionConfigZ = z
  *  the rules do not coerce strings, so an ISO string reaching Firestore is a
  *  type error that fails CLOSED (`inWindow` refuses every submission and the
  *  author sees "nobody can submit", not an error). */
-const WindowZ = z.object({ from: z.iso.datetime().optional(), until: z.iso.datetime().optional() }).strict();
+/** A window bound that lives on ANOTHER record, read at write time.
+ *
+ *  `window.from` is one absolute instant for the whole collection, which is
+ *  enough for a survey and useless for anything recurring: "each class opens
+ *  three days before it starts, at 08:00" is a bound PER RECORD. So the bound
+ *  is not computed in the rules — they have no usable date arithmetic and
+ *  `request.time` is UTC, which is the wrong answer for "08:00" — it is
+ *  computed by whoever schedules the class, stored on the class record as
+ *  epoch millis, and merely COMPARED here.
+ *
+ *  `ref` is the field on the record being written that names the target
+ *  (`classId`); `collection` is the cid the target lives in, fixed in the
+ *  declaration so that a path is never built out of a value a submitter wrote;
+ *  `field` is the epoch-millis field on the target.
+ *
+ *  Not spelled `in` — that is an operator in the rules language, and
+ *  `w.fromField.in` does not parse there. */
+const WindowRefZ = z.object({ ref: z.string().trim().min(1), collection: NameZ, field: z.string().trim().min(1) }).strict();
+
+const WindowZ = z.object({ from: z.iso.datetime().optional(), until: z.iso.datetime().optional(), fromField: WindowRefZ.optional() }).strict();
 
 const ValidateZ = z
   .object({
@@ -127,6 +177,19 @@ const SubmitZ = z
     idField: z.string().trim().min(1).optional(),
     validate: ValidateZ.optional(),
     window: WindowZ.optional(),
+    /** A field the rules PIN to the server clock on create: the record must
+     *  carry `request.time` in it, and may never change it afterwards.
+     *
+     *  What it buys is an order nobody can jump. A first-come app takes its
+     *  capacity from rank rather than from a count — the rules cannot count
+     *  documents, so "the first 8" can only ever be a reading of the rows —
+     *  and a rank is only as honest as the timestamp it sorts by. `idFrom`
+     *  stops a person holding two places; nothing else stops them writing
+     *  yesterday's date into the field that decides who got there first.
+     *
+     *  Binds EVERY create, the writer branch included, so a staff-entered row
+     *  cannot be back-dated into the queue either. */
+    stampField: z.string().trim().min(1).optional(),
     /** Per CURRENT STATUS, never a flat list: a flat list lets a customer move
      *  an approved booking's `startAt` without anyone re-approving it. */
     selfUpdate: z.record(z.string().trim().min(1), z.array(z.string().trim().min(1))).optional(),

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -152,7 +152,9 @@ function compact(entries: Record<string, unknown>): Record<string, unknown> {
  *  requires `z.iso.datetime()`), so a NaN here would be a programming error;
  *  it is still checked, because a NaN written to Firestore fails closed in the
  *  same silent way an ISO string does. */
-function windowMillis(window: { from?: string | undefined; until?: string | undefined } | undefined): Record<string, number> | undefined {
+function windowMillis(
+  window: { from?: string | undefined; until?: string | undefined; fromField?: Record<string, string> | undefined } | undefined,
+): Record<string, unknown> | undefined {
   if (!window) return undefined;
   const out: Record<string, number> = {};
   if (window.from !== undefined) out.fromMs = Date.parse(window.from);
@@ -160,7 +162,13 @@ function windowMillis(window: { from?: string | undefined; until?: string | unde
   if (Object.values(out).some((value) => !Number.isFinite(value))) {
     throw new Error(`publish: window bound is not a parseable timestamp (${JSON.stringify(window)})`);
   }
-  return Object.keys(out).length > 0 ? out : undefined;
+  // `fromField` passes through unlowered — it names a field on another record,
+  // and the value it points at is already epoch millis (whoever schedules the
+  // class writes it). There is nothing here to convert, and dropping it is the
+  // failure this function's own comment warns about: the rules would stop
+  // seeing a bound the author declared, and the window would silently be open.
+  const projected: Record<string, unknown> = { ...out, ...(window.fromField === undefined ? {} : { fromField: window.fromField }) };
+  return Object.keys(projected).length > 0 ? projected : undefined;
 }
 
 /** One `public.submit[cid]`, with its window lowered. Everything else passes

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -10,7 +10,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 import { AuthoredAppZ } from "../../src/collection/server/publishManifest";
-import { publishProblems } from "../../src/collection/server/publishChecks";
+import { publishProblems, promotedRoleProblems } from "../../src/collection/server/publishChecks";
 
 const OWNER = "owner@salon.jp";
 /** The repository's shared collections, as publish sees them: a cid and the
@@ -446,4 +446,38 @@ test("a per-record window bound must be reachable from the submission", () => {
   // shut for good rather than open.
   const problems = problemsFor({ public: { submit: { bookings: { ...BOOKING, createFields: ["name"] } } } });
   refuses(problems, "window.fromField.ref names 'serviceId'");
+});
+
+// --- the pair publish actually writes ---------------------------------------
+
+test("an assignee whose field never reached the deploy is refused at publish", () => {
+  // deploy A (no assigneeField) → edit B (add the field AND the member) →
+  // publish, without redeploying. Every manifest-level check passes on a
+  // declaration that is internally sound, while what lands is A's field-less
+  // configuration beside B's roster: that one member is refused every write and
+  // the app keeps working for everybody else.
+  const declared = app({
+    members: { [OWNER]: { "*": "owner" }, "anna@salon.jp": { bookings: "assignee" } },
+    collections: { bookings: { assigneeField: "stylistEmail" } },
+  });
+  const stagedDoc = (config: Record<string, unknown>) => ({
+    cid: "bookings",
+    doc: { publishedSchema: { title: "b", icon: "event", primaryKey: "id", fields: {} }, deployedAt: 1, deployedBy: OWNER, config },
+  });
+
+  // The manifest alone is sound, which is exactly why this needed its own check.
+  assert.deepEqual(publishProblems(declared, CIDS, OWNER), []);
+
+  refuses(promotedRoleProblems(declared, [stagedDoc({})] as never), "carries no assigneeField");
+  assert.deepEqual(promotedRoleProblems(declared, [stagedDoc({ assigneeField: "stylistEmail" })] as never), []);
+});
+
+test("a collection with nothing staged is left to the gate that names them all", () => {
+  // "not staged, so there is no reviewed version to promote" lists every
+  // missing collection at once; repeating it per member would bury it.
+  const declared = app({
+    members: { [OWNER]: { "*": "owner" }, "anna@salon.jp": { bookings: "assignee" } },
+    collections: { bookings: { assigneeField: "stylistEmail" } },
+  });
+  assert.deepEqual(promotedRoleProblems(declared, []), []);
 });

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -370,3 +370,80 @@ test("a per-collection role is not app-wide owner", () => {
   const problems = publishProblems(AuthoredAppZ.parse({ aid: "app_test", members: { [OWNER]: { bookings: "owner" } } }), CIDS, OWNER);
   refuses(problems, "members must give you app-wide owner");
 });
+
+// --- the assignee role ------------------------------------------------------
+
+const STYLIST = "stylist-a@salon.jp";
+
+test("assignee needs the field that says which rows are the member's", () => {
+  // The nastiest failure shape available: it fails closed for ONE member. The
+  // owner who set the app up sees it working, and the stylist is told
+  // "permission denied" with nothing naming a cause.
+  const problems = problemsFor({ members: { [OWNER]: { "*": "owner" }, [STYLIST]: { bookings: "assignee" } } });
+  refuses(problems, "collections.bookings.assigneeField does not say which field");
+
+  assert.deepEqual(
+    problemsFor({
+      members: { [OWNER]: { "*": "owner" }, [STYLIST]: { bookings: "assignee" } },
+      collections: { bookings: { assigneeField: "stylistEmail" } },
+    }),
+    [],
+  );
+});
+
+test("assignee cannot be app-wide", () => {
+  // Which rows are yours is per collection. An app-wide one would need the
+  // same field name to be right in every collection, and where it is missing
+  // it means "no access at all" rather than "no scoping here".
+  const problems = problemsFor({
+    members: { [OWNER]: { "*": "owner" }, [STYLIST]: { "*": "assignee" } },
+    collections: { bookings: { assigneeField: "stylistEmail" } },
+  });
+  refuses(problems, 'holds "assignee" under "*"');
+});
+
+test("a role on a collection that does not exist is reported", () => {
+  // The member holds the role on nothing, and on the collection they were
+  // meant to hold it on they fall back to their '*' role — or to nothing.
+  refuses(problemsFor({ members: { [OWNER]: { "*": "owner" }, [STYLIST]: { bokings: "editor" } } }), "members names 'bokings'");
+});
+
+// --- the server-stamped field -----------------------------------------------
+
+const QUEUE = { auth: "verifiedEmail" as const, createFields: ["classId", "createdAt"], stampField: "createdAt" };
+
+test("a stamped field the submission may not carry shuts the form", () => {
+  // `hasOnly(createFields)` refuses the key the stamp check requires, so every
+  // submission is denied — and the declaration reads as if it were working.
+  const problems = problemsFor({ public: { submit: { bookings: { ...QUEUE, createFields: ["classId"] } } } });
+  refuses(problems, "which is not in createFields");
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: QUEUE } } }), []);
+});
+
+test("a stamped field the submitter may edit later is not a stamp", () => {
+  // Whatever it orders — a first-come queue, an audit trail — could then be
+  // rewritten by the person it ranks.
+  const problems = problemsFor({
+    public: { submit: { bookings: { ...QUEUE, selfUpdate: { requested: ["createdAt"] } } } },
+  });
+  refuses(problems, "which is the field stampField pins to the server clock");
+});
+
+// --- a window bound that lives on another record ----------------------------
+
+const OPENS = { ref: "serviceId", collection: "services", field: "opensAt" };
+const BOOKING = { auth: "verifiedEmail" as const, createFields: ["serviceId"], window: { fromField: OPENS } };
+
+test("a per-record window bound must point at a real collection", () => {
+  const problems = problemsFor({ public: { submit: { bookings: { ...BOOKING, window: { fromField: { ...OPENS, collection: "classes" } } } } } });
+  refuses(problems, "window.fromField.collection names 'classes'");
+  assert.deepEqual(problemsFor({ public: { submit: { bookings: BOOKING } } }), []);
+});
+
+test("a per-record window bound must be reachable from the submission", () => {
+  // The rules take the target's id from a field ON THE SUBMISSION. If the
+  // submitter never writes it there is nothing to look up, and the form is
+  // shut for good rather than open.
+  const problems = problemsFor({ public: { submit: { bookings: { ...BOOKING, createFields: ["name"] } } } });
+  refuses(problems, "window.fromField.ref names 'serviceId'");
+});

--- a/packages/core/test/collection/test_publishProject.ts
+++ b/packages/core/test/collection/test_publishProject.ts
@@ -90,6 +90,29 @@ test("a one-sided window publishes only the bound that was declared", () => {
   assert.deepEqual(submit.window, { untilMs: Date.parse("2026-12-31T23:59:59Z") });
 });
 
+test("a per-record window bound survives the lowering that has nothing to lower", () => {
+  // `fromField` names a field on ANOTHER record and the value it points at is
+  // already epoch millis, so there is no conversion — which is exactly how a
+  // key gets dropped by a function whose job is converting. Dropped, the rules
+  // stop seeing a bound the author declared and the window is silently OPEN.
+  const app = authored({
+    public: {
+      submit: {
+        bookings: {
+          auth: "verifiedEmail",
+          createFields: ["customerEmail", "classId"],
+          window: { until: "2026-12-31T23:59:59Z", fromField: { ref: "classId", collection: "services", field: "opensAt" } },
+        },
+      },
+    },
+  });
+  const submit = publishedSubmit(projectApp(app, [], STAMP, null).app, "bookings");
+  assert.deepEqual(submit.window, {
+    untilMs: Date.parse("2026-12-31T23:59:59Z"),
+    fromField: { ref: "classId", collection: "services", field: "opensAt" },
+  });
+});
+
 test("memberEmails is derived from members, and a hand-written one is overwritten", () => {
   // `membersConsistent()` refuses any write where the two disagree, so an
   // authored value could only ever turn publish into a bare permission error.

--- a/packages/core/test/collection/test_sharedHostSurface.ts
+++ b/packages/core/test/collection/test_sharedHostSurface.ts
@@ -31,6 +31,10 @@ const HOST_SURFACE = [
   "APP_MANIFEST_FILE",
   // the gates — what publish refuses, and which live records a schema breaks
   "publishProblems",
+  // The pair publish actually writes: the staged configuration beside the
+  // manifest's roster. Separate from `publishProblems` because it needs what
+  // deploy staged, which is a read the host makes.
+  "promotedRoleProblems",
   "bindsSubmitterIdentity",
   "validateCollectionRecords",
   "MAX_RECORD_ISSUES",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.11.0",
+    "@mulmoclaude/core": "^3.12.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",


### PR DESCRIPTION
共有アプリの宣言語彙に 3 つ足す。いずれも `../mulmoserver` の firestore.rules と対になるもので、この PR は「宣言できるようにする」までを持つ。設計は mulmoterminal の `plans/feat-shared-app-assignee-role.md` と `plans/feat-shared-app-first-come.md`。

## `assignee` ロール + `collections.<cid>.assigneeField`

「美容師が自分の担当予約だけ承認する」が既存の 4 ロールでは書けなかった。`writerOf` は行を見ないので editor は同僚の予約も触れ、`ownRow` は `public.submit` の投稿者（客）を指すので担当者には使えない。

絞りをコレクション設定側に置くと**受付係が表現できなくなる**（全予約を触る editor でいてほしいのに絞られる）ので、名簿側に 5 つ目のロールとして足す。読みは絞らない — 当日の全体スケジュールが見えないと使い物にならないため。

突き合わせる値はアドレス。`ref` が保存するのは参照先の主キー slug でありアドレスではないので、ルールから staff レコードを `get()` するのではなく、アドレスを持つ平のフィールドを宣言させる。

## `public.submit.<cid>.stampField`

レコードが `request.time` を持つことを create で強制し、以後変更させない。先着アプリは**定員を件数ではなく順位から導く**（ルールは件数を数えられない）ので、順位の元になる時刻が偽装できると列に割り込める。`idFrom` は二重申込みを防ぐが時刻の偽装は防がない。

## `public.submit.<cid>.window.fromField`

`window.from` はコレクション全体に 1 個の絶対時刻で、「各クラスの 3 日前の 8 時」が書けない。ルールで日付計算はしない（`request.time` は UTC で「8 時」の答えを間違える）ので、境界は開催側が epoch millis で対象レコードに書き、ルールは読んで比べるだけにする。

`in` ではなく `collection` と綴っているのは、`in` がルール言語の**演算子**で `w.fromField.in` が構文エラーになるため。

## publish の拒否 3 つ

いずれも fail-closed の罠。assignee を持つのに assigneeField が無い（**その 1 人だけ**が全拒否され、オーナーの画面では動いて見える）、stampField が createFields に無い（全投稿が拒否）、fromField が実在しないコレクションや投稿が書かないフィールドを指す（窓が永久に閉じる）。ついでに `members` のコレクション別キーも未知 cid の掃除対象に入れた。

スキーマとの突き合わせ（stampField が datetime か等）はここに入れていない。`PublishableCollection` がスキーマを持たないのは意図的な境界で、宣言 × スキーマの検査は既にホスト側（MulmoTerminal の `publicInputProblems`）にある。

## 確認

`yarn typecheck` / `yarn lint`（error 0）/ `test/collection/*` 186 件 pass。テストは refusal と、その隣に立つ**通るべき宣言**を対で追加。

**この PR だけでは何も変わらない** — ルールが読むまでは宣言が載るだけ。deploy 順は rules → core → MulmoTerminal。

work in mulmoterminal

## Summary by Sourcery

Introduce new shared-app declaration options for row-scoped assignee roles and per-record submission windows, and add publish-time checks to fail fast on misconfigured queues and member roles.

New Features:
- Add an `assignee` member role and `collections.<cid>.assigneeField` to support row-scoped responsibility within collections.
- Add `public.submit.<cid>.stampField` to pin a record field to server time for first-come ordering that cannot be backdated or edited.
- Add `public.submit.<cid>.window.fromField` to declare per-record submission windows driven by another collection’s epoch-millis field.

Enhancements:
- Extend publish-time validation to detect misconfigured assignee roles, stamp fields, window-from references, and member roles pointing at unknown collection IDs.
- Preserve `window.fromField` through publish lowering so per-record window bounds remain effective in the deployed manifest.

Build:
- Bump the core package version from 3.11.0 to 3.12.0 to reflect the new declaration capabilities and validations.

Tests:
- Add collection publish-check tests covering assignee role configuration, stamped field behavior, and per-record window-from references.
- Add project publish tests ensuring per-record window bounds survive manifest lowering unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added assignee-based collection roles with configurable record-matching fields.
  - Added server-generated timestamp fields for submissions.
  - Added per-record submission window bounds based on collection fields.
  - Preserved record-based window settings when publishing projects.

- **Bug Fixes**
  - Strengthened validation for invalid roles, missing fields, unknown collections, and unsafe timestamp configurations.
  - Improved validation of submission window references and required data fields.

- **Chores**
  - Updated the core package to version 3.12.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->