### PR TITLE
feat(collections): アプリのページを監査対象ごとに宣言できるようにする（core 3.14.0）

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,51 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Added
+
+#### A shared app can declare a page per audience, not only a public one (#2877)
+
+`public.view` named ONE page, for anonymous visitors. `views[]` names as many as
+the app needs, each saying who it is for:
+
+```json
+"views": [
+  { "id": "public", "audience": "public", "path": "views/booking.html", "collections": ["slots"] },
+  { "id": "desk",   "audience": "member", "path": "views/desk.html",    "collections": ["bookings"] }
+]
+```
+
+`audience` decides which DOCUMENT the page is published to, and therefore who
+may read it — a rule cannot hide a field, so "the front desk sees this" is a
+place rather than a filter. `member` lands under `apps/{aid}/member` (anyone
+holding a role) and `participant` under `apps/{aid}/roster` (the whole roster);
+`public` keeps `config/view`, which is already deployed. `id` becomes the
+document id, so it carries a grammar rather than merely being unique.
+
+The declaration is projected PER TIER (`projectAppViews`). A participant cannot
+read `apps/{aid}` — their classmates' addresses are on it — so the datasets
+their page draws, and the field their own row is found by, can only reach them
+through their tier's own config. One shared projection could not serve both:
+handed the staff datasets, a participant's page builds a query the rules refuse,
+which fails rather than showing less.
+
+`public.view` still parses and normalizes to `id: "public"`. Declaring both is
+refused rather than resolved silently. Only one `public` view is allowed —
+`config/view` is a single document, so a second would be published nowhere and
+which was live would depend on declaration order.
+
+Publish refuses a `participant` page naming a collection a participant cannot
+reach, and judges that against the `participantRead` publish will PROMOTE (what
+deploy staged) rather than what `app.json` says now.
+
+Design: mulmoterminal `plans/feat-shared-app-member-view.md`. The rules are
+mulmoserver#168 and the runtime mulmoserver#169; both go out before a host
+writes any of this.
+
+### Package releases
+
+Ships `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@3.14.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ### Fixed
 
 #### A shared record's identity is its document id, not a field a submitter can name

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/appViews.ts
+++ b/packages/core/src/collection/server/appViews.ts
@@ -1,0 +1,183 @@
+// The pages a published app shows, per AUDIENCE.
+//
+// One declaration (`views[]`), three audiences, and a different place to put
+// each — because a Firestore rule cannot hide a field, so who may read a page
+// is decided by which DOCUMENT it lands on:
+//
+//   public       apps/{aid}/config/*     allow read: if true
+//   member       apps/{aid}/member/*     staffOf  — holds a role, anywhere
+//   participant  apps/{aid}/roster/*     listedIn — on the roster at all
+//
+// Three things here are decisions rather than plumbing.
+//
+//   `views[]` REPLACES `public.view`, and the reason is timing rather than
+//   vocabulary. Renaming a key an author has written is a migration the moment
+//   one app publishes it; nothing has yet, so the generalisation is free
+//   today and is not free next month. The old shape keeps parsing for one
+//   release and normalizes into this one.
+//
+//   THE ID IS THE ADDRESS. `views[].id` becomes the document id `live:{id}` /
+//   `staged:{id}`, which is why it carries a grammar rather than merely being
+//   unique: a `/` in it would address a different path, and staging and
+//   withdrawal would then tidy somewhere else entirely.
+//
+//   THE DECLARATION IS PROJECTED PER TIER, not published once and read by
+//   everyone. `apps/{aid}` is reader-only (a participant reading it would see
+//   their classmates' addresses), so a participant's page cannot learn the
+//   view's datasets, let alone the field its own row is found by. And a single
+//   shared projection cannot serve both: handed the staff datasets, a
+//   participant's page builds a query the rules refuse — it does not render
+//   less, it fails.
+import type { AuthoredApp, AuthoredSubmit } from "./publishManifest";
+
+/** The audiences a view may be written for. A CLOSED set: each one names a
+ *  tier with a rule behind it, so an unknown value has nowhere to be
+ *  published to and is refused before it gets there. */
+export const VIEW_AUDIENCES = ["public", "member", "participant"] as const;
+export type ViewAudience = (typeof VIEW_AUDIENCES)[number];
+
+/** Where each audience's documents live under `apps/{aid}`. `public` is not
+ *  here: it keeps `config/public` + `config/view`, which are already published
+ *  and already read by a deployed runtime. */
+export const VIEW_TIER: Readonly<Record<Exclude<ViewAudience, "public">, "member" | "roster">> = {
+  member: "member",
+  participant: "roster",
+};
+
+/** The id `public.view` normalizes to. Fixed rather than derived, so two
+ *  implementations of the same normalization cannot pick different ones. */
+export const PUBLIC_VIEW_ID = "public";
+
+/** `config` is the projection's own document in every tier (`live:config`),
+ *  so a view may not be called that — the two would be the same document. */
+export const RESERVED_VIEW_IDS: readonly string[] = ["config"];
+
+/** What an id may be.
+ *
+ *  Narrow on purpose: this value is written by the author, and it becomes a
+ *  Firestore document id under a `live:` / `staged:` prefix. Excluding `:`
+ *  keeps the prefix and the id from running together; excluding `/`, `.` and
+ *  `__…__` keeps it a legal document id that addresses the path it says. */
+export const VIEW_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const VIEW_ID_SHAPE = "must be lowercase letters, digits and hyphens, start with a letter or digit, and be at most 64 characters (e.g. front-desk)";
+
+/** A view as the author wrote it, once normalized: one shape, whichever of
+ *  the two declarations it came from. `where` is the path it was written at,
+ *  carried only so a refusal names the key the author can go and edit. */
+export interface NormalizedView {
+  id: string;
+  audience: ViewAudience;
+  path: string;
+  collections: string[];
+  where: string;
+}
+
+export type NormalizedViewsResult = { ok: true; views: NormalizedView[] } | { ok: false; problems: string[] };
+
+/** Both declarations of the same thing, in one file.
+ *
+ *  Refused rather than merged or preferred: whichever way it were resolved,
+ *  the author would have written two answers and been shown neither. */
+const BOTH_FORMS =
+  "app.json declares both `views` and `public.view`. These are the same thing — `public.view` is the older spelling — and publishing would have to choose one silently. " +
+  'Move the `public.view` entry into `views` as { id: "public", audience: "public", … } and delete it.';
+
+/** The one shape everything downstream reads.
+ *
+ *  Every caller — the publish gate, the projection, the host that writes the
+ *  documents — goes through this, so "which declaration was used" is decided
+ *  exactly once. */
+export function normalizeViews(app: AuthoredApp): NormalizedViewsResult {
+  const legacy = app.public?.view;
+  const authored = app.views;
+  if (legacy !== undefined && authored !== undefined) return { ok: false, problems: [BOTH_FORMS] };
+
+  const views: NormalizedView[] = (authored ?? []).map((view, index) => ({
+    id: view.id,
+    audience: view.audience,
+    path: view.path,
+    collections: view.collections,
+    where: `views[${index}]`,
+  }));
+  if (legacy !== undefined) {
+    // Checked even though the branch above already refuses the pair: the
+    // reserved id is a property of the normalization, not of the order these
+    // two refusals happen to be written in.
+    if (views.some((view) => view.id === PUBLIC_VIEW_ID)) {
+      return { ok: false, problems: [`views declares id '${PUBLIC_VIEW_ID}', which is reserved for the older \`public.view\` spelling. ${BOTH_FORMS}`] };
+    }
+    views.push({ id: PUBLIC_VIEW_ID, audience: "public", path: legacy.path, collections: legacy.collections, where: "public.view" });
+  }
+
+  const problems: string[] = [];
+  const seen = new Map<string, string>();
+  for (const view of views) {
+    if (RESERVED_VIEW_IDS.includes(view.id)) {
+      problems.push(`${view.where}.id is '${view.id}', which is reserved: each audience's own declaration is published at that document id.`);
+    } else if (!VIEW_ID_PATTERN.test(view.id)) {
+      // The id becomes a document id, so this is not style. A `/` in it
+      // addresses a different path — staging writes one place and withdrawal
+      // tidies another, and neither says anything.
+      problems.push(`${view.where}.id is '${view.id}': a view id ${VIEW_ID_SHAPE}. It becomes the document id this view is published at.`);
+    } else if (view.id === PUBLIC_VIEW_ID && view.audience !== "public") {
+      problems.push(`${view.where}.id is '${PUBLIC_VIEW_ID}' with audience '${view.audience}': that id belongs to the public page.`);
+    }
+    const first = seen.get(view.id);
+    if (first !== undefined) {
+      problems.push(
+        `${view.where}.id is '${view.id}', which ${first} already uses. The id is the document a view is published at, so two of them are one page — ` +
+          "whichever was written second would silently replace the first, in staging and again at publish.",
+      );
+    } else seen.set(view.id, view.where);
+  }
+  return problems.length > 0 ? { ok: false, problems } : { ok: true, views };
+}
+
+/** How one audience reaches one collection's records.
+ *
+ *  The parent page builds the query from this; the view never touches
+ *  Firestore. `own` is not a filter the rules apply for the reader — an
+ *  unscoped `list` on an own-row collection is DENIED, not narrowed — so the
+ *  scope has to travel with the declaration or the page fails. */
+export interface ProjectedViewCollection {
+  cid: string;
+  scope: "all" | "own";
+  /** `scope: "own"` — the field carrying the reader's verified address. */
+  emailField?: string;
+  /** `scope: "own"` — the row is the document whose id is the reader's uid. */
+  ownDocId?: "auth.uid";
+}
+
+/** How a participant reaches `cid`, or null if they cannot.
+ *
+ *  Mirrors the rules' read branches for someone holding no role:
+ *  `partRead` (the whole collection) and `ownRow` (their own record, found
+ *  by the submit declaration's `emailField` or by a uid-derived id). */
+export function participantScope(app: AuthoredApp, cid: string): ProjectedViewCollection | null {
+  if ((app.participantRead ?? []).includes(cid)) return { cid, scope: "all" };
+  const submit: AuthoredSubmit | undefined = app.public?.submit?.[cid];
+  if (submit?.emailField !== undefined) return { cid, scope: "own", emailField: submit.emailField };
+  if (submit?.idFrom === "auth.uid") return { cid, scope: "own", ownDocId: "auth.uid" };
+  return null;
+}
+
+/** The declaration as one non-public audience may see it — the document
+ *  published at `apps/{aid}/{tier}/live:config`, and deployed at
+ *  `staged:config`.
+ *
+ *  The roster is NOT here, and neither is anything about another member: this
+ *  is read by everyone the tier admits, which for `roster` includes every
+ *  participant. */
+export interface AppViewConfigDoc extends Record<string, unknown> {
+  name?: string;
+  views: { id: string; collections: ProjectedViewCollection[] }[];
+  /** The submit declarations for the collections these views draw, so the page
+   *  can show what may be sent rather than discovering it from a denial. */
+  submit: Record<string, Record<string, unknown>>;
+  publishedAt: number;
+}
+
+/** The document ids one tier uses. `live:` and `staged:` are the only two
+ *  prefixes, so a single `match` covers the projection and every view. */
+export const viewDocId = (stage: "live" | "staged", viewId: string): string => `${stage}:${viewId}`;
+export const VIEW_CONFIG_ID = "config";

