### PR TITLE
fix: keep runtime files under config/ out of format and lint (#2873)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,14 @@ test-results-live/
 /.mulmoclaude/
 /.session-token
 /.server-port
+# `config/` can't join the list above wholesale — it is the one workspace dir
+# that also holds committed build config. Ignore its contents and re-admit
+# those two files, so scheduler state / roles / dashboard and friends stay
+# uncommittable. Prettier reads .gitignore, so this also keeps `yarn format`
+# off files the running app rewrites (#2873).
+/config/*
+!/config/eslint.packages.mjs
+!/config/tsconfig.packages.json
 
 # V8 heap snapshots written by the dev server on near-OOM (scripts/dev-server.mjs)
 *.heapsnapshot

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ test-results-live/
 # those two files, so scheduler state / roles / dashboard and friends stay
 # uncommittable. Prettier reads .gitignore, so this also keeps `yarn format`
 # off files the running app rewrites (#2873).
+#
+# Committing a NEW file here takes a negation in two places: below, and in
+# `eslint.config.mjs`'s ignores. `git add` refuses an ignored path outright,
+# so the first half announces itself; the eslint half does not.
 /config/*
 !/config/eslint.packages.mjs
 !/config/tsconfig.packages.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,15 @@ export default [
   },
   {
     ignores: [
+      // Runtime workspace files the app rewrites while it runs (scheduler
+      // state, roles, dashboard, …) when the workspace IS the checkout.
+      // `.gitignore` covers prettier, which reads it; eslint does not, and
+      // the `prettier/prettier` rule below applies to every file — JSON
+      // included — so the same paths need re-stating here (#2873). The two
+      // committed build configs are re-admitted so they stay linted.
+      "config/*",
+      "!config/eslint.packages.mjs",
+      "!config/tsconfig.packages.json",
       "lib",
       "src/plugins/spreadsheet/engine",
       "packages/*/dist",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,7 +44,9 @@ export default [
       // `.gitignore` covers prettier, which reads it; eslint does not, and
       // the `prettier/prettier` rule below applies to every file — JSON
       // included — so the same paths need re-stating here (#2873). The two
-      // committed build configs are re-admitted so they stay linted.
+      // committed build configs are re-admitted so they stay linted. A new
+      // committed file under `config/` needs a negation in both places —
+      // `git add` refuses the ignored path, but nothing flags the miss here.
       "config/*",
       "!config/eslint.packages.mjs",
       "!config/tsconfig.packages.json",

--- a/plans/fix-2873-ignore-runtime-config-files.md
+++ b/plans/fix-2873-ignore-runtime-config-files.md
@@ -1,0 +1,76 @@
+# fix #2873 — runtime files under `config/` break `yarn format` and `yarn lint`
+
+## Symptom
+
+After the scheduler runs, a commit-time check fails on a tree nobody edited:
+
+```
+[warn] config/scheduler/state.json
+[warn] Code style issues fixed in the above file.
+```
+
+## Root cause
+
+`config/` is a workspace directory (`WORKSPACE_DIRS.configs`, eager-created at boot)
+*and* the home of two committed build configs. In the layout where the workspace IS
+the checkout, the running app writes into the same `config/` the repo tracks.
+
+The failure is deterministic, not content-dependent: the writers use
+`JSON.stringify(obj, null, 2)`, which emits no trailing newline, and Prettier
+requires one for JSON. So the file is reformatted on *every* run even when the
+content is unchanged.
+
+`.gitignore` (#2632) lists the other runtime roots — `/data/`, `/artifacts/`,
+`/conversations/` … — but omits `/config/` precisely because of those two
+committed files. So `config/` was the one gap.
+
+## Scope is wider than the issue reports
+
+Reproduced in-tree with the real toolchain, runtime files present:
+
+| tool | exit | finding |
+|---|---|---|
+| `prettier --check 'config/**/*.json'` | 1 | 5 files |
+| `eslint config` | 1 | ✖ 5 problems (5 errors) |
+
+- **Not one file.** `config/scheduler/{state,tasks}.json`, `config/roles/*.json`,
+  `config/dashboard.json`, `config/news-read-state.json` — plus, in a live
+  workspace, `settings.json`, `mcp.json`, `interests.json`,
+  `reference-dirs.json`, `workspace-dirs.json`, `shortcuts.json`, `plugins/`,
+  `helps/`, `marp-themes/`.
+- **`yarn lint` breaks too**, which the issue does not mention. The config object
+  at `eslint.config.mjs:142` declares no `files`, so it applies to every file and
+  its `prettier/prettier` rule reaches JSON.
+
+`dashboard-io.ts` and `shortcuts-io.ts` already append `\n` by hand — evidence
+this was being patched one file at a time.
+
+## Fix
+
+Two edits; both are needed because **Prettier reads `.gitignore` and ESLint does not**.
+
+1. `.gitignore` — ignore `config/`'s contents, re-admit the two committed files.
+   Fixes Prettier *and* the `git status` noise, which is the more dangerous half
+   (untracked runtime files are one `git add` away from being committed).
+2. `eslint.config.mjs` `ignores` — the same three lines, for the lint half.
+
+Rejected: the issue's `.prettierignore` + `config/scheduler/` suggestion — it
+leaves the other `config/*.json` files and does not fix `yarn lint`.
+
+Rejected: moving the two build configs out of `config/` and ignoring `/config/`
+wholesale. Structurally cleaner, but rewrites `extends` / `import` paths in ~40
+`packages/*/tsconfig.json` and `eslint.config.mjs` files — disproportionate here.
+
+## Verification
+
+Runtime files recreated before each run (they are rewritten by any formatter that
+touches them, so a stale tree reads as a false pass):
+
+| state | prettier | eslint |
+|---|---|---|
+| before | exit 1, 5 files | exit 1, 5 errors |
+| `.gitignore` only | exit 0 | exit 1, 5 errors ← proves the second edit is load-bearing |
+| both edits | exit 0 | exit 0 |
+
+`config/tsconfig.packages.json` stays genuinely linted under the negation — it
+reports no `ignored` warning, so it is not silently skipped.

--- a/plans/fix-2873-ignore-runtime-config-files.md
+++ b/plans/fix-2873-ignore-runtime-config-files.md
@@ -4,7 +4,7 @@
 
 After the scheduler runs, a commit-time check fails on a tree nobody edited:
 
-```
+```text
 [warn] config/scheduler/state.json
 [warn] Code style issues fixed in the above file.
 ```


### PR DESCRIPTION
## Summary

`config/` is the one workspace directory that also holds committed build config, so it was left out of the `.gitignore` block added in #2632. Where the workspace IS the checkout, the running app writes scheduler state, roles, dashboard and friends straight into the tracked tree — and every one of them is a `yarn format` / `yarn lint` target.

This ignores `config/`'s contents and re-admits the two committed build configs. Prettier reads `.gitignore`, so one entry covers both formatting and `git status` noise; ESLint does not read it, so the same three lines are re-stated in `eslint.config.mjs`.

**The reported scope was too narrow on two counts**, both verified by running the real toolchain against runtime files:

| | exit | finding |
|---|---|---|
| `prettier --check 'config/**/*.json'` | 1 | **5 files**, not 1 |
| `eslint config` | 1 | ✖ 5 problems — **`yarn lint` breaks too**, unreported |

The failure is deterministic rather than content-dependent: the writers use `JSON.stringify(obj, null, 2)`, which emits no trailing newline, and Prettier requires one for JSON. The file is reformatted on every run even when nothing changed. `dashboard-io.ts` and `shortcuts-io.ts` already append `\n` by hand — this was being patched one file at a time.

## Items to Confirm / Review

1. **The negation is the load-bearing part.** `/config/*` ignores everything, then `!config/eslint.packages.mjs` and `!config/tsconfig.packages.json` re-admit the only two committed files. I confirmed `config/tsconfig.packages.json` is still *genuinely* linted (no `ignored` warning, so it is not silently skipped) — but this is the piece to re-check if a third file is ever committed under `config/`, since it would be ignored by default.
2. **Why two files and not just `.prettierignore`.** Measured: with only the `.gitignore` entry, prettier goes to exit 0 but eslint still reports 5 errors. Both edits are needed. The issue's suggestion (`.prettierignore` + `config/scheduler/`) fixes neither the other `config/*.json` files nor lint.
3. **ESLint blast radius.** I diffed full `yarn lint` output with and without the change; the only files that stop being linted are the 5 runtime `config/` ones. Nothing else in the repo moves.
4. **Not run: `yarn build` / `yarn typecheck`.** Work was done in a git worktree sharing the main checkout's `node_modules`, so workspace packages resolve to the other tree and typecheck results would be misleading (this also explains a pre-existing `no-unsafe-argument` error in `server/events/collection-change.ts`, which I verified is identical with and without my change). A `.gitignore` + eslint-`ignores` + markdown change cannot affect `tsc`/`vite`; CI is the ground truth here.
5. **Deliberately not done:** moving the two build configs out of `config/` so `/config/` could be ignored wholesale, like `/data/` and `/artifacts/`. Structurally cleaner, but it rewrites `extends` / `import` paths across ~40 `packages/*/tsconfig.json` and `eslint.config.mjs` files. Happy to do it as a follow-up if preferred.

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2873 対策できる？

Follow-up, after being shown that the scope was wider than the issue reported (5 files, and `yarn lint` breaking too), the user chose the minimal fix — `.gitignore` plus `eslint.config.mjs` ignores — taken through to a PR.

## Verification

Runtime files were recreated before each measurement — any formatter that touches them rewrites them, so a stale tree reads as a false pass:

| state | prettier | eslint |
|---|---|---|
| before | exit 1, 5 files | exit 1, 5 errors |
| `.gitignore` only | exit 0 | exit 1, 5 errors |
| both edits | **exit 0** | **exit 0** |

`yarn format` exits 0 and leaves no tracked file modified. `git status` shows no runtime noise with the app's files present.

Plan: `plans/fix-2873-ignore-runtime-config-files.md`

Closes #2873

work in mulmoclaude4

## Summary by Sourcery

Ignore runtime-generated files under config/ from linting and formatting while keeping the committed build configs checked in and linted.

Enhancements:
- Update ESLint configuration to ignore runtime files under config/ and explicitly re-include the two committed build config files.
- Add a plan document describing the issue with runtime config files breaking format/lint and the chosen mitigation.

Build:
- Extend .gitignore to exclude runtime files under config/ while re-admitting the two tracked build config files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime-generated configuration files from triggering formatting and linting failures.
  * Continued validation for the intended package configuration files.

* **Documentation**
  * Added documentation describing the configuration-file handling updates and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->