### PR TITLE
fix(ci): align the three packages/dist cache keys on root package.json (#2888)

### DIFF
--- a/.github/workflows/lint_test_windows.yaml
+++ b/.github/workflows/lint_test_windows.yaml
@@ -112,7 +112,7 @@ jobs:
             packages/bridges/*/dist
             packages/plugins/*/dist
             packages/services/*/dist
-          key: pkg-dist-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'packages/bridges/*/src/**', 'packages/bridges/*/tsconfig.json', 'packages/bridges/*/package.json', 'packages/plugins/*/src/**', 'packages/plugins/*/tsconfig.json', 'packages/plugins/*/package.json', 'packages/services/*/src/**', 'packages/services/*/tsconfig.json', 'packages/services/*/package.json', 'build-config/tsconfig.packages.json', 'yarn.lock') }}
+          key: pkg-dist-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'packages/bridges/*/src/**', 'packages/bridges/*/tsconfig.json', 'packages/bridges/*/package.json', 'packages/plugins/*/src/**', 'packages/plugins/*/tsconfig.json', 'packages/plugins/*/package.json', 'packages/services/*/src/**', 'packages/services/*/tsconfig.json', 'packages/services/*/package.json', 'build-config/tsconfig.packages.json', 'yarn.lock', 'package.json') }}
       - name: Build internal packages (required before typecheck)
         if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
         run: yarn build:packages

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -238,7 +238,7 @@ jobs:
           packages/bridges/*/dist
           packages/plugins/*/dist
           packages/services/*/dist
-        key: pkg-dist-${{ runner.os }}-22.x-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'packages/bridges/*/src/**', 'packages/bridges/*/tsconfig.json', 'packages/bridges/*/package.json', 'packages/plugins/*/src/**', 'packages/plugins/*/tsconfig.json', 'packages/plugins/*/package.json', 'packages/services/*/src/**', 'packages/services/*/tsconfig.json', 'packages/services/*/package.json', 'build-config/tsconfig.packages.json', 'yarn.lock') }}
+        key: pkg-dist-${{ runner.os }}-22.x-${{ hashFiles('packages/*/src/**', 'packages/*/tsconfig.json', 'packages/*/package.json', 'packages/bridges/*/src/**', 'packages/bridges/*/tsconfig.json', 'packages/bridges/*/package.json', 'packages/plugins/*/src/**', 'packages/plugins/*/tsconfig.json', 'packages/plugins/*/package.json', 'packages/services/*/src/**', 'packages/services/*/tsconfig.json', 'packages/services/*/package.json', 'build-config/tsconfig.packages.json', 'yarn.lock', 'package.json') }}
     - name: Build internal packages
       if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
       run: yarn build:packages

--- a/plans/fix-2888-pkg-dist-cache-key.md
+++ b/plans/fix-2888-pkg-dist-cache-key.md
@@ -1,0 +1,78 @@
+# fix #2888 — align the three `packages/dist` cache keys
+
+## What was wrong
+
+Three `actions/cache` steps cache `packages/*/dist`. Only one hashed the root
+`package.json`:
+
+| file:line | job | `package.json` |
+|---|---|---|
+| `pull_request.yaml:115` | `lint_test` | ✅ |
+| `pull_request.yaml:241` | `e2e` | ❌ |
+| `lint_test_windows.yaml:115` | `lint_test` (Windows) | ❌ |
+
+## Not a new theory — a known bug left half-fixed
+
+`3208224c5` (2026-07-14) already diagnosed and fixed this, and its message records
+the observed failure:
+
+> the cache key hashed `packages/*/src` + per-package manifests but NOT the root
+> `package.json`, where `build:packages` (the explicit workspace build list) lives.
+> So adding a package to that list didn't bust the cache: a prior failed run had
+> saved a dist snapshot WITHOUT the new package under the same key, and the next
+> run restored it, skipped `build:packages`, and failed typecheck with **TS2307**.
+
+That commit changed **1 file, 1 line**. The e2e key in the same file and the whole
+Windows workflow were never updated.
+
+## Why it is still reachable
+
+The `pkg-dist` caches have **no `restore-keys`** — the `restore-keys` nearby belong
+to the puppeteer cache. So restore happens only on an exact key match. When root
+`package.json` changes alone:
+
+- `lint_test` — key changes, rebuilds (correct)
+- `e2e` / Windows — key does **not** change, restores the pre-change dist on an
+  exact match, and `if: cache-hit != 'true'` then skips `yarn build:packages`
+
+That is the same path `3208224c5` fixed. Both jobs run on every PR, so nothing
+gates it.
+
+## Second consequence: a documented guarantee that silently stopped holding
+
+The e2e step carries this comment, added in `08f2ebb5b` (2026-04-27) when the two
+keys were identical:
+
+```yaml
+# Same packages/dist cache as lint_test — shares the cache key
+# across both jobs on ubuntu-latest + node 22.x, so whichever
+# finishes building first warms the cache for the other.
+```
+
+Adding one file to the `lint_test` hash inputs in 2026-07-14 made the two hashes
+permanently different, so the keys can never match and the sharing has not worked
+since. `yarn build:packages` has been running twice per PR on ubuntu 22.x.
+
+So this is a **regression with a date**, not a long-standing gap.
+
+## Fix
+
+Append `'package.json'` to the two remaining `hashFiles(...)` lists so all three
+share one input list. Fixing only the one CodeRabbit flagged would leave Windows
+inconsistent with the job it is named after.
+
+## Verification
+
+- All three `pkg-dist` `hashFiles(...)` input lists are now **byte-identical**
+  (`sort -u` over them → 1 distinct list; the only other `hashFiles` in these files
+  is the unrelated `hashFiles('yarn.lock')` puppeteer cache)
+- With `matrix.node-version` resolved to `22.x`, the two `pull_request.yaml` key
+  expressions collapse to **1 distinct string** — the condition the e2e comment
+  promises, and the thing that was broken
+- Both workflows parse (`YAML.parse`), and the parsed `Cache packages/dist` step of
+  each job reports `package.json in key: true`
+- Diff is exactly 2 changed lines, both `key:` lines
+
+Cache-key behaviour cannot be proven from a PR run (the effect appears on the *next*
+run after a root `package.json` change), so the checks above are structural; CI's
+`workflow-lint (actionlint + zizmor)` gates syntax.