--- a/packages/core/src/collection/server/appViews.ts
+++ b/packages/core/src/collection/server/appViews.ts
@@ -82,12 +82,11 @@ const BOTH_FORMS =
   "app.json declares both `views` and `public.view`. These are the same thing — `public.view` is the older spelling — and publishing would have to choose one silently. " +
   'Move the `public.view` entry into `views` as { id: "public", audience: "public", … } and delete it.';
 
-/** The one shape everything downstream reads.
+/** The two declarations, as one list, or the refusal that they are both there.
  *
- *  Every caller — the publish gate, the projection, the host that writes the
- *  documents — goes through this, so "which declaration was used" is decided
- *  exactly once. */
-export function normalizeViews(app: AuthoredApp): NormalizedViewsResult {
+ *  `public.view` becomes an entry under the reserved id, so everything
+ *  downstream reads one shape and "which spelling was used" is decided once. */
+function declaredViews(app: AuthoredApp): NormalizedViewsResult {
   const legacy = app.public?.view;
   const authored = app.views;
   if (legacy !== undefined && authored !== undefined) return { ok: false, problems: [BOTH_FORMS] };
@@ -99,38 +98,79 @@ export function normalizeViews(app: AuthoredApp): NormalizedViewsResult {
     collections: view.collections,
     where: `views[${index}]`,
   }));
-  if (legacy !== undefined) {
-    // Checked even though the branch above already refuses the pair: the
-    // reserved id is a property of the normalization, not of the order these
-    // two refusals happen to be written in.
-    if (views.some((view) => view.id === PUBLIC_VIEW_ID)) {
-      return { ok: false, problems: [`views declares id '${PUBLIC_VIEW_ID}', which is reserved for the older \`public.view\` spelling. ${BOTH_FORMS}`] };
-    }
-    views.push({ id: PUBLIC_VIEW_ID, audience: "public", path: legacy.path, collections: legacy.collections, where: "public.view" });
+  if (legacy === undefined) return { ok: true, views };
+  // Checked even though the branch above already refuses the pair: the
+  // reserved id is a property of the normalization, not of the order these
+  // two refusals happen to be written in.
+  if (views.some((view) => view.id === PUBLIC_VIEW_ID)) {
+    return { ok: false, problems: [`views declares id '${PUBLIC_VIEW_ID}', which is reserved for the older \`public.view\` spelling. ${BOTH_FORMS}`] };
   }
+  return { ok: true, views: [...views, { id: PUBLIC_VIEW_ID, audience: "public", path: legacy.path, collections: legacy.collections, where: "public.view" }] };
+}
 
