### PR TITLE
chore(ci): actions のメジャー更新を Dependabot で拾えるようにする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# Dependabot version updates.
+#
+# NOTE: security updates are a separate, repository-level setting and were
+# already running without this file (see the `dependabot/npm_and_yarn/*`
+# branches). Version updates require this file — which is why no
+# `actions/*` bump had ever been proposed, and every first-party action
+# drifted a full major behind. (#2875)
+#
+# npm is deliberately NOT listed: this is a ~50-workspace monorepo, so npm
+# version updates would open an impractical number of PRs. npm CVEs keep
+# arriving through security updates, so nothing is left uncovered.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    # `github-actions` scans .github/workflows from the repository root.
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      # Match the existing npm security-update commits
+      # ("chore(deps): bump nanoid from 3.3.16 to 3.3.18").
+      prefix: "chore(deps)"
+    groups:
+      # One PR for all actions rather than one each. .github/zizmor.yml
+      # tag-pins first-party actions specifically to avoid Dependabot churn
+      # (#1423); a moving major tag (@v7) only triggers a PR when the MAJOR
+      # changes, so grouping keeps that to a single PR a few times a year.
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Codex needs full history to inspect the PR diff via `gh`.
           fetch-depth: 0
@@ -93,12 +93,12 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
 
       - name: Cache global npm tarballs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.npm
           key: codex-cli-${{ env.CODEX_VERSION }}-node22

--- a/.github/workflows/dead-code-scan.yaml
+++ b/.github/workflows/dead-code-scan.yaml
@@ -54,13 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # No git pushes from this job; don't leave the token in
           # .git/config (zizmor artipacked).
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 22.x
           # The cache key is node-cache-<os>-<arch>-yarn-<lockfile hash> — no

--- a/.github/workflows/docker_sandbox_windows.yaml
+++ b/.github/workflows/docker_sandbox_windows.yaml
@@ -46,12 +46,12 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           # No `cache: yarn` — measured on this job, it makes it slower. See

--- a/.github/workflows/duplication-scan.yaml
+++ b/.github/workflows/duplication-scan.yaml
@@ -55,7 +55,7 @@ jobs:
       # this job so the rest of the workflow keeps read-only defaults.
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # No git pushes from this job; don't leave the token in
           # .git/config (zizmor artipacked).

--- a/.github/workflows/e2e_live_no_llm.yaml
+++ b/.github/workflows/e2e_live_no_llm.yaml
@@ -59,11 +59,11 @@ jobs:
           - happy-tour               # L-HAPPY-TOUR: capability sweep (chat turn skips on E2E_LIVE_NO_LLM=1, the other 15 steps run)
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false  # no git push; zizmor artipacked
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "yarn"

--- a/.github/workflows/lint_test_windows.yaml
+++ b/.github/workflows/lint_test_windows.yaml
@@ -51,11 +51,11 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false  # no git push; zizmor artipacked
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           # Deliberately no `cache: yarn`. It does work — `[3/5] Fetching
@@ -77,7 +77,7 @@ jobs:
       # restore-keys lets a yarn.lock change land on a warm node_modules
       # tree (yarn install fills in the diff) instead of a cold cache.
       - name: Cache node_modules
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: node_modules
           key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
@@ -90,7 +90,7 @@ jobs:
       # Keyed on yarn.lock (busts on a puppeteer bump); restore-keys keeps a
       # warm browser across unrelated lockfile changes.
       - name: Cache puppeteer browsers
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -105,7 +105,7 @@ jobs:
       # version because emitted JS can differ across them.
       - name: Cache packages/dist
         id: pkg-dist-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             packages/*/dist

--- a/.github/workflows/mulmoclaude_smoke.yaml
+++ b/.github/workflows/mulmoclaude_smoke.yaml
@@ -61,12 +61,12 @@ jobs:
     # ~12 min cold. 20 min leaves headroom for transient slowness.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false  # no git push; zizmor artipacked
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24.x
           cache: yarn

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       run_e2e: ${{ steps.filter.outputs.run_e2e }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false  # no git push; zizmor artipacked
@@ -73,11 +73,11 @@ jobs:
         node-version: [22.x, 24.x]
         os: [ubuntu-latest, macos-latest]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false  # no git push; zizmor artipacked
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn
@@ -90,7 +90,7 @@ jobs:
     # restore-keys lets an unrelated lockfile change still land on a warm
     # browser (postinstall re-downloads only if the pinned revision differs).
     - name: Cache puppeteer browsers
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -105,7 +105,7 @@ jobs:
     # version because emitted JS can differ across them.
     - name: Cache packages/dist
       id: pkg-dist-cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: |
           packages/*/dist
