### PR TITLE
feat(collections): 枠の排他と、公開ページのビューを宣言できるようにする

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -106,6 +106,56 @@ field the submission never writes (which shuts the window for good). A member's
 per-collection keys also joined the unknown-cid sweep.
 
 
+#### One booking per slot: a document id that is a CLAIM about another record
+
+The other answer to "who got there first". A class has a capacity, the rules
+cannot count, so a first-come queue reads an order off `stampField`. A slot is
+not countable at all — it is ONE thing — so the contested identity goes into the
+document id, where Firestore decides it atomically: the second person to want
+that slot is writing a document that already exists, which is an update, which
+the public submission path never allows. No transaction and no retry.
+
+**`public.submit.<cid>.idFrom: "field"`** with **`idField`** makes the booking's
+id the slot's id. **`idIn`** (`{ collection, where? }`) is what makes that claim
+worth anything: uniqueness alone only stops the same string being written twice,
+and nothing stops a client bypassing the page and inventing a slot. `exists()`
+is a FLOOR — a cancelled slot exists too — so the declaration may pin a state as
+well. Publish REQUIRES `idIn` in this mode; without it the app silently accepts
+bookings for things that do not exist.
+
+**`public.submit.<cid>.window.untilField`** is the closing bound's per-record
+twin, and it ships with the mode rather than later: a desk that opens per slot
+and never closes is not a booking desk. Exclusive where `fromField` is
+inclusive, so one slot's closing instant and the next one's opening instant may
+be the same number.
+
+**`public.submit.<cid>.mirror`** and **`collections.<cid>.mirrorOf`** are the
+two halves of a public projection. A booking carries a name, an address and a
+phone number, and Firestore rules cannot hide a field, so the public page must
+not read bookings at all — it reads a slot row whose `state` is a COPY of "does
+a booking with this id exist". The rules accept the two writes only as one
+batch, in BOTH directions, so the copy cannot drift into advertising a slot
+somebody already holds. Anybody may write the projection, because the only value
+that passes is the true one and `state` is the only field that may move — which
+is how a visitor who was just refused repairs the row that offered it to them.
+
+**`public.view`** names one HTML file and the datasets it is handed. A form is
+enough to ANSWER something and not enough to CHOOSE from what is available, and
+a stylist-by-hour grid is not the far end of a table. The datasets are declared
+rather than inferred from `public.read`, because inferring them produces this
+feature's worst failure: the view renders, the data never arrives, and it draws
+an empty grid with nothing anywhere to say why.
+
+Publish refuses, each for a failure nothing else would report: a `field` id with
+no `idIn` or naming a collection that does not exist (or itself, which a create
+can never satisfy); either half of a mirror without the other, a mirror of
+itself, and — the one a manifest-only check misses — a mirror whose `mirrorOf`
+was never DEPLOYED, since publish takes one half from `app.json` and the other
+from staging; an `untilField` naming an unknown collection or an unwritten
+field; a view fed a collection outside `public.read`; and a `view.path` that is
+not exactly one HTML file directly under `views/` (the host reads that path to
+decide what to publish, and what it publishes is world-readable).
+
 #### Publishing a shared app: `manageCollection` action `publishApp`
 
 A repository that declares a shared app (`app.json` + collections with
@@ -238,7 +288,7 @@ is people.
 
 ### Package releases
 
-Ships `@mulmoclaude/core@3.12.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/core@3.13.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -26,6 +26,7 @@
 // everything, which is the one bug this file could have that would look like
 // safety.
 
+import type { CollectionFieldSpec, CollectionSchema } from "../core/schema";
 import { isSafeCustomViewPath } from "../core/templatePath";
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
 import { stagedRuleConfig, type StagedSchemaDoc } from "./publishProject";
@@ -755,31 +756,120 @@ export function promotedRoleProblems(app: AuthoredApp, staged: { cid: string; do
  *  its schema does, but a shared collection's records are written through it,
  *  and "the field exists on some rows" is not something a gate can promise. */
 function promotedRefFieldProblems(app: AuthoredApp, staged: { cid: string; doc: StagedSchemaDoc }[]): string[] {
-  const fieldsOf = new Map(staged.map((entry) => [entry.cid, new Set(Object.keys(entry.doc.publishedSchema.fields ?? {}))]));
-  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => [
-    ...refFieldProblem(fieldsOf, cid, `idIn.where.field`, submit.idIn?.collection, submit.idIn?.where?.field),
-    ...refFieldProblem(fieldsOf, cid, `window.fromField.field`, submit.window?.fromField?.collection, submit.window?.fromField?.field),
-    ...refFieldProblem(fieldsOf, cid, `window.untilField.field`, submit.window?.untilField?.collection, submit.window?.untilField?.field),
-  ]);
+  const schemaOf = new Map(staged.map((entry) => [entry.cid, entry.doc.publishedSchema]));
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => submitRefProblems(schemaOf, cid, submit));
+}
+
+function submitRefProblems(schemaOf: ReadonlyMap<string, CollectionSchema>, cid: string, submit: AuthoredSubmit): string[] {
+  return [
+    ...idInRefProblems(schemaOf, cid, submit),
+    ...boundRefProblems(schemaOf, cid, "fromField", submit.window?.fromField),
+    ...boundRefProblems(schemaOf, cid, "untilField", submit.window?.untilField),
+  ];
+}
+
+function idInRefProblems(schemaOf: ReadonlyMap<string, CollectionSchema>, cid: string, submit: AuthoredSubmit): string[] {
+  const where = submit.idIn?.where;
+  if (where === undefined) return [];
+  return [
+    ...refFieldProblem(schemaOf, cid, "idIn.where.field", submit.idIn?.collection, where.field),
+    ...comparableProblem(schemaOf, cid, submit.idIn?.collection, where),
+  ];
+}
+
+function boundRefProblems(
+  schemaOf: ReadonlyMap<string, CollectionSchema>,
+  cid: string,
+  key: string,
+  ref: { ref: string; collection: string; field: string } | undefined,
+): string[] {
+  if (ref === undefined) return [];
+  return [...refFieldProblem(schemaOf, cid, `window.${key}.field`, ref.collection, ref.field), ...millisProblem(schemaOf, cid, `window.${key}.field`, ref)];
+}
+
+/** The field spec a reference points at, or undefined when there is nothing
+ *  staged to judge it against (the host refuses that separately, naming every
+ *  missing collection at once). */
+function referencedField(
+  schemaOf: ReadonlyMap<string, CollectionSchema>,
+  target: string | undefined,
+  field: string | undefined,
+): CollectionFieldSpec | undefined {
+  if (target === undefined || field === undefined) return undefined;
+  return schemaOf.get(target)?.fields?.[field];
+}
+
+/** An enum's domain, or undefined for every other kind. Narrowed by the key
+ *  rather than asserted: `fields` is a discriminated union and only some of
+ *  its members carry `values`. */
+function enumValues(spec: CollectionFieldSpec): readonly string[] | undefined {
+  return spec.type === "enum" ? spec.values : undefined;
 }
 
 function refFieldProblem(
-  fieldsOf: ReadonlyMap<string, ReadonlySet<string>>,
+  schemaOf: ReadonlyMap<string, CollectionSchema>,
   cid: string,
   key: string,
   target: string | undefined,
   field: string | undefined,
 ): string[] {
   if (target === undefined || field === undefined) return [];
-  const fields = fieldsOf.get(target);
-  // Nothing staged for the target at all is the host's own refusal, which
-  // names every missing collection at once.
-  if (fields === undefined || fields.has(field)) return [];
-  const known = [...fields].sort().join(", ");
+  const schema = schemaOf.get(target);
+  if (schema === undefined || referencedField(schemaOf, target, field) !== undefined) return [];
+  const known = Object.keys(schema.fields ?? {})
+    .sort()
+    .join(", ");
   return [
     `public.submit.${cid}.${key} names '${field}', which the STAGED schema of '${target}' — the one publish promotes — does not declare. ` +
       `The rules read that field off the record and compare it, so as written every submission is refused with nothing to explain it. ` +
       `Fields on '${target}': ${known.length > 0 ? known : "(none)"}.`,
+  ];
+}
+
+/** A comparison the rules can never satisfy is as dead as a missing field, and
+ *  looks even more correct on the page: an `enum` whose domain does not contain
+ *  the value, or a boolean field compared with a string. */
+function comparableProblem(
+  schemaOf: ReadonlyMap<string, CollectionSchema>,
+  cid: string,
+  target: string | undefined,
+  where: { field: string; equals: string | number | boolean },
+): string[] {
+  const spec = referencedField(schemaOf, target, where.field);
+  if (spec === undefined) return [];
+  const said = JSON.stringify(where.equals);
+  const values = enumValues(spec);
+  if (values !== undefined) {
+    if (values.includes(String(where.equals))) return [];
+    return [
+      `public.submit.${cid}.idIn.where.equals is ${said}, which is not one of the values '${where.field}' can hold on '${String(target)}' ` +
+        `(${values.join(", ") || "(none)"}). The comparison can never be true, so every submission is refused.`,
+    ];
+  }
+  const wanted = spec.type === "number" ? "number" : spec.type === "boolean" ? "boolean" : "string";
+  if (typeof where.equals === wanted) return [];
+  return [
+    `public.submit.${cid}.idIn.where.equals is ${said}, and '${where.field}' on '${String(target)}' is a ${spec.type} field. ` +
+      `The rules compare the stored value with this one and never coerce, so the comparison can never be true and every submission is refused.`,
+  ];
+}
+
+/** A per-record window bound is EPOCH MILLIS, because the rules have no date
+ *  arithmetic and do not coerce: they compare `request.time.toMillis()` with
+ *  whatever is stored. A `datetime` field holds an ISO string, which is a type
+ *  error that fails closed — the window never opens, and nothing says so. */
+function millisProblem(
+  schemaOf: ReadonlyMap<string, CollectionSchema>,
+  cid: string,
+  key: string,
+  ref: { collection: string; field: string } | undefined,
+): string[] {
+  const spec = referencedField(schemaOf, ref?.collection, ref?.field);
+  if (spec === undefined || spec.type === "number") return [];
+  return [
+    `public.submit.${cid}.${key} names '${String(ref?.field)}' on '${String(ref?.collection)}', which is a ${spec.type} field. A per-record bound is ` +
+      `EPOCH MILLIS: the rules compare it with request.time.toMillis() and never coerce, so anything else is a type error that refuses every ` +
+      `submission — the window simply never opens. Store the instant as a number.`,
   ];
 }
 

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -731,7 +731,56 @@ function publicViewProblems(app: AuthoredApp, collections: readonly PublishableC
 export function promotedRoleProblems(app: AuthoredApp, staged: { cid: string; doc: StagedSchemaDoc }[]): string[] {
   const promoted = stagedRuleConfig(staged).collections ?? {};
   const stagedCids = new Set(staged.map((entry) => entry.cid));
-  return [...promotedAssigneeProblems(app, promoted, stagedCids), ...promotedMirrorProblems(app, promoted, stagedCids)];
+  return [
+    ...promotedAssigneeProblems(app, promoted, stagedCids),
+    ...promotedMirrorProblems(app, promoted, stagedCids),
+    ...promotedRefFieldProblems(app, staged),
+  ];
+}
+
+/** The FIELDS a rule reads off another record — `idIn.where.field` and the two
+ *  window bounds — checked against the schema publish is about to promote.
+ *
+ *  These are checked here rather than in `publishProblems` because that gate
+ *  is given a cid and a primary key per collection and nothing else, on
+ *  purpose: it reads the DECLARATION. A field name can only be judged against
+ *  a schema, and the schema that matters is the STAGED one — the version
+ *  publish promotes — not whatever the working tree says now.
+ *
+ *  What a typo costs: `where: { field: "staet" }` publishes cleanly, the
+ *  rules' comparison can never match, and every submission is denied with no
+ *  message. The author's own app looks broken with nothing to read.
+ *
+ *  Only fields the schema DECLARES are accepted. A record may carry more than
+ *  its schema does, but a shared collection's records are written through it,
+ *  and "the field exists on some rows" is not something a gate can promise. */
+function promotedRefFieldProblems(app: AuthoredApp, staged: { cid: string; doc: StagedSchemaDoc }[]): string[] {
+  const fieldsOf = new Map(staged.map((entry) => [entry.cid, new Set(Object.keys(entry.doc.publishedSchema.fields ?? {}))]));
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => [
+    ...refFieldProblem(fieldsOf, cid, `idIn.where.field`, submit.idIn?.collection, submit.idIn?.where?.field),
+    ...refFieldProblem(fieldsOf, cid, `window.fromField.field`, submit.window?.fromField?.collection, submit.window?.fromField?.field),
+    ...refFieldProblem(fieldsOf, cid, `window.untilField.field`, submit.window?.untilField?.collection, submit.window?.untilField?.field),
+  ]);
+}
+
+function refFieldProblem(
+  fieldsOf: ReadonlyMap<string, ReadonlySet<string>>,
+  cid: string,
+  key: string,
+  target: string | undefined,
+  field: string | undefined,
+): string[] {
+  if (target === undefined || field === undefined) return [];
+  const fields = fieldsOf.get(target);
+  // Nothing staged for the target at all is the host's own refusal, which
+  // names every missing collection at once.
+  if (fields === undefined || fields.has(field)) return [];
+  const known = [...fields].sort().join(", ");
+  return [
+    `public.submit.${cid}.${key} names '${field}', which the STAGED schema of '${target}' — the one publish promotes — does not declare. ` +
+      `The rules read that field off the record and compare it, so as written every submission is refused with nothing to explain it. ` +
+      `Fields on '${target}': ${known.length > 0 ? known : "(none)"}.`,
+  ];
 }
 
 function promotedAssigneeProblems(app: AuthoredApp, promoted: Record<string, AuthoredCollectionConfig>, stagedCids: ReadonlySet<string>): string[] {

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -26,6 +26,7 @@
 // everything, which is the one bug this file could have that would look like
 // safety.
 
+import { isSafeCustomViewPath } from "../core/templatePath";
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
 import { stagedRuleConfig, type StagedSchemaDoc } from "./publishProject";
 
@@ -661,11 +662,24 @@ function publicViewProblems(app: AuthoredApp, collections: readonly PublishableC
   const known = new Set(collections.map((collection) => collection.cid));
   const readable = new Set(app.public?.read ?? []);
   const problems: string[] = [];
-  // Exactly one basename under views/. A prefix-and-suffix test accepts
-  // `views/../../secrets.html`, and the HOST reads this value as a path to
-  // publish -- so a declaration could hand any HTML file in the checkout to
-  // the world, onto a document whose rule is `allow read: if true`.
-  if (!/^views\/[^/]+\.html$/.test(view.path)) {
+  // The SAME validator the host's own custom views use, rather than a second
+  // opinion about what a safe view path is.
+  //
+  // Two ad-hoc attempts were wrong here in the same afternoon: a prefix-and-
+  // suffix test let `views/../../secrets.html` through, and `views/[^/]+\.html`
+  // still let `views/..\..\secrets.html` through, because a backslash is not a
+  // slash on this side of the check and IS a separator on Windows. This one
+  // rejects `..`, backslashes, leading slashes and anything outside
+  // `[A-Za-z0-9._-]` per segment.
+  //
+  // It matters more here than for a host view: the host reads this path to
+  // decide which file to copy onto a document whose rule is
+  // `allow read: if true`, so the blast radius of a bad path is the world
+  // rather than the author's own iframe. Nested paths ARE allowed by the
+  // shared validator; the extra `views/<one name>.html` shape below is this
+  // publisher's own narrowing, kept because there is no reason for a published
+  // view to live in a subdirectory.
+  if (!isSafeCustomViewPath(view.path) || view.path.split("/").length !== 2) {
     problems.push(
       `public.view.path is '${view.path}': a published view is exactly one HTML file directly inside the collection's own views/ directory ` +
         "(e.g. views/booking.html) — no sub-directories, and no segments that climb out of it. The host reads this as a file to publish, " +

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -239,7 +239,7 @@ function ruleReadFields(submit: AuthoredSubmit): { field: string; why: string }[
   if (submit.emailField !== undefined) {
     fields.push({ field: submit.emailField, why: `public.submit.<cid>.emailField — the rules compare it to the submitter's verified address` });
   }
-  if (submit.idFrom === "auth.uid+field" && submit.idField !== undefined) {
+  if ((submit.idFrom === "auth.uid+field" || submit.idFrom === "field") && submit.idField !== undefined) {
     fields.push({ field: submit.idField, why: `public.submit.<cid>.idField — the rules rebuild the document id from it` });
   }
   return fields;
@@ -279,6 +279,7 @@ function submitCoherenceProblems(app: AuthoredApp, cid: string, submit: Authored
       `public.submit.${cid}.idFrom is "auth.uid+field" but no idField is declared: the rules rebuild the document id from that field and refuse every create.`,
     );
   }
+  problems.push(...fieldIdProblems(cid, submit));
   if ((submit.selfUpdate !== undefined || submit.selfTransitions !== undefined) && !collection?.statusField) {
     problems.push(
       `public.submit.${cid}.selfUpdate / selfTransitions are declared per CURRENT STATUS, but collections.${cid} declares no statusField: ` +
@@ -288,6 +289,43 @@ function submitCoherenceProblems(app: AuthoredApp, cid: string, submit: Authored
   if (submit.audience === "participant" && Object.keys(app.members).length === 0) {
     problems.push(
       `public.submit.${cid}.audience is "participant" but the roster is empty: the rules resolve the submitter's role from members, so every submission is refused.`,
+    );
+  }
+  return problems;
+}
+
+/** `idFrom: "field"` makes the document id a CLAIM ABOUT ANOTHER RECORD, and
+ *  the claim is only worth what is checked.
+ *
+ *  `idIn` is required rather than optional, and that is the whole point of
+ *  refusing here: without it the id is any string a stranger likes, so the app
+ *  quietly accepts bookings for slots that do not exist. Nothing downstream
+ *  ever notices — the booking is real, its slot is not — which is exactly the
+ *  kind of hole a gate is for and a rule cannot state.
+ *
+ *  `idIn` without the mode is refused for the opposite reason: the rules read
+ *  it only in that branch, so an author who wrote it believes a check is
+ *  running that is not. */
+function fieldIdProblems(cid: string, submit: AuthoredSubmit): string[] {
+  const problems: string[] = [];
+  if (submit.idFrom === "field") {
+    if (submit.idField === undefined) {
+      problems.push(
+        `public.submit.${cid}.idFrom is "field" but no idField is declared: the rules take the document id from that field and refuse every create.`,
+      );
+    }
+    if (submit.idIn === undefined) {
+      problems.push(
+        `public.submit.${cid}.idFrom is "field" but no idIn is declared: the document id is then any string a submitter chooses, so the app accepts records ` +
+          `pointing at things that do not exist. Name the collection the id must be found in — and, when only some of those records may be claimed, the state ` +
+          `they must be in: "idIn": { "collection": "slots", "where": { "field": "state", "equals": "open" } }.`,
+      );
+    }
+  } else if (submit.idIn !== undefined) {
+    const mode = submit.idFrom === undefined ? "absent" : JSON.stringify(submit.idFrom);
+    problems.push(
+      `public.submit.${cid}.idIn is declared but idFrom is ${mode}: the rules read idIn only for ` +
+        `idFrom "field", so as written nothing checks the referenced record and the declaration promises a check it does not perform.`,
     );
   }
   return problems;
@@ -366,6 +404,8 @@ export function publishProblems(app: AuthoredApp, collections: readonly Publisha
     ...assigneeProblems(app),
     ...stampProblems(app),
     ...windowRefProblems(app, collections),
+    ...mirrorProblems(app, collections),
+    ...publicViewProblems(app, collections),
   ];
 }
 
@@ -473,24 +513,138 @@ function stampProblems(app: AuthoredApp): string[] {
  *  good. */
 function windowRefProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
   const known = new Set(collections.map((collection) => collection.cid));
-  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
-    const ref = submit.window?.fromField;
-    if (ref === undefined) return [];
-    const problems: string[] = [];
-    if (!known.has(ref.collection)) {
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => [
+    ...windowBoundProblems(cid, submit, known, "fromField", submit.window?.fromField, "opening"),
+    ...windowBoundProblems(cid, submit, known, "untilField", submit.window?.untilField, "closing"),
+  ]);
+}
+
+/** Both bounds, checked identically. `untilField` arrived with the booking
+ *  desk and reads exactly like its twin, so a check that knew only about
+ *  `fromField` would let the closing half through unchecked — and a closing
+ *  bound that names nothing does not leave the door ajar, it refuses every
+ *  submission with no explanation. */
+function windowBoundProblems(
+  cid: string,
+  submit: AuthoredSubmit,
+  known: ReadonlySet<string>,
+  key: string,
+  ref: { ref: string; collection: string; field: string } | undefined,
+  which: string,
+): string[] {
+  if (ref === undefined) return [];
+  const problems: string[] = [];
+  if (!known.has(ref.collection)) {
+    problems.push(
+      `public.submit.${cid}.window.${key}.collection names '${ref.collection}', which is not a shared collection in this repository. ` +
+        `The rules read the ${which} time off a record there, so nothing can ever be submitted. Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : "(none)"}.`,
+    );
+  }
+  if (!submit.createFields.includes(ref.ref)) {
+    problems.push(
+      `public.submit.${cid}.window.${key}.ref names '${ref.ref}', which is not in createFields. The rules take the target record's id from that field ON THE ` +
+        "SUBMISSION — if the submitter never writes it, there is nothing to look up and every submission is refused.",
+    );
+  }
+  return problems;
+}
+
+/** The two halves of a mirror, checked as the pair they only work as.
+ *
+ *  `mirror` on the submission and `mirrorOf` on the projection are separate
+ *  keys in separate places, and each is inert without the other: a booking
+ *  whose slot declares no `mirrorOf` can never be created (the rules demand a
+ *  paired write that the projection's own rule will refuse), and a projection
+ *  whose authority declares no `mirror` drifts unbounded because nothing makes
+ *  the two move together. Both failures are silent, and one of them —
+ *  advertising a slot somebody already holds — is the exact thing the mirror
+ *  exists to prevent.
+ *
+ *  Also refuses a collection mirroring ITSELF, which reads as a typo and
+ *  behaves as an unwritable collection: every create would have to prove its
+ *  own document is simultaneously taken and open. */
+function mirrorProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const known = new Set(collections.map((collection) => collection.cid));
+  const names = known.size > 0 ? [...known].sort().join(", ") : "(none)";
+  return [
+    ...Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => mirrorClaimProblems(app, cid, submit, known, names)),
+    ...Object.entries(app.collections ?? {}).flatMap(([cid, collection]) => mirrorOfProblems(app, cid, collection, known, names)),
+  ];
+}
+
+/** The submission side: `public.submit[cid].mirror`. */
+function mirrorClaimProblems(app: AuthoredApp, cid: string, submit: AuthoredSubmit, known: ReadonlySet<string>, names: string): string[] {
+  const { mirror } = submit;
+  if (mirror === undefined) return [];
+  if (mirror === cid) {
+    return [`public.submit.${cid}.mirror names its own collection: the projection is a SEPARATE record, and as written no create can satisfy the rules.`];
+  }
+  if (!known.has(mirror)) {
+    return [
+      `public.submit.${cid}.mirror names '${mirror}', which is not a shared collection in this repository. ` +
+        `The rules require the projection to move in the same write, so every submission is refused. Shared collections here: ${names}.`,
+    ];
+  }
+  if (app.collections?.[mirror]?.mirrorOf !== cid) {
+    return [
+      `public.submit.${cid}.mirror names '${mirror}', but collections.${mirror} does not declare mirrorOf: "${cid}". ` +
+        "The two halves only work as a pair — the submission side demands the projection move with it, and the projection side is what allows that move — " +
+        "so as written every submission is refused.",
+    ];
+  }
+  return [];
+}
+
+/** The projection side: `collections[cid].mirrorOf`. */
+function mirrorOfProblems(app: AuthoredApp, cid: string, collection: AuthoredCollectionConfig, known: ReadonlySet<string>, names: string): string[] {
+  const authority = collection.mirrorOf;
+  if (authority === undefined) return [];
+  if (!known.has(authority)) {
+    return [
+      `collections.${cid}.mirrorOf names '${authority}', which is not a shared collection in this repository. ` +
+        `Nothing can then be true of it, so the projection's state may never be written. Shared collections here: ${names}.`,
+    ];
+  }
+  if (app.public?.submit?.[authority]?.mirror !== cid) {
+    return [
+      `collections.${cid}.mirrorOf names '${authority}', but public.submit.${authority} does not declare mirror: "${cid}". ` +
+        "Only the pair keeps the projection honest: without the other half a record can be created without moving this one, and the public page goes on " +
+        "offering something that is already taken.",
+    ];
+  }
+  return [];
+}
+
+/** What the public view is handed. Declared, never inferred — a view whose
+ *  datasets were guessed from `public.read` renders perfectly and draws an
+ *  empty grid, with nothing in the page, the rules or the log to say why. */
+function publicViewProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const view = app.public?.view;
+  if (view === undefined) return [];
+  const known = new Set(collections.map((collection) => collection.cid));
+  const readable = new Set(app.public?.read ?? []);
+  const problems: string[] = [];
+  if (!view.path.startsWith("views/") || !view.path.endsWith(".html")) {
+    problems.push(
+      `public.view.path is '${view.path}': a published view is one HTML file inside the collection's own views/ directory (e.g. views/booking.html).`,
+    );
+  }
+  for (const cid of view.collections) {
+    if (!known.has(cid)) {
       problems.push(
-        `public.submit.${cid}.window.fromField.collection names '${ref.collection}', which is not a shared collection in this repository. ` +
-          `The rules read the opening time off a record there, so nothing can ever be submitted. Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : "(none)"}.`,
+        `public.view.collections names '${cid}', which is not a shared collection in this repository. ` +
+          `Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : "(none)"}.`,
+      );
+      continue;
+    }
+    if (!readable.has(cid)) {
+      problems.push(
+        `public.view.collections names '${cid}', which is not in public.read: the page reads these with the VISITOR's permissions, so the rules refuse the ` +
+          "read and the view draws an empty page. Nothing errors — this is the failure that looks like a working view with no data.",
       );
     }
-    if (!submit.createFields.includes(ref.ref)) {
-      problems.push(
-        `public.submit.${cid}.window.fromField.ref names '${ref.ref}', which is not in createFields. The rules take the target record's id from that field ON THE ` +
-          "SUBMISSION — if the submitter never writes it, there is nothing to look up and every submission is refused.",
-      );
-    }
-    return problems;
-  });
+  }
+  return problems;
 }
 
 /** What publish will actually promote, checked as the PAIR it becomes.

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -767,6 +767,12 @@ function promotedAssigneeProblems(app: AuthoredApp, promoted: Record<string, Aut
  *  and removing it FROM the staged side while the submission still demands it
  *  is the drift this pair exists to prevent. */
 function promotedMirrorProblems(app: AuthoredApp, promoted: Record<string, AuthoredCollectionConfig>, stagedCids: ReadonlySet<string>): string[] {
+  return [...addedMirrorProblems(app, promoted, stagedCids), ...strandedMirrorProblems(app, promoted)];
+}
+
+/** The manifest asks for a projection the promoted configuration will not
+ *  allow: every submission denied, and nothing on the page to say why. */
+function addedMirrorProblems(app: AuthoredApp, promoted: Record<string, AuthoredCollectionConfig>, stagedCids: ReadonlySet<string>): string[] {
   return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
     const { mirror } = submit;
     // Nothing staged at all is the host's own refusal, which names every
@@ -777,6 +783,31 @@ function promotedMirrorProblems(app: AuthoredApp, promoted: Record<string, Autho
       `public.submit.${cid}.mirror names '${mirror}', and the STAGED version of '${mirror}' — the one publish promotes — does not declare mirrorOf: "${cid}", ` +
         "even if app.json declares it now. Publish writes the submission side from app.json and the collection side from the deploy, so what lands is a " +
         "booking that must move its projection beside a projection that refuses to move: every submission is denied, with nothing on the page to say why. " +
+        "Run deploy again, so the version being published is the one the declaration describes.",
+    ];
+  });
+}
+
+/** The other direction, and the DANGEROUS one.
+ *
+ *  Take a live pair, delete BOTH halves from `app.json`, and publish without
+ *  redeploying. The submission side comes from the manifest, so nothing
+ *  requires the projection to move any more; the collection side comes from
+ *  staging, which still says `mirrorOf`, so the projection stays writable.
+ *  Bookings are then created while the public row goes on saying `open` — the
+ *  precise failure the pair exists to prevent, arrived at by removing it.
+ *
+ *  Refused rather than tolerated because the app keeps WORKING: submissions
+ *  succeed. Only the public page is wrong, and only to the people reading it. */
+function strandedMirrorProblems(app: AuthoredApp, promoted: Record<string, AuthoredCollectionConfig>): string[] {
+  return Object.entries(promoted).flatMap(([cid, config]) => {
+    const authority = config.mirrorOf;
+    if (authority === undefined) return [];
+    if (app.public?.submit?.[authority]?.mirror === cid) return [];
+    return [
+      `the STAGED version of '${cid}' — the one publish promotes — declares mirrorOf: "${authority}", and app.json no longer declares ` +
+        `public.submit.${authority}.mirror: "${cid}". What lands is a projection that is still writable beside submissions that no longer have to move it, ` +
+        `so records can be created while '${cid}' goes on advertising them as available. Nothing fails: the app works and the public page lies. ` +
         "Run deploy again, so the version being published is the one the declaration describes.",
     ];
   });

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -331,6 +331,42 @@ function fieldIdProblems(cid: string, submit: AuthoredSubmit): string[] {
   return problems;
 }
 
+/** Every `idIn` target, checked against the collections this repository has.
+ *
+ *  Separate from {@link fieldIdProblems} for the reason the file is split at
+ *  all: that one reads the declaration alone, this one needs to know what
+ *  exists. */
+function idTargetProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const known = new Set(collections.map((collection) => collection.cid));
+  const names = known.size > 0 ? [...known].sort().join(", ") : "(none)";
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => idInTargetProblems(cid, submit, known, names));
+}
+
+/** Where a `field` id says its record must be found.
+ *
+ *  A typo passes every other check: the rules look the record up in a
+ *  collection that does not exist, the lookup can never succeed, and every
+ *  submission is refused with no explanation anywhere. A collection pointing
+ *  at ITSELF is worse than a typo — on a create the document being written
+ *  does not exist yet, so it is a declaration that can never accept anything. */
+function idInTargetProblems(cid: string, submit: AuthoredSubmit, known: ReadonlySet<string>, names: string): string[] {
+  const target = submit.idIn?.collection;
+  if (target === undefined) return [];
+  if (target === cid) {
+    return [
+      `public.submit.${cid}.idIn.collection names '${cid}' itself: a create writes a document that does not exist yet, so the record can never be found ` +
+        "and every submission is refused. Name the collection of the thing being claimed (the slots, the seats, the assets).",
+    ];
+  }
+  if (!known.has(target)) {
+    return [
+      `public.submit.${cid}.idIn.collection names '${target}', which is not a shared collection in this repository. The rules look the record up there, ` +
+        `so nothing can ever be submitted. Shared collections here: ${names}.`,
+    ];
+  }
+  return [];
+}
+
 /** The staged reveal reads its flag off the PARENT record, so the path to that
  *  parent is not optional decoration — without it the gate never opens. */
 function gateCoherenceProblems(cid: string, collection: AuthoredCollectionConfig): string[] {
@@ -404,6 +440,7 @@ export function publishProblems(app: AuthoredApp, collections: readonly Publisha
     ...assigneeProblems(app),
     ...stampProblems(app),
     ...windowRefProblems(app, collections),
+    ...idTargetProblems(app, collections),
     ...mirrorProblems(app, collections),
     ...publicViewProblems(app, collections),
   ];
@@ -624,9 +661,15 @@ function publicViewProblems(app: AuthoredApp, collections: readonly PublishableC
   const known = new Set(collections.map((collection) => collection.cid));
   const readable = new Set(app.public?.read ?? []);
   const problems: string[] = [];
-  if (!view.path.startsWith("views/") || !view.path.endsWith(".html")) {
+  // Exactly one basename under views/. A prefix-and-suffix test accepts
+  // `views/../../secrets.html`, and the HOST reads this value as a path to
+  // publish -- so a declaration could hand any HTML file in the checkout to
+  // the world, onto a document whose rule is `allow read: if true`.
+  if (!/^views\/[^/]+\.html$/.test(view.path)) {
     problems.push(
-      `public.view.path is '${view.path}': a published view is one HTML file inside the collection's own views/ directory (e.g. views/booking.html).`,
+      `public.view.path is '${view.path}': a published view is exactly one HTML file directly inside the collection's own views/ directory ` +
+        "(e.g. views/booking.html) — no sub-directories, and no segments that climb out of it. The host reads this as a file to publish, " +
+        "and what it publishes is world-readable.",
     );
   }
   for (const cid of view.collections) {
@@ -674,6 +717,10 @@ function publicViewProblems(app: AuthoredApp, collections: readonly PublishableC
 export function promotedRoleProblems(app: AuthoredApp, staged: { cid: string; doc: StagedSchemaDoc }[]): string[] {
   const promoted = stagedRuleConfig(staged).collections ?? {};
   const stagedCids = new Set(staged.map((entry) => entry.cid));
+  return [...promotedAssigneeProblems(app, promoted, stagedCids), ...promotedMirrorProblems(app, promoted, stagedCids)];
+}
+
+function promotedAssigneeProblems(app: AuthoredApp, promoted: Record<string, AuthoredCollectionConfig>, stagedCids: ReadonlySet<string>): string[] {
   return Object.entries(app.members).flatMap(([email, roles]) =>
     Object.entries(roles).flatMap(([cid, role]) => {
       // A cid with nothing staged at all is the host's "not staged, so there is
@@ -689,4 +736,34 @@ export function promotedRoleProblems(app: AuthoredApp, staged: { cid: string; do
       ];
     }),
   );
+}
+
+/** The mirror's other half, checked against what publish will actually
+ *  promote — the same trap as the assignee's field, reached by the same route.
+ *
+ *  `mirror` is published from the MANIFEST (it lives in `public.submit`) while
+ *  `mirrorOf` is promoted from what DEPLOY staged. Add both halves to
+ *  `app.json` and publish without redeploying, and what lands is a submission
+ *  demanding a paired projection write beside a projection whose rule config
+ *  does not allow it: every booking is refused, and the declaration on disk
+ *  looks perfectly sound.
+ *
+ *  Refused in the reverse direction too. Removing `mirrorOf` from a live app
+ *  and publishing without a deploy leaves the projection accepting nothing —
+ *  and removing it FROM the staged side while the submission still demands it
+ *  is the drift this pair exists to prevent. */
+function promotedMirrorProblems(app: AuthoredApp, promoted: Record<string, AuthoredCollectionConfig>, stagedCids: ReadonlySet<string>): string[] {
+  return Object.entries(app.public?.submit ?? {}).flatMap(([cid, submit]) => {
+    const { mirror } = submit;
+    // Nothing staged at all is the host's own refusal, which names every
+    // missing collection at once.
+    if (mirror === undefined || !stagedCids.has(mirror)) return [];
+    if (promoted[mirror]?.mirrorOf === cid) return [];
+    return [
+      `public.submit.${cid}.mirror names '${mirror}', and the STAGED version of '${mirror}' — the one publish promotes — does not declare mirrorOf: "${cid}", ` +
+        "even if app.json declares it now. Publish writes the submission side from app.json and the collection side from the deploy, so what lands is a " +
+        "booking that must move its projection beside a projection that refuses to move: every submission is denied, with nothing on the page to say why. " +
+        "Run deploy again, so the version being published is the one the declaration describes.",
+    ];
+  });
 }

--- a/packages/core/src/collection/server/publishManifest.ts
+++ b/packages/core/src/collection/server/publishManifest.ts
@@ -111,6 +111,14 @@ const CollectionConfigZ = z
      *  declaration with the role and no field is refused (`assigneeProblems`),
      *  because that member would silently hold nothing. */
     assigneeField: z.string().trim().min(1).optional(),
+    /** This collection is the public projection of `mirrorOf` — the other
+     *  half of `public.submit[...].mirror`, declared here because the rules
+     *  read it when the PROJECTION is written rather than when the record is.
+     *
+     *  What it buys: `state` may be written by anybody, and only to the value
+     *  the authority actually says, so a visitor who was refused a slot can
+     *  repair the stale row that offered it to them. */
+    mirrorOf: NameZ.optional(),
     peerVisibility: z.enum(["public", "hidden"]).optional(),
     revealGated: z.boolean().optional(),
     gatedFrom: NameZ.optional(),
@@ -153,7 +161,40 @@ const CollectionConfigZ = z
  *  `w.fromField.in` does not parse there. */
 const WindowRefZ = z.object({ ref: z.string().trim().min(1), collection: NameZ, field: z.string().trim().min(1) }).strict();
 
-const WindowZ = z.object({ from: z.iso.datetime().optional(), until: z.iso.datetime().optional(), fromField: WindowRefZ.optional() }).strict();
+/** The closing bound's per-record twin, and it ships WITH `fromField` rather
+ *  than as a symmetric extra: a booking desk that opens per slot and never
+ *  closes is not a booking desk. Same shape, opposite comparison — and
+ *  EXCLUSIVE where `fromField` is inclusive, so one slot's closing instant and
+ *  the next one's opening instant may be the same number. */
+const WindowZ = z
+  .object({
+    from: z.iso.datetime().optional(),
+    until: z.iso.datetime().optional(),
+    fromField: WindowRefZ.optional(),
+    untilField: WindowRefZ.optional(),
+  })
+  .strict();
+
+/** Which record a `field` document id must name, and what state it must be in.
+ *
+ *  `idFrom: "field"` alone only stops the same string being written twice —
+ *  nothing stops a client bypassing the page and inventing a slot, so the
+ *  rules check the referenced record themselves. `exists()` is a FLOOR: a
+ *  cancelled slot and a slot nobody may book any more exist too, which is what
+ *  `where` is for.
+ *
+ *  Always the object form, never a bare collection name. Two shapes for one
+ *  key is the kind of thing a generator gets right once and wrong afterwards,
+ *  and the rules read `s.idIn.collection` either way. */
+const IdInZ = z
+  .object({
+    collection: NameZ,
+    where: z
+      .object({ field: z.string().trim().min(1), equals: z.union([z.string(), z.number(), z.boolean()]) })
+      .strict()
+      .optional(),
+  })
+  .strict();
 
 const ValidateZ = z
   .object({
@@ -173,8 +214,26 @@ const SubmitZ = z
     emailField: z.string().trim().min(1).optional(),
     createFields: z.array(z.string().trim().min(1)).min(1),
     initialStatus: z.string().trim().min(1).optional(),
-    idFrom: z.enum(["auto", "auth.uid", "auth.uid+field"]).optional(),
+    /** `field` is the mode that makes a CONTESTED resource exclusive: the
+     *  booking's document id IS the slot's id, so the second person to want
+     *  that slot is writing a document that already exists — an update, which
+     *  the public submission path never allows. Firestore decides that
+     *  atomically, so unlike a countable capacity (see `stampField`) this is
+     *  first-come ENFORCED rather than first-come read off a rank. */
+    idFrom: z.enum(["auto", "auth.uid", "auth.uid+field", "field"]).optional(),
     idField: z.string().trim().min(1).optional(),
+    /** Required by `idFrom: "field"` — see {@link IdInZ}. */
+    idIn: IdInZ.optional(),
+    /** The collection holding this record's PUBLIC PROJECTION, one row per
+     *  contested thing, sharing its document id.
+     *
+     *  A booking carries a name, an address and a phone number, and Firestore
+     *  rules cannot hide a field, so the public page must not read bookings at
+     *  all. It reads the projection instead, whose `state` is a copy of "does
+     *  a booking with this id exist" — and the rules accept the two writes
+     *  only as one batch, in both directions, so the copy cannot drift into
+     *  advertising a slot that is gone. */
+    mirror: NameZ.optional(),
     validate: ValidateZ.optional(),
     window: WindowZ.optional(),
     /** A field the rules PIN to the server clock on create: the record must
@@ -209,6 +268,24 @@ const PublicZ = z
      *  well as its own declaration. */
     enabled: z.boolean().optional(),
     read: z.array(NameZ).optional(),
+    /** The page the public sees, instead of the generated form.
+     *
+     *  A form is enough to ANSWER something and not enough to CHOOSE from
+     *  what is available — a stylist-by-hour grid is not the far end of a
+     *  table. So the app may name one HTML file, which the host publishes to
+     *  `config/view` and the public page renders in a sandboxed iframe.
+     *
+     *  `submit` stays declared alongside: the view sends an INTENT, and the
+     *  page it is embedded in performs the write against these rules.
+     *
+     *  `collections` is declared rather than inferred from `read`. Inferring
+     *  it produces the worst failure this feature has — the view renders, the
+     *  data it wanted was never sent, and it draws an empty grid with no error
+     *  anywhere. */
+    view: z
+      .object({ path: z.string().trim().min(1), collections: z.array(NameZ).min(1) })
+      .strict()
+      .optional(),
     submit: z.record(NameZ, SubmitZ).optional(),
   })
   .strict();

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -153,7 +153,14 @@ function compact(entries: Record<string, unknown>): Record<string, unknown> {
  *  it is still checked, because a NaN written to Firestore fails closed in the
  *  same silent way an ISO string does. */
 function windowMillis(
-  window: { from?: string | undefined; until?: string | undefined; fromField?: Record<string, string> | undefined } | undefined,
+  window:
+    | {
+        from?: string | undefined;
+        until?: string | undefined;
+        fromField?: Record<string, string> | undefined;
+        untilField?: Record<string, string> | undefined;
+      }
+    | undefined,
 ): Record<string, unknown> | undefined {
   if (!window) return undefined;
   const out: Record<string, number> = {};
@@ -167,7 +174,11 @@ function windowMillis(
   // class writes it). There is nothing here to convert, and dropping it is the
   // failure this function's own comment warns about: the rules would stop
   // seeing a bound the author declared, and the window would silently be open.
-  const projected: Record<string, unknown> = { ...out, ...(window.fromField === undefined ? {} : { fromField: window.fromField }) };
+  const projected: Record<string, unknown> = {
+    ...out,
+    ...(window.fromField === undefined ? {} : { fromField: window.fromField }),
+    ...(window.untilField === undefined ? {} : { untilField: window.untilField }),
+  };
   return Object.keys(projected).length > 0 ? projected : undefined;
 }
 

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -123,6 +123,20 @@ export interface PublishedConfigDoc extends Record<string, unknown> {
   enabled: boolean;
   read: string[];
   submit: Record<string, Record<string, unknown>>;
+  /** That the app HAS a published view, and which datasets it asked for.
+   *
+   *  This is the only place the public page can learn it: the rules' app
+   *  document is reader-only and deliberately carries no view, and the HTML
+   *  itself lands in a SEPARATE document (`config/view`) because a 1 MiB limit
+   *  applies per document. Omitted here, the page has the HTML and no idea
+   *  what to send it — the feature does not work at all.
+   *
+   *  The authored PATH is deliberately not published. It names a file in the
+   *  author's repository, which the browser cannot use and which nobody should
+   *  be handed on a world-readable document; what the page needs is the
+   *  dataset list, and `publishedAt` beside it is what pins this declaration
+   *  to the HTML published in the same run. */
+  view?: { collections: string[] };
   publishedAt: number;
 }
 
@@ -263,6 +277,7 @@ export function projectApp(
     enabled: authored.public?.enabled === true,
     read: authored.public?.read ?? [],
     submit,
+    ...(authored.public?.view === undefined ? {} : { view: { collections: authored.public.view.collections } }),
     publishedAt: stamp.publishedAt,
   };
   if (authored.name !== undefined) config.name = authored.name;

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -659,11 +659,64 @@ test("refuses a view fed a collection the visitor may not read", () => {
   );
 });
 
-test("refuses a view that is not one HTML file under views/", () => {
+test("refuses a view that is not one HTML file directly under views/", () => {
   refuses(
     viewed((view) => {
       view.path = "../../etc/passwd";
     }),
-    "one HTML file inside",
+    "exactly one HTML file",
   );
+  // The one a prefix-and-suffix test lets through, and the reason this is a
+  // regex: the host reads the path to decide which file to publish, and what
+  // it publishes is `allow read: if true`.
+  refuses(
+    viewed((view) => {
+      view.path = "views/../../secrets.html";
+    }),
+    "exactly one HTML file",
+  );
+  refuses(
+    viewed((view) => {
+      view.path = "views/nested/booking.html";
+    }),
+    "exactly one HTML file",
+  );
+});
+
+test("refuses an idIn pointing at nothing, or at itself", () => {
+  refuses(
+    salon((draft) => {
+      bookingOf(draft).idIn = { collection: "slotz", where: { field: "state", equals: "open" } };
+    }),
+    "idIn.collection names 'slotz'",
+  );
+  // On a create the document being written does not exist yet, so a
+  // self-referential idIn is a declaration nothing can ever satisfy.
+  refuses(
+    salon((draft) => {
+      bookingOf(draft).idIn = { collection: "bookings" };
+    }),
+    "names 'bookings' itself",
+  );
+});
+
+test("refuses a mirror whose other half was never deployed", () => {
+  // The same trap as the assignee's field, reached the same way: publish takes
+  // the submission side from app.json and the collection side from the DEPLOY.
+  // Declare both halves, publish without redeploying, and what lands is a
+  // booking that must move its projection beside a projection that refuses to
+  // move -- every submission denied, on a declaration that reads as correct.
+  const declared = app(salonDraft() as unknown as Record<string, unknown>);
+  const stagedDoc = (cid: string, config: Record<string, unknown>) => ({
+    cid,
+    doc: { publishedSchema: { title: cid, icon: "event", primaryKey: "id", fields: {} }, deployedAt: 1, deployedBy: OWNER, config },
+  });
+
+  // Sound on disk, which is why this needed a check of its own.
+  assert.deepEqual(publishProblems(declared, SALON_CIDS, OWNER), []);
+
+  const stale = [stagedDoc("bookings", {}), stagedDoc("slots", {})];
+  refuses(promotedRoleProblems(declared, stale as never), "does not declare mirrorOf");
+  const fresh = [stagedDoc("bookings", {}), stagedDoc("slots", { mirrorOf: "bookings" })];
+  assert.deepEqual(promotedRoleProblems(declared, fresh as never), []);
 });

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -681,6 +681,20 @@ test("refuses a view that is not one HTML file directly under views/", () => {
     }),
     "exactly one HTML file",
   );
+  // A backslash is not a slash to a regex and IS a separator on Windows, so
+  // this is the same escape wearing a different coat.
+  refuses(
+    viewed((view) => {
+      view.path = "views/..\\..\\secrets.html";
+    }),
+    "exactly one HTML file",
+  );
+  refuses(
+    viewed((view) => {
+      view.path = "/etc/views/passwd.html";
+    }),
+    "exactly one HTML file",
+  );
 });
 
 test("refuses an idIn pointing at nothing, or at itself", () => {

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -714,6 +714,22 @@ test("refuses an idIn pointing at nothing, or at itself", () => {
   );
 });
 
+/** A staged collection as publish sees it: the schema deploy promoted, and
+ *  that collection's rule configuration. `slots` carries the three fields the
+ *  salon declaration reads off it — without them the ref-field check fires
+ *  first and a mirror test would pass on the wrong refusal. */
+const SLOT_FIELDS = { state: { type: "string" }, opensAt: { type: "number" }, closesAt: { type: "number" } };
+
+const stagedSalonDoc = (cid: string, config: Record<string, unknown>) => ({
+  cid,
+  doc: {
+    publishedSchema: { title: cid, icon: "event", primaryKey: "id", fields: cid === "slots" ? SLOT_FIELDS : {} },
+    deployedAt: 1,
+    deployedBy: OWNER,
+    config,
+  },
+});
+
 test("refuses a mirror whose other half was never deployed", () => {
   // The same trap as the assignee's field, reached the same way: publish takes
   // the submission side from app.json and the collection side from the DEPLOY.
@@ -721,17 +737,13 @@ test("refuses a mirror whose other half was never deployed", () => {
   // booking that must move its projection beside a projection that refuses to
   // move -- every submission denied, on a declaration that reads as correct.
   const declared = app(salonDraft() as unknown as Record<string, unknown>);
-  const stagedDoc = (cid: string, config: Record<string, unknown>) => ({
-    cid,
-    doc: { publishedSchema: { title: cid, icon: "event", primaryKey: "id", fields: {} }, deployedAt: 1, deployedBy: OWNER, config },
-  });
 
   // Sound on disk, which is why this needed a check of its own.
   assert.deepEqual(publishProblems(declared, SALON_CIDS, OWNER), []);
 
-  const stale = [stagedDoc("bookings", {}), stagedDoc("slots", {})];
+  const stale = [stagedSalonDoc("bookings", {}), stagedSalonDoc("slots", {})];
   refuses(promotedRoleProblems(declared, stale as never), "does not declare mirrorOf");
-  const fresh = [stagedDoc("bookings", {}), stagedDoc("slots", { mirrorOf: "bookings" })];
+  const fresh = [stagedSalonDoc("bookings", {}), stagedSalonDoc("slots", { mirrorOf: "bookings" })];
   assert.deepEqual(promotedRoleProblems(declared, fresh as never), []);
 });
 
@@ -746,17 +758,49 @@ test("refuses a mirror REMOVED from the declaration but not from the deploy", ()
   delete withoutPair.public.submit.bookings.mirror;
   delete withoutPair.collections.slots.mirrorOf;
   const declared = app(withoutPair as unknown as Record<string, unknown>);
-  const stagedDoc = (cid: string, config: Record<string, unknown>) => ({
-    cid,
-    doc: { publishedSchema: { title: cid, icon: "event", primaryKey: "id", fields: {} }, deployedAt: 1, deployedBy: OWNER, config },
-  });
 
   // The declaration on disk is sound — the pair is simply gone from it.
   assert.deepEqual(publishProblems(declared, SALON_CIDS, OWNER), []);
 
-  const stale = [stagedDoc("bookings", {}), stagedDoc("slots", { mirrorOf: "bookings" })];
+  const stale = [stagedSalonDoc("bookings", {}), stagedSalonDoc("slots", { mirrorOf: "bookings" })];
   refuses(promotedRoleProblems(declared, stale as never), "app.json no longer declares");
   // Deployed after the removal, the two agree again and publish is free.
-  const fresh = [stagedDoc("bookings", {}), stagedDoc("slots", {})];
+  const fresh = [stagedSalonDoc("bookings", {}), stagedSalonDoc("slots", {})];
   assert.deepEqual(promotedRoleProblems(declared, fresh as never), []);
+});
+
+test("refuses a field the referenced record's staged schema does not declare", () => {
+  // A typo in a field NAME publishes cleanly and denies every submission with
+  // no message: the rules read the field off the record, find nothing, and
+  // refuse. It cannot be caught by the declaration gate, which is given a cid
+  // and a primary key per collection — only a schema can judge a field name,
+  // and the schema that matters is the one publish promotes.
+  const stagedWithFields = (cid: string, fields: string[], config: Record<string, unknown> = {}) => ({
+    cid,
+    doc: {
+      publishedSchema: {
+        title: cid,
+        icon: "event",
+        primaryKey: "id",
+        fields: Object.fromEntries(fields.map((field) => [field, { type: "string" }])),
+      },
+      deployedAt: 1,
+      deployedBy: OWNER,
+      config,
+    },
+  });
+  const stagedFor = (slotFields: string[]) => [
+    stagedWithFields("bookings", ["slot", "status"]),
+    stagedWithFields("slots", slotFields, { mirrorOf: "bookings" }),
+  ];
+
+  const declared = app(salonDraft() as unknown as Record<string, unknown>);
+  // The salon declaration reads three fields off `slots`; with all three
+  // present publish is free.
+  assert.deepEqual(promotedRoleProblems(declared, stagedFor(["state", "opensAt", "closesAt"]) as never), []);
+
+  // One at a time, so a passing case cannot be hiding behind another failure.
+  refuses(promotedRoleProblems(declared, stagedFor(["opensAt", "closesAt"]) as never), "idIn.where.field names 'state'");
+  refuses(promotedRoleProblems(declared, stagedFor(["state", "closesAt"]) as never), "window.fromField.field names 'opensAt'");
+  refuses(promotedRoleProblems(declared, stagedFor(["state", "opensAt"]) as never), "window.untilField.field names 'closesAt'");
 });

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -481,3 +481,189 @@ test("a collection with nothing staged is left to the gate that names them all",
   });
   assert.deepEqual(promotedRoleProblems(declared, []), []);
 });
+
+// --- the slot booking: a document id that is a CLAIM about another record ----
+
+/** The declaration the salon template writes, in full. Every case below starts
+ *  from this and breaks exactly one thing: the interesting failures here are
+ *  all "one half of a pair is missing" rather than "the shape is wrong". */
+interface SalonDraft {
+  // Named members rather than an index signature: every case below reaches for
+  // `bookings` and `slots` by name, and an index signature would make each one
+  // possibly-undefined and bury the assertion in guards.
+  collections: { bookings: Record<string, unknown>; slots: Record<string, unknown> };
+  public: { enabled: boolean; read: string[]; view?: { path: string; collections: string[] }; submit: { bookings: Record<string, unknown> } };
+}
+
+const salonDraft = (): SalonDraft => ({
+  collections: {
+    bookings: { statusField: "status", transitions: { initial: ["requested"] }, submitOnly: true },
+    slots: { mirrorOf: "bookings" },
+  },
+  public: {
+    enabled: true,
+    read: ["slots"],
+    submit: {
+      bookings: {
+        auth: "verifiedEmail",
+        emailField: "customerEmail",
+        createFields: ["slot", "customerName", "customerEmail", "status"],
+        initialStatus: "requested",
+        idFrom: "field",
+        idField: "slot",
+        idIn: { collection: "slots", where: { field: "state", equals: "open" } },
+        mirror: "slots",
+        window: {
+          fromField: { ref: "slot", collection: "slots", field: "opensAt" },
+          untilField: { ref: "slot", collection: "slots", field: "closesAt" },
+        },
+      },
+    },
+  },
+});
+
+const SALON_CIDS = [
+  { cid: "bookings", primaryKey: "id" },
+  { cid: "slots", primaryKey: "id" },
+];
+
+/** Break one thing about the salon declaration, and report what publish says. */
+const salon = (mutate: (draft: SalonDraft) => void): string[] => {
+  const draft = salonDraft();
+  mutate(draft);
+  return problemsFor({ collections: draft.collections, public: draft.public }, SALON_CIDS);
+};
+
+const bookingOf = (draft: SalonDraft): Record<string, unknown> => draft.public.submit.bookings;
+const windowOf = (draft: SalonDraft): Record<string, unknown> => bookingOf(draft).window as Record<string, unknown>;
+
+test("the whole booking declaration passes", () => {
+  // First, and not a formality: every refusal below is only meaningful against
+  // a neighbour that publishes.
+  assert.deepEqual(
+    salon(() => {}),
+    [],
+  );
+});
+
+test("refuses a field id with nothing to check it against", () => {
+  // Without idIn the document id is any string a submitter likes, so the app
+  // accepts bookings for slots that do not exist. Nothing downstream notices.
+  refuses(
+    salon((draft) => {
+      delete bookingOf(draft).idIn;
+    }),
+    "no idIn is declared",
+  );
+});
+
+test("refuses a field id with no field", () => {
+  refuses(
+    salon((draft) => {
+      delete bookingOf(draft).idField;
+    }),
+    "no idField is declared",
+  );
+});
+
+test("refuses idIn where the rules would never read it", () => {
+  // Declared under `auth.uid` it looks like a check and is not one.
+  refuses(
+    salon((draft) => {
+      bookingOf(draft).idFrom = "auth.uid";
+      delete bookingOf(draft).idField;
+    }),
+    "the rules read idIn only for",
+  );
+});
+
+test("refuses a field id whose field a submitter may not write", () => {
+  refuses(
+    salon((draft) => {
+      bookingOf(draft).createFields = ["customerName", "customerEmail", "status"];
+    }),
+    "createFields must include",
+  );
+});
+
+test("refuses half a mirror, from either side", () => {
+  refuses(
+    salon((draft) => {
+      delete draft.collections.slots.mirrorOf;
+    }),
+    "does not declare mirrorOf",
+  );
+  refuses(
+    salon((draft) => {
+      delete bookingOf(draft).mirror;
+    }),
+    "does not declare mirror",
+  );
+});
+
+test("refuses a mirror of itself and a mirror of nothing", () => {
+  refuses(
+    salon((draft) => {
+      bookingOf(draft).mirror = "bookings";
+    }),
+    "names its own collection",
+  );
+  refuses(
+    salon((draft) => {
+      bookingOf(draft).mirror = "ghosts";
+      draft.collections.slots = {};
+    }),
+    "not a shared collection",
+  );
+});
+
+test("checks the closing bound as thoroughly as the opening one", () => {
+  refuses(
+    salon((draft) => {
+      windowOf(draft).untilField = { ref: "slot", collection: "ghosts", field: "closesAt" };
+    }),
+    "window.untilField.collection names 'ghosts'",
+  );
+  refuses(
+    salon((draft) => {
+      windowOf(draft).untilField = { ref: "whenever", collection: "slots", field: "closesAt" };
+    }),
+    "window.untilField.ref names 'whenever'",
+  );
+});
+
+// --- the public view --------------------------------------------------------
+
+const viewed = (mutate: (view: { path: string; collections: string[] }) => void): string[] =>
+  salon((draft) => {
+    const view = { path: "views/booking.html", collections: ["slots"] };
+    mutate(view);
+    draft.public.view = view;
+  });
+
+test("a declared public view passes", () => {
+  assert.deepEqual(
+    viewed(() => {}),
+    [],
+  );
+});
+
+test("refuses a view fed a collection the visitor may not read", () => {
+  // The worst failure this feature has: the view renders, the data never
+  // arrives, and it draws an empty grid with nothing anywhere to say why.
+  refuses(
+    viewed((view) => {
+      view.collections = ["slots", "bookings"];
+    }),
+    "not in public.read",
+  );
+});
+
+test("refuses a view that is not one HTML file under views/", () => {
+  refuses(
+    viewed((view) => {
+      view.path = "../../etc/passwd";
+    }),
+    "one HTML file inside",
+  );
+});

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -734,3 +734,29 @@ test("refuses a mirror whose other half was never deployed", () => {
   const fresh = [stagedDoc("bookings", {}), stagedDoc("slots", { mirrorOf: "bookings" })];
   assert.deepEqual(promotedRoleProblems(declared, fresh as never), []);
 });
+
+test("refuses a mirror REMOVED from the declaration but not from the deploy", () => {
+  // The dangerous direction, and the one a submission-side walk cannot see.
+  // Delete both halves from app.json and publish without redeploying: nothing
+  // requires the projection to move any more, while the promoted collection
+  // still allows it to be written. Bookings are created and the public row
+  // goes on saying `open`. Every check passes; every submission succeeds; only
+  // the page is wrong.
+  const withoutPair = salonDraft();
+  delete withoutPair.public.submit.bookings.mirror;
+  delete withoutPair.collections.slots.mirrorOf;
+  const declared = app(withoutPair as unknown as Record<string, unknown>);
+  const stagedDoc = (cid: string, config: Record<string, unknown>) => ({
+    cid,
+    doc: { publishedSchema: { title: cid, icon: "event", primaryKey: "id", fields: {} }, deployedAt: 1, deployedBy: OWNER, config },
+  });
+
+  // The declaration on disk is sound — the pair is simply gone from it.
+  assert.deepEqual(publishProblems(declared, SALON_CIDS, OWNER), []);
+
+  const stale = [stagedDoc("bookings", {}), stagedDoc("slots", { mirrorOf: "bookings" })];
+  refuses(promotedRoleProblems(declared, stale as never), "app.json no longer declares");
+  // Deployed after the removal, the two agree again and publish is free.
+  const fresh = [stagedDoc("bookings", {}), stagedDoc("slots", {})];
+  assert.deepEqual(promotedRoleProblems(declared, fresh as never), []);
+});

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -769,38 +769,65 @@ test("refuses a mirror REMOVED from the declaration but not from the deploy", ()
   assert.deepEqual(promotedRoleProblems(declared, fresh as never), []);
 });
 
+/** The salon's two collections as deploy staged them, with `slots` fields
+ *  chosen per case: what these tests are about is what the STAGED schema says. */
+const stagedWithFields = (cid: string, fields: Record<string, unknown>, config: Record<string, unknown> = {}) => ({
+  cid,
+  doc: {
+    publishedSchema: { title: cid, icon: "event", primaryKey: "id", fields },
+    deployedAt: 1,
+    deployedBy: OWNER,
+    config,
+  },
+});
+
+/** What the salon declaration actually needs off `slots`: a state to compare
+ *  and two bounds the rules read as epoch millis. */
+const SOUND = { state: { type: "string" }, opensAt: { type: "number" }, closesAt: { type: "number" } };
+
+const stagedFor = (slotFields: Record<string, unknown>) => [
+  stagedWithFields("bookings", { slot: { type: "string" }, status: { type: "string" } }),
+  stagedWithFields("slots", slotFields, { mirrorOf: "bookings" }),
+];
+
 test("refuses a field the referenced record's staged schema does not declare", () => {
   // A typo in a field NAME publishes cleanly and denies every submission with
   // no message: the rules read the field off the record, find nothing, and
   // refuse. It cannot be caught by the declaration gate, which is given a cid
   // and a primary key per collection — only a schema can judge a field name,
   // and the schema that matters is the one publish promotes.
-  const stagedWithFields = (cid: string, fields: string[], config: Record<string, unknown> = {}) => ({
-    cid,
-    doc: {
-      publishedSchema: {
-        title: cid,
-        icon: "event",
-        primaryKey: "id",
-        fields: Object.fromEntries(fields.map((field) => [field, { type: "string" }])),
-      },
-      deployedAt: 1,
-      deployedBy: OWNER,
-      config,
-    },
-  });
-  const stagedFor = (slotFields: string[]) => [
-    stagedWithFields("bookings", ["slot", "status"]),
-    stagedWithFields("slots", slotFields, { mirrorOf: "bookings" }),
-  ];
 
   const declared = app(salonDraft() as unknown as Record<string, unknown>);
-  // The salon declaration reads three fields off `slots`; with all three
-  // present publish is free.
-  assert.deepEqual(promotedRoleProblems(declared, stagedFor(["state", "opensAt", "closesAt"]) as never), []);
+  // With all three present and of the right kind, publish is free.
+  assert.deepEqual(promotedRoleProblems(declared, stagedFor(SOUND) as never), []);
 
   // One at a time, so a passing case cannot be hiding behind another failure.
-  refuses(promotedRoleProblems(declared, stagedFor(["opensAt", "closesAt"]) as never), "idIn.where.field names 'state'");
-  refuses(promotedRoleProblems(declared, stagedFor(["state", "closesAt"]) as never), "window.fromField.field names 'opensAt'");
-  refuses(promotedRoleProblems(declared, stagedFor(["state", "opensAt"]) as never), "window.untilField.field names 'closesAt'");
+  const without = (field: string) => Object.fromEntries(Object.entries(SOUND).filter(([name]) => name !== field));
+  refuses(promotedRoleProblems(declared, stagedFor(without("state")) as never), "idIn.where.field names 'state'");
+  refuses(promotedRoleProblems(declared, stagedFor(without("opensAt")) as never), "window.fromField.field names 'opensAt'");
+  refuses(promotedRoleProblems(declared, stagedFor(without("closesAt")) as never), "window.untilField.field names 'closesAt'");
+});
+
+test("refuses a comparison the rules could never satisfy", () => {
+  // A field that EXISTS can still be unreachable. These publish cleanly and
+  // deny every submission, and the declaration reads as correct in both cases.
+  const declared = app(salonDraft() as unknown as Record<string, unknown>);
+  const enumState = (values: string[]) => ({ state: { type: "enum", values }, opensAt: { type: "number" }, closesAt: { type: "number" } });
+
+  // An enum whose domain contains the value is exactly right.
+  assert.deepEqual(promotedRoleProblems(declared, stagedFor(enumState(["open", "taken"])) as never), []);
+  refuses(promotedRoleProblems(declared, stagedFor(enumState(["free", "taken"])) as never), "not one of the values");
+
+  // A bound the rules read as epoch millis, stored as an ISO string: a type
+  // error that fails closed, so the window never opens and nothing says why.
+  refuses(
+    promotedRoleProblems(declared, stagedFor({ state: { type: "string" }, opensAt: { type: "datetime" }, closesAt: { type: "number" } }) as never),
+    "is a datetime field",
+  );
+
+  // Comparing a boolean field with a string.
+  refuses(
+    promotedRoleProblems(declared, stagedFor({ state: { type: "boolean" }, opensAt: { type: "number" }, closesAt: { type: "number" } }) as never),
+    "is a boolean field",
+  );
 });

--- a/packages/core/test/collection/test_publishProject.ts
+++ b/packages/core/test/collection/test_publishProject.ts
@@ -150,16 +150,23 @@ test("BOTH per-record bounds survive it, and the closing one is the easier to lo
   assert.equal(submit.mirror, "slots");
 });
 
-test("the public view is NOT projected into the rules' app document", () => {
-  // `apps/{aid}.public` is what the rules read on every single write, and they
-  // have no use for an HTML path. The view reaches the page through the
-  // world-readable config document the host publishes beside it, so putting it
-  // here would be weight on the authorization document and nothing else.
+test("the public view reaches the CONFIG document, and only that one", () => {
+  // Two halves of one requirement, which is why they are one test. The rules'
+  // app document is read on every single write and has no use for a view, so
+  // it must not carry one. The world-readable config document is the ONLY
+  // place the public page can learn that a view exists and what to send it —
+  // omit it there and the page has HTML it cannot feed, which is the feature
+  // not working at all rather than a missing extra.
   const app = authored({
     public: { enabled: true, read: ["slots"], view: { path: "views/booking.html", collections: ["slots"] } },
   });
-  const published = projectApp(app, [], STAMP, null).app as Record<string, Record<string, unknown>>;
-  assert.deepEqual(published.public, { enabled: true, read: ["slots"] });
+  const projected = projectApp(app, [], STAMP, null);
+  assert.deepEqual((projected.app as Record<string, Record<string, unknown>>).public, { enabled: true, read: ["slots"] });
+  assert.deepEqual(projected.config.view, { collections: ["slots"] });
+  // The authored PATH names a file in the author's repository. The browser
+  // cannot use it and nobody should be handed it on a document whose rule is
+  // `allow read: if true`.
+  assert.equal(JSON.stringify(projected.config).includes("views/booking.html"), false);
 });
 
 test("memberEmails is derived from members, and a hand-written one is overwritten", () => {

--- a/packages/core/test/collection/test_publishProject.ts
+++ b/packages/core/test/collection/test_publishProject.ts
@@ -113,6 +113,55 @@ test("a per-record window bound survives the lowering that has nothing to lower"
   });
 });
 
+test("BOTH per-record bounds survive it, and the closing one is the easier to lose", () => {
+  // `untilField` arrived after `fromField` and reads identically, which is
+  // precisely how the second one gets left out of a function that names the
+  // first. Dropped, the desk that opens per slot never closes: every slot goes
+  // on taking bookings after its deadline, and the declaration says otherwise.
+  const app = authored({
+    public: {
+      submit: {
+        bookings: {
+          auth: "verifiedEmail",
+          createFields: ["customerEmail", "slot"],
+          idFrom: "field",
+          idField: "slot",
+          idIn: { collection: "slots", where: { field: "state", equals: "open" } },
+          mirror: "slots",
+          window: {
+            fromField: { ref: "slot", collection: "slots", field: "opensAt" },
+            untilField: { ref: "slot", collection: "slots", field: "closesAt" },
+          },
+        },
+      },
+    },
+  });
+  const submit = publishedSubmit(projectApp(app, [], STAMP, null).app, "bookings");
+  assert.deepEqual(submit.window, {
+    fromField: { ref: "slot", collection: "slots", field: "opensAt" },
+    untilField: { ref: "slot", collection: "slots", field: "closesAt" },
+  });
+  // The keys the rules read for exclusivity pass through untouched — there is
+  // nothing to lower, and dropping any of them turns "one booking per slot"
+  // into "any string a submitter likes" with no error anywhere.
+  assert.equal(submit.idFrom, "field");
+  assert.equal(submit.idField, "slot");
+  assert.deepEqual(submit.idIn, { collection: "slots", where: { field: "state", equals: "open" } });
+  assert.equal(submit.mirror, "slots");
+});
+
+test("the public view is NOT projected into the rules' app document", () => {
+  // `apps/{aid}.public` is what the rules read on every single write, and they
+  // have no use for an HTML path. The view reaches the page through the
+  // world-readable config document the host publishes beside it, so putting it
+  // here would be weight on the authorization document and nothing else.
+  const app = authored({
+    public: { enabled: true, read: ["slots"], view: { path: "views/booking.html", collections: ["slots"] } },
+  });
+  const published = projectApp(app, [], STAMP, null).app as Record<string, Record<string, unknown>>;
+  assert.deepEqual(published.public, { enabled: true, read: ["slots"] });
+});
+
 test("memberEmails is derived from members, and a hand-written one is overwritten", () => {
   // `membersConsistent()` refuses any write where the two disagree, so an
   // authored value could only ever turn publish into a bare permission error.

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.12.0",
+    "@mulmoclaude/core": "^3.13.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",


### PR DESCRIPTION
mulmoterminal `plans/feat-shared-app-public-view.md` の **1（`idFrom: "field"`）** と
**2（公開ビュー）** の core 側。ルール側は **mulmoserver #164**、そちらが先に本番へ出る。

`@mulmoclaude/core` **3.12.0 → 3.13.0**。

## 宣言に足すもの

| キー | 何を言うか |
|---|---|
| `public.submit.<cid>.idFrom: "field"` | 予約の id は枠の id。2 人目は既存ドキュメントへの書き込み＝ update になり拒否される |
| `public.submit.<cid>.idIn` | その id が実在し、かつ宣言された状態であること。`{collection, where?}` |
| `public.submit.<cid>.mirror` | 公開される射影のコレクション。予約と対の batch でしか動かない |
| `collections.<cid>.mirrorOf` | 鏡の反対側。`state` は権威の写しであって第 2 の真実ではない |
| `public.submit.<cid>.window.untilField` | 枠ごとの締切。`fromField` の対 |
| `public.view` | 公開ページに出す HTML と、そこへ渡すコレクション |

## publish が拒否するもの（と、その理由）

- **`idFrom: "field"` に `idIn` が無い** — id は投稿者が書いた任意の文字列になり、
  実在しない枠の予約が黙って通る。**必須にする**
- **`idFrom` が別の値なのに `idIn` がある** — ルールはその分岐でしか読まない。
  著者は動いていない検査を動いていると思う
- **鏡の片側だけ** — 両方向で検査する。`mirror` があって `mirrorOf` が無ければ
  申込みは全部拒否され、`mirrorOf` があって `mirror` が無ければ射影が黙ってずれる
- **自分自身の鏡・存在しない鏡**
- **`untilField` の collection / ref** — `fromField` と同じ検査。片方だけ検査すると、
  締切の宣言が「開かない受付」になって理由が出ない
- **`public.view.collections` が `public.read` に無い** — この機能の最悪の壊れ方で、
  ビューは描けるのにデータが来ない。エラーはどこにも出ない
- **`public.view.path` が `views/*.html` でない**

## 射影で気をつけた 2 点

**`untilField` は落ちやすい。** `windowMillis` は ISO を epoch に変換する関数で、
`fromField` は「変換するものが無いので通す」形で入っている。同じ形の 2 つ目は
そのまま落ちる — 落ちれば締切は消え、宣言と挙動が食い違う。両方にテストを置いた。

**`public.view` は `apps/{aid}.public` に載せない。** そこはルールが**毎回の書き込みで**
読む文書で、HTML のパスを置く理由が無い。ビューはホストが書く world-readable な
config 文書から公開ページに届く。

## 検証

- `yarn test`（core）: **918 件 pass / 0 fail**
- `yarn typecheck` / `yarn lint`: エラー 0

## 次

1. **mulmoserver #164 を deploy**（ルールが先）
2. これを publish（npm）
3. mulmoserver のランタイム（`PublicApp` / bridge）
4. mulmoterminal（`config/view` の書き出しと撤去、排他キーの凍結、salon テンプレート）

## Summary by Sourcery

Add support for field-based exclusive IDs, mirrored public projections, and declared public HTML views for collections, including validation and projection logic updates.

New Features:
- Allow collections to declare document IDs derived from a field and constrained by an existing collection and optional state.
- Support declaring mirror collections that hold public projections of authoritative records to keep public availability in sync.
- Introduce a public view declaration that specifies an HTML template and the collections it reads for data.

Enhancements:
- Extend window configuration to support per-record closing bounds alongside existing opening bounds, ensuring both survive publishing.
- Strengthen publish-time coherence checks for window bounds, mirror relationships, and public view readability to prevent silent misconfigurations.

Build:
- Bump @mulmoclaude/core version from 3.12.0 to 3.13.0.

Tests:
- Add salon booking template tests covering field-based IDs, mirrors, window bounds, and public views, including failure scenarios for incomplete or inconsistent declarations.
- Add projection tests to ensure both window bounds, exclusivity keys, and public view declarations are correctly handled during publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for collection mirroring and public views with configurable paths and readable collections.
  * Added field-based submission IDs, referenced-record validation, and per-record closing windows.
  * Preserved expanded window and mirroring settings when publishing project configurations.

* **Bug Fixes**
  * Improved publishing validation for IDs, window references, mirror relationships, public-view paths, and collection access.
  * Added checks to prevent invalid or inconsistent publication configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->