-  const problems: string[] = [];
-  const seen = new Map<string, string>();
-  for (const view of views) {
-    if (RESERVED_VIEW_IDS.includes(view.id)) {
-      problems.push(`${view.where}.id is '${view.id}', which is reserved: each audience's own declaration is published at that document id.`);
-    } else if (!VIEW_ID_PATTERN.test(view.id)) {
-      // The id becomes a document id, so this is not style. A `/` in it
-      // addresses a different path — staging writes one place and withdrawal
-      // tidies another, and neither says anything.
-      problems.push(`${view.where}.id is '${view.id}': a view id ${VIEW_ID_SHAPE}. It becomes the document id this view is published at.`);
-    } else if (view.id === PUBLIC_VIEW_ID && view.audience !== "public") {
-      problems.push(`${view.where}.id is '${PUBLIC_VIEW_ID}' with audience '${view.audience}': that id belongs to the public page.`);
-    }
-    const first = seen.get(view.id);
-    if (first !== undefined) {
-      problems.push(
-        `${view.where}.id is '${view.id}', which ${first} already uses. The id is the document a view is published at, so two of them are one page — ` +
-          "whichever was written second would silently replace the first, in staging and again at publish.",
-      );
-    } else seen.set(view.id, view.where);
+/** Whether one id may be used, and what to say when it may not. */
+function viewIdProblems(view: NormalizedView): string[] {
+  if (RESERVED_VIEW_IDS.includes(view.id)) {
+    return [`${view.where}.id is '${view.id}', which is reserved: each audience's own declaration is published at that document id.`];
   }
-  return problems.length > 0 ? { ok: false, problems } : { ok: true, views };
+  if (!VIEW_ID_PATTERN.test(view.id)) {
+    // The id becomes a document id, so this is not style. A `/` in it
+    // addresses a different path — staging writes one place and withdrawal
+    // tidies another, and neither says anything.
+    return [`${view.where}.id is '${view.id}': a view id ${VIEW_ID_SHAPE}. It becomes the document id this view is published at.`];
+  }
+  if (view.id === PUBLIC_VIEW_ID && view.audience !== "public") {
+    return [`${view.where}.id is '${PUBLIC_VIEW_ID}' with audience '${view.audience}': that id belongs to the public page.`];
+  }
+  return [];
+}
+
+/** ONE public page per app, and the reason is the wire rather than taste.
+ *
+ *  The public runtime reads a single `config/view` document and a single
+ *  `config/public.view` declaration beside it. A second `audience: "public"`
+ *  entry would pass every other check and then be published nowhere — and
+ *  which of the two became the live page would depend on declaration order,
+ *  silently. The member tiers have no such limit: `id` is their address, and
+ *  each one gets its own document.
+ *
+ *  The refusal is here rather than "one day we will support it" precisely
+ *  because the failure is invisible: nothing errors, and the author sees a
+ *  successful publish of a page nobody is served. */
+function singlePublicProblems(views: NormalizedView[]): string[] {
+  const [first, ...rest] = views.filter((view) => view.audience === "public");
+  if (first === undefined) return [];
+  return rest.map(
+    (view) =>
+      `${view.where} is a second audience "public" view, after ${first.where}. The public page is published at ONE document (config/view), so only one of ` +
+      'them could ever be served — and which, would depend on the order they were written in. Give the others audience "member" or "participant", ' +
+      "which are addressed by id and may have as many as the app needs.",
+  );
+}
+
+/** The one shape everything downstream reads.
+ *
+ *  Every caller — the publish gate, the projection, the host that writes the
+ *  documents — goes through this, so "which declaration was used" is decided
+ *  exactly once. */
+export function normalizeViews(app: AuthoredApp): NormalizedViewsResult {
+  const declared = declaredViews(app);
+  if (!declared.ok) return declared;
+  const problems: string[] = [...singlePublicProblems(declared.views)];
+  const seen = new Map<string, string>();
+  for (const view of declared.views) {
+    problems.push(...viewIdProblems(view));
+    const first = seen.get(view.id);
+    if (first === undefined) {
+      seen.set(view.id, view.where);
+      continue;
+    }
+    problems.push(
+      `${view.where}.id is '${view.id}', which ${first} already uses. The id is the document a view is published at, so two of them are one page — ` +
+        "whichever was written second would silently replace the first, in staging and again at publish.",
+    );
+  }
+  return problems.length > 0 ? { ok: false, problems } : { ok: true, views: declared.views };
 }
 
 /** How one audience reaches one collection's records.
@@ -152,9 +192,18 @@ export interface ProjectedViewCollection {
  *
  *  Mirrors the rules' read branches for someone holding no role:
  *  `partRead` (the whole collection) and `ownRow` (their own record, found
- *  by the submit declaration's `emailField` or by a uid-derived id). */
-export function participantScope(app: AuthoredApp, cid: string): ProjectedViewCollection | null {
-  if ((app.participantRead ?? []).includes(cid)) return { cid, scope: "all" };
+ *  by the submit declaration's `emailField` or by a uid-derived id).
+ *
+ *  `participantRead` is a PARAMETER rather than read off the manifest, and
+ *  that is the whole point of the signature. Publish does not promote the
+ *  manifest's value: `projectPublish` overwrites `participantRead` with what
+ *  the STAGED schemas carry, so a cid added since the last deploy is in the
+ *  manifest and not in the rules. Deriving the scope from the manifest would
+ *  publish `scope: "all"` for a collection the promoted rules then deny —
+ *  and removing one gives the mirror-image false refusal. The caller passes
+ *  the set that will actually be in force. */
+export function participantScope(app: AuthoredApp, cid: string, participantRead: readonly string[]): ProjectedViewCollection | null {
+  if (participantRead.includes(cid)) return { cid, scope: "all" };
   const submit: AuthoredSubmit | undefined = app.public?.submit?.[cid];
   if (submit?.emailField !== undefined) return { cid, scope: "own", emailField: submit.emailField };
   if (submit?.idFrom === "auth.uid") return { cid, scope: "own", ownDocId: "auth.uid" };

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -82,6 +82,10 @@ export {
 } from "./publishManifest";
 export {
   projectApp,
+  projectAppViews,
+  appViewTierPath,
+  viewConfigDocId,
+  type AppViewTier,
   projectDeploy,
   projectPublish,
   stagedRuleConfig,
@@ -103,6 +107,25 @@ export {
   type StagedSchemaDoc,
 } from "./publishProject";
 export { publishProblems, promotedRoleProblems, bindsSubmitterIdentity, type PublishableCollection } from "./publishChecks";
+// The app's pages, per audience: the declaration (`views[]`, generalised from
+// `public.view`), where each audience's documents live, and what the parent
+// page needs in order to query for them.
+export {
+  normalizeViews,
+  participantScope,
+  viewDocId,
+  PUBLIC_VIEW_ID,
+  RESERVED_VIEW_IDS,
+  VIEW_AUDIENCES,
+  VIEW_CONFIG_ID,
+  VIEW_ID_PATTERN,
+  VIEW_TIER,
+  type AppViewConfigDoc,
+  type NormalizedView,
+  type NormalizedViewsResult,
+  type ProjectedViewCollection,
+  type ViewAudience,
+} from "./appViews";
 export type { LoadedCollection } from "./discoveredCollection";
 export * from "./paths";
 export * from "./templatePath";

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -712,12 +712,10 @@ function viewCollectionProblems(app: AuthoredApp, view: NormalizedView, cid: str
         "read and the view draws an empty page. Nothing errors — this is the failure that looks like a working view with no data.",
     ];
   }
-  if (view.audience === "participant" && participantScope(app, cid) === null) {
-    return [
-      `${view.where}.collections names '${cid}', which a participant cannot read: it is not in participantRead, and public.submit.${cid} declares neither ` +
-        'an emailField nor idFrom "auth.uid", so there is no row the rules would call theirs. The page would be refused the read, not handed fewer records.',
-    ];
-  }
+  // No participant check here. Whether a participant reaches a collection
+  // depends on `participantRead`, and publish does not promote the manifest's
+  // — it promotes the STAGED schemas'. That check belongs with the other
+  // promoted-pair ones, in `promotedRoleProblems`.
   return [];
 }
 
@@ -759,7 +757,35 @@ export function promotedRoleProblems(app: AuthoredApp, staged: { cid: string; do
     ...promotedAssigneeProblems(app, promoted, stagedCids),
     ...promotedMirrorProblems(app, promoted, stagedCids),
     ...promotedRefFieldProblems(app, staged),
+    ...promotedParticipantViewProblems(app, staged),
   ];
+}
+
+/** A participant's page, checked against the `participantRead` publish will
+ *  actually PROMOTE.
+ *
+ *  Not against the manifest's. `projectPublish` overwrites `participantRead`
+ *  with what the staged schemas carry, so a cid added to the manifest since the
+ *  last deploy is not in the rules — and a page written for it would be
+ *  published, offered, and then refused the read. The manifest half of this
+ *  file cannot see that; the promoted half can, which is why the check lives
+ *  here rather than beside the other view checks. */
+function promotedParticipantViewProblems(app: AuthoredApp, staged: { cid: string; doc: StagedSchemaDoc }[]): string[] {
+  const normalized = normalizeViews(app);
+  if (!normalized.ok) return [];
+  const participantRead = stagedRuleConfig(staged).participantRead ?? [];
+  return normalized.views
+    .filter((view) => view.audience === "participant")
+    .flatMap((view) =>
+      view.collections
+        .filter((cid) => participantScope(app, cid, participantRead) === null)
+        .map(
+          (cid) =>
+            `${view.where}.collections names '${cid}', which a participant cannot read once this publishes: it is not in the participantRead that DEPLOY ` +
+            `staged, and public.submit.${cid} declares neither an emailField nor idFrom "auth.uid", so there is no row the rules would call theirs. ` +
+            "The page would be refused the read, not handed fewer records. (Adding it to participantRead in app.json is not enough — deploy first.)",
+        ),
+    );
 }
 
 /** The FIELDS a rule reads off another record — `idIn.where.field` and the two

--- a/packages/core/src/collection/server/publishChecks.ts
+++ b/packages/core/src/collection/server/publishChecks.ts
@@ -28,6 +28,7 @@
 
 import type { CollectionFieldSpec, CollectionSchema } from "../core/schema";
 import { isSafeCustomViewPath } from "../core/templatePath";
+import { normalizeViews, participantScope, type NormalizedView } from "./appViews";
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
 import { stagedRuleConfig, type StagedSchemaDoc } from "./publishProject";
 
@@ -444,7 +445,7 @@ export function publishProblems(app: AuthoredApp, collections: readonly Publisha
     ...windowRefProblems(app, collections),
     ...idTargetProblems(app, collections),
     ...mirrorProblems(app, collections),
-    ...publicViewProblems(app, collections),
+    ...viewProblems(app, collections),
   ];
 }
 
@@ -654,55 +655,77 @@ function mirrorOfProblems(app: AuthoredApp, cid: string, collection: AuthoredCol
   return [];
 }
 
-/** What the public view is handed. Declared, never inferred — a view whose
- *  datasets were guessed from `public.read` renders perfectly and draws an
- *  empty grid, with nothing in the page, the rules or the log to say why. */
-function publicViewProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
-  const view = app.public?.view;
-  if (view === undefined) return [];
+/** What each view is handed, and whether its audience can actually read it.
+ *
+ *  Declared, never inferred — a view whose datasets were guessed from
+ *  `public.read` renders perfectly and draws an empty grid, with nothing in
+ *  the page, the rules or the log to say why.
+ *
+ *  The reachability check below is that same failure, once per audience. A
+ *  `public` view naming a collection outside `public.read` draws nothing; a
+ *  `participant` view naming one the participant reaches by neither
+ *  `participantRead` nor their own row is worse, because an unscoped list on
+ *  an own-row collection is DENIED rather than narrowed — the page does not
+ *  render less, it fails.
+ *
+ *  There is deliberately no such check for `member`. Every read a role opens
+ *  is unscoped, and WHICH role a given member holds is not a property of the
+ *  declaration: a stylist scoped to `bookings` and an owner read the same
+ *  projection. That one is settled at the entrance, by trying the read. */
+/** The path, for one view. The SAME validator the host's own custom views use,
+ *  rather than a second opinion about what a safe view path is.
+ *
+ *  Two ad-hoc attempts were wrong here in the same afternoon: a prefix-and-
+ *  suffix test let `views/../../secrets.html` through, and `views/[^/]+\.html`
+ *  still let `views/..\..\secrets.html` through, because a backslash is not a
+ *  slash on this side of the check and IS a separator on Windows. This one
+ *  rejects `..`, backslashes, leading slashes and anything outside
+ *  `[A-Za-z0-9._-]` per segment.
+ *
+ *  It matters more here than for a host view: the host reads this path to
+ *  decide which file to copy onto a document other people read — for a public
+ *  view, a document whose rule is `allow read: if true`, so the blast radius of
+ *  a bad path is the world rather than the author's own iframe. Nested paths
+ *  ARE allowed by the shared validator; the extra `views/<one name>.html` shape
+ *  is this publisher's own narrowing, kept because there is no reason for a
+ *  published view to live in a subdirectory. */
+function viewPathProblems(view: NormalizedView): string[] {
+  if (isSafeCustomViewPath(view.path) && view.path.split("/").length === 2) return [];
+  return [
+    `${view.where}.path is '${view.path}': a published view is exactly one HTML file directly inside the collection's own views/ directory ` +
+      "(e.g. views/booking.html) — no sub-directories, and no segments that climb out of it. The host reads this as a file to publish.",
+  ];
+}
+
+/** One dataset, for one view: does it exist here, and can the audience it is
+ *  handed to actually read it? */
+function viewCollectionProblems(app: AuthoredApp, view: NormalizedView, cid: string, known: ReadonlySet<string>): string[] {
+  if (!known.has(cid)) {
+    return [
+      `${view.where}.collections names '${cid}', which is not a shared collection in this repository. ` +
+        `Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : "(none)"}.`,
+    ];
+  }
+  if (view.audience === "public" && !(app.public?.read ?? []).includes(cid)) {
+    return [
+      `${view.where}.collections names '${cid}', which is not in public.read: the page reads these with the VISITOR's permissions, so the rules refuse the ` +
+        "read and the view draws an empty page. Nothing errors — this is the failure that looks like a working view with no data.",
+    ];
+  }
+  if (view.audience === "participant" && participantScope(app, cid) === null) {
+    return [
+      `${view.where}.collections names '${cid}', which a participant cannot read: it is not in participantRead, and public.submit.${cid} declares neither ` +
+        'an emailField nor idFrom "auth.uid", so there is no row the rules would call theirs. The page would be refused the read, not handed fewer records.',
+    ];
+  }
+  return [];
+}
+
+function viewProblems(app: AuthoredApp, collections: readonly PublishableCollection[]): string[] {
+  const normalized = normalizeViews(app);
+  if (!normalized.ok) return normalized.problems;
   const known = new Set(collections.map((collection) => collection.cid));
-  const readable = new Set(app.public?.read ?? []);
-  const problems: string[] = [];
-  // The SAME validator the host's own custom views use, rather than a second
-  // opinion about what a safe view path is.
-  //
-  // Two ad-hoc attempts were wrong here in the same afternoon: a prefix-and-
-  // suffix test let `views/../../secrets.html` through, and `views/[^/]+\.html`
-  // still let `views/..\..\secrets.html` through, because a backslash is not a
-  // slash on this side of the check and IS a separator on Windows. This one
-  // rejects `..`, backslashes, leading slashes and anything outside
-  // `[A-Za-z0-9._-]` per segment.
-  //
-  // It matters more here than for a host view: the host reads this path to
-  // decide which file to copy onto a document whose rule is
-  // `allow read: if true`, so the blast radius of a bad path is the world
-  // rather than the author's own iframe. Nested paths ARE allowed by the
-  // shared validator; the extra `views/<one name>.html` shape below is this
-  // publisher's own narrowing, kept because there is no reason for a published
-  // view to live in a subdirectory.
-  if (!isSafeCustomViewPath(view.path) || view.path.split("/").length !== 2) {
-    problems.push(
-      `public.view.path is '${view.path}': a published view is exactly one HTML file directly inside the collection's own views/ directory ` +
-        "(e.g. views/booking.html) — no sub-directories, and no segments that climb out of it. The host reads this as a file to publish, " +
-        "and what it publishes is world-readable.",
-    );
-  }
-  for (const cid of view.collections) {
-    if (!known.has(cid)) {
-      problems.push(
-        `public.view.collections names '${cid}', which is not a shared collection in this repository. ` +
-          `Shared collections here: ${known.size > 0 ? [...known].sort().join(", ") : "(none)"}.`,
-      );
-      continue;
-    }
-    if (!readable.has(cid)) {
-      problems.push(
-        `public.view.collections names '${cid}', which is not in public.read: the page reads these with the VISITOR's permissions, so the rules refuse the ` +
-          "read and the view draws an empty page. Nothing errors — this is the failure that looks like a working view with no data.",
-      );
-    }
-  }
-  return problems;
+  return normalized.views.flatMap((view) => [...viewPathProblems(view), ...view.collections.flatMap((cid) => viewCollectionProblems(app, view, cid, known))]);
 }
 
 /** What publish will actually promote, checked as the PAIR it becomes.

--- a/packages/core/src/collection/server/publishManifest.ts
+++ b/packages/core/src/collection/server/publishManifest.ts
@@ -39,6 +39,9 @@
 import { z } from "zod";
 import { isValidCollectionName } from "../core/collectionKey";
 import { parseAppManifest, type AppManifestResult } from "./appManifest";
+// Values only; `appViews` imports nothing but types from here, so the pair is
+// not a runtime cycle.
+import { VIEW_AUDIENCES } from "./appViews";
 
 /** A collection id / app id, held to the one name rule (`SAFE_SLUG_PATTERN`)
  *  that `sharedCollectionKey` applies. Stated once so a path built later
@@ -290,6 +293,31 @@ const PublicZ = z
   })
   .strict();
 
+/** One page the app shows, and who it is for.
+ *
+ *  Generalised from `public.view` (which is still accepted, and normalizes
+ *  into this — see `appViews.ts`). The audience is what decides which document
+ *  the HTML is published to, and therefore who may read it: a rule cannot hide
+ *  a field, so "the front desk sees this" is a place, not a filter.
+ *
+ *  `id` is not decoration. It becomes the document id the page is published
+ *  at, which is what lets one audience have more than one page — the front
+ *  desk and the stock room — and what lets a withdrawn view be found and
+ *  deleted. Its grammar is enforced at the gate, not here, so the refusal can
+ *  say what the value is used for.
+ *
+ *  `collections` is declared rather than inferred, for the reason `public.view`
+ *  gives: an inferred list renders a perfect page with no data in it, and
+ *  nothing anywhere says why. */
+const ViewZ = z
+  .object({
+    id: z.string().trim().min(1),
+    audience: z.enum(VIEW_AUDIENCES),
+    path: z.string().trim().min(1),
+    collections: z.array(NameZ).min(1),
+  })
+  .strict();
+
 /** The URL name an app is handed out under: `https://<host>/{slug}`.
  *
  *  A SEPARATE name from the `aid`, and that separation is the point (design
@@ -349,6 +377,9 @@ export const AuthoredAppZ = z
     collections: z.record(NameZ, CollectionConfigZ).optional(),
     participantRead: z.array(NameZ).optional(),
     public: PublicZ.optional(),
+    /** The app's pages, per audience. See {@link ViewZ}; `public.view` is the
+     *  older spelling of the `public` one and normalizes into this list. */
+    views: z.array(ViewZ).optional(),
   })
   .strict();
 

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -38,6 +38,17 @@
 
 import { isRecord } from "@mulmoclaude/common";
 import type { CollectionSchema } from "../core/schema";
