### PR TITLE
fix(collections): 未設定の embed（idField が空）を fail-soft 表示にする

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -121,6 +121,20 @@ Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`,
 
 ### Fixed
 
+#### An embed whose optional `idField` is empty reads as unset, not as a broken link (#2863)
+
+`embedTargetId()` resolves an absent or empty `idField` to `""`, and the schema
+contract calls that a fail-soft "no record". The detail panel had only two
+branches — `found` and everything else — so a reference the author simply had
+not filled in got the red "missing" card, with the id blank in the message
+(「projects に「」のレコードが見つかりません」). An optional link that is
+normally empty (task → project, task → goal) therefore made every healthy record
+look broken, one red card per embed.
+
+An embed with no target id now renders the same em-dash the panel's other empty
+fields use. The card stays for the case it was written for: an `idField` naming
+a record the target collection does not have.
+
 #### A shared record's identity is its document id, not a field a submitter can name
 
 The security rules can pin the DOCUMENT ID of a submission — `idFrom` ties it to

--- a/e2e/tests/collection-embed-unset.spec.ts
+++ b/e2e/tests/collection-embed-unset.spec.ts
@@ -1,0 +1,100 @@
+// E2E coverage for an UNSET `embed` field. An `embed` whose `idField`
+// points at an OPTIONAL `ref` resolves to an empty target id when the ref
+// was never filled in — which the schema contract calls fail-soft "no
+// record", not a dangling reference. The detail panel must render that as
+// an empty field; only a ref pointing at a record that does NOT exist gets
+// the red "missing" card.
+//
+// Records are opened through the `?selected=` deep link rather than a row
+// click: the list row carries the `ref` cell as a link, so a click at the
+// row's centre can land on it and navigate to the target collection.
+
+import { test, expect } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const PROJECTS_DETAIL = {
+  collection: {
+    slug: "projects",
+    title: "Projects",
+    icon: "folder",
+    source: "user",
+    schema: {
+      title: "Projects",
+      icon: "folder",
+      dataPath: "data/projects/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        name: { type: "string", label: "Name", required: true },
+      },
+    },
+  },
+  items: [{ id: "apollo", name: "Apollo" }],
+};
+
+// `projectId` is deliberately NOT required — the case the fix is about.
+const TASKS_DETAIL = {
+  collection: {
+    slug: "tasks",
+    title: "Tasks",
+    icon: "task_alt",
+    source: "user",
+    schema: {
+      title: "Tasks",
+      icon: "task_alt",
+      dataPath: "data/tasks/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        title: { type: "string", label: "Title", required: true },
+        projectId: { type: "ref", to: "projects", label: "Project" },
+        project: { type: "embed", to: "projects", idField: "projectId", label: "Project (embedded)" },
+      },
+    },
+  },
+  items: [
+    { id: "linked", title: "Linked", projectId: "apollo" },
+    { id: "unset", title: "Unset" },
+    { id: "blank", title: "Blank", projectId: "" },
+    { id: "ghost", title: "Ghost", projectId: "vanished" },
+  ],
+};
+
+test.describe("collection embed — unset vs dangling", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await page.route(
+      (url) => url.pathname === "/api/collections/tasks",
+      (route) => route.fulfill({ json: TASKS_DETAIL }),
+    );
+    await page.route(
+      (url) => url.pathname === "/api/collections/projects",
+      (route) => route.fulfill({ json: PROJECTS_DETAIL }),
+    );
+  });
+
+  test("a resolved embed still renders the embedded record card", async ({ page }) => {
+    await page.goto("/collections/tasks?selected=linked");
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    await expect(page.getByTestId("collections-embed-project")).toBeVisible();
+    await expect(page.getByTestId("collections-embed-project-name")).toHaveText("Apollo");
+    await expect(page.getByTestId("collections-embed-unset-project")).toHaveCount(0);
+  });
+
+  for (const recordId of ["unset", "blank"]) {
+    test(`an unset embed (${recordId} idField) renders the empty-field glyph, not the missing card`, async ({ page }) => {
+      await page.goto(`/collections/tasks?selected=${recordId}`);
+      await expect(page.getByTestId("collections-detail")).toBeVisible();
+      await expect(page.getByTestId("collections-embed-unset-project")).toHaveText("—");
+      await expect(page.getByTestId("collections-embed-missing-project")).toHaveCount(0);
+      await expect(page.getByTestId("collections-embed-project")).toHaveCount(0);
+    });
+  }
+
+  test("an embed pointing at a deleted record still reports it as missing", async ({ page }) => {
+    await page.goto("/collections/tasks?selected=ghost");
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+    await expect(page.getByTestId("collections-embed-missing-project")).toContainText("vanished");
+    await expect(page.getByTestId("collections-embed-unset-project")).toHaveCount(0);
+  });
+});

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionEmbedView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionEmbedView.vue
@@ -41,6 +41,12 @@
     </div>
   </a>
 
+  <!-- Unset: an optional `idField` whose value is empty, which the schema
+       contract resolves fail-soft to "no record" — nothing is broken, so it
+       reads as an empty field, not as the dangling reference below. -->
+  <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -- bare "—" empty-value glyph, same treatment as the other read-only detail branches. -->
+  <span v-else-if="!view.recordId" class="text-slate-300" :data-testid="`collections-embed-unset-${fieldKey}`">—</span>
+
   <div v-else class="relative rounded-xl border border-red-100 bg-red-50/30 p-4 pl-5 shadow-sm" :data-testid="`collections-embed-${fieldKey}`">
     <!-- Left Accent Stripe for Error/Missing -->
     <div class="absolute left-0 top-0 bottom-0 w-1 bg-red-400 rounded-l-xl"></div>

--- a/plans/fix-2863-embed-unset-fail-soft.md
+++ b/plans/fix-2863-embed-unset-fail-soft.md
@@ -46,8 +46,9 @@
 
 - unit: `buildEmbedViews` に空 `idField` のケース。既存は `"ghost"`（リンク切れ）だけで、
   「`found: false` かつ `recordId: ""`」＝描画が分岐する状態を押さえていない
-- e2e: `collection-embed-unset.spec.ts`。1コレクション3レコード（解決する / ghost / 未設定）で
-  ①未設定は em-dash で赤カードが出ない ②ghost は今までどおり赤カード、を実ブラウザで確認する
+- e2e: `collection-embed-unset.spec.ts`。1コレクション4レコード（解決する / `idField` のキーが無い /
+  `idField` が空文字 / ghost）で ①未設定の2つは em-dash で赤カードが出ない ②ghost は今までどおり
+  赤カード ③解決するものは今までどおりカード、を実ブラウザで確認する
   （Vue コンポーネントの単体テストはこのリポジトリに無いので、描画分岐の ground truth は e2e）
 
 ## 影響範囲

--- a/plans/fix-2863-embed-unset-fail-soft.md
+++ b/plans/fix-2863-embed-unset-fail-soft.md
@@ -1,0 +1,56 @@
+# 未設定の embed（`idField` が空）を fail-soft 表示にする (#2863)
+
+## 症状
+
+任意（`required` でない）の `ref` を `idField` に取る `embed` は、その値が空のときレコード詳細で
+赤い「レコードが見つかりません」カードになる。id を差し込む位置が空なので
+「`projects` に「」のレコードが見つかりません」という文になる。リンク切れではなく
+**まだ設定していないだけ**なので、正常なレコードが恒常的にエラー表示になる。
+
+## 契約
+
+`packages/core/src/collection/core/schemaZ.ts` の `EmbedFieldZ`:
+
+> `idField` (…); an absent/empty value resolves fail-soft to "no record"
+
+`schema.ts` の `embedTargetId()` も「どちらも当てはまらないときは空文字 — 呼び出し側が
+'no record' として描く」と書いて空を正常系で返している。赤枠 + `error_outline` は fail-soft の
+表示ではない。
+
+## 原因
+
+2つの状態が1つの boolean に潰れている。
+
+1. `embedTargetId()` — `idField` が空なら `""`
+2. `useCollectionRendering.renderers.ts` `buildEmbedViews()` — `found: Boolean(item)`。
+   「参照が空」も「参照先が無い」も同じ `false`
+3. `CollectionEmbedView.vue` — 分岐は `v-if="view.found"` と `v-else`（赤カード）の2本だけ
+
+## 直し方
+
+**`CollectionEmbedView.vue` の1ファイルだけ。core も i18n も触らない。**
+
+区別に必要な情報はビューモデルに既にある（`recordId`）。赤カードの手前に
+`v-else-if="!view.recordId"` を1本足し、他の空フィールドと同じ em-dash を描く。
+固定 `id` の embed は `recordId` が空にならないので、per-record な `idField` の embed だけが拾われる。
+
+採らなかった案:
+
+- 文言（「未設定」等）を出す → `CollectionMessages` 経由で 8 ロケール全部の追従が要る。
+  em-dash はパネル内の他の空フィールド（`ref` / boolean 欠落 / 各種 fallback）と揃うので、
+  新しい語彙を増やすより既存の語彙に合わせる方が良い。
+- `EmbedView.found` を3状態にする → 設計は綺麗だが `found` は公開済み API で core + plugin の
+  2本リリースになる。描画分岐の修正にその代償は見合わない。
+
+## テスト
+
+- unit: `buildEmbedViews` に空 `idField` のケース。既存は `"ghost"`（リンク切れ）だけで、
+  「`found: false` かつ `recordId: ""`」＝描画が分岐する状態を押さえていない
+- e2e: `collection-embed-unset.spec.ts`。1コレクション3レコード（解決する / ghost / 未設定）で
+  ①未設定は em-dash で赤カードが出ない ②ghost は今までどおり赤カード、を実ブラウザで確認する
+  （Vue コンポーネントの単体テストはこのリポジトリに無いので、描画分岐の ground truth は e2e）
+
+## 影響範囲
+
+`idField` を持つ embed のうち storage フィールドが `required` でないもの。表示のみで、
+保存経路・射影・サーバ側には触れない。

--- a/test/plugins/collection/test_collectionRenderers.ts
+++ b/test/plugins/collection/test_collectionRenderers.ts
@@ -146,6 +146,21 @@ describe("buildEmbedViews", () => {
     assert.equal(billTo.recordId, "ghost");
   });
 
+  // An UNSET optional embed: `found` is false like the ghost case above, but
+  // `recordId` is empty — that pair is what the renderer branches on to show an
+  // empty field instead of the dangling-reference card.
+  it("leaves recordId empty when the idField itself is empty", () => {
+    const schema = makeSchema({ billTo: field("embed", { to: "profiles", idField: "customerId" }) });
+    for (const record of [{ customerId: "" }, {}]) {
+      const { billTo } = buildEmbedViews(schema, embedCache, record, "en-US");
+      assert.ok(billTo);
+      assert.equal(billTo.found, false);
+      assert.equal(billTo.recordId, "");
+      assert.deepEqual(billTo.rows, []);
+      assert.equal(billTo.targetSlug, "profiles");
+    }
+  });
+
   it("returns an empty object when the schema is null (no collection loaded)", () => {
     assert.deepEqual(buildEmbedViews(null, embedCache, null, "en-US"), {});
   });


### PR DESCRIPTION
## Summary

任意（`required` でない）の `ref` を `idField` に取る `embed` は、その値が空のときレコード詳細で赤い「レコードが見つかりません」カードになっていた。id を差し込む位置が空なので「`projects` に「」のレコードが見つかりません」という文になる。リンク切れではなく **まだ設定していないだけ** なので、正常なレコードが恒常的にエラー表示になっていた（embed が2つあるレコードでは赤カードが2枚）。

スキーマの契約側は最初から fail-soft と書いている:

- `packages/core/src/collection/core/schemaZ.ts` `EmbedFieldZ` — “`idField` (…); **an absent/empty value resolves fail-soft to "no record"**”
- `schema.ts` `embedTargetId()` — “empty string when neither applies — the caller renders that as 'no record'”

`CollectionEmbedView.vue` に分岐を1本足し、target id が無い embed はパネル内の他の空フィールドと同じ em-dash で描く。赤カードは本来の用途（参照先に存在しない id）だけに残る。

```vue
<span v-else-if="!view.recordId" class="text-slate-300" :data-testid="`collections-embed-unset-${fieldKey}`">—</span>
```

Closes #2863

## Items to Confirm / Review

- **em-dash で良いか（文言を出さないか）**。「未設定」等を出すと `CollectionMessages` 経由で 8 ロケール全部の追従が要る。パネル内の他の空フィールド（`ref` / boolean 欠落 / 各種 fallback）は全部 em-dash なので、新しい語彙を増やすより既存に合わせた。ここは UX の判断なので見てほしい。
- **`recordId` を判定に使っていること**。`EmbedView.found` を3状態にする方が設計としては綺麗だが、`found` は公開済み API なので core + plugin の2本リリースになる。区別に必要な情報は `recordId` に既にあるので、描画分岐の修正にその代償は見合わないと判断した。固定 `id` の embed は `recordId` が空にならないので、per-record な `idField` の embed だけが拾われる。
- **`eslint-disable-next-line @intlify/vue-i18n/no-raw-text`** を1行足している。同ファイル L34 の em-dash と同じ理由・同じ書式（`EM_DASH` は helpers 内の module-private const で export されていないため、テンプレートからは参照できない）。
- **npm 配布**: 報告は MulmoTerminal（npm の `@mulmoclaude/collection-plugin` 3.1.0）からで、そちらに届けるにはマージ後に collection-plugin の publish が別途必要。この PR ではバージョンを上げていない。

## 実装と検証

**変更ファイル**

| ファイル | 内容 |
|---|---|
| `packages/plugins/collection-plugin/src/vue/components/CollectionEmbedView.vue` | 分岐1本（+6行） |
| `test/plugins/collection/test_collectionRenderers.ts` | `buildEmbedViews` に空 `idField`（キー無し / 空文字）のケース |
| `e2e/tests/collection-embed-unset.spec.ts` | 新規。解決する / 未設定 / 空文字 / ghost の4本 |
| `plans/fix-2863-embed-unset-fail-soft.md` | プラン |
| `docs/CHANGELOG.md` | Unreleased の Fixed に追記 |

既存の unit は `customerId: "ghost"`（リンク切れ）だけで、「`found: false` かつ `recordId: ""`」= 描画が分岐する状態を押さえていなかった。Vue コンポーネントの単体テストはこのリポジトリに無いので、描画分岐の ground truth は e2e に置いた。e2e はレコードを `?selected=` のディープリンクで開いている — 一覧の行は `ref` セルをリンクとして持つので、行の中央クリックがそれに当たって参照先コレクションへ遷移してしまうため（実際に一度踏んだ）。

**検証**

- `yarn format` → `lint`（error 0）→ `typecheck` → `build` → `yarn test`（exit 0）
- 新 e2e 4本 green、`collection` 系 e2e **86本 green**
- **修正を戻すと赤くなることを確認した**: ソースを戻して plugin と app を再ビルドすると未設定の2本が `toHaveText("—")` で落ち、戻すと再び green。e2e はプラグインの `dist` を読むので、ソースを戻すだけでは赤くならない（最初これで一度騙された）

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2863 これ、対策できる？
- （実装と検証の報告に対して）コミット → push → PR 作成まで進めてよい

work in mulmoclaude2

## Summary by Sourcery

Render embeds with empty optional id fields as unset rather than broken links, aligning the UI with the schema’s fail-soft "no record" contract.

Bug Fixes:
- Treat embeds whose optional idField resolves to an empty target id as empty fields, leaving the missing-record error card only for references pointing to non-existent records.

Documentation:
- Document the corrected handling of embeds with empty optional idField values in the changelog.

Tests:
- Add unit coverage for buildEmbedViews when an embed’s idField is absent or an empty string.
- Add end-to-end tests verifying unset embeds render the empty-field glyph while truly missing targets still show the error card.

Chores:
- Add a planning document outlining the cause, fix, and test strategy for the unset-embed fail-soft behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Embeds with an absent or blank optional ID now display an em dash instead of a missing-record error.
  * References to genuinely deleted or unresolved records continue to show the missing-record state.

* **Tests**
  * Added coverage for resolved, blank, unset, and dangling embedded references.

* **Documentation**
  * Documented the updated embed behavior in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->