### PR TITLE
feat(collections): 一覧の並び順を slug / 表示名で切り替えられるようにする (#2836)

### DIFF
--- a/e2e/tests/collection-index-sort.spec.ts
+++ b/e2e/tests/collection-index-sort.spec.ts
@@ -1,0 +1,93 @@
+// E2E for the collections-index display order (#2836): the Slug / Name toggle
+// reorders the cards, the choice survives a reload (localStorage), and the
+// control stays out of the way when there is nothing to order.
+//
+// The slugs and titles below deliberately disagree, so each assertion pins a
+// real reordering rather than one order that happens to match both keys.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const COLLECTIONS_LIST = {
+  collections: [
+    { slug: "alpha", title: "Zebra", icon: "bookmark", source: "user" },
+    { slug: "beta", title: "Mango", icon: "bookmark", source: "user" },
+    { slug: "gamma", title: "Apple", icon: "bookmark", source: "user" },
+  ],
+};
+
+const BY_SLUG = ["alpha", "beta", "gamma"];
+const BY_TITLE = ["gamma", "beta", "alpha"];
+
+async function mockCollections(page: Page, json: unknown = COLLECTIONS_LIST): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections",
+    (route) => route.fulfill({ json }),
+  );
+}
+
+/** Slugs in the order the cards are laid out in the DOM. */
+async function renderedSlugs(page: Page): Promise<string[]> {
+  const ids = await page
+    .locator('[data-testid^="collections-index-card-"]')
+    .evaluateAll((nodes) => nodes.map((node) => node.getAttribute("data-testid") ?? ""));
+  return ids.map((testId) => testId.replace("collections-index-card-", ""));
+}
+
+test.describe("collections index display order", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockCollections(page);
+  });
+
+  test("defaults to slug order and switches to name order on click", async ({ page }) => {
+    await page.goto("/collections");
+    await expect(page.getByTestId("collections-index-card-alpha")).toBeVisible();
+
+    // Default matches the server's discovery order, so nothing moves for a user
+    // who never touches the toggle.
+    expect(await renderedSlugs(page)).toEqual(BY_SLUG);
+    await expect(page.getByTestId("collections-sort-slug")).toHaveAttribute("aria-pressed", "true");
+    // Labels come from the plugin's own i18n bundle; a missing key renders the
+    // raw key path instead, which every testid-only assertion would sail past.
+    await expect(page.getByTestId("collections-sort")).toContainText("Order");
+    await expect(page.getByTestId("collections-sort-title")).toHaveText("Name");
+
+    await page.getByTestId("collections-sort-title").click();
+
+    await expect.poll(() => renderedSlugs(page)).toEqual(BY_TITLE);
+    await expect(page.getByTestId("collections-sort-title")).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByTestId("collections-sort-slug")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("keeps the chosen order across a reload", async ({ page }) => {
+    await page.goto("/collections");
+    await page.getByTestId("collections-sort-title").click();
+    await expect.poll(() => renderedSlugs(page)).toEqual(BY_TITLE);
+
+    await page.reload();
+
+    await expect(page.getByTestId("collections-index-card-alpha")).toBeVisible();
+    expect(await renderedSlugs(page)).toEqual(BY_TITLE);
+    await expect(page.getByTestId("collections-sort-title")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("switching back to slug restores the discovery order", async ({ page }) => {
+    await page.goto("/collections");
+    await page.getByTestId("collections-sort-title").click();
+    await expect.poll(() => renderedSlugs(page)).toEqual(BY_TITLE);
+
+    await page.getByTestId("collections-sort-slug").click();
+
+    await expect.poll(() => renderedSlugs(page)).toEqual(BY_SLUG);
+    await expect(page.getByTestId("collections-sort-slug")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("hides the toggle when a single collection leaves nothing to order", async ({ page }) => {
+    await mockCollections(page, { collections: [COLLECTIONS_LIST.collections[0]] });
+    await page.goto("/collections");
+
+    await expect(page.getByTestId("collections-index-card-alpha")).toBeVisible();
+    await expect(page.getByTestId("collections-sort")).toBeHidden();
+  });
+});

--- a/e2e/tests/collection-index-sort.spec.ts
+++ b/e2e/tests/collection-index-sort.spec.ts
@@ -86,6 +86,28 @@ test.describe("collections index display order", () => {
     await expect(page.getByTestId("collections-sort-slug")).toHaveAttribute("aria-pressed", "true");
   });
 
+  test("hides the toggle when a FILTER leaves a single card, and brings it back", async ({ page }) => {
+    // The single-collection case below would also pass an implementation that
+    // counted the unfiltered list (CodeRabbit on #2896). This one only passes
+    // when the count follows what is actually on screen. The read-only entry is
+    // what makes the facet chips render at all.
+    await mockCollections(page, {
+      collections: [...COLLECTIONS_LIST.collections, { slug: "delta", title: "Data", icon: "database", source: "user", readonly: true }],
+    });
+    await page.goto("/collections");
+    await expect(page.getByTestId("collections-sort")).toBeVisible();
+
+    await page.getByTestId("collections-filter-data").click();
+
+    await expect(page.getByTestId("collections-index-card-delta")).toBeVisible();
+    await expect(page.getByTestId("collections-index-card-beta")).toBeHidden();
+    await expect(page.getByTestId("collections-sort")).toBeHidden();
+
+    await page.getByTestId("collections-filter-all").click();
+
+    await expect(page.getByTestId("collections-sort")).toBeVisible();
+  });
+
   test("hides the toggle when a single collection leaves nothing to order", async ({ page }) => {
     await mockCollections(page, { collections: [COLLECTIONS_LIST.collections[0]] });
     await page.goto("/collections");

--- a/e2e/tests/collection-index-sort.spec.ts
+++ b/e2e/tests/collection-index-sort.spec.ts
@@ -8,16 +8,19 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockAllApis } from "../fixtures/api";
 
+// Served in an order no client-side comparator would reproduce by accident, so
+// the default mode is pinned to "hand back exactly what the server sent" rather
+// than to "re-sort by slug and hope it matches" (Codex + Sourcery on #2896).
 const COLLECTIONS_LIST = {
   collections: [
-    { slug: "alpha", title: "Zebra", icon: "bookmark", source: "user" },
-    { slug: "beta", title: "Mango", icon: "bookmark", source: "user" },
+    { slug: "beta", title: "Zebra", icon: "bookmark", source: "user" },
+    { slug: "alpha", title: "Mango", icon: "bookmark", source: "user" },
     { slug: "gamma", title: "Apple", icon: "bookmark", source: "user" },
   ],
 };
 
-const BY_SLUG = ["alpha", "beta", "gamma"];
-const BY_TITLE = ["gamma", "beta", "alpha"];
+const SERVER_ORDER = ["beta", "alpha", "gamma"];
+const BY_TITLE = ["gamma", "alpha", "beta"];
 
 async function mockCollections(page: Page, json: unknown = COLLECTIONS_LIST): Promise<void> {
   await page.route(
@@ -40,13 +43,13 @@ test.describe("collections index display order", () => {
     await mockCollections(page);
   });
 
-  test("defaults to slug order and switches to name order on click", async ({ page }) => {
+  test("keeps the server order by default and switches to name order on click", async ({ page }) => {
     await page.goto("/collections");
-    await expect(page.getByTestId("collections-index-card-alpha")).toBeVisible();
+    await expect(page.getByTestId("collections-index-card-beta")).toBeVisible();
 
-    // Default matches the server's discovery order, so nothing moves for a user
-    // who never touches the toggle.
-    expect(await renderedSlugs(page)).toEqual(BY_SLUG);
+    // Default hands back the server's discovery order verbatim, so nothing moves
+    // for a user who never touches the toggle.
+    expect(await renderedSlugs(page)).toEqual(SERVER_ORDER);
     await expect(page.getByTestId("collections-sort-slug")).toHaveAttribute("aria-pressed", "true");
     // Labels come from the plugin's own i18n bundle; a missing key renders the
     // raw key path instead, which every testid-only assertion would sail past.
@@ -67,19 +70,19 @@ test.describe("collections index display order", () => {
 
     await page.reload();
 
-    await expect(page.getByTestId("collections-index-card-alpha")).toBeVisible();
+    await expect(page.getByTestId("collections-index-card-beta")).toBeVisible();
     expect(await renderedSlugs(page)).toEqual(BY_TITLE);
     await expect(page.getByTestId("collections-sort-title")).toHaveAttribute("aria-pressed", "true");
   });
 
-  test("switching back to slug restores the discovery order", async ({ page }) => {
+  test("switching back to slug restores the server order", async ({ page }) => {
     await page.goto("/collections");
     await page.getByTestId("collections-sort-title").click();
     await expect.poll(() => renderedSlugs(page)).toEqual(BY_TITLE);
 
     await page.getByTestId("collections-sort-slug").click();
 
-    await expect.poll(() => renderedSlugs(page)).toEqual(BY_SLUG);
+    await expect.poll(() => renderedSlugs(page)).toEqual(SERVER_ORDER);
     await expect(page.getByTestId("collections-sort-slug")).toHaveAttribute("aria-pressed", "true");
   });
 
@@ -87,7 +90,7 @@ test.describe("collections index display order", () => {
     await mockCollections(page, { collections: [COLLECTIONS_LIST.collections[0]] });
     await page.goto("/collections");
 
-    await expect(page.getByTestId("collections-index-card-alpha")).toBeVisible();
+    await expect(page.getByTestId("collections-index-card-beta")).toBeVisible();
     await expect(page.getByTestId("collections-sort")).toBeHidden();
   });
 });

--- a/packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts
+++ b/packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts
@@ -1,0 +1,56 @@
+// Display order for the collections index (#2836), persisted to localStorage.
+//
+// The server's `discoverCollections()` order (slug ascending) stays the
+// canonical one — it is shared with the watchers, the ontology and the mobile
+// remote — so the user's choice is applied here, over the fetched list, and
+// never pushed down into discovery.
+
+export const INDEX_SORT_KEYS = ["slug", "title"] as const;
+export type CollectionIndexSort = (typeof INDEX_SORT_KEYS)[number];
+
+export const DEFAULT_INDEX_SORT: CollectionIndexSort = "slug";
+
+/** Minimal shape the order depends on — keeps the comparator usable from a
+ *  test without constructing a whole `CollectionSummary`. */
+export interface SortableCollection {
+  slug: string;
+  title: string;
+}
+
+export function isCollectionIndexSort(value: unknown): value is CollectionIndexSort {
+  return typeof value === "string" && INDEX_SORT_KEYS.some((key) => key === value);
+}
+
+/** Order the index list by the chosen key. Titles are compared with the UI
+ *  locale's collator — the browser default varies by OS, so the same workspace
+ *  would otherwise sort differently per machine. Ties break on slug, which is
+ *  unique, so two collections sharing a title keep a stable order instead of
+ *  swapping places on every re-render. */
+export function sortCollectionsForIndex<T extends SortableCollection>(list: readonly T[], key: CollectionIndexSort, locale: string): T[] {
+  const collator = new Intl.Collator(locale, { numeric: true });
+  return [...list].sort((left, right) => {
+    const byKey = key === "title" ? collator.compare(left.title, right.title) : collator.compare(left.slug, right.slug);
+    return byKey !== 0 ? byKey : collator.compare(left.slug, right.slug);
+  });
+}
+
+const STORAGE_KEY = "collection_index_sort";
+
+export function readCollectionIndexSort(): CollectionIndexSort {
+  try {
+    const raw: unknown = localStorage.getItem(STORAGE_KEY);
+    return isCollectionIndexSort(raw) ? raw : DEFAULT_INDEX_SORT;
+  } catch {
+    // localStorage unavailable (private mode / disabled) — fall back to the
+    // default rather than breaking the index.
+    return DEFAULT_INDEX_SORT;
+  }
+}
+
+export function writeCollectionIndexSort(key: CollectionIndexSort): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, key);
+  } catch {
+    // Best-effort preference: quota / disabled storage must not break the view.
+  }
+}

--- a/packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts
+++ b/packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts
@@ -21,16 +21,24 @@ export function isCollectionIndexSort(value: unknown): value is CollectionIndexS
   return typeof value === "string" && INDEX_SORT_KEYS.some((key) => key === value);
 }
 
-/** Order the index list by the chosen key. Titles are compared with the UI
- *  locale's collator — the browser default varies by OS, so the same workspace
- *  would otherwise sort differently per machine. Ties break on slug, which is
- *  unique, so two collections sharing a title keep a stable order instead of
+/** Order the index list by the chosen key.
+ *
+ *  `slug` returns the fetched order untouched. Re-sorting it here would have to
+ *  reproduce discovery's `slug.localeCompare` exactly, and any drift moves cards
+ *  for users who never open the toggle — a `numeric: true` collator, for one,
+ *  puts `s2` ahead of `s10` where discovery puts `s10` first.
+ *
+ *  `title` is compared with the UI locale's collator: the browser default varies
+ *  by OS, so the same workspace would otherwise sort differently per machine.
+ *  Ties break on slug — which is unique, and compared the way discovery compares
+ *  it — so two collections sharing a title keep a stable order instead of
  *  swapping places on every re-render. */
 export function sortCollectionsForIndex<T extends SortableCollection>(list: readonly T[], key: CollectionIndexSort, locale: string): T[] {
+  if (key === "slug") return [...list];
   const collator = new Intl.Collator(locale, { numeric: true });
   return [...list].sort((left, right) => {
-    const byKey = key === "title" ? collator.compare(left.title, right.title) : collator.compare(left.slug, right.slug);
-    return byKey !== 0 ? byKey : collator.compare(left.slug, right.slug);
+    const byTitle = collator.compare(left.title, right.title);
+    return byTitle !== 0 ? byTitle : left.slug.localeCompare(right.slug);
   });
 }
 

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -70,29 +70,50 @@
         </div>
 
         <div v-else>
-          <!-- Data filter chips: only shown when the workspace actually has
-               read-only (dataSource-backed) collections to separate out. -->
-          <div v-if="hasReadonlyCollections" class="flex items-center gap-1.5 mb-4" data-testid="collections-filter-chips">
-            <button
-              v-for="chip in FILTER_CHIPS"
-              :key="chip"
-              type="button"
-              class="px-3 h-7 rounded-full text-xs font-semibold border transition-colors"
-              :class="
-                filter === chip
-                  ? 'bg-indigo-600 border-indigo-600 text-white'
-                  : 'bg-white border-slate-200 text-slate-500 hover:text-slate-700 hover:bg-slate-50'
-              "
-              :data-testid="`collections-filter-${chip}`"
-              @click="filter = chip"
-            >
-              {{ t(`collectionsView.filter.${chip}`) }}
-            </button>
+          <!-- Data filter chips (only when the workspace actually has read-only
+               dataSource-backed collections to separate out) and the display-order
+               toggle, which sits on the right of the same row either way. -->
+          <div v-if="hasReadonlyCollections || canSort" class="flex items-center gap-3 mb-4">
+            <div v-if="hasReadonlyCollections" class="flex items-center gap-1.5" data-testid="collections-filter-chips">
+              <button
+                v-for="chip in FILTER_CHIPS"
+                :key="chip"
+                type="button"
+                class="px-3 h-7 rounded-full text-xs font-semibold border transition-colors"
+                :class="
+                  filter === chip
+                    ? 'bg-indigo-600 border-indigo-600 text-white'
+                    : 'bg-white border-slate-200 text-slate-500 hover:text-slate-700 hover:bg-slate-50'
+                "
+                :data-testid="`collections-filter-${chip}`"
+                @click="filter = chip"
+              >
+                {{ t(`collectionsView.filter.${chip}`) }}
+              </button>
+            </div>
+
+            <div v-if="canSort" class="ml-auto flex items-center gap-2" data-testid="collections-sort">
+              <span class="text-xs font-medium text-slate-400">{{ t("collectionsView.sort.label") }}</span>
+              <div class="flex items-center gap-0.5 rounded-lg bg-slate-100 p-0.5">
+                <button
+                  v-for="key in INDEX_SORT_KEYS"
+                  :key="key"
+                  type="button"
+                  class="px-3 h-7 rounded-md text-xs font-semibold transition-colors"
+                  :class="sort === key ? 'bg-white text-indigo-700 shadow-sm' : 'text-slate-500 hover:text-slate-700'"
+                  :data-testid="`collections-sort-${key}`"
+                  :aria-pressed="sort === key"
+                  @click="setSort(key)"
+                >
+                  {{ t(`collectionsView.sort.${key}`) }}
+                </button>
+              </div>
+            </div>
           </div>
 
           <div class="grid gap-4 sm:grid-cols-2">
             <div
-              v-for="collection in filteredCollections"
+              v-for="collection in visibleCollections"
               :key="collection.slug"
               class="group relative rounded-xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md hover:border-indigo-300 transition-all duration-300 cursor-pointer flex items-center gap-4 focus:outline-none focus:ring-2 focus:ring-indigo-500/20"
               role="button"
@@ -177,9 +198,10 @@ import { useCollectionUi } from "../scopedUi";
 import DiscoverPanel from "./DiscoverPanel.vue";
 import CollectionOntologyGraphView from "./CollectionOntologyGraphView.vue";
 import NewCollectionModal from "./NewCollectionModal.vue";
+import { INDEX_SORT_KEYS, readCollectionIndexSort, sortCollectionsForIndex, writeCollectionIndexSort, type CollectionIndexSort } from "../collectionIndexSort";
 import type { CollectionSummary } from "@mulmoclaude/core/collection";
 
-const { t } = useCollectionI18n();
+const { t, locale } = useCollectionI18n();
 // Host couplings (list/navigate/chat/shortcuts/pin) via the injected binding.
 const cui = useCollectionUi();
 const { pinToggle, reconcileShortcuts } = cui;
@@ -204,6 +226,20 @@ const filteredCollections = computed<CollectionSummary[]>(() => {
   if (filter.value === "data") return collections.value.filter((collection) => collection.readonly === true);
   return collections.value;
 });
+
+// Display order (#2836). A UI-local preference layered over the fetched list —
+// the server's discovery order stays slug-ascending for the watchers, the
+// ontology and the mobile remote, which all read the same call. Sorting title-
+// first gives the user a way to arrange the index by renaming a title, which is
+// safe, instead of renaming a slug, which means migrating the data.
+const sort = ref<CollectionIndexSort>(readCollectionIndexSort());
+const canSort = computed<boolean>(() => collections.value.length > 1);
+const visibleCollections = computed<CollectionSummary[]>(() => sortCollectionsForIndex(filteredCollections.value, sort.value, locale.value));
+
+function setSort(key: CollectionIndexSort): void {
+  sort.value = key;
+  writeCollectionIndexSort(key);
+}
 
 async function loadCollections(): Promise<void> {
   loading.value = true;

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -233,7 +233,9 @@ const filteredCollections = computed<CollectionSummary[]>(() => {
 // first gives the user a way to arrange the index by renaming a title, which is
 // safe, instead of renaming a slug, which means migrating the data.
 const sort = ref<CollectionIndexSort>(readCollectionIndexSort());
-const canSort = computed<boolean>(() => collections.value.length > 1);
+// Reads the FILTERED list, not the whole one: a facet that leaves a single card
+// leaves nothing to order, and a toggle that cannot change what you see is noise.
+const canSort = computed<boolean>(() => filteredCollections.value.length > 1);
 const visibleCollections = computed<CollectionSummary[]>(() => sortCollectionsForIndex(filteredCollections.value, sort.value, locale.value));
 
 function setSort(key: CollectionIndexSort): void {

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -57,6 +57,7 @@ const deMessages: CollectionMessages = {
     readonlyChip: "Schreibgeschützt",
     itemsEmptyReadonly: "Noch keine Zeilen in der Datendatei. Füge der Datei Zeilen hinzu, dann erscheinen sie hier.",
     filter: { all: "Alle", editable: "Bearbeitbar", data: "Daten" },
+    sort: { label: "Sortierung", slug: "Slug", title: "Name" },
     mapTab: "Karte",
     mapEmpty: "Noch nichts zu zeigen — die Karte entsteht von selbst, sobald Sammlungen und ihre Verknüpfungen entstehen.",
     mapRecordCount: "{count} Einträge",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -54,6 +54,7 @@ const enMessages = {
     readonlyChip: "Read-only",
     itemsEmptyReadonly: "No rows in the data file yet. Add rows to the file and they appear here.",
     filter: { all: "All", editable: "Editable", data: "Data" },
+    sort: { label: "Order", slug: "Slug", title: "Name" },
     mapTab: "Map",
     mapEmpty: "Nothing to map yet — the map draws itself as collections and the links between them appear.",
     mapRecordCount: "{count} records",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -57,6 +57,7 @@ const esMessages: CollectionMessages = {
     readonlyChip: "Solo lectura",
     itemsEmptyReadonly: "El archivo de datos aún no tiene filas. Añádelas al archivo y aparecerán aquí.",
     filter: { all: "Todas", editable: "Editables", data: "Datos" },
+    sort: { label: "Orden", slug: "Slug", title: "Nombre" },
     mapTab: "Mapa",
     mapEmpty: "Nada que mostrar todavía: el mapa se dibuja solo a medida que aparecen colecciones y los enlaces entre ellas.",
     mapRecordCount: "{count} registros",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -58,6 +58,7 @@ const frMessages: CollectionMessages = {
     readonlyChip: "Lecture seule",
     itemsEmptyReadonly: "Le fichier de données ne contient pas encore de lignes. Ajoutez-en au fichier et elles apparaîtront ici.",
     filter: { all: "Toutes", editable: "Modifiables", data: "Données" },
+    sort: { label: "Tri", slug: "Slug", title: "Nom" },
     mapTab: "Carte",
     mapEmpty: "Rien à afficher pour l'instant — la carte se dessine d'elle-même à mesure que les collections et leurs liens apparaissent.",
     mapRecordCount: "{count} enregistrements",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -56,6 +56,7 @@ const jaMessages: CollectionMessages = {
     readonlyChip: "読み取り専用",
     itemsEmptyReadonly: "データファイルにまだ行がありません。ファイルに行を追加するとここに表示されます。",
     filter: { all: "すべて", editable: "編集可能", data: "データ" },
+    sort: { label: "並び順", slug: "Slug", title: "表示名" },
     mapTab: "マップ",
     mapEmpty: "まだ表示するものがありません。コレクションとその間のリンクが増えると、マップが自動的に描かれます。",
     mapRecordCount: "{count} 件のレコード",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -56,6 +56,7 @@ const koMessages: CollectionMessages = {
     readonlyChip: "읽기 전용",
     itemsEmptyReadonly: "데이터 파일에 아직 행이 없습니다. 파일에 행을 추가하면 여기에 표시됩니다.",
     filter: { all: "전체", editable: "편집 가능", data: "데이터" },
+    sort: { label: "정렬", slug: "Slug", title: "이름" },
     mapTab: "맵",
     mapEmpty: "아직 표시할 내용이 없습니다. 컬렉션과 그 사이의 링크가 생기면 맵이 자동으로 그려집니다.",
     mapRecordCount: "레코드 {count}개",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -57,6 +57,7 @@ const ptBRMessages: CollectionMessages = {
     readonlyChip: "Somente leitura",
     itemsEmptyReadonly: "O arquivo de dados ainda não tem linhas. Adicione linhas ao arquivo e elas aparecerão aqui.",
     filter: { all: "Todas", editable: "Editáveis", data: "Dados" },
+    sort: { label: "Ordem", slug: "Slug", title: "Nome" },
     mapTab: "Mapa",
     mapEmpty: "Nada para mostrar ainda — o mapa se desenha sozinho conforme coleções e os vínculos entre elas aparecem.",
     mapRecordCount: "{count} registros",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -55,6 +55,7 @@ const zhMessages: CollectionMessages = {
     readonlyChip: "只读",
     itemsEmptyReadonly: "数据文件中还没有行。在文件中添加行后会显示在这里。",
     filter: { all: "全部", editable: "可编辑", data: "数据" },
+    sort: { label: "排序", slug: "Slug", title: "名称" },
     mapTab: "地图",
     mapEmpty: "暂无可显示的内容。随着集合及其之间的链接增多，地图会自动绘制。",
     mapRecordCount: "{count} 条记录",

--- a/plans/feat-2836-collections-index-sort.md
+++ b/plans/feat-2836-collections-index-sort.md
@@ -1,0 +1,76 @@
+# feat(collections): コレクション一覧の並び順をユーザーが選べるようにする (#2836)
+
+## 背景
+
+コレクション一覧の並び順は slug の辞書順に固定で、利用者が変える手段が無い。そのため「並び順を整えたい」
+という軽い要望が「slug を改名する」という重い操作（新 slug で作り直し → データ移送 → 旧削除）に誘導されて
+いる。実際に Discord でその経路を辿った報告があり、移行後も旧 slug のデータを指したままでデータ喪失の
+一歩手前だった。
+
+表示名（title）は dataPath と結合していないためいつでも安全に変えられる。並び順のキーを
+「slug 順 / 表示名順」で切り替えられるようにすれば、「順番を変えたい → 表示名を直す」に誘導でき、
+slug に手を入れる動機を減らせる。
+
+## 方針: ソートは UI に閉じる
+
+並び順の発生源はコードベースに1箇所しかない。
+
+```ts
+// packages/core/src/collection/server/discovery.ts:288
+return [...merged.values()].sort((left, right) => left.slug.localeCompare(right.slug));
+```
+
+**ここは触らない。** `discoverCollections()` の戻り値の順序は一覧 UI 以外にも共有されているため:
+
+| 消費者 | 用途 |
+|---|---|
+| `server/api/routes/collections.ts` | 一覧 API |
+| `server/remoteHost/handlers/listCollections.ts` | モバイル（Remote Host）一覧 |
+| `packages/core/src/collection-watchers/watcher.ts` | コレクション監視 |
+| `packages/core/src/collection/server/ontology.ts` | Map タブ（slug 順前提） |
+
+ソートは `CollectionsIndexView.vue` の computed の中だけで行い、discovery 側は canonical order のまま
+据え置く。これにより API・エージェント・監視・モバイルの見え方は一切変わらない。
+
+## 変更点
+
+1. **`packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts`（新規）**
+   - `CollectionIndexSort = "slug" | "title"`
+   - `sortCollectionsForIndex(list, key, locale)` — 純粋関数。`Intl.Collator(locale, { numeric: true })` で
+     比較し、**同名タイトルのタイブレークは slug**（安定順序の担保）。
+   - localStorage の read/write（既存 `collectionViewMode.ts` と同じ形。不正値は握って既定値に落とす）。
+2. **`CollectionsIndexView.vue`** — sort state + computed + トグル UI。既存のフィルタチップ行に相乗り
+   （チップは readonly コレクションがある時だけ出るので、行自体を `justify-between` に組み替えて
+   ソートトグルは常時右寄せ）。コレクションが 2 件未満のときはトグルを出さない。
+3. **i18n** — `collectionsView.sort.{label,slug,title}` を 8 ロケール（en/ja/zh/ko/es/pt-BR/fr/de）に lockstep で追加。
+4. **テスト**
+   - `test/utils/collections/test_collectionIndexSort.ts` — 純粋関数の unit test（既存
+     `test_tableSortDisplay.ts` と同じ配置規約）。
+   - `e2e/tests/collection-index-sort.spec.ts` — 実ブラウザでカードの並びが切り替わること、
+     リロード後も保持されることを断定。
+
+## 明示的にやらないこと
+
+- **discovery.ts のソート変更**（上記のとおり波及先が広い）。
+- **モバイル（Remote Host）側**への同機能追加。desktop だけ並びが変わるため端末間で見え方は割れるが、
+  モバイルは別 UI・別導線なので本 issue のスコープ外とする。必要なら追って別 issue。
+- **FeedsView** の並び順。同じ index パターンだが対象外（一覧間で基準が割れるのは許容、軽微）。
+- **表示名を編集する UI**。title は skill 側 schema にあり、現状 UI からは編集できない。本 issue の狙いを
+  完全に満たすには編集導線も要るかもしれないが、まずソートキー切替だけ入れて様子を見る。PR に明記する。
+- **五十音順**。日本語タイトルの辞書順は五十音順にならない（漢字が読み順に並ばない）が、OS のファイル
+  一覧と同じ挙動なので issue の方針どおりそのまま入れる。読み仮名は持たせない。
+
+## 確認事項
+
+- ピン留めの並び順は壊れない。一覧は `reconcileShortcuts(collections)` を呼ぶが、
+  `src/composables/useShortcuts.ts` の `reconcile()` は既存 `shortcuts.value` の順序を保ったまま
+  prune / title 更新するだけで、渡された配列の順序を採用しない（#2519 の手動ピン順と無干渉）。
+  念のため、渡す配列はソート前の `collections.value` のままにする。
+- `localeCompare` の既定ロケールはブラウザ依存なので、UI ロケール（`useCollectionI18n()` の `locale`）を
+  明示的に `Intl.Collator` へ渡す。
+- 既存 e2e はカードの可視性しか見ておらず順序を断定していないため、影響しない。
+
+## リリース
+
+`@mulmoclaude/collection-plugin` は publish 済みパッケージ。npm 版ユーザーへ届けるには version bump +
+依存レンジ sweep + タグ付き publish が別途必要（本 PR では行わず、通常のリリースフローに委ねる）。

--- a/test/utils/collections/test_collectionIndexSort.ts
+++ b/test/utils/collections/test_collectionIndexSort.ts
@@ -25,9 +25,31 @@ const SAMPLE: SortableCollection[] = [
   { slug: "memo", title: "Apple" },
 ];
 
+// What `discoverCollections()` does before the list ever reaches the browser
+// (packages/core/src/collection/server/discovery.ts). Written out rather than
+// imported so the expectation is pinned to the RULE, not to a fixture that
+// would drift with it.
+const inDiscoveryOrder = <T extends SortableCollection>(list: readonly T[]): T[] => [...list].sort((left, right) => left.slug.localeCompare(right.slug));
+
 describe("sortCollectionsForIndex", () => {
-  it("orders by slug when the key is slug, whatever the input order", () => {
-    assert.deepEqual(slugsOf(sortCollectionsForIndex(SAMPLE, "slug", "en")), ["budget", "memo", "reading-list"]);
+  it("hands back the server's order untouched in slug mode", () => {
+    const discovered = inDiscoveryOrder(SAMPLE);
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(discovered, "slug", "en")), slugsOf(discovered));
+  });
+
+  it("does not reorder digit-bearing slugs in slug mode", () => {
+    // Regression (Codex + Sourcery on #2896): a `numeric: true` collator puts
+    // `s2` ahead of `s10`, while discovery's `slug.localeCompare` puts `s10`
+    // first. Sorting again on the client moved cards for users who never open
+    // the toggle — the one thing the default mode must never do.
+    const discovered = inDiscoveryOrder([
+      { slug: "s2", title: "Sprint 2" },
+      { slug: "s10", title: "Sprint 10" },
+      { slug: "x1", title: "X 1" },
+      { slug: "x02", title: "X 02" },
+    ]);
+    assert.deepEqual(slugsOf(discovered), ["s10", "s2", "x02", "x1"]);
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(discovered, "slug", "en")), slugsOf(discovered));
   });
 
   it("orders by title when the key is title", () => {
@@ -61,7 +83,15 @@ describe("sortCollectionsForIndex", () => {
     assert.deepEqual(slugsOf(sortCollectionsForIndex(numbered, "title", "en")), ["s2", "s10"]);
   });
 
-  it("uses the locale's collator for Japanese titles — kana ahead of kanji, and kanji NOT by reading", () => {
+  it("uses the locale's collator for Japanese titles — kana ahead of kanji, and kanji NOT by reading", (ctx) => {
+    // A small-icu runtime has no `ja` collation data and resolves the request
+    // down to root, where this order does not hold. Skip rather than assert an
+    // order the runtime cannot produce — and rather than mock `Intl.Collator`,
+    // which would only assert the mock (Sourcery's suggestion on #2896).
+    if (new Intl.Collator("ja").resolvedOptions().locale !== "ja") {
+      ctx.skip("runtime lacks ja collation data (small-icu)");
+      return;
+    }
     // The order the issue documents and accepts (#2836): dictionary order, the
     // same a file manager shows, NOT 五十音順 — 家計簿 sorts by code point, so it
     // lands after the kana titles rather than under か.

--- a/test/utils/collections/test_collectionIndexSort.ts
+++ b/test/utils/collections/test_collectionIndexSort.ts
@@ -1,0 +1,96 @@
+// Unit tests for the collections-index display order
+// (packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts) — the pure
+// comparator behind the "Slug / Name" toggle (#2836). Pinned here so the view
+// stays a thin reactive shell, and so the tie-break (the part a re-render would
+// otherwise expose as flicker) has a test that does not need a browser.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_INDEX_SORT,
+  INDEX_SORT_KEYS,
+  isCollectionIndexSort,
+  sortCollectionsForIndex,
+  type SortableCollection,
+} from "../../../packages/plugins/collection-plugin/src/vue/collectionIndexSort";
+
+const slugsOf = (list: readonly SortableCollection[]): string[] => list.map((entry) => entry.slug);
+
+// Titles deliberately disagree with the slugs, so a comparator that ignored the
+// key and always fell back to slug would fail the title case.
+const SAMPLE: SortableCollection[] = [
+  { slug: "reading-list", title: "Zebra" },
+  { slug: "budget", title: "Mango" },
+  { slug: "memo", title: "Apple" },
+];
+
+describe("sortCollectionsForIndex", () => {
+  it("orders by slug when the key is slug, whatever the input order", () => {
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(SAMPLE, "slug", "en")), ["budget", "memo", "reading-list"]);
+  });
+
+  it("orders by title when the key is title", () => {
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(SAMPLE, "title", "en")), ["memo", "budget", "reading-list"]);
+  });
+
+  it("breaks a title tie on slug so equal titles keep a stable order", () => {
+    const tied: SortableCollection[] = [
+      { slug: "zebra", title: "Notes" },
+      { slug: "alpha", title: "Notes" },
+    ];
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(tied, "title", "en")), ["alpha", "zebra"]);
+    // Re-sorting an already-sorted list must not swap the pair back.
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(sortCollectionsForIndex(tied, "title", "en"), "title", "en")), ["alpha", "zebra"]);
+  });
+
+  it("does not mutate the input list", () => {
+    const input: SortableCollection[] = [
+      { slug: "b", title: "B" },
+      { slug: "a", title: "A" },
+    ];
+    sortCollectionsForIndex(input, "title", "en");
+    assert.deepEqual(slugsOf(input), ["b", "a"]);
+  });
+
+  it("sorts embedded numbers naturally, not as text", () => {
+    const numbered: SortableCollection[] = [
+      { slug: "s10", title: "Sprint 10" },
+      { slug: "s2", title: "Sprint 2" },
+    ];
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(numbered, "title", "en")), ["s2", "s10"]);
+  });
+
+  it("uses the locale's collator for Japanese titles — kana ahead of kanji, and kanji NOT by reading", () => {
+    // The order the issue documents and accepts (#2836): dictionary order, the
+    // same a file manager shows, NOT 五十音順 — 家計簿 sorts by code point, so it
+    // lands after the kana titles rather than under か.
+    const japanese: SortableCollection[] = [
+      { slug: "budget", title: "家計簿" },
+      { slug: "reading-list", title: "読書リスト" },
+      { slug: "calendar", title: "カレンダー" },
+    ];
+    assert.deepEqual(slugsOf(sortCollectionsForIndex(japanese, "title", "ja")), ["calendar", "budget", "reading-list"]);
+  });
+
+  it("returns an empty list unchanged", () => {
+    assert.deepEqual(sortCollectionsForIndex([], "title", "en"), []);
+  });
+});
+
+describe("isCollectionIndexSort", () => {
+  it("accepts every declared key", () => {
+    for (const key of INDEX_SORT_KEYS) assert.equal(isCollectionIndexSort(key), true);
+  });
+
+  it("rejects anything else, including non-strings a corrupted store could hold", () => {
+    for (const value of ["", "name", "Slug", null, undefined, 3, {}, ["slug"]]) {
+      assert.equal(isCollectionIndexSort(value), false);
+    }
+  });
+
+  it("has slug as the default, matching the server's discovery order", () => {
+    assert.equal(DEFAULT_INDEX_SORT, "slug");
+    assert.equal(isCollectionIndexSort(DEFAULT_INDEX_SORT), true);
+  });
+});


### PR DESCRIPTION
## Summary

コレクション一覧に「並び順」トグル（**Slug / 表示名**）を足しました。既定は今までどおり slug 順なので、
触らないユーザーの見え方は変わりません。選択は localStorage に保存され、リロード後も保たれます。

狙いは #2836 のとおり、**slug を改名する動機を減らす**こと。表示名は dataPath と結合していないため
いつでも安全に変えられるので、「並び順を変えたい → 表示名を直す」に誘導できます。

### ソートは UI に閉じた

並び順の発生源はコードベースに 1 箇所しかありません。

```ts
// packages/core/src/collection/server/discovery.ts:288
return [...merged.values()].sort((left, right) => left.slug.localeCompare(right.slug));
```

**ここは触っていません。** `discoverCollections()` の戻り値は一覧 UI 以外にも共有されているためです。

| 消費者 | 用途 |
|---|---|
| `server/api/routes/collections.ts` | 一覧 API |
| `server/remoteHost/handlers/listCollections.ts` | モバイル（Remote Host）一覧 |
| `packages/core/src/collection-watchers/watcher.ts` | コレクション監視 |
| `packages/core/src/collection/server/ontology.ts` | Map タブ（slug 順前提） |

ソートは `CollectionsIndexView.vue` の computed の中だけで行うので、API・エージェント・監視・モバイルの
見え方は一切変わりません。

### 変更点

- `packages/plugins/collection-plugin/src/vue/collectionIndexSort.ts`（新規）— 純粋な比較子 +
  localStorage 永続化（既存 `collectionViewMode.ts` と同じ形）
- `CollectionsIndexView.vue` — トグル UI。既存のフィルタチップ行に相乗り（チップは readonly
  コレクションがある時だけ出るので、行を組み替えてトグルは常に右寄せ）。コレクションが 1 件のときは出さない
- i18n 8 ロケール（en/ja/zh/ko/es/pt-BR/fr/de）
- unit test 10 件 + e2e 4 件

## Items to Confirm / Review

1. **モバイルは対象外にしました。** Remote Host の一覧は discovery 順のままなので、desktop で表示名順に
   していても**スマホでは slug 順**に見えます。端末間で並びが割れるのを許容するか、モバイルにも同じ
   トグルを入れるか、判断をお願いします（入れるなら別 issue が妥当と考えています）。
2. **表示名を編集する UI が現状ありません。** title は skill 側の schema にあり、変更はチャット経由です。
   本 issue の狙い（slug をいじる動機を減らす）を完全に満たすには編集導線も要るかもしれません。まずは
   ソートキー切替だけ入れて様子を見る判断です。
3. **五十音順にはなりません。** issue の方針どおり辞書順のまま入れています（漢字は読み順に並ばない）。
   OS のファイル一覧と同じ挙動で、テストで固定しました。読み仮名は持たせていません。
4. **`FeedsView` は対象外**です。同じ index パターンですが今回は触っていないため、一覧間で並び基準が
   割れます（軽微と判断）。
5. **ピン留めの順序には影響しません**（確認済み）。一覧は `reconcileShortcuts()` を呼びますが、
   `src/composables/useShortcuts.ts` の `reconcile()` は既存 `shortcuts.value` の順序を保ったまま
   prune / title 更新するだけで、渡された配列の順序を採用しません。念のため渡す配列はソート前のままに
   してあります（#2519 の手動ピン順と無干渉）。
6. **リリース**: `@mulmoclaude/collection-plugin` は publish 済みパッケージです。npm 版ユーザーに届けるには
   version bump + 依存レンジ sweep + タグ付き publish が別途必要ですが、本 PR では行っていません。

## 実装上の判断

- **タイブレークは slug**。表示名が重複したときに再描画で順序が入れ替わらないようにするため。
  テストで「ソート済みを再ソートしても入れ替わらない」ことまで固定しています。
- **`Intl.Collator` に UI ロケールを明示的に渡す**。`localeCompare` の既定ロケールはブラウザ依存で、
  同じワークスペースが端末ごとに違う順に並んでしまうためです。`numeric: true` なので
  「Sprint 2 → Sprint 10」も自然順になります。
- **永続化は localStorage**（端末ごと）。サーバ設定にはしていません。既存の
  `collectionViewMode.ts`（ビューモード / テーブルのソート）と同じ扱いに揃えました。

## 検証

- `yarn format` / `yarn lint`（0 error）/ `yarn typecheck` / `yarn build` — すべて通過
- `yarn test` — 全ファイル pass、fail 0（新規 unit test 10 件を含む）
- `yarn test:e2e --grep "collections index display order"` — **4 件 pass**。実ブラウザでカードの DOM 順が
  切り替わること、リロード後も保たれること、1 件のときトグルが出ないこと、そして**ラベルが i18n から
  解決されること**（キー漏れは testid だけの断定をすり抜けるため）を確認しています。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2836 これできる？副作用ない？
- 安全に進める

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Add a user-selectable display-order toggle to the collections index, allowing switching between slug and title-based ordering while keeping the server discovery order unchanged for non-UI consumers.

New Features:
- Introduce a Slug / Name sort toggle in the collections index to let users choose the card display order.
- Persist the selected collections index sort mode per device using localStorage.

Enhancements:
- Refactor collections index rendering to use a computed, locale-aware sorted list and hide the sort control when there is only one collection.
- Extend plugin i18n bundles with sort labels and options across supported locales.

Documentation:
- Add an internal plan document describing the collections index sorting feature, scope decisions, and release considerations.

Tests:
- Add unit tests for the collections index sort helper, covering stability, locale behavior, and invalid persisted values.
- Add Playwright E2E tests to verify UI ordering, persistence across reloads, and conditional visibility of the sort toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sorting controls to collection lists, allowing sorting by slug or display name.
  - Preserves the selected sort preference across page reloads.
  - Maintains the default server-provided order when sorting by slug.
  - Applies locale-aware ordering with consistent tie-breaking.
  - Hides sorting controls when fewer than two collections are displayed.
  - Added localized sorting labels across supported languages.

- **Tests**
  - Added unit and end-to-end coverage for sorting behavior, persistence, localization, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->