+import {
+  normalizeViews,
+  participantScope,
+  VIEW_CONFIG_ID,
+  VIEW_TIER,
+  viewDocId,
+  type AppViewConfigDoc,
+  type NormalizedView,
+  type ProjectedViewCollection,
+  type ViewAudience,
+} from "./appViews";
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
 
 /** Who and when. Threaded in rather than read from a clock inside the
@@ -273,11 +284,22 @@ export function projectApp(
     previousPublished: previousOf(existing),
   });
 
+  // Refusals belong to the gate (`publishProblems`), which has already run by
+  // the time anything is projected. A declaration that cannot be normalized
+  // here is a programming error, and projecting half of it would publish a
+  // page with no data.
+  const normalized = normalizeViews(authored);
+  if (!normalized.ok) throw new Error(`publish: views declaration is not publishable (${normalized.problems.join(" ")})`);
+  const publicView = normalized.views.find((view) => view.audience === "public");
+
   const config: PublishedConfigDoc = {
     enabled: authored.public?.enabled === true,
     read: authored.public?.read ?? [],
     submit,
-    ...(authored.public?.view === undefined ? {} : { view: { collections: authored.public.view.collections } }),
+    // Read through the normalization, not off `public.view`: an app that
+    // declares its public page in `views[]` must publish the same document, or
+    // the page has the HTML and no idea what to send it.
+    ...(publicView === undefined ? {} : { view: { collections: publicView.collections } }),
     publishedAt: stamp.publishedAt,
   };
   if (authored.name !== undefined) config.name = authored.name;
@@ -521,3 +543,81 @@ export const appSlugDoc = (aid: string, published: boolean): AppSlugDoc => ({ ai
 export const appStagingPath = (aid: string): string => `apps/${aid}/staging`;
 /** The public-config documents' parent path. */
 export const appConfigPath = (aid: string): string => `apps/${aid}/config`;