### PR DESCRIPTION
## Summary

Three `actions/cache` steps cache `packages/*/dist`, but only one hashed the root `package.json`:

| file:line | job | before | after |
|---|---|---|---|
| `pull_request.yaml:115` | `lint_test` | ✅ | ✅ |
| `pull_request.yaml:241` | `e2e` | ❌ | ✅ |
| `lint_test_windows.yaml:115` | `lint_test` (Windows) | ❌ | ✅ |

**This is not a new theory — it is a known bug left half-fixed.** `3208224c5` (2026-07-14) already diagnosed it, and its commit message records the observed failure:

> the cache key hashed `packages/*/src` + per-package manifests but NOT the root `package.json`, where `build:packages` (the explicit workspace build list) lives. So adding a package to that list didn't bust the cache: a prior failed run had saved a dist snapshot WITHOUT the new package under the same key, and the next run restored it, skipped `build:packages`, and failed typecheck with **TS2307**.

That commit changed **1 file, 1 line**. The e2e key in the same file and the entire Windows workflow kept the old input list.

**Still reachable**, because the `pkg-dist` caches have **no `restore-keys`** (the ones nearby belong to the puppeteer cache), so restore happens only on an exact key match. When root `package.json` changes alone, `e2e` and Windows compute an unchanged key, restore the pre-change dist, and `if: cache-hit != 'true'` skips `yarn build:packages` — the same path `3208224c5` fixed. Both jobs run on every PR.

**It also broke a documented guarantee.** The e2e step says:

```yaml
# Same packages/dist cache as lint_test — shares the cache key
# across both jobs on ubuntu-latest + node 22.x, so whichever
# finishes building first warms the cache for the other.
```

That held when `08f2ebb5b` (2026-04-27) wrote it. Since `3208224c5` the two hashes have differed, so the keys can never match and `yarn build:packages` has been running **twice per PR** on ubuntu 22.x. A regression with a date, not a long-standing gap.

## Items to Confirm / Review

1. **Fixing all three, not just the one flagged.** CodeRabbit raised only the e2e key on #2884. Applying that alone would leave `lint_test_windows` inconsistent with the job it is named after, and would leave half of the `3208224c5` failure mode live.
2. **First run after merge will be a cache miss** on `e2e` and Windows — the key changes by design. That is the fix working, not a regression. Subsequent runs share on ubuntu 22.x.
3. **Cache behaviour cannot be proven by this PR's own CI.** The effect shows up on the *next* run after a root `package.json` change, so my verification is structural (below) plus actionlint in CI. Flagging that explicitly rather than implying the green check proves the caching works.

## Verification

- All three `pkg-dist` `hashFiles(...)` input lists are now **byte-identical** — `sort -u` over them yields **1** distinct list. The only other `hashFiles` in these files is the unrelated `hashFiles('yarn.lock')` puppeteer cache.
- With `matrix.node-version` resolved to `22.x`, the two `pull_request.yaml` key expressions collapse to **1 distinct string** — precisely the condition the e2e comment promises, and the thing that was broken.
- Both workflows parse via `YAML.parse`, and walking the parsed structure, every job's `Cache packages/dist` step reports `package.json in key: true`.
- Diff is exactly **2 changed lines**, both `key:` lines.

## User Prompt

> すぐ解消しよう

Following #2884, where CodeRabbit flagged the e2e cache key and I deferred it as pre-existing and out of scope for that path refactor, filing #2888 instead.

Plan: `plans/fix-2888-pkg-dist-cache-key.md`

Closes #2888

work in mulmoclaude4

## Summary by Sourcery

Align CI cache keys for packages/dist across workflows to ensure root package.json changes invalidate caches consistently and restore cross-job cache sharing.

CI:
- Update e2e workflow packages/dist cache key to include root package.json in hashFiles inputs.
- Update Windows lint_test workflow packages/dist cache key to include root package.json in hashFiles inputs so it matches the linux job.

Documentation:
- Add a plan document detailing the pkg-dist cache key bug, its impact, and the rationale for aligning all three cache keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package-distribution cache invalidation when the root package configuration changes.
  * Prevented stale cache restores from causing package builds to be skipped in end-to-end and Windows workflows.

* **Documentation**
  * Added documentation describing the cache issue, its impact, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->