### PR TITLE
feat(collections): 監査対象ごとに「何を変えられるか」を射影する

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### The projection says what each audience may CHANGE, and who may change it (#2891)
+
+`{tier}/config` gains `write[]`: per collection, the status field a transition
+moves, the transitions THIS audience may make, the assignee field, and the mail
+one queues. Nothing here grants anything — `firestore.rules` already allows
+every one of these writes — it tells a page which buttons exist and lets a
+refusal name itself instead of arriving as a permission error that names
+nothing.
+
+The transition tables differ per tier and that is the point. Staff move along
+`collections[cid].transitions`; the person who booked moves along
+`public.submit[cid].selfTransitions`. Publishing one table to both draws an
+approve button on a customer's page that the rules refuse when pressed.
+
+`writers` (owner / editor) and `rowWriters` (assignee) travel with it, into the
+`member` tier only. One `member/config` is read by everybody `staffOf` admits,
+and holding a role somewhere is not the same as being able to change a given
+collection — a `viewer` reads the same entry as the front desk. It cannot be
+answered per principal (one document, many readers) and the reader cannot look
+their own role up: `apps/{aid}` is `readerOf(a, '*')`, which a per-collection
+role does not satisfy. So the roster's answer travels with the declaration and
+the page compares its own address to it. The assignment CANDIDATES are the two
+lists together, derived rather than published a third time.
+
+At publish the write tables follow the PROMOTED collection config, beside
+`participantRead` and for the same reason: a manifest edited since the last
+deploy would otherwise advertise transitions the live rules deny.
+
+Design: mulmoterminal `plans/feat-shared-app-member-write.md`. The runtime is
+mulmoserver#171 and #172; both go out before a host publishes any of this.
+
 #### A shared app can declare a page per audience, not only a public one (#2877)
 
 `public.view` named ONE page, for anonymous visitors. `views[]` names as many as
@@ -51,7 +82,7 @@ writes any of this.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@3.14.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@3.15.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ### Fixed
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/core/src/collection/server/appViews.ts
+++ b/packages/core/src/collection/server/appViews.ts
@@ -271,8 +271,17 @@ export interface ProjectedViewWrite {
   transitions?: Record<string, string[]>;
   /** The field naming the member a row belongs to. `member` tier only. */
   assigneeField?: string;
-  /** Who may be named in it. `member` tier only — see below. */
-  assignees?: string[];
+  /** Who may write EVERY row here — the `owner` / `editor` holders. `member`
+   *  tier only, and it is what makes the tier's one shared document honest:
+   *  see {@link writersOf}. */
+  writers?: string[];
+  /** Who may write only the rows ASSIGNED to them — the `assignee` holders.
+   *  Present with `assigneeField`, since without one the role grants nothing.
+   *
+   *  The assignment CANDIDATES are these two lists together, and are left to
+   *  be derived rather than published a third time: a separate list would be
+   *  one more thing that can disagree with the two the rules actually read. */
+  rowWriters?: string[];
   /** `member` tier only: the rules let only a writer (or the row's own
    *  assignee) queue mail, so a participant handed this could only be refused. */
   mail?: AuthoredMail;
@@ -286,30 +295,41 @@ function roleOn(app: AuthoredApp, address: string, cid: string): string | undefi
   return held[cid] ?? held["*"];
 }
 
-/** Roles that may be named in an `assigneeField`.
- *
- *  `viewer` and `participant` are not here: assigning to them writes a row
- *  nobody can then touch, because the assignee branch of the rules requires
- *  the holder to BE the assignee. */
-const ASSIGNABLE_ROLES = ["owner", "editor", "assignee"];
-
-/** The addresses that may be assigned this collection's rows.
- *
- *  Published into the `member` tier and NOWHERE else, and that is a decision
- *  rather than an omission: the person doing the reassigning cannot read the
- *  roster (`apps/{aid}` is `readerOf(a, '*')`, and a stylist scoped to
- *  `bookings` holds no `*` role), so without this they have nothing to choose
- *  from — and a free-text address that is not on the roster produces a row
- *  NOBODY can write afterwards. So staff addresses are visible to staff, which
- *  is already true of the approval mail they send each other. Participants
- *  read the `roster` tier and never see this.
+/** The addresses holding one of `roles` on `cid`.
  *
  *  Sorted, for the same reason `memberEmails` is: a second publish of an
  *  unchanged declaration must produce an unchanged document. */