+
+/** Where one audience's pages live. `member` is read by anyone holding a role;
+ *  `roster` by anyone on the roster, participants included. */
+export const appViewTierPath = (aid: string, tier: "member" | "roster"): string => `apps/${aid}/${tier}`;
+
+/** One audience's tier, as publish (or deploy) must write it.
+ *
+ *  Both tiers are returned even when empty, deliberately. An app that WITHDREW
+ *  its member pages produces an empty tier, and a host that only ever saw the
+ *  tiers with something in them would leave the previous pages live — the
+ *  failure `config/view` already had, where a declaration was withdrawn and
+ *  the world went on reading the page. */
+export interface AppViewTier {
+  tier: "member" | "roster";
+  audience: Exclude<ViewAudience, "public">;
+  /** The projection document, for `{tier}/live:config` or `{tier}/staged:config`.
+   *  Meaningless when `views` is empty — the host deletes the tier instead. */
+  config: AppViewConfigDoc;
+  /** The views to publish, in declaration order. The host reads each `path`
+   *  and writes it to `{tier}/live:{id}`. */
+  views: NormalizedView[];
+}
+
+/** What one audience may see of one collection.
+ *
+ *  For `member` this is always the whole collection: every read branch a role
+ *  opens (`readerOf`) is unscoped. Whether THIS member holds the role is not
+ *  knowable here — one projection is read by every member of the tier — and is
+ *  settled where it can be, by the entrance trying the read.
+ *
+ *  For `participant` it is the rules' own answer, which is why it can be null:
+ *  a participant with neither `participantRead` nor an own-row submit path
+ *  cannot read the collection at all, and a page handed it would fail rather
+ *  than render less. */
+function scopeFor(authored: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): ProjectedViewCollection | null {
+  return audience === "member" ? { cid, scope: "all" } : participantScope(authored, cid);
+}
+
+/** Project the declaration into the per-audience documents.
+ *
+ *  Pure, like `projectApp`: the HTML is not here (the host reads the files),
+ *  and neither is the clock. What is here is the answer to "what may this
+ *  audience read, and how" — computed once, so the page never has to guess and
+ *  never has to discover it from a denial. */
+export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp): AppViewTier[] {
+  const normalized = normalizeViews(authored);
+  if (!normalized.ok) throw new Error(`publish: views declaration is not publishable (${normalized.problems.join(" ")})`);
+  const audiences: Exclude<ViewAudience, "public">[] = ["member", "participant"];
+  return audiences.map((audience) => {
+    const views = normalized.views.filter((view) => view.audience === audience);
+    const cids = [...new Set(views.flatMap((view) => view.collections))];
+    const declaredSubmit = authored.public?.submit ?? {};
+    const submit = Object.fromEntries(
+      cids.flatMap((cid) => {
+        const spec = declaredSubmit[cid];
+        return spec === undefined ? [] : [[cid, projectSubmit(spec)] as const];
+      }),
+    );
+    const config: AppViewConfigDoc = {
+      views: views.map((view) => ({
+        id: view.id,
+        // A collection with no scope is dropped rather than published as
+        // unreachable: the gate has already refused the declaration, so
+        // reaching here with one is a programming error, and a page that
+        // queries it is denied.
+        collections: view.collections.map((cid) => scopeFor(authored, audience, cid)).filter((scope): scope is ProjectedViewCollection => scope !== null),
+      })),
+      submit,
+      publishedAt: stamp.publishedAt,
+    };
+    if (authored.name !== undefined) config.name = authored.name;
+    return { tier: VIEW_TIER[audience], audience, config, views };
+  });
+}
+
+/** The document a tier's projection is published at. Beside the views
+ *  themselves, under one `match` — see `firestore.rules`. */
+export const viewConfigDocId = (stage: "live" | "staged"): string => viewDocId(stage, VIEW_CONFIG_ID);

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -577,8 +577,13 @@ export interface AppViewTier {
  *  a participant with neither `participantRead` nor an own-row submit path
  *  cannot read the collection at all, and a page handed it would fail rather
  *  than render less. */
-function scopeFor(authored: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): ProjectedViewCollection | null {
-  return audience === "member" ? { cid, scope: "all" } : participantScope(authored, cid);
+function scopeFor(
+  authored: AuthoredApp,
+  audience: Exclude<ViewAudience, "public">,
+  cid: string,
+  participantRead: readonly string[],
+): ProjectedViewCollection | null {
+  return audience === "member" ? { cid, scope: "all" } : participantScope(authored, cid, participantRead);
 }
 
 /** Project the declaration into the per-audience documents.
@@ -587,7 +592,12 @@ function scopeFor(authored: AuthoredApp, audience: Exclude<ViewAudience, "public
  *  and neither is the clock. What is here is the answer to "what may this
  *  audience read, and how" — computed once, so the page never has to guess and
  *  never has to discover it from a denial. */
-export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp): AppViewTier[] {
+export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp, promoted?: { participantRead?: readonly string[] }): AppViewTier[] {
+  // What the RULES will say, not what the manifest says. Publish replaces
+  // `participantRead` with the staged schemas' own (see `projectPublish`), so
+  // at publish the caller passes that; at deploy the manifest IS what is being
+  // staged, and the default is right.
+  const participantRead = promoted?.participantRead ?? authored.participantRead ?? [];
   const normalized = normalizeViews(authored);
   if (!normalized.ok) throw new Error(`publish: views declaration is not publishable (${normalized.problems.join(" ")})`);
   const audiences: Exclude<ViewAudience, "public">[] = ["member", "participant"];
@@ -608,7 +618,9 @@ export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp): App
         // unreachable: the gate has already refused the declaration, so
         // reaching here with one is a programming error, and a page that
         // queries it is denied.
-        collections: view.collections.map((cid) => scopeFor(authored, audience, cid)).filter((scope): scope is ProjectedViewCollection => scope !== null),
+        collections: view.collections
+          .map((cid) => scopeFor(authored, audience, cid, participantRead))
+          .filter((scope): scope is ProjectedViewCollection => scope !== null),
       })),
       submit,
       publishedAt: stamp.publishedAt,