@@ -162,10 +162,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false  # no git push; zizmor artipacked
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24.x
       - name: Enable Yarn 4 via Corepack
@@ -217,11 +217,11 @@ jobs:
       matrix:
         shard: [1, 2]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         persist-credentials: false  # no git push; zizmor artipacked
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: 22.x
         cache: 'yarn'
@@ -231,7 +231,7 @@ jobs:
     # finishes building first warms the cache for the other.
     - name: Cache packages/dist
       id: pkg-dist-cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: |
           packages/*/dist
@@ -255,7 +255,7 @@ jobs:
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Cache Playwright browsers
       id: playwright-cache
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # full history scan needs every commit
           persist-credentials: false  # read-only scan; don't persist the token

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # No git pushes from this job; don't leave the token in
           # .git/config (zizmor artipacked).

--- a/plans/chore-2875-dependabot-github-actions.md
+++ b/plans/chore-2875-dependabot-github-actions.md
@@ -1,0 +1,101 @@
+# actions のメジャー更新を Dependabot で拾う (#2875)
+
+## 背景
+
+`.github/workflows/secret-scan.yml` を別リポジトリへ移植する際、actions の pin が
+リポジトリ全体で **揃って1つ古い** ことに気づいた。個別のワークフローの問題ではない。
+
+真因は **`.github/dependabot.yml` が存在しない** こと。この状態を正確に言うと:
+
+- **security updates は動いている**。GitHub のリポジトリ設定側で有効なので
+  `dependabot.yml` が無くても走る。`dependabot/npm_and_yarn/nanoid-3.3.18` (#2840) など、
+  npm 側の脆弱性 bump は実際に PR が来ている。
+- **version updates は設定されていない**。こちらは `dependabot.yml` が必須で、
+  ファイルが無い＝どの ecosystem も対象外。`github-actions` の PR が過去に1本も無いのはこのため。
+
+actions のメジャー更新は脆弱性ではないので security updates では拾われない。
+結果、誰も手で上げなければ古いまま留まる。**バージョンを手で上げるだけでは数ヶ月後に同じ状態に戻る。**
+
+## 現状（`origin/main` c69def758 で実測）
+
+| action | 現在の pin | 最新 | 使用箇所 |
+| --- | --- | --- | --- |
+| `actions/checkout` | `@v6` | **`v7.0.1`** | 13 箇所 / 10 ファイル |
+| `actions/setup-node` | `@v6` | **`v7.0.0`** | 9 箇所 / 7 ファイル |
+| `actions/cache` | `@v5` | **`v6.1.0`** | 8 箇所 / 3 ファイル |
+| `actions/upload-artifact` | `@v7` | `v7.0.1` | 5 箇所 / 3 ファイル（最新・対応不要） |
+
+first-party 以外で使っているのは `github/codeql-action/upload-sarif` の1本のみで、
+SHA pin + バージョンコメント付き。Dependabot は SHA pin もコメントごと更新できる。
+
+## 破壊的変更の確認（リリースノートを実際に読んで確認）
+
+- **`checkout` v7.0.0**: 実質的な挙動変更は
+  [#2454](https://github.com/actions/checkout/pull/2454) の
+  「`pull_request_target` / `workflow_run` での fork PR チェックアウトを禁止」のみ。
+  **このリポジトリでは影響しない**:
+  - `pull_request_target` を使うのは `pr_triage.yaml` だけで、そこには `uses: actions/checkout`
+    が一切無い（27 行目のコメントどおり、意図的に攻撃者コードを取得しない設計）。
+  - `workflow_run` を使うワークフローは存在しない。
+
+  さらに、この破壊的変更は **v6.1.0 に backport 済み**
+  ([#2500](https://github.com/actions/checkout/pull/2500))。`@v6` は動くメジャータグなので
+  現時点で既に新挙動を引いている。つまり v7 へ上げても挙動は変わらない。
+  残りは ESM 化と依存更新。
+
+- **`setup-node` v7.0.0**: ESM 化、`cache-primary-key` / `cache-matched-key` の output 追加、
+  `NODE_AUTH_TOKEN` のダミー export 削除、ドキュメント更新。入力の API は互換。
+
+- **`cache` v6.0.0**: [#1760](https://github.com/actions/cache/pull/1760)
+  「Update packages, migrate to ESM」のみ。v6.1.0 は read-only cache access の扱いを追加。
+
+## この PR でやること
+
+1. **`.github/dependabot.yml` を追加**（これが本題）。`package-ecosystem: github-actions`,
+   `directory: "/"`, weekly。
+2. その上で pin を最新メジャーへ: `checkout` → `@v7`、`setup-node` → `@v7`、`cache` → `@v6`。
+   `upload-artifact` は既に `@v7` で最新なので触らない。
+
+1 だけでも Dependabot が翌週 PR を出すが、2 を同じ PR でやっておくと
+「Dependabot を入れた直後に3本の PR が飛んでくる」のを避けられ、初回の状態が静かになる。
+
+## dependabot.yml の設計
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns: ["*"]
+```
+
+- **`groups` で1 PR にまとめる**: `.github/zizmor.yml` は「SHA pin は Dependabot の churn を
+  招くので first-party actions はタグ pin にする」と明記している (#1423)。その方針と整合させる。
+  タグ pin (`@v7`) なので Dependabot が PR を出すのは **メジャーが変わったときだけ**
+  （`v7` は v7.x を自分で追従する）。年に数回で、まとめれば1本になる。
+- **`commit-message.prefix: chore(deps)`**: 既存の npm security update の
+  `chore(deps): bump nanoid from 3.3.16 to 3.3.18` と揃える。
+- **`directory: "/"`**: `github-actions` ecosystem はリポジトリルート指定で
+  `.github/workflows` 配下を走査する。
+
+### npm の version updates は入れない（意図的な非対象）
+
+このリポジトリは workspace が約 50 ある monorepo なので、npm の version updates を有効にすると
+PR の量が現実的でない。#2875 が求めているのも actions 側。npm の脆弱性は今も
+security updates が拾っているので、穴は空かない。必要になったら別途判断する。
+
+## 検証
+
+- `actionlint` + `zizmor`（`workflow-lint.yaml` が `.github/**` の変更で走る）で
+  ワークフロー側の構文と security を確認。
+- `dependabot.yml` 自体は上記2つの対象外なので、YAML として妥当なこと + GitHub 公式スキーマの
+  必須キー（`version: 2`, `updates[].package-ecosystem`, `.directory`, `.schedule.interval`）を確認。
+  マージ後は Dependabot の「Last checked」がリポジトリ設定画面に出るので、そこで実地確認する。
+- pin 更新は CI 全体（`pull_request.yaml` / `lint_test_windows.yaml` / smoke / e2e）が
+  そのまま新しい action で走ることが ground truth。


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` を追加し、GitHub Actions の **version updates** を有効化する。あわせて現時点で1つ古いままだった first-party actions の pin を最新メジャーへ上げる。

真因は「個別のワークフローが古い」ことではなく、**version updates が一度も設定されていなかった**こと。正確には:

- **security updates は動いていた**。リポジトリ設定側の機能なので `dependabot.yml` が無くても走る。実際 `dependabot/npm_and_yarn/nanoid-3.3.18` (#2840) など npm の脆弱性 bump は届いていた。
- **version updates は未設定**。こちらは `dependabot.yml` が必須で、ファイルが無い＝どの ecosystem も対象外。`github-actions` の PR が過去に1本も無いのはこのため。

actions のメジャー更新は脆弱性ではないので security updates では拾われない。だから誰も手で上げなければ古いまま留まる — **pin を手で上げるだけでは数ヶ月後に同じ状態に戻る。**

| action | before | after | 箇所 |
| --- | --- | --- | --- |
| `actions/checkout` | `@v6` | `@v7` | 13 |
| `actions/setup-node` | `@v6` | `@v7` | 9 |
| `actions/cache` | `@v5` | `@v6` | 8 |
| `actions/upload-artifact` | `@v7` | （据え置き） | 5 — 既に最新 |

## Items to Confirm / Review

1. **`checkout` v7 の破壊的変更がこのリポジトリに影響しない、という判断**（下記「破壊的変更の確認」）。ここが唯一の実質的リスクなので、独立に確認してほしい。
2. **`groups` で全 actions を1 PR にまとめた設計判断**。`.github/zizmor.yml` は「SHA pin は Dependabot の churn を招くので first-party はタグ pin」と明記している (#1423)。タグ pin なので PR はメジャー変更時のみ＝年に数回、それをさらに1本にまとめる方針で意図に沿っていると判断したが、逆に「まとめず個別に来たほうが切り分けやすい」という好みもあり得る。
3. **npm の version updates を入れなかった判断**。workspace 約50 の monorepo で有効化すると PR 量が現実的でない。npm の脆弱性は今も security updates が拾うので穴は空かない。この判断でよいか。
4. **`cache` v5→v6 を含めた点**。issue では「v5.1.0 はまだメンテされている」ため任意扱いだった。全部最新に揃えると Dependabot の初回 PR が静かになるので含めたが、据え置きたい場合は言ってほしい。

## 破壊的変更の確認（リリースノートを読んで確認）

- **`checkout` v7.0.0**: 実質的な挙動変更は [actions/checkout#2454](https://github.com/actions/checkout/pull/2454) の「`pull_request_target` / `workflow_run` での fork PR チェックアウトを禁止」のみ。**このリポジトリには影響しない**:
  - `pull_request_target` を使うのは `pr_triage.yaml` だけで、そこには `uses: actions/checkout` が一切無い（同ファイル 27 行目のコメントどおり、意図的に攻撃者コードを取得しない設計）。
  - `workflow_run` を使うワークフローは存在しない。

  さらにこの変更は **v6.1.0 に backport 済み** ([#2500](https://github.com/actions/checkout/pull/2500))。`@v6` は動くメジャータグなので **現時点で既に新挙動を引いている** — つまり v7 へ上げても挙動は変わらない。残りは ESM 化と依存更新。
- **`setup-node` v7.0.0**: ESM 化、`cache-primary-key` / `cache-matched-key` の output 追加、ダミー `NODE_AUTH_TOKEN` export の削除、ドキュメント更新。入力の API は互換。
- **`cache` v6.0.0**: [#1760](https://github.com/actions/cache/pull/1760)「Update packages, migrate to ESM」のみ。v6.1.0 で read-only cache access の扱いが入った。

## 検証（実際に走らせた結果）

- **`actionlint` 1.7.12**（`workflow-lint.yaml` が pin しているのと同一バージョン、ローカルの Homebrew 版）→ exit 0、指摘なし。
- **`zizmor` 1.25.2**（同じく CI pin と同一バージョンを `uvx` で取得）→ `--persona=regular` で `No findings to report. Good job! (1 ignored, 31 suppressed)`。
- **`dependabot.yml` の妥当性**: 公式スキーマ (`json.schemastore.org/dependabot-2.0.json`) に対して `check-jsonschema` で検証 → `ok -- validation done`。`dependabot.yml` は actionlint / zizmor の対象外なので、別途この検証をかけた。
- **タグの実在確認**: `git ls-remote --tags` で `actions/checkout@v7` / `actions/setup-node@v7` / `actions/cache@v6` の移動メジャータグが実在することを確認。
- CI 本体（`pull_request.yaml` / `lint_test_windows.yaml` / smoke / e2e）が新しい action でそのまま緑になることが最終的な ground truth。この PR の CI で確認する。

**ローカルで確認できていないこと**: Dependabot が実際に PR を出すところまではマージ後にしか確認できない（設定はマージ先のデフォルトブランチから読まれるため）。マージ後、リポジトリ設定の Dependabot の "Last checked" で実地確認する。

## 実装方針

1. `.github/dependabot.yml` を追加（本題）。`package-ecosystem: github-actions`, `directory: "/"`, `interval: weekly`, `commit-message.prefix: "chore(deps)"`（既存の npm security update の `chore(deps): bump nanoid from 3.3.16 to 3.3.18` と揃える）、`groups` で全 actions を1 PR に。
2. その上で pin を最新メジャーへ更新。

1 だけでも Dependabot が翌週に PR を出すが、2 を同じ PR でやっておくと「入れた直後に3本飛んでくる」のを避けられ、初回の状態が静かになる。

プラン: `plans/chore-2875-dependabot-github-actions.md`

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2875 あげて

refs #2875

work in mulmoclaude2

## Summary by Sourcery

Enable automated version updates for GitHub Actions and align pinned actions with their latest major versions.

New Features:
- Add Dependabot configuration to manage weekly version updates for GitHub Actions with grouped PRs.

Enhancements:
- Update all first-party GitHub Actions pins from v6/v5 to the latest v7/v6 majors across CI workflows.
- Document the background, design, and validation plan for introducing Dependabot-managed GitHub Actions updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, test, scanning, and sandbox workflows to use current action versions.
  * Added weekly automated checks for GitHub Actions updates, with related updates grouped together.
  * Continued excluding npm package updates from this automation.

* **Documentation**
  * Added guidance covering action version maintenance, compatibility considerations, and workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->