-function assignableTo(app: AuthoredApp, cid: string): string[] {
+function holdersOf(app: AuthoredApp, cid: string, roles: readonly string[]): string[] {
   return Object.keys(app.members)
-    .filter((address) => ASSIGNABLE_ROLES.includes(roleOn(app, address, cid) ?? ""))
+    .filter((address) => roles.includes(roleOn(app, address, cid) ?? ""))
     .sort();
+}
+
+/** Who may write every row of `cid`, and who may write only their own.
+ *
+ *  WHY ADDRESSES ARE PUBLISHED AT ALL. One `member/config` document is read by
+ *  everyone the tier admits, and the tier only establishes that somebody holds
+ *  SOME role SOMEWHERE — so a `viewer`, or a stylist scoped to another
+ *  collection, reads the same entry as the front desk. Without these lists the
+ *  page would draw approve and reassign for all of them and the rules would
+ *  refuse when pressed, which is the declaration/enforcement mismatch this
+ *  whole mechanism exists to prevent.
+ *
+ *  It cannot be answered per principal instead: the document is written once
+ *  at publish and read by many, and the reader cannot look their own role up —
+ *  `apps/{aid}` is `readerOf(a, '*')`, and a stylist carrying only
+ *  `{bookings: "editor"}` holds no `*` role. So the ROSTER'S ANSWER travels
+ *  with the declaration and the page compares its own address to it.
+ *
+ *  The cost is that staff addresses are visible to staff. That is already true
+ *  of the approval mail they send each other, and participants read the
+ *  `roster` tier, which never carries these.
+ *
+ *  A SNAPSHOT, like everything else published: a member added since the last
+ *  publish is absent until the next one. The rules are the authority either
+ *  way — this only decides which buttons are drawn. */
+function writersOf(app: AuthoredApp, cid: string): string[] {
+  return holdersOf(app, cid, ["owner", "editor"]);
 }
 
 /** The transition half: which table applies, and the field it moves.
@@ -327,19 +347,29 @@ function transitionPart(app: AuthoredApp, audience: Exclude<ViewAudience, "publi
   return part;
 }
 
-/** The assignment half. `member` only — see {@link assignableTo}. */
+/** The assignment half. `member` only — see {@link writersOf}.
+ *
+ *  `rowWriters` rides here rather than beside `writers`, because the
+ *  `assignee` role grants nothing at all without a field to compare against
+ *  (`isAssigned` in the rules requires one, and publish refuses the pair). */
 function assignPart(app: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): Partial<ProjectedViewWrite> {
   const assigneeField = app.collections?.[cid]?.assigneeField;
   if (audience !== "member" || assigneeField === undefined) return {};
-  return { assigneeField, assignees: assignableTo(app, cid) };
+  return { assigneeField, rowWriters: holdersOf(app, cid, ["assignee"]) };
 }
 
 /** What `audience` may change about `cid`, or null when the answer is nothing.
  *
- *  The two audiences differ in WHICH transition table applies and in whether
- *  assignment exists at all; they agree that the status field is the
- *  collection's, since the rules read one field either way. */
+ *  The two audiences differ in WHICH transition table applies, in whether
+ *  assignment exists at all, and in whether the roster's answer travels with
+ *  it; they agree that the status field is the collection's, since the rules
+ *  read one field either way. */
 export function writeFor(app: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): ProjectedViewWrite | null {
   const write: ProjectedViewWrite = { cid, ...transitionPart(app, audience, cid), ...assignPart(app, audience, cid) };
-  return Object.keys(write).length > 1 ? write : null;
+  if (Object.keys(write).length === 1) return null;
+  // Only the staff tier: a participant writes their own row, which the rules
+  // answer from the record rather than from a role, and publishing the roster's
+  // writers to them would be an address list for nothing.
+  if (audience === "member") write.writers = writersOf(app, cid);
+  return write;
 }

--- a/packages/core/src/collection/server/appViews.ts
+++ b/packages/core/src/collection/server/appViews.ts
@@ -28,7 +28,7 @@
 //   shared projection cannot serve both: handed the staff datasets, a
 //   participant's page builds a query the rules refuse — it does not render
 //   less, it fails.
-import type { AuthoredApp, AuthoredSubmit } from "./publishManifest";
+import type { AuthoredApp, AuthoredMail, AuthoredSubmit } from "./publishManifest";
 
 /** The audiences a view may be written for. A CLOSED set: each one names a
  *  tier with a rule behind it, so an unknown value has nowhere to be
@@ -223,6 +223,11 @@ export interface AppViewConfigDoc extends Record<string, unknown> {
   /** The submit declarations for the collections these views draw, so the page
    *  can show what may be sent rather than discovering it from a denial. */
   submit: Record<string, Record<string, unknown>>;
+  /** What this audience may CHANGE about those collections — see
+   *  {@link writeFor}. One entry per collection that has anything writable, in
+   *  the order the views declare them; absent entries mean "read only", which
+   *  is what a page with no buttons is drawn from. */
+  write: ProjectedViewWrite[];
   publishedAt: number;
 }
 