--- a/packages/core/test/collection/test_appViews.ts
+++ b/packages/core/test/collection/test_appViews.ts
@@ -1,0 +1,146 @@
+// The app's pages, per audience: what normalizes, what is refused, and what
+// each audience is handed.
+//
+// Every refusal here is paired with the neighbouring declaration that must
+// still pass — a file of refusals alone is satisfied by an implementation that
+// refuses everything, which from inside its own suite looks like safety.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeViews, participantScope, viewDocId, PUBLIC_VIEW_ID } from "../../src/collection/server/appViews";
+import { projectAppViews } from "../../src/collection/server/publishProject";
+import { AuthoredAppZ } from "../../src/collection/server/publishManifest";
+
+const OWNER = "owner@salon.jp";
+const STAMP = { publishedAt: 1_700_000_000_000, email: OWNER, uid: "u-owner" };
+
+const app = (overrides: Record<string, unknown>) => AuthoredAppZ.parse({ aid: "app_views", members: { [OWNER]: { "*": "owner" } }, ...overrides });
+
+const DESK = { id: "desk", audience: "member", path: "views/desk.html", collections: ["bookings"] };
+
+const problemsOf = (overrides: Record<string, unknown>): string[] => {
+  const result = normalizeViews(app(overrides));
+  return result.ok ? [] : result.problems;
+};
+
+function refuses(problems: string[], fragment: string): void {
+  const bullets = problems.map((problem) => `  - ${problem}`).join("\n");
+  assert.ok(
+    problems.some((problem) => problem.includes(fragment)),
+    `expected a problem mentioning ${JSON.stringify(fragment)}, got:\n${bullets || "  (none)"}`,
+  );
+}
+
+// --- normalization ----------------------------------------------------------
+
+test("the older public.view spelling normalizes into the list, under the reserved id", () => {
+  const result = normalizeViews(app({ public: { view: { path: "views/booking.html", collections: ["slots"] } } }));
+  assert.ok(result.ok);
+  assert.deepEqual(result.views, [{ id: PUBLIC_VIEW_ID, audience: "public", path: "views/booking.html", collections: ["slots"], where: "public.view" }]);
+});
+
+test("an app declaring neither spelling normalizes to nothing, not to a problem", () => {
+  const result = normalizeViews(app({}));
+  assert.ok(result.ok);
+  assert.deepEqual(result.views, []);
+});
+
+test("refuses both spellings at once rather than choosing one silently", () => {
+  refuses(problemsOf({ views: [DESK], public: { view: { path: "views/booking.html", collections: ["slots"] } } }), "declares both");
+});
+
+test("refuses an id that is not a legal document id — it IS the document id", () => {
+  // The one that matters: staging would write one path and withdrawal would
+  // tidy another, and neither says anything.
+  refuses(problemsOf({ views: [{ ...DESK, id: "desk/../evil" }] }), "It becomes the document id");
+  refuses(problemsOf({ views: [{ ...DESK, id: "live:desk" }] }), "It becomes the document id");
+  refuses(problemsOf({ views: [{ ...DESK, id: "Desk" }] }), "It becomes the document id");
+  refuses(problemsOf({ views: [{ ...DESK, id: "-desk" }] }), "It becomes the document id");
+  assert.deepEqual(problemsOf({ views: [{ ...DESK, id: "front-desk-2" }] }), []);
+});
+
+test("refuses the id the projection itself is published at", () => {
+  refuses(problemsOf({ views: [{ ...DESK, id: "config" }] }), "which is reserved");
+});
+
+test("refuses the public id on a page that is not the public one", () => {
+  refuses(problemsOf({ views: [{ ...DESK, id: "public" }] }), "belongs to the public page");
+  assert.deepEqual(problemsOf({ views: [{ ...DESK, id: "public", audience: "public" }] }), []);
+});
+
+test("refuses two views at one id — they would be one page", () => {
+  refuses(problemsOf({ views: [DESK, { ...DESK, path: "views/stock.html" }] }), "already uses");
+});
+
+test("accepts two views for one audience, which is the point of the id", () => {
+  assert.deepEqual(problemsOf({ views: [DESK, { ...DESK, id: "stock", path: "views/stock.html" }] }), []);
+});
+
+test("refuses an audience outside the closed set, at the parser", () => {
+  assert.throws(() => app({ views: [{ ...DESK, audience: "editor" }] }));
+});
+
+// --- what each audience is handed -------------------------------------------
+
+test("a participant reads a participantRead collection whole, and their own row otherwise", () => {
+  const declared = app({
+    participantRead: ["notices"],
+    public: {
+      submit: {
+        bookings: { auth: "verifiedEmail", createFields: ["email"], emailField: "email" },
+        seats: { auth: "anonymous", createFields: ["x"], idFrom: "auth.uid" },
+      },
+    },
+  });
+  assert.deepEqual(participantScope(declared, "notices"), { cid: "notices", scope: "all" });
+  assert.deepEqual(participantScope(declared, "bookings"), { cid: "bookings", scope: "own", emailField: "email" });
+  assert.deepEqual(participantScope(declared, "seats"), { cid: "seats", scope: "own", ownDocId: "auth.uid" });
+  // Neither: the rules would refuse the read, so there is nothing to hand a page.
+  assert.equal(participantScope(declared, "ledger"), null);
+});
+
+test("the projection separates the tiers, and a staff page is not in the participants' one", () => {
+  const tiers = projectAppViews(
+    app({
+      participantRead: ["notices"],
+      views: [
+        DESK,
+        { id: "mine", audience: "participant", path: "views/mine.html", collections: ["notices"] },
+        { id: "public", audience: "public", path: "views/booking.html", collections: ["slots"] },
+      ],
+    }),
+    STAMP,
+  );
+  const member = tiers.find((tier) => tier.audience === "member");
+  const participant = tiers.find((tier) => tier.audience === "participant");
+  assert.equal(member?.tier, "member");
+  assert.equal(participant?.tier, "roster");
+  assert.deepEqual(
+    member?.config.views,
+    [{ id: "desk", collections: [{ cid: "bookings", scope: "all" }] }],
+    "the front desk reads the whole collection, and only the front desk's tier knows the page exists",
+  );
+  assert.deepEqual(participant?.config.views, [{ id: "mine", collections: [{ cid: "notices", scope: "all" }] }]);
+  // The public page is neither tier's business: it keeps config/public.
+  assert.equal(
+    tiers.flatMap((tier) => tier.views).some((view) => view.audience === "public"),
+    false,
+  );
+});
+
+test("both tiers come back even when empty, so a withdrawal has something to act on", () => {
+  const tiers = projectAppViews(app({}), STAMP);
+  assert.deepEqual(
+    tiers.map((tier) => [tier.tier, tier.views.length]),
+    [
+      ["member", 0],
+      ["roster", 0],
+    ],
+  );
+});
+
+test("the document id carries the stage, and the id the author wrote", () => {
+  assert.equal(viewDocId("live", "desk"), "live:desk");
+  assert.equal(viewDocId("staged", "desk"), "staged:desk");
+});

--- a/packages/core/test/collection/test_appViews.ts
+++ b/packages/core/test/collection/test_appViews.ts
@@ -93,11 +93,44 @@ test("a participant reads a participantRead collection whole, and their own row 
       },
     },
   });
-  assert.deepEqual(participantScope(declared, "notices"), { cid: "notices", scope: "all" });
-  assert.deepEqual(participantScope(declared, "bookings"), { cid: "bookings", scope: "own", emailField: "email" });
-  assert.deepEqual(participantScope(declared, "seats"), { cid: "seats", scope: "own", ownDocId: "auth.uid" });
+  const promoted = ["notices"];
+  assert.deepEqual(participantScope(declared, "notices", promoted), { cid: "notices", scope: "all" });
+  assert.deepEqual(participantScope(declared, "bookings", promoted), { cid: "bookings", scope: "own", emailField: "email" });
+  assert.deepEqual(participantScope(declared, "seats", promoted), { cid: "seats", scope: "own", ownDocId: "auth.uid" });
   // Neither: the rules would refuse the read, so there is nothing to hand a page.
-  assert.equal(participantScope(declared, "ledger"), null);
+  assert.equal(participantScope(declared, "ledger", promoted), null);
+});
+
+test("the participant scope follows what will be PROMOTED, not what the manifest says", () => {
+  // `projectPublish` overwrites `participantRead` with the staged schemas' own,
+  // so a cid added to app.json since the last deploy is not in the rules.
+  // Reading the manifest here would publish `scope: "all"` for a collection the
+  // rules then deny — the page fails rather than showing less.
+  const declared = app({ participantRead: ["notices"] });
+  assert.equal(participantScope(declared, "notices", []), null);
+  const tiers = projectAppViews(
+    app({ participantRead: ["notices"], views: [{ id: "mine", audience: "participant", path: "views/mine.html", collections: ["notices"] }] }),
+    STAMP,
+    { participantRead: [] },
+  );
+  assert.deepEqual(tiers.find((tier) => tier.audience === "participant")?.config.views, [{ id: "mine", collections: [] }]);
+});
+
+test("more than one public page is refused: there is only one document to publish it at", () => {
+  // Nothing would error. `config/view` is a single document, so the second
+  // entry is published nowhere and which one is live depends on the order they
+  // were written in.
+  refuses(
+    problemsOf({
+      views: [
+        { ...DESK, id: "one", audience: "public" },
+        { ...DESK, id: "two", audience: "public" },
+      ],
+    }),
+    "a second audience",
+  );
+  // The member tiers have no such limit — the id IS the address there.
+  assert.deepEqual(problemsOf({ views: [DESK, { ...DESK, id: "stock" }] }), []);
 });
 
 test("the projection separates the tiers, and a staff page is not in the participants' one", () => {

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -719,24 +719,27 @@ test("a member view passes without being in public.read — it is not the public
   );
 });
 