@@ -230,3 +235,111 @@ export interface AppViewConfigDoc extends Record<string, unknown> {
  *  prefixes, so a single `match` covers the projection and every view. */
 export const viewDocId = (stage: "live" | "staged", viewId: string): string => `${stage}:${viewId}`;
 export const VIEW_CONFIG_ID = "config";
+
+// ---------------------------------------------------------------------------
+// What an audience may CHANGE
+//
+// mulmoterminal plans/feat-shared-app-member-write.md. The rules already allow
+// every write below — `isWriter`, the assignee branch, `ownRow` + `selfWriteOk`
+// — so nothing here grants anything. What it does is tell the page which
+// buttons exist, and let the parent name a refusal the rules would answer with
+// a bare permission error.
+//
+// THE VOCABULARY IS CLOSED: a transition moves one declared status field, an
+// assignment moves one declared assignee field, and there is no third thing.
+// A general patch would be no less safe (the rules bind either way) and two
+// things worse: a bug in the page reaches as far as the member's role does,
+// and nothing above can say what happened.
+//
+// AND IT IS PROJECTED PER TIER, because "which transitions" is a different
+// question for each audience. Staff move `pending → approved`
+// (`collections[cid].transitions`); the person who booked moves
+// `pending → cancelled` (`public.submit[cid].selfTransitions`). Publishing one
+// table to both draws an approve button on a participant's page that the rules
+// refuse when pressed — declaration and enforcement disagreeing, which is the
+// one failure this whole mechanism exists to prevent.
+
+/** What one audience may change about one collection.
+ *
+ *  An entry exists only where something is actually writable; a collection a
+ *  tier may only read is absent rather than present and empty. */
+export interface ProjectedViewWrite {
+  cid: string;
+  /** The field a transition moves. Without it there are no transitions. */
+  statusField?: string;
+  /** `{ <current status>: [<status>...] }`, for THIS audience. */
+  transitions?: Record<string, string[]>;
+  /** The field naming the member a row belongs to. `member` tier only. */
+  assigneeField?: string;
+  /** Who may be named in it. `member` tier only — see below. */
+  assignees?: string[];
+  /** `member` tier only: the rules let only a writer (or the row's own
+   *  assignee) queue mail, so a participant handed this could only be refused. */
+  mail?: AuthoredMail;
+}
+
+/** The role a member holds on one collection, by the rules' own resolution:
+ *  the per-collection entry, else the `*` fallback, else none. */
+function roleOn(app: AuthoredApp, address: string, cid: string): string | undefined {
+  const held = app.members[address];
+  if (held === undefined) return undefined;
+  return held[cid] ?? held["*"];
+}
+
+/** Roles that may be named in an `assigneeField`.
+ *
+ *  `viewer` and `participant` are not here: assigning to them writes a row
+ *  nobody can then touch, because the assignee branch of the rules requires
+ *  the holder to BE the assignee. */
+const ASSIGNABLE_ROLES = ["owner", "editor", "assignee"];
+
+/** The addresses that may be assigned this collection's rows.
+ *
+ *  Published into the `member` tier and NOWHERE else, and that is a decision
+ *  rather than an omission: the person doing the reassigning cannot read the
+ *  roster (`apps/{aid}` is `readerOf(a, '*')`, and a stylist scoped to
+ *  `bookings` holds no `*` role), so without this they have nothing to choose
+ *  from — and a free-text address that is not on the roster produces a row
+ *  NOBODY can write afterwards. So staff addresses are visible to staff, which
+ *  is already true of the approval mail they send each other. Participants
+ *  read the `roster` tier and never see this.
+ *
+ *  Sorted, for the same reason `memberEmails` is: a second publish of an
+ *  unchanged declaration must produce an unchanged document. */
+function assignableTo(app: AuthoredApp, cid: string): string[] {
+  return Object.keys(app.members)
+    .filter((address) => ASSIGNABLE_ROLES.includes(roleOn(app, address, cid) ?? ""))
+    .sort();
+}
+
+/** The transition half: which table applies, and the field it moves.
+ *
+ *  Both halves or neither. A status field with no table would offer every
+ *  value; a table with no field has nothing to write it to. */
+function transitionPart(app: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): Partial<ProjectedViewWrite> {
+  const config = app.collections?.[cid];
+  const transitions = audience === "member" ? config?.transitions : app.public?.submit?.[cid]?.selfTransitions;
+  if (config?.statusField === undefined || transitions === undefined) return {};
+  const part: Partial<ProjectedViewWrite> = { statusField: config.statusField, transitions };
+  // The rules let only a writer (or the row's own assignee) queue mail, so a
+  // participant handed this could only ever be refused.
+  if (audience === "member" && config.mail !== undefined) part.mail = config.mail;
+  return part;
+}
+
+/** The assignment half. `member` only — see {@link assignableTo}. */
+function assignPart(app: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): Partial<ProjectedViewWrite> {
+  const assigneeField = app.collections?.[cid]?.assigneeField;
+  if (audience !== "member" || assigneeField === undefined) return {};
+  return { assigneeField, assignees: assignableTo(app, cid) };
+}
+
+/** What `audience` may change about `cid`, or null when the answer is nothing.
+ *
+ *  The two audiences differ in WHICH transition table applies and in whether
+ *  assignment exists at all; they agree that the status field is the
+ *  collection's, since the rules read one field either way. */
+export function writeFor(app: AuthoredApp, audience: Exclude<ViewAudience, "public">, cid: string): ProjectedViewWrite | null {
+  const write: ProjectedViewWrite = { cid, ...transitionPart(app, audience, cid), ...assignPart(app, audience, cid) };
+  return Object.keys(write).length > 1 ? write : null;
+}

--- a/packages/core/src/collection/server/index.ts
+++ b/packages/core/src/collection/server/index.ts
@@ -114,6 +114,7 @@ export {
   normalizeViews,
   participantScope,
   viewDocId,
+  writeFor,
   PUBLIC_VIEW_ID,
   RESERVED_VIEW_IDS,
   VIEW_AUDIENCES,
@@ -124,6 +125,7 @@ export {
   type NormalizedView,
   type NormalizedViewsResult,
   type ProjectedViewCollection,
+  type ProjectedViewWrite,
   type ViewAudience,
 } from "./appViews";
 export type { LoadedCollection } from "./discoveredCollection";

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -610,6 +610,37 @@ export interface PromotedRuleConfig {
   collections?: Record<string, AuthoredCollectionConfig>;
 }
 
+/** What this audience may CHANGE, per collection it draws.
+ *
+ *  The `collections` config is the PROMOTED one where there is one: at publish
+ *  the rules run against what deploy staged, so projecting the manifest's
+ *  would advertise transitions the live rules deny. */
+export function tierWrites(
+  authored: AuthoredApp,
+  audience: Exclude<ViewAudience, "public">,
+  cids: string[],
+  promoted: PromotedRuleConfig,
+): ProjectedViewWrite[] {
+  const effective: AuthoredApp = promoted.collections === undefined ? authored : { ...authored, collections: promoted.collections };
+  // Read-only collections are absent rather than present and empty: an entry
+  // is what a page draws a button from.
+  return cids.map((cid) => writeFor(effective, audience, cid)).filter((entry): entry is ProjectedViewWrite => entry !== null);
+}
+
+/** What this audience may READ, and how to query for it.
+ *
+ *  A collection with no scope is dropped rather than published as unreachable:
+ *  the gate has already refused the declaration, so reaching here with one is
+ *  a programming error, and a page that queries it is denied. */
+export function tierViews(authored: AuthoredApp, audience: Exclude<ViewAudience, "public">, views: NormalizedView[], participantRead: readonly string[]) {
+  return views.map((view) => ({
+    id: view.id,
+    collections: view.collections
+      .map((cid) => scopeFor(authored, audience, cid, participantRead))
+      .filter((scope): scope is ProjectedViewCollection => scope !== null),
+  }));
+}
+
 /** One tier's projection: what this audience may read, and what it may change. */
 function tierConfig(
   authored: AuthoredApp,
@@ -619,22 +650,9 @@ function tierConfig(
   promoted: PromotedRuleConfig,
 ): AppViewConfigDoc {
   const cids = [...new Set(views.flatMap((view) => view.collections))];
-  const participantRead = promoted.participantRead ?? authored.participantRead ?? [];
-  const effective: AuthoredApp = promoted.collections === undefined ? authored : { ...authored, collections: promoted.collections };
   const config: AppViewConfigDoc = {
-    // Every collection these views draw, asked what THIS audience may change
-    // about it. Read-only ones are absent rather than present and empty.
-    write: cids.map((cid) => writeFor(effective, audience, cid)).filter((entry): entry is ProjectedViewWrite => entry !== null),
-    views: views.map((view) => ({
-      id: view.id,
-      // A collection with no scope is dropped rather than published as
-      // unreachable: the gate has already refused the declaration, so
-      // reaching here with one is a programming error, and a page that
-      // queries it is denied.
-      collections: view.collections
-        .map((cid) => scopeFor(authored, audience, cid, participantRead))
-        .filter((scope): scope is ProjectedViewCollection => scope !== null),
-    })),
+    write: tierWrites(authored, audience, cids, promoted),
+    views: tierViews(authored, audience, views, promoted.participantRead ?? authored.participantRead ?? []),
     submit: tierSubmit(authored, cids),
     publishedAt: stamp.publishedAt,
   };

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -594,44 +594,73 @@ function scopeFor(
  *  and neither is the clock. What is here is the answer to "what may this
  *  audience read, and how" — computed once, so the page never has to guess and
  *  never has to discover it from a denial. */
-export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp, promoted?: { participantRead?: readonly string[] }): AppViewTier[] {
-  // What the RULES will say, not what the manifest says. Publish replaces
-  // `participantRead` with the staged schemas' own (see `projectPublish`), so
-  // at publish the caller passes that; at deploy the manifest IS what is being
-  // staged, and the default is right.
-  const participantRead = promoted?.participantRead ?? authored.participantRead ?? [];
+/** What the RULES will be in force with, as against what the manifest says.
+ *
+ *  `projectPublish` replaces BOTH `participantRead` and `collections` with what
+ *  the staged schemas carry, so at publish the promoted pair is what decides
+ *  whether a read is allowed and which transitions exist. They travel together
+ *  deliberately: passing one and not the other publishes a page whose datasets
+ *  follow revision A and whose buttons follow revision B.
+ *
+ *  At DEPLOY the manifest is exactly what is being staged, so the default is
+ *  right — and today deploy is the only caller, because publish PROMOTES the
+ *  staged documents rather than re-projecting them. */
+export interface PromotedRuleConfig {
+  participantRead?: readonly string[];
+  collections?: Record<string, AuthoredCollectionConfig>;
+}
+
+/** One tier's projection: what this audience may read, and what it may change. */
+function tierConfig(
+  authored: AuthoredApp,
+  audience: Exclude<ViewAudience, "public">,
+  views: NormalizedView[],
+  stamp: PublishStamp,
+  promoted: PromotedRuleConfig,
+): AppViewConfigDoc {
+  const cids = [...new Set(views.flatMap((view) => view.collections))];
+  const participantRead = promoted.participantRead ?? authored.participantRead ?? [];
+  const effective: AuthoredApp = promoted.collections === undefined ? authored : { ...authored, collections: promoted.collections };
+  const config: AppViewConfigDoc = {
+    // Every collection these views draw, asked what THIS audience may change
+    // about it. Read-only ones are absent rather than present and empty.
+    write: cids.map((cid) => writeFor(effective, audience, cid)).filter((entry): entry is ProjectedViewWrite => entry !== null),
+    views: views.map((view) => ({
+      id: view.id,
+      // A collection with no scope is dropped rather than published as
+      // unreachable: the gate has already refused the declaration, so
+      // reaching here with one is a programming error, and a page that
+      // queries it is denied.
+      collections: view.collections
+        .map((cid) => scopeFor(authored, audience, cid, participantRead))
+        .filter((scope): scope is ProjectedViewCollection => scope !== null),
+    })),
+    submit: tierSubmit(authored, cids),
+    publishedAt: stamp.publishedAt,
+  };
+  if (authored.name !== undefined) config.name = authored.name;
+  return config;
+}
+
+/** The submit declarations for the collections these views draw, so a page can
+ *  show what may be sent rather than discovering it from a denial. */
+function tierSubmit(authored: AuthoredApp, cids: string[]): Record<string, Record<string, unknown>> {
+  const declared = authored.public?.submit ?? {};
+  return Object.fromEntries(
+    cids.flatMap((cid) => {
+      const spec = declared[cid];
+      return spec === undefined ? [] : [[cid, projectSubmit(spec)] as const];
+    }),
+  );
+}
+
+export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp, promoted: PromotedRuleConfig = {}): AppViewTier[] {
   const normalized = normalizeViews(authored);
   if (!normalized.ok) throw new Error(`publish: views declaration is not publishable (${normalized.problems.join(" ")})`);
   const audiences: Exclude<ViewAudience, "public">[] = ["member", "participant"];
   return audiences.map((audience) => {
     const views = normalized.views.filter((view) => view.audience === audience);
-    const cids = [...new Set(views.flatMap((view) => view.collections))];
-    const declaredSubmit = authored.public?.submit ?? {};
-    const submit = Object.fromEntries(
-      cids.flatMap((cid) => {
-        const spec = declaredSubmit[cid];
-        return spec === undefined ? [] : [[cid, projectSubmit(spec)] as const];
-      }),
-    );
-    const config: AppViewConfigDoc = {
-      // Every collection these views draw, asked what THIS audience may change
-      // about it. Read-only ones are absent rather than present and empty.
-      write: cids.map((cid) => writeFor(authored, audience, cid)).filter((entry): entry is ProjectedViewWrite => entry !== null),
-      views: views.map((view) => ({
-        id: view.id,
-        // A collection with no scope is dropped rather than published as
-        // unreachable: the gate has already refused the declaration, so
-        // reaching here with one is a programming error, and a page that
-        // queries it is denied.
-        collections: view.collections
-          .map((cid) => scopeFor(authored, audience, cid, participantRead))
-          .filter((scope): scope is ProjectedViewCollection => scope !== null),
-      })),
-      submit,
-      publishedAt: stamp.publishedAt,
-    };
-    if (authored.name !== undefined) config.name = authored.name;
-    return { tier: VIEW_TIER[audience], audience, config, views };
+    return { tier: VIEW_TIER[audience], audience, config: tierConfig(authored, audience, views, stamp, promoted), views };
   });
 }
 

--- a/packages/core/src/collection/server/publishProject.ts
+++ b/packages/core/src/collection/server/publishProject.ts
@@ -44,9 +44,11 @@ import {
   VIEW_CONFIG_ID,
   VIEW_TIER,
   viewDocId,
+  writeFor,
   type AppViewConfigDoc,
   type NormalizedView,
   type ProjectedViewCollection,
+  type ProjectedViewWrite,
   type ViewAudience,
 } from "./appViews";
 import type { AuthoredApp, AuthoredCollectionConfig, AuthoredSubmit } from "./publishManifest";
@@ -612,6 +614,9 @@ export function projectAppViews(authored: AuthoredApp, stamp: PublishStamp, prom
       }),
     );
     const config: AppViewConfigDoc = {
+      // Every collection these views draw, asked what THIS audience may change
+      // about it. Read-only ones are absent rather than present and empty.
+      write: cids.map((cid) => writeFor(authored, audience, cid)).filter((entry): entry is ProjectedViewWrite => entry !== null),
       views: views.map((view) => ({
         id: view.id,
         // A collection with no scope is dropped rather than published as

--- a/packages/core/test/collection/test_appViews.ts
+++ b/packages/core/test/collection/test_appViews.ts
@@ -186,36 +186,44 @@ test("the document id carries the stage, and the id the author wrote", () => {
 // when pressed, which is declaration and enforcement disagreeing.
 
 const STYLIST = "stylist@salon.jp";
+const RECEPTION = "reception@salon.jp";
+const OBSERVER = "observer@salon.jp";
 const CUSTOMER = "customer@example.jp";
+
+/** One roster carrying every role the rules distinguish, because the staff
+ *  tier's single document is read by all of them. */
+const SALON_MEMBERS = {
+  [OWNER]: { "*": "owner" },
+  [RECEPTION]: { bookings: "editor" },
+  [STYLIST]: { bookings: "assignee" },
+  // Holds a role, so `staffOf` admits them — and may write nothing.
+  [OBSERVER]: { bookings: "viewer" },
+  [CUSTOMER]: { "*": "participant" },
+};
+
+const SALON_COLLECTIONS = {
+  bookings: {
+    statusField: "status",
+    transitions: { initial: ["pending"], pending: ["approved", "rejected"], approved: ["done"] },
+    assigneeField: "stylistEmail",
+    mail: { toField: "email", on: { "booking-approved": { from: ["pending"], to: "approved" } } },
+  },
+};
+
+const SALON_PUBLIC = {
+  submit: {
+    bookings: { auth: "verifiedEmail", emailField: "email", createFields: ["email", "startAt"], selfTransitions: { pending: ["cancelled"] } },
+  },
+};
+
+const SALON_VIEWS = [
+  { id: "desk", audience: "member", path: "views/desk.html", collections: ["bookings"] },
+  { id: "mine", audience: "participant", path: "views/mine.html", collections: ["bookings"] },
+];
 
 /** A salon whose bookings are approved by staff and cancelled by the customer. */
 const salon = (overrides: Record<string, unknown> = {}) =>
-  app({
-    members: { [OWNER]: { "*": "owner" }, [STYLIST]: { bookings: "assignee" }, [CUSTOMER]: { "*": "participant" } },
-    collections: {
-      bookings: {
-        statusField: "status",
-        transitions: { initial: ["pending"], pending: ["approved", "rejected"], approved: ["done"] },
-        assigneeField: "stylistEmail",
-        mail: { toField: "email", on: { "booking-approved": { from: ["pending"], to: "approved" } } },
-      },
-    },
-    public: {
-      submit: {
-        bookings: {
-          auth: "verifiedEmail",
-          emailField: "email",
-          createFields: ["email", "startAt"],
-          selfTransitions: { pending: ["cancelled"] },
-        },
-      },
-    },
-    views: [
-      { id: "desk", audience: "member", path: "views/desk.html", collections: ["bookings"] },
-      { id: "mine", audience: "participant", path: "views/mine.html", collections: ["bookings"] },
-    ],
-    ...overrides,
-  });
+  app({ members: SALON_MEMBERS, collections: SALON_COLLECTIONS, public: SALON_PUBLIC, views: SALON_VIEWS, ...overrides });
 
 const writeOf = (authored: ReturnType<typeof app>, tier: "member" | "roster") =>
   projectAppViews(authored, STAMP)
@@ -232,15 +240,44 @@ test("the two audiences get DIFFERENT transition tables for the same field", () 
   assert.equal(theirs[0]?.statusField, "status");
 });
 
-test("assignment, and who may be assigned, reach the staff tier only", () => {
+test("the roster's answer to WHO may write travels with the declaration", () => {
+  // The point of the pair. One `member/config` is read by everybody the tier
+  // admits — the receptionist, the stylist scoped to their own rows, and an
+  // observer who may write nothing — and none of them can look their own role
+  // up (`apps/{aid}` is `readerOf(a, '*')`, which a per-collection role does
+  // not satisfy). Without these lists the page draws approve for all three and
+  // the rules refuse two of them when pressed.
+  const staff = writeOf(salon(), "member");
+  assert.deepEqual(staff[0]?.writers, [OWNER, RECEPTION].sort(), "owner and editor write every row");
+  assert.deepEqual(staff[0]?.rowWriters, [STYLIST], "the assignee writes only the rows assigned to them");
+  // A viewer is in neither, which is the whole difference between "holds a
+  // role" and "may change this".
+  assert.ok(!(staff[0]?.writers ?? []).includes(OBSERVER));
+  assert.ok(!(staff[0]?.rowWriters ?? []).includes(OBSERVER));
+  // And the assignment candidates are these two together — not published a
+  // third time, so a third list cannot disagree with the two the rules read.
+  assert.deepEqual([...(staff[0]?.writers ?? []), ...(staff[0]?.rowWriters ?? [])].sort(), [OWNER, RECEPTION, STYLIST].sort());
+});
+
+test("assignment, and every address, reach the staff tier only", () => {
   const staff = writeOf(salon(), "member");
   assert.equal(staff[0]?.assigneeField, "stylistEmail");
-  // The customer holds `participant` and the stylist holds `assignee`: naming
-  // a viewer or a participant writes a row nobody may touch afterwards.
-  assert.deepEqual(staff[0]?.assignees, [OWNER, STYLIST].sort());
   const theirs = writeOf(salon(), "roster");
   assert.equal(theirs[0]?.assigneeField, undefined);
-  assert.equal(theirs[0]?.assignees, undefined);
+  // A participant writes their own row, which the rules answer from the record
+  // rather than from a role — so an address list there would be a roster leak
+  // for nothing.
+  assert.equal(theirs[0]?.writers, undefined);
+  assert.equal(theirs[0]?.rowWriters, undefined);
+});
+
+test("the assignee role with no field to compare grants nothing, and says so", () => {
+  // `isAssigned` in the rules requires the field, so publishing `rowWriters`
+  // without one would name people who cannot write after all.
+  const noField = salon({ collections: { bookings: { statusField: "status", transitions: { pending: ["approved"] } } } });
+  const staff = writeOf(noField, "member");
+  assert.equal(staff[0]?.rowWriters, undefined);
+  assert.deepEqual(staff[0]?.writers, [OWNER, RECEPTION].sort(), "the unscoped writers are still named");
 });
 
 test("the mail a transition queues reaches the staff tier only", () => {
@@ -264,6 +301,27 @@ test("a status field with no table, and a table with no field, are both nothing"
   const noTable = salon({ collections: { bookings: { statusField: "status", assigneeField: "stylistEmail" } } });
   assert.equal(writeOf(noTable, "member")[0]?.transitions, undefined);
   assert.equal(writeOf(noTable, "member")[0]?.assigneeField, "stylistEmail");
+  // The OTHER tier reads a different table, so dropping the staff one must not
+  // take the customer's cancel with it: the two are independent declarations.
+  assert.deepEqual(writeOf(noTable, "roster")[0]?.transitions, { pending: ["cancelled"] });
+
   const noField = salon({ collections: { bookings: { transitions: { pending: ["approved"] } } } });
   assert.deepEqual(writeOf(noField, "member"), []);
+  // And with no status field there is nothing to write either table to, so the
+  // participant loses their move as well — for the same reason, not by accident.
+  assert.deepEqual(writeOf(noField, "roster"), []);
+});
+
+test("the write tables follow what publish PROMOTES, not what the manifest says", () => {
+  // The mirror of the `participantRead` case above, and the same failure: at
+  // publish `projectPublish` replaces `collections` with what the staged
+  // schemas carry, so a manifest edited since the last deploy would advertise
+  // transitions the live rules deny. Both halves are passed together — one
+  // without the other publishes datasets from revision A beside buttons from B.
+  const promoted = { collections: { bookings: { statusField: "status", transitions: { pending: ["approved"] } } } };
+  const staff = projectAppViews(salon({ collections: { bookings: { statusField: "state", transitions: { open: ["closed"] } } } }), STAMP, promoted)
+    .filter((entry) => entry.tier === "member")
+    .flatMap((entry) => entry.config.write);
+  assert.equal(staff[0]?.statusField, "status");
+  assert.deepEqual(staff[0]?.transitions, { pending: ["approved"] });
 });

--- a/packages/core/test/collection/test_appViews.ts
+++ b/packages/core/test/collection/test_appViews.ts
@@ -177,3 +177,93 @@ test("the document id carries the stage, and the id the author wrote", () => {
   assert.equal(viewDocId("live", "desk"), "live:desk");
   assert.equal(viewDocId("staged", "desk"), "staged:desk");
 });
+
+// --- what each audience may CHANGE -----------------------------------------
+//
+// The rules already allow every write these entries describe. What is pinned
+// here is that the two audiences are handed DIFFERENT tables — a participant
+// offered the staff transitions draws an approve button that the rules refuse
+// when pressed, which is declaration and enforcement disagreeing.
+
+const STYLIST = "stylist@salon.jp";
+const CUSTOMER = "customer@example.jp";
+
+/** A salon whose bookings are approved by staff and cancelled by the customer. */
+const salon = (overrides: Record<string, unknown> = {}) =>
+  app({
+    members: { [OWNER]: { "*": "owner" }, [STYLIST]: { bookings: "assignee" }, [CUSTOMER]: { "*": "participant" } },
+    collections: {
+      bookings: {
+        statusField: "status",
+        transitions: { initial: ["pending"], pending: ["approved", "rejected"], approved: ["done"] },
+        assigneeField: "stylistEmail",
+        mail: { toField: "email", on: { "booking-approved": { from: ["pending"], to: "approved" } } },
+      },
+    },
+    public: {
+      submit: {
+        bookings: {
+          auth: "verifiedEmail",
+          emailField: "email",
+          createFields: ["email", "startAt"],
+          selfTransitions: { pending: ["cancelled"] },
+        },
+      },
+    },
+    views: [
+      { id: "desk", audience: "member", path: "views/desk.html", collections: ["bookings"] },
+      { id: "mine", audience: "participant", path: "views/mine.html", collections: ["bookings"] },
+    ],
+    ...overrides,
+  });
+
+const writeOf = (authored: ReturnType<typeof app>, tier: "member" | "roster") =>
+  projectAppViews(authored, STAMP)
+    .filter((entry) => entry.tier === tier)
+    .flatMap((entry) => entry.config.write);
+
+test("the two audiences get DIFFERENT transition tables for the same field", () => {
+  const staff = writeOf(salon(), "member");
+  const theirs = writeOf(salon(), "roster");
+  assert.deepEqual(staff[0]?.transitions, { initial: ["pending"], pending: ["approved", "rejected"], approved: ["done"] });
+  // The participant's own transitions, and nothing of the staff's: an
+  // `approved` button on their page is refused the moment it is pressed.
+  assert.deepEqual(theirs[0]?.transitions, { pending: ["cancelled"] });
+  assert.equal(theirs[0]?.statusField, "status");
+});
+
+test("assignment, and who may be assigned, reach the staff tier only", () => {
+  const staff = writeOf(salon(), "member");
+  assert.equal(staff[0]?.assigneeField, "stylistEmail");
+  // The customer holds `participant` and the stylist holds `assignee`: naming
+  // a viewer or a participant writes a row nobody may touch afterwards.
+  assert.deepEqual(staff[0]?.assignees, [OWNER, STYLIST].sort());
+  const theirs = writeOf(salon(), "roster");
+  assert.equal(theirs[0]?.assigneeField, undefined);
+  assert.equal(theirs[0]?.assignees, undefined);
+});
+
+test("the mail a transition queues reaches the staff tier only", () => {
+  // The rules let only a writer (or the row's own assignee) queue mail, so a
+  // participant handed this could only ever be refused.
+  assert.equal(writeOf(salon(), "member")[0]?.mail?.toField, "email");
+  assert.equal(writeOf(salon(), "roster")[0]?.mail, undefined);
+});
+
+test("a collection with nothing writable is ABSENT, not present and empty", () => {
+  // A page draws its buttons from these entries; an empty one would be a
+  // collection with a button that does nothing.
+  const readOnly = salon({ collections: { bookings: { statusField: "status" } }, public: { submit: {} } });
+  assert.deepEqual(writeOf(readOnly, "member"), []);
+  assert.deepEqual(writeOf(readOnly, "roster"), []);
+});
+
+test("a status field with no table, and a table with no field, are both nothing", () => {
+  // Half a declaration is not half a feature: a field with no table would
+  // offer every value, and a table with no field has nothing to write to.
+  const noTable = salon({ collections: { bookings: { statusField: "status", assigneeField: "stylistEmail" } } });
+  assert.equal(writeOf(noTable, "member")[0]?.transitions, undefined);
+  assert.equal(writeOf(noTable, "member")[0]?.assigneeField, "stylistEmail");
+  const noField = salon({ collections: { bookings: { transitions: { pending: ["approved"] } } } });
+  assert.deepEqual(writeOf(noField, "member"), []);
+});

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^2.1.0",
     "@mulmoclaude/collection-plugin": "^3.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^3.14.0",
+    "@mulmoclaude/core": "^3.15.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^2.2.0",
     "@mulmoclaude/html-plugin": "^3.0.0",


### PR DESCRIPTION
共有アプリのメンバービューは今のところ**読むだけ**で、承認も担当の付け替えもオーナーの Mac を開けないとできない。書きの側で D7（ホストは実行経路にいない）が守れていない。

## 何を足したか

`apps/{aid}/{member,roster}/{live,staged}:config` に **`write[]`** を足す。1 コレクションにつき 1 エントリで、書けるものが何も無いコレクションは**載らない**（空で載せない — ページはこれを見てボタンを描くので、空のエントリは「何もしないボタン」になる）。

```jsonc
"write": [
  { "cid": "bookings",
    "statusField": "status",
    "transitions": { "pending": ["approved", "rejected"] },
    "assigneeField": "stylistEmail",
    "assignees": ["owner@salon.jp", "stylist@salon.jp"],
    "mail": { "toField": "email", "on": { "booking-approved": { "from": ["pending"], "to": "approved" } } } }
]
```

## 決定

- **ルールは変えていないし、これは何も許可しない。** `updateWith` は既に `isWriter` / assignee 分岐 / `ownRow` + `selfWriteOk` を持ち、`transitionOk` が全員を縛る。この射影は「どのボタンがあるか」をページに伝え、親が拒否に名前を付けられるようにするだけ
- **語彙は閉じる**（状態遷移と担当の付け替えの 2 つだけ）。汎用のパッチにしても安全性は変わらない（ルールが権威）が、ページのバグがそのメンバーの権限いっぱいまで届き、何が起きたか親が言えなくなる
- **階層ごとに違う遷移表。** スタッフは `collections[cid].transitions`、本人は `public.submit[cid].selfTransitions`。同じ表を両方に載せると participant のページに approved ボタンが出て、押した瞬間に拒まれる — 宣言と執行がずれる
- **`assignees` と `mail` は `member` 階層だけ。** 付け替える人は名簿を読めない（`apps/{aid}` は `readerOf(a,'*')` で、`bookings` だけ editor のスタイリストは `*` を持たない）ので候補が無ければ選べず、名簿に無いアドレスを書くと**誰にも書けない行**になる。mail はルール上 writer と当人の assignee しか queue できないので、participant に渡しても拒まれるだけ

スタッフのアドレスがスタッフに見えることになる。これは判断で、承認メールの差出人として既に成り立っている関係であり、participant が読む `roster` 階層には決して載らない。

## テスト

`test_appViews.ts` に 5 本。2 つの階層が**違う表**を受け取ること、`assignees` / `mail` が member にしか出ないこと、書けないコレクションが載らないこと、宣言が半分（フィールドだけ・表だけ）なら何も出ないこと。core 全体 950 pass。

設計: mulmoterminal `plans/feat-shared-app-member-write.md`（同時に PR）

version 3.15.0

work in mulmoterminal

## Summary by Sourcery

Project what each audience may change in shared app collections and expose it in view configs for UI button rendering.

New Features:
- Add per-collection write projections to app view configs describing allowed status transitions, assignments, and mail actions per audience.

Enhancements:
- Differentiate staff and participant audiences by applying distinct transition tables and limiting assignee and mail metadata to member views.
- Treat read-only collections and incomplete write declarations as having no write entry in the projection to avoid non-functional UI actions.

Build:
- Bump core package version to 3.15.0 and re-export the new write projection API surface from the collection server index.

Tests:
- Extend app view projection tests to cover audience-specific write projections, assignee visibility, mail availability, and handling of read-only or partially declared collections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audience-specific write controls to app views.
  * Participants can access permitted status transitions.
  * Staff members can assign records, manage assignees, and send member-only mail.
  * Non-writable collections are excluded from published view configurations.
  * Writable capabilities now reflect promoted collection and participant access settings.

* **Bug Fixes**
  * Incomplete status-transition settings are no longer exposed as writable options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->