-test("refuses a participant view naming a collection a participant cannot reach", () => {
+test("refuses a participant view naming a collection the PROMOTED rules will not let them read", () => {
   // Worse than the public case: an unscoped list on an own-row collection is
   // DENIED rather than narrowed, so the page fails rather than rendering less.
-  refuses(
-    salon((draft) => {
-      draft.views = [{ id: "mine", audience: "participant", path: "views/mine.html", collections: ["slots"] }];
-    }),
-    "which a participant cannot read",
-  );
-  // The neighbouring declaration: the same page, on a collection the roster
-  // may read whole.
-  assert.deepEqual(
-    salon((draft) => {
-      draft.participantRead = ["slots"];
-      draft.views = [{ id: "mine", audience: "participant", path: "views/mine.html", collections: ["slots"] }];
-    }),
-    [],
-  );
+  //
+  // And judged against what DEPLOY staged, not against app.json: publish
+  // overwrites `participantRead` with the staged schemas' own, so adding a cid
+  // to the manifest and publishing without redeploying produces exactly the
+  // page this refuses — offered to the participant, then refused the read.
+  const declared = app({
+    participantRead: ["slots"],
+    views: [{ id: "mine", audience: "participant", path: "views/mine.html", collections: ["slots"] }],
+  });
+  const staged = (participantRead: boolean) => [
+    { cid: "slots", doc: { publishedSchema: { title: "s", icon: "event", primaryKey: "id", fields: {} }, deployedAt: 1, deployedBy: OWNER, participantRead } },
+  ];
+
+  // The manifest alone is sound, which is why this needed the promoted gate.
+  assert.deepEqual(publishProblems(declared, [{ cid: "slots", primaryKey: "id" }], OWNER), []);
+
+  refuses(promotedRoleProblems(declared, staged(false) as never), "which a participant cannot read once this publishes");
+  assert.deepEqual(promotedRoleProblems(declared, staged(true) as never), []);
 });
 
 test("the path check binds every audience, not just the public one", () => {

--- a/packages/core/test/collection/test_publishChecks.ts
+++ b/packages/core/test/collection/test_publishChecks.ts
@@ -493,6 +493,9 @@ interface SalonDraft {
   // possibly-undefined and bury the assertion in guards.
   collections: { bookings: Record<string, unknown>; slots: Record<string, unknown> };
   public: { enabled: boolean; read: string[]; view?: { path: string; collections: string[] }; submit: { bookings: Record<string, unknown> } };
+  /** The app's pages, per audience — the generalisation of `public.view`. */
+  views?: Record<string, unknown>[];
+  participantRead?: string[];
 }
 
 const salonDraft = (): SalonDraft => ({
@@ -531,7 +534,15 @@ const SALON_CIDS = [
 const salon = (mutate: (draft: SalonDraft) => void): string[] => {
   const draft = salonDraft();
   mutate(draft);
-  return problemsFor({ collections: draft.collections, public: draft.public }, SALON_CIDS);
+  return problemsFor(
+    {
+      collections: draft.collections,
+      public: draft.public,
+      ...(draft.views === undefined ? {} : { views: draft.views }),
+      ...(draft.participantRead === undefined ? {} : { participantRead: draft.participantRead }),
+    },
+    SALON_CIDS,
+  );
 };
 
 const bookingOf = (draft: SalonDraft): Record<string, unknown> => draft.public.submit.bookings;
@@ -694,6 +705,55 @@ test("refuses a view that is not one HTML file directly under views/", () => {
       view.path = "/etc/views/passwd.html";
     }),
     "exactly one HTML file",
+  );
+});
+
+// --- the same gate, once per audience ---------------------------------------
+
+test("a member view passes without being in public.read — it is not the public page", () => {
+  assert.deepEqual(
+    salon((draft) => {
+      draft.views = [{ id: "desk", audience: "member", path: "views/desk.html", collections: ["bookings"] }];
+    }),
+    [],
+  );
+});
+
+test("refuses a participant view naming a collection a participant cannot reach", () => {
+  // Worse than the public case: an unscoped list on an own-row collection is
+  // DENIED rather than narrowed, so the page fails rather than rendering less.
+  refuses(
+    salon((draft) => {
+      draft.views = [{ id: "mine", audience: "participant", path: "views/mine.html", collections: ["slots"] }];
+    }),
+    "which a participant cannot read",
+  );
+  // The neighbouring declaration: the same page, on a collection the roster
+  // may read whole.
+  assert.deepEqual(
+    salon((draft) => {
+      draft.participantRead = ["slots"];
+      draft.views = [{ id: "mine", audience: "participant", path: "views/mine.html", collections: ["slots"] }];
+    }),
+    [],
+  );
+});
+
+test("the path check binds every audience, not just the public one", () => {
+  refuses(
+    salon((draft) => {
+      draft.views = [{ id: "desk", audience: "member", path: "views/../../secrets.html", collections: ["bookings"] }];
+    }),
+    "exactly one HTML file",
+  );
+});
+
+test("refuses a view naming a collection this repository does not publish, whoever it is for", () => {
+  refuses(
+    salon((draft) => {
+      draft.views = [{ id: "desk", audience: "member", path: "views/desk.html", collections: ["nowhere"] }];
+    }),
+    "which is not a shared collection",
   );
 });
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.13.0",
+    "@mulmoclaude/core": "^3.14.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",


### PR DESCRIPTION
mulmoterminal `plans/feat-shared-app-member-view.md` の**実装順 2**（core 側）。
ルールは mulmoserver #168 で、そちらが先に本番へ出る。

## `public.view` を `views[]` に一般化する

```json
"views": [
  { "id": "public", "audience": "public", "path": "views/booking.html", "collections": ["slots"] },
  { "id": "desk",   "audience": "member", "path": "views/desk.html",   "collections": ["bookings"] }
]
```

**理由は語彙ではなくタイミング。** 著者が書いたキーの改名は、1 つでも
publish された瞬間に移行作業になる。`public.view` を宣言したアプリはまだ
1 つも無いので、今なら 1 行の読み替えで済み、来月には済まない。

旧形は当面受け付けて、予約 id `"public"` の `audience: "public"` に正規化する。
**両方書いてある宣言は拒否**する（どちらを採ったかを黙って決めない）。

## `id` は飾りではなく置き場所

`live:{id}` / `staged:{id}` という**ドキュメント ID そのもの**になるので、
一意なだけでは足りない。`^[a-z0-9][a-z0-9-]{0,63}$` を強制し、
`config`（射影自身の置き場所）は予約する。`/` が入れば staging は 1 か所に
書き、撤去は別の場所を掃除して、どちらも何も言わない。

これがあるから **1 つの監査対象に複数のページ**（受付と在庫）を置ける。

## 監査対象ごとに射影する

`apps/{aid}` の read は `readerOf` なので、**participant は宣言を 1 行も
読めない**（名簿には他人のメールアドレスが載る、という意図的な設計）。
そして 1 枚の射影を全員が読む形にもできない — participant にスタッフ用の
`collections` を渡すと、親がその宣言でクエリを組んで**ルール拒否で落ちる**。
見えないのではなく、失敗する。

`projectAppViews` が 2 つの階層を返す:

| 階層 | ルール | 何が載るか |
|---|---|---|
| `member` | `staffOf` | ビューごとの `collections`（全件）、submit |
| `roster` | `listedIn` | 同上。ただし**読み方付き** — 全件（`participantRead`）か自分の行（`emailField` / `idFrom: "auth.uid"`）か |

絞っていない `list` は拒否されるので、**絞り方が宣言と一緒に届かないと
ページは動かない**。どちらの経路も無いコレクションを participant のビューに
渡す宣言は publish が拒否する。

**member 側に同じ検査は無い。** 誰がどのロールを持つかは宣言の性質ではなく
（`bookings` だけ editor のスタイリストとオーナーが同じ射影を読む）、
入口が実際に読んでみて決める。

**空の階層も必ず返す。** ページを撤去したアプリが空を返すと、ホストが
「中身のある階層」しか見ないままになり、前のページが公開され続ける
（`config/view` が持っていたのと同じ壊れ方）。

## テスト

`test/collection/test_appViews.ts` を追加（13 件）、`test_publishChecks.ts` に
監査対象ごとの門を 4 件。拒否のテストには必ず「通るべき隣」を対にしてある。

- `yarn typecheck` / `yarn test`（940 pass）/ `yarn lint` 通過

## この後

mulmoserver のランタイム（`/m/{slug}`）が次で、MulmoTerminal の publish は
その**後**（古いランタイムに新しい宣言を publish すると、名簿の人は
「何もありません」を見るのに、publish した本人には成功に見える）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

## Summary by Sourcery

Generalize app view declarations to a per-audience `views[]` model, validate and project them into member/roster tiers, and wire this into publish checks and projection for core 3.14.0.

New Features:
- Introduce a `views[]` declaration allowing apps to define multiple pages per audience (public, member, participant) with explicit collections.
- Add projection of app views into per-audience tiers (`member` and `roster`), including helpers for tier paths and view config document ids.

Bug Fixes:
- Ensure withdrawn or empty view tiers are still published so hosts can correctly remove previously published pages instead of leaving stale content visible.
- Prevent publishing views that point at nonexistent shared collections or unreachable participant datasets, avoiding pages that silently fail or show no data.

Enhancements:
- Normalize legacy `public.view` into the new `views[]` structure with robust id grammar and audience handling, and enforce a closed set of view audiences.
- Extend publish-time checks to validate view paths and collection reachability for all audiences, reusing the shared safe view path validator.
- Expose new view-related types and helpers from the collection server index for host/runtime integration.

Build:
- Bump @mulmoclaude/core version from 3.13.0 to 3.14.0.

Tests:
- Add dedicated tests for view normalization, participant scopes, per-tier projections, and view document id generation.
- Extend publish checks tests to cover multi-audience views, invalid paths, unreachable participant collections, and references to unpublished collections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audience-specific app views for public, member, and participant access.
  * Views can define custom paths and selected collections with audience-aware permissions.
  * Added staged and live view configurations for publishing workflows.

* **Bug Fixes**
  * Improved validation for view identifiers, paths, duplicate declarations, collection references, and access reachability.
  * Preserved compatibility with existing public view declarations while preventing conflicting configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->