### PR TITLE
feat(collections): 一覧を検索欄で絞り込めるようにする

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### The collections index has a search box (#2837)
+
+A substring over title and slug, case-insensitive, ANDed with the existing
+Editable/Data chips. No match shows the same empty state the record list uses,
+and its link clears both narrowings — either one can be the reason the grid went
+empty.
+
+The issue proposed user-defined tags with chips. Search goes first because tags
+start empty on every collection that already exists: the filter only works once
+someone (or the agent, at creation time) has classified things, and until then a
+tag chip row narrows nothing. A search box works on the first workspace it meets,
+needs no schema field, no agent-facing documentation, and no registry export — the
+summary the index already fetches carries both searched values.
+
+What it deliberately does not do is hide anything by default, so the "human vs
+internal collection" half of the request is untouched and stays open.
+
 #### The projection says what each audience may CHANGE, and who may change it (#2891)
 
 `{tier}/config` gains `write[]`: per collection, the status field a transition

--- a/e2e/tests/collection-index-search.spec.ts
+++ b/e2e/tests/collection-index-search.spec.ts
@@ -1,0 +1,77 @@
+// E2E for the Collections index search box: a substring over title + slug
+// narrows the card grid, ANDed with the Editable/Data chip facet. The chips
+// only render when a read-only collection exists; the search box has no such
+// condition, so it is the narrowing available before anything is classified.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const COLLECTIONS_LIST = {
+  collections: [
+    { slug: "tasks", title: "Tasks", icon: "task_alt", source: "project" },
+    { slug: "task-templates", title: "Task Templates", icon: "content_copy", source: "project" },
+    { slug: "clients", title: "顧客", icon: "contact_page", source: "user" },
+    { slug: "stock-quotes", title: "Stock Quotes", icon: "trending_up", source: "user", readonly: true },
+  ],
+};
+
+async function mockCollections(page: Page): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections",
+    (route) => route.fulfill({ json: COLLECTIONS_LIST }),
+  );
+}
+
+const cardCount = (page: Page): Promise<number> => page.locator('[data-testid^="collections-index-card-"]').count();
+
+test.describe("collections index search", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAllApis(page);
+    await mockCollections(page);
+    await page.goto("/collections");
+    await expect(page.getByTestId("collections-index-card-tasks")).toBeVisible();
+  });
+
+  test("a substring narrows the grid to the matching cards", async ({ page }) => {
+    await page.getByTestId("collections-index-search").fill("task");
+    await expect(page.getByTestId("collections-index-card-tasks")).toBeVisible();
+    await expect(page.getByTestId("collections-index-card-task-templates")).toBeVisible();
+    await expect(page.getByTestId("collections-index-card-clients")).toHaveCount(0);
+    expect(await cardCount(page)).toBe(2);
+  });
+
+  test("the match is case-insensitive, hits the slug, and works on a non-ASCII title", async ({ page }) => {
+    const search = page.getByTestId("collections-index-search");
+    await search.fill("STOCK");
+    await expect(page.getByTestId("collections-index-card-stock-quotes")).toBeVisible();
+    // "k-qu" appears in the slug only — never in a title.
+    await search.fill("k-qu");
+    await expect(page.getByTestId("collections-index-card-stock-quotes")).toBeVisible();
+    await search.fill("顧");
+    await expect(page.getByTestId("collections-index-card-clients")).toBeVisible();
+    expect(await cardCount(page)).toBe(1);
+  });
+
+  test("no match shows the empty state, and clearing restores every card", async ({ page }) => {
+    await page.getByTestId("collections-index-search").fill("nothing-matches-this");
+    await expect(page.getByTestId("collections-index-no-matches")).toBeVisible();
+    expect(await cardCount(page)).toBe(0);
+
+    await page.getByTestId("collections-index-search-clear").click();
+    await expect(page.getByTestId("collections-index-no-matches")).toHaveCount(0);
+    expect(await cardCount(page)).toBe(4);
+  });
+
+  test("the search ANDs with the Data chip", async ({ page }) => {
+    await page.getByTestId("collections-filter-data").click();
+    expect(await cardCount(page)).toBe(1);
+
+    await page.getByTestId("collections-index-search").fill("tasks");
+    await expect(page.getByTestId("collections-index-no-matches")).toBeVisible();
+
+    // The empty-state link clears BOTH narrowings — either one can be the
+    // reason the grid went empty.
+    await page.getByTestId("collections-index-no-matches").getByRole("button").click();
+    expect(await cardCount(page)).toBe(4);
+  });
+});

--- a/packages/plugins/collection-plugin/src/vue/collectionsIndexFilter.ts
+++ b/packages/plugins/collection-plugin/src/vue/collectionsIndexFilter.ts
@@ -1,0 +1,25 @@
+import { itemMatchesQuery, type CollectionSummary } from "@mulmoclaude/core/collection";
+
+/** Editable / Data facet over the installed list. */
+export const INDEX_FILTER_CHIPS = ["all", "editable", "data"] as const;
+export type CollectionIndexFilter = (typeof INDEX_FILTER_CHIPS)[number];
+
+function matchesChip(collection: CollectionSummary, filter: CollectionIndexFilter): boolean {
+  if (filter === "editable") return collection.readonly !== true;
+  if (filter === "data") return collection.readonly === true;
+  return true;
+}
+
+/** Search matches only what the card SHOWS — title and slug. Running the record
+ *  matcher over the whole summary would also read `source` / `readonly`, so
+ *  "project" or "true" would silently select rows the reader never typed for.
+ *  Takes the raw input: `itemMatchesQuery` lowercases the value but not the
+ *  needle, and a blank query matches everything. */
+export function collectionMatchesQuery(collection: CollectionSummary, query: string): boolean {
+  return itemMatchesQuery({ title: collection.title, slug: collection.slug }, query.trim().toLowerCase());
+}
+
+/** The installed list as rendered: the chip facet AND the search box. */
+export function filterIndexCollections(collections: CollectionSummary[], filter: CollectionIndexFilter, query: string): CollectionSummary[] {
+  return collections.filter((collection) => matchesChip(collection, filter) && collectionMatchesQuery(collection, query));
+}

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -70,27 +70,66 @@
         </div>
 
         <div v-else>
-          <!-- Data filter chips: only shown when the workspace actually has
+          <div class="flex items-center flex-wrap gap-x-3 gap-y-2 mb-4">
+            <div class="relative flex-1 min-w-[12rem] max-w-xs">
+              <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-slate-400 pointer-events-none">
+                <span class="material-icons text-lg">search</span>
+              </span>
+              <input
+                v-model="searchQuery"
+                type="text"
+                :placeholder="t('collectionsView.indexSearchPlaceholder')"
+                :aria-label="t('collectionsView.indexSearchPlaceholder')"
+                class="w-full bg-white border border-slate-200/80 rounded-xl pl-9 pr-8 py-1.5 text-xs placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 transition-all font-medium"
+                data-testid="collections-index-search"
+              />
+              <button
+                v-if="searchQuery"
+                type="button"
+                :aria-label="t('collectionsView.clearSearch')"
+                class="absolute inset-y-0 right-0 flex items-center pr-2.5 text-slate-400 hover:text-slate-600"
+                data-testid="collections-index-search-clear"
+                @click="searchQuery = ''"
+              >
+                <span class="material-icons text-sm">close</span>
+              </button>
+            </div>
+
+            <!-- Data filter chips: only shown when the workspace actually has
                read-only (dataSource-backed) collections to separate out. -->
-          <div v-if="hasReadonlyCollections" class="flex items-center gap-1.5 mb-4" data-testid="collections-filter-chips">
-            <button
-              v-for="chip in FILTER_CHIPS"
-              :key="chip"
-              type="button"
-              class="px-3 h-7 rounded-full text-xs font-semibold border transition-colors"
-              :class="
-                filter === chip
-                  ? 'bg-indigo-600 border-indigo-600 text-white'
-                  : 'bg-white border-slate-200 text-slate-500 hover:text-slate-700 hover:bg-slate-50'
-              "
-              :data-testid="`collections-filter-${chip}`"
-              @click="filter = chip"
-            >
-              {{ t(`collectionsView.filter.${chip}`) }}
+            <div v-if="hasReadonlyCollections" class="flex items-center gap-1.5" data-testid="collections-filter-chips">
+              <button
+                v-for="chip in INDEX_FILTER_CHIPS"
+                :key="chip"
+                type="button"
+                class="px-3 h-7 rounded-full text-xs font-semibold border transition-colors"
+                :class="
+                  filter === chip
+                    ? 'bg-indigo-600 border-indigo-600 text-white'
+                    : 'bg-white border-slate-200 text-slate-500 hover:text-slate-700 hover:bg-slate-50'
+                "
+                :data-testid="`collections-filter-${chip}`"
+                @click="filter = chip"
+              >
+                {{ t(`collectionsView.filter.${chip}`) }}
+              </button>
+            </div>
+          </div>
+
+          <div
+            v-if="filteredCollections.length === 0"
+            class="flex flex-col items-center justify-center py-20 text-sm text-slate-400 gap-2"
+            data-testid="collections-index-no-matches"
+          >
+            <span class="material-icons text-4xl text-slate-300">search_off</span>
+            <p class="font-semibold text-slate-600">{{ t("collectionsView.indexNoMatches") }}</p>
+            <!-- Clears the chip too — either narrowing can be the one that emptied the grid. -->
+            <button type="button" class="text-xs text-indigo-600 font-semibold hover:underline" @click="((searchQuery = ''), (filter = 'all'))">
+              {{ t("collectionsView.clearSearch") }}
             </button>
           </div>
 
-          <div class="grid gap-4 sm:grid-cols-2">
+          <div v-else class="grid gap-4 sm:grid-cols-2">
             <div
               v-for="collection in filteredCollections"
               :key="collection.slug"
@@ -177,6 +216,7 @@ import { useCollectionUi } from "../scopedUi";
 import DiscoverPanel from "./DiscoverPanel.vue";
 import CollectionOntologyGraphView from "./CollectionOntologyGraphView.vue";
 import NewCollectionModal from "./NewCollectionModal.vue";
+import { INDEX_FILTER_CHIPS, filterIndexCollections, type CollectionIndexFilter } from "../collectionsIndexFilter";
 import type { CollectionSummary } from "@mulmoclaude/core/collection";
 
 const { t } = useCollectionI18n();
@@ -193,17 +233,13 @@ const collections = ref<CollectionSummary[]>([]);
 const loading = ref(true);
 const loadError = ref<string | null>(null);
 
-// Editable / Data facet over the installed list. Chips render only when a
-// read-only (dataSource) collection exists — the facet is noise otherwise.
-const FILTER_CHIPS = ["all", "editable", "data"] as const;
-type CollectionFilter = (typeof FILTER_CHIPS)[number];
-const filter = ref<CollectionFilter>("all");
+// Chips render only when a read-only (dataSource) collection exists — the
+// facet is noise otherwise. The search box has no such condition: it is the
+// narrowing that works before anyone has classified anything.
+const filter = ref<CollectionIndexFilter>("all");
+const searchQuery = ref("");
 const hasReadonlyCollections = computed<boolean>(() => collections.value.some((collection) => collection.readonly === true));
-const filteredCollections = computed<CollectionSummary[]>(() => {
-  if (filter.value === "editable") return collections.value.filter((collection) => collection.readonly !== true);
-  if (filter.value === "data") return collections.value.filter((collection) => collection.readonly === true);
-  return collections.value;
-});
+const filteredCollections = computed<CollectionSummary[]>(() => filterIndexCollections(collections.value, filter.value, searchQuery.value));
 
 async function loadCollections(): Promise<void> {
   loading.value = true;

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionsIndexView.vue
@@ -123,8 +123,7 @@
           >
             <span class="material-icons text-4xl text-slate-300">search_off</span>
             <p class="font-semibold text-slate-600">{{ t("collectionsView.indexNoMatches") }}</p>
-            <!-- Clears the chip too — either narrowing can be the one that emptied the grid. -->
-            <button type="button" class="text-xs text-indigo-600 font-semibold hover:underline" @click="((searchQuery = ''), (filter = 'all'))">
+            <button type="button" class="text-xs text-indigo-600 font-semibold hover:underline" @click="clearNarrowing">
               {{ t("collectionsView.clearSearch") }}
             </button>
           </div>
@@ -240,6 +239,14 @@ const filter = ref<CollectionIndexFilter>("all");
 const searchQuery = ref("");
 const hasReadonlyCollections = computed<boolean>(() => collections.value.some((collection) => collection.readonly === true));
 const filteredCollections = computed<CollectionSummary[]>(() => filterIndexCollections(collections.value, filter.value, searchQuery.value));
+
+// The empty state clears the chip as well as the query: either narrowing can be
+// the one that emptied the grid, and the reader can't tell which from an empty
+// grid.
+function clearNarrowing(): void {
+  searchQuery.value = "";
+  filter.value = "all";
+}
 
 async function loadCollections(): Promise<void> {
   loading.value = true;

--- a/packages/plugins/collection-plugin/src/vue/lang/de.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/de.ts
@@ -46,6 +46,8 @@ const deMessages: CollectionMessages = {
     title: "Sammlungen",
     backToIndex: "Zurück zu Sammlungen",
     indexEmpty: "Keine Sammlungen installiert. Markiere auf der Skills-Seite eine Skill mit Schema, um sie hier zu sehen.",
+    indexSearchPlaceholder: "Sammlungen suchen…",
+    indexNoMatches: "Keine passenden Sammlungen",
     editItem: "Bearbeiten",
     openItem: "{id} öffnen",
     confirmDelete: "Diesen Eintrag löschen? Das kann nicht rückgängig gemacht werden.",

--- a/packages/plugins/collection-plugin/src/vue/lang/en.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/en.ts
@@ -43,6 +43,8 @@ const enMessages = {
     title: "Collections",
     backToIndex: "Back to collections",
     indexEmpty: "No collections installed. Star a skill that ships a schema from the Skills page to see it here.",
+    indexSearchPlaceholder: "Search collections…",
+    indexNoMatches: "No matching collections",
     editItem: "Edit",
     openItem: "Open {id}",
     confirmDelete: "Delete this item? This cannot be undone.",

--- a/packages/plugins/collection-plugin/src/vue/lang/es.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/es.ts
@@ -46,6 +46,8 @@ const esMessages: CollectionMessages = {
     title: "Colecciones",
     backToIndex: "Volver a colecciones",
     indexEmpty: "No hay colecciones instaladas. Marca con estrella una skill que incluya un schema desde la página Skills para verla aquí.",
+    indexSearchPlaceholder: "Buscar colecciones…",
+    indexNoMatches: "No hay colecciones coincidentes",
     editItem: "Editar",
     openItem: "Abrir {id}",
     confirmDelete: "¿Eliminar este elemento? Esta acción no se puede deshacer.",

--- a/packages/plugins/collection-plugin/src/vue/lang/fr.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/fr.ts
@@ -46,6 +46,8 @@ const frMessages: CollectionMessages = {
     title: "Collections",
     backToIndex: "Retour aux collections",
     indexEmpty: "Aucune collection installée. Mettez une étoile sur une compétence avec un schema depuis la page Skills pour la voir ici.",
+    indexSearchPlaceholder: "Rechercher des collections…",
+    indexNoMatches: "Aucune collection correspondante",
     editItem: "Modifier",
     openItem: "Ouvrir {id}",
     confirmDelete: "Supprimer cet élément ? Cette action est irréversible.",

--- a/packages/plugins/collection-plugin/src/vue/lang/ja.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ja.ts
@@ -45,6 +45,8 @@ const jaMessages: CollectionMessages = {
     title: "コレクション",
     backToIndex: "コレクション一覧に戻る",
     indexEmpty: "インストール済みのコレクションがありません。スキーマを含むスキルを Skills ページからスター付けすると、ここに表示されます。",
+    indexSearchPlaceholder: "コレクションを検索…",
+    indexNoMatches: "一致するコレクションがありません",
     editItem: "編集",
     openItem: "{id} を開く",
     confirmDelete: "この項目を削除しますか？元に戻せません。",

--- a/packages/plugins/collection-plugin/src/vue/lang/ko.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ko.ts
@@ -45,6 +45,8 @@ const koMessages: CollectionMessages = {
     title: "컬렉션",
     backToIndex: "컬렉션 목록으로 돌아가기",
     indexEmpty: "설치된 컬렉션이 없습니다. Skills 페이지에서 스키마를 포함한 스킬에 별표를 추가하면 여기에 표시됩니다.",
+    indexSearchPlaceholder: "컬렉션 검색…",
+    indexNoMatches: "일치하는 컬렉션이 없습니다",
     editItem: "편집",
     openItem: "{id} 열기",
     confirmDelete: "이 항목을 삭제하시겠습니까? 되돌릴 수 없습니다.",

--- a/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/ptBR.ts
@@ -46,6 +46,8 @@ const ptBRMessages: CollectionMessages = {
     title: "Coleções",
     backToIndex: "Voltar para coleções",
     indexEmpty: "Nenhuma coleção instalada. Marque com estrela uma skill que inclua um schema na página Skills para vê-la aqui.",
+    indexSearchPlaceholder: "Buscar coleções…",
+    indexNoMatches: "Nenhuma coleção correspondente",
     editItem: "Editar",
     openItem: "Abrir {id}",
     confirmDelete: "Excluir este item? Esta ação não pode ser desfeita.",

--- a/packages/plugins/collection-plugin/src/vue/lang/zh.ts
+++ b/packages/plugins/collection-plugin/src/vue/lang/zh.ts
@@ -44,6 +44,8 @@ const zhMessages: CollectionMessages = {
     title: "集合",
     backToIndex: "返回集合列表",
     indexEmpty: "尚未安装任何集合。在「技能」页面对带有 schema 的技能加星即可在此显示。",
+    indexSearchPlaceholder: "搜索集合…",
+    indexNoMatches: "没有匹配的集合",
     editItem: "编辑",
     openItem: "打开 {id}",
     confirmDelete: "删除此项？此操作无法撤销。",

--- a/plans/feat-2837-collections-index-search.md
+++ b/plans/feat-2837-collections-index-search.md
@@ -1,0 +1,56 @@
+# コレクション一覧を検索欄で絞り込む (#2837)
+
+## 何を作るか
+
+`/collections` の一覧（installed タブ）に小さな検索欄を足し、**title と slug の部分一致**（大小文字無視）で
+カードを絞り込む。状態は永続化しない。サーバ変更なし。
+
+## なぜタグではなく検索か
+
+issue の元案は「利用者が定義するタグ + チップで絞り込み」だが、先に検索を入れる。
+
+- **タグは全既存コレクションが「未分類」から始まる。** issue 自身が最大の懸念として挙げている
+  （エージェントが作成時に付けないと絞り込みが機能しない）。検索は初日から全件に効く
+- スキーマ変更・エージェント向け docs（#2312 と同じ問題）・レジストリのエクスポート、どれも要らない。
+  `CollectionSummary` は `slug` / `title` を既に持つのでクライアント側だけで完結する
+- issue が挙げる設計上の宿題2つ —「チップ行に2軸が混ざる」「チップの表示条件」— は、
+  テキスト欄がチップとは別の入力である以上どちらも発生しない
+
+**カバーしないもの**: 「人間用 / AI内部用の区別・既定で非表示」。検索は能動的に絞るだけで既定の一覧を変えない。
+ここは永続的な印が要るので別 issue に切り出す（tag 一式が必要かは、検索が入った後で判断する）。
+
+## 実装
+
+**検索対象は title と slug だけ** — カードに出ているもの。`CollectionSummary` 全体を
+レコード用の `itemMatchesQuery` に通すと `source` / `readonly` にも当たり、"project" や "true" で
+黙って絞れてしまう。
+
+マッチャ自体は core の `itemMatchesQuery`（`packages/core/src/collection/core/textSearch.ts`）を
+そのまま使う。小文字化 + `includes` の規則を2箇所に書かない。
+
+新規 `packages/plugins/collection-plugin/src/vue/collectionsIndexFilter.ts`（純粋関数）:
+
+- `INDEX_FILTER_CHIPS` / `CollectionIndexFilter` — 既存のチップ定義を view から移す
+- `collectionMatchesQuery(collection, query)`
+- `filterIndexCollections(collections, filter, query)` — チップと検索の AND
+
+`CollectionsIndexView.vue`:
+
+- 検索欄（`search` アイコン + input + クリアボタン）。レコード検索の `CollectionToolbar` と同じ見た目
+- チップ行と同じ行に置く。チップは今までどおり読み取り専用コレクションがあるときだけ出る
+- 該当なしの表示（`search_off` + 文言 + クリア）。レコード一覧の該当なしと同じ形
+
+i18n は 2 キー追加（`indexSearchPlaceholder` / `indexNoMatches`）を **8ロケール全部**に。
+「検索をクリア」は既存の `clearSearch` を再利用する。
+
+## テスト
+
+- unit: `test/plugins/collection/test_collectionsIndexFilter.ts` — チップ × クエリの組み合わせ、
+  空クエリ、前後空白、大小文字、`source` / `readonly` に当たらないこと
+- e2e: `e2e/tests/collection-index-search.spec.ts` — 実ブラウザで入力 → カードが減る → クリアで戻る →
+  該当なし表示
+
+## 関連
+
+- #1874 — 起点。残課題のうち「フィルタ/検索」をここで閉じる
+- #2836 — 表示順（別軸）

--- a/test/plugins/collection/test_collectionsIndexFilter.ts
+++ b/test/plugins/collection/test_collectionsIndexFilter.ts
@@ -1,0 +1,78 @@
+// Unit tests for the collections-index narrowing
+// (packages/plugins/collection-plugin/src/vue/collectionsIndexFilter.ts):
+// the Editable/Data chip facet AND the search box, over the summary list the
+// index renders.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import type { CollectionSummary } from "@mulmoclaude/core/collection";
+import { collectionMatchesQuery, filterIndexCollections } from "../../../packages/plugins/collection-plugin/src/vue/collectionsIndexFilter";
+
+const summary = (slug: string, title: string, extra: Partial<CollectionSummary> = {}): CollectionSummary => ({
+  slug,
+  title,
+  icon: "list",
+  source: "project",
+  ...extra,
+});
+
+const COLLECTIONS: CollectionSummary[] = [
+  summary("tasks", "Tasks"),
+  summary("task-templates", "Task Templates"),
+  summary("clients", "顧客"),
+  summary("stock-quotes", "Stock Quotes", { readonly: true }),
+];
+
+const slugsOf = (collections: CollectionSummary[]): string[] => collections.map((collection) => collection.slug);
+
+describe("collectionMatchesQuery", () => {
+  it("matches a substring of the title or the slug, case-insensitively", () => {
+    assert.equal(collectionMatchesQuery(summary("stock-quotes", "Stock Quotes"), "quot"), true);
+    assert.equal(collectionMatchesQuery(summary("stock-quotes", "Stock Quotes"), "STOCK"), true);
+    assert.equal(collectionMatchesQuery(summary("stock-quotes", "Stock Quotes"), "k-qu"), true);
+    assert.equal(collectionMatchesQuery(summary("stock-quotes", "Stock Quotes"), "invoices"), false);
+  });
+
+  it("matches a non-ASCII title", () => {
+    assert.equal(collectionMatchesQuery(summary("clients", "顧客"), "顧"), true);
+  });
+
+  // The card shows title + slug; source/readonly are rendered as a dot and a
+  // badge, so typing their underlying values must not select rows.
+  it("does not match the metadata behind the badges", () => {
+    const readonlyProject = summary("stock-quotes", "Stock Quotes", { readonly: true });
+    assert.equal(collectionMatchesQuery(readonlyProject, "project"), false);
+    assert.equal(collectionMatchesQuery(readonlyProject, "true"), false);
+    assert.equal(collectionMatchesQuery(readonlyProject, "list"), false);
+  });
+});
+
+describe("filterIndexCollections", () => {
+  it("returns everything for the all chip and an empty query", () => {
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "all", "")), ["tasks", "task-templates", "clients", "stock-quotes"]);
+  });
+
+  it("keeps the chip facet: editable excludes read-only, data keeps only it", () => {
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "editable", "")), ["tasks", "task-templates", "clients"]);
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "data", "")), ["stock-quotes"]);
+  });
+
+  it("narrows by substring, matching every collection whose title or slug contains it", () => {
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "all", "task")), ["tasks", "task-templates"]);
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "all", "templates")), ["task-templates"]);
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "all", "nothing")), []);
+  });
+
+  it("ANDs the chip with the query", () => {
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "data", "stock")), ["stock-quotes"]);
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "editable", "stock")), []);
+  });
+
+  // A trailing space is what a query looks like mid-typing; it must not empty
+  // the grid the way a raw `includes(" ")` would.
+  it("trims surrounding whitespace, and blank input is not a filter", () => {
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "all", "  task ")), ["tasks", "task-templates"]);
+    assert.deepEqual(slugsOf(filterIndexCollections(COLLECTIONS, "all", "   ")), ["tasks", "task-templates", "clients", "stock-quotes"]);
+  });
+});


### PR DESCRIPTION
## Summary

`/collections`（installed タブ）に検索欄を足し、**title と slug の部分一致**（大小文字無視）でカードを絞れるようにした。既存の Editable / Data チップとは AND。該当なしはレコード一覧と同じ空表示で、そのリンクは**両方の**絞り込みをクリアする（どちらが空にした側かは決められないため）。状態は永続化しない。サーバ変更なし。

#2837 は「利用者が定義するタグ + チップで絞り込み」として書かれているが、**タグの前に検索を入れる**判断をした。理由:

- **タグは既存コレクションが全て「未分類」から始まる。** issue 自身が最大の懸念として挙げている点で（エージェントが作成時に付けないと機能しない）、最初の一手にならない。検索は初日から全件に効く
- スキーマ変更・エージェント向け docs（#2312 と同じ発見性の問題）・レジストリのエクスポート、どれも要らない。`CollectionSummary` は `slug` / `title` を既に持つのでクライアント側だけで完結する
- issue が挙げる設計上の宿題2つ —「チップ行に2軸が混ざる」「チップの表示条件」— は、テキスト欄がチップとは別の入力である以上どちらも発生しない

**#2837 は閉じない**（`Closes` を付けていない）。「人間用 / AI内部用の区別・既定で非表示」は検索では解けない —— 検索は能動的に絞るだけで既定の一覧を変えないため。そこは永続的な印が要るので issue に残す。

## Items to Confirm / Review

- **検索対象を title と slug に限ったこと。** カードがその2つしか出していないため。`CollectionSummary` 全体をレコード用の `itemMatchesQuery` に通すと `source` / `readonly` にも当たり、"project" や "true" で黙って絞れてしまう（unit で押さえた）。説明文まで含めたい場合は `CollectionSummary` にフィールドが無いのでサーバ側の変更が要る
- **検索欄を常時出していること。** チップ行は今までどおり読み取り専用コレクションがあるときだけ出るが、検索欄に条件を付けなかった。「まだ何も分類していない人にとって唯一効く絞り込み」なので出し分けない方が良いと判断した。コレクションが2〜3件のときは余分に見えるかもしれない
- **該当なしのリンクがチップも `all` に戻すこと。** レコード一覧の該当なし（フラグチップも一緒にクリアする）に合わせた
- **タグを入れないという判断そのもの。** 上記の理由で見送ったが、ここはプロダクト判断なので異論があれば
- 新規 `collectionsIndexFilter.ts` は collection-plugin 内の単一利用者向けなので `docs/shared-utils.md` には載せていない（あのカタログは surface をまたいで共有するヘルパーの目録のため）

## 実装と検証

**変更ファイル**

| ファイル | 内容 |
|---|---|
| `packages/plugins/collection-plugin/src/vue/collectionsIndexFilter.ts` | 新規。純粋関数（`collectionMatchesQuery` / `filterIndexCollections` / チップ定義）。マッチャは core の `itemMatchesQuery` をそのまま使い、小文字化 + `includes` を2箇所に書かない |
| `.../components/CollectionsIndexView.vue` | 検索欄（`CollectionToolbar` と同じ見た目）、該当なし表示、絞り込みをヘルパーへ委譲 |
| `.../vue/lang/{de,en,es,fr,ja,ko,ptBR,zh}.ts` | `indexSearchPlaceholder` / `indexNoMatches` を8ロケール。「検索をクリア」は既存の `clearSearch` を再利用 |
| `test/plugins/collection/test_collectionsIndexFilter.ts` | 新規 8ケース |
| `e2e/tests/collection-index-search.spec.ts` | 新規 4ケース |
| `plans/feat-2837-collections-index-search.md` / `docs/CHANGELOG.md` | プランと Unreleased への追記 |

**検証**

- `yarn format` → `lint`（error 0）→ `typecheck` → `build` → `yarn test`（exit 0）
- 新 e2e 4本 green、`collection` 系 e2e **90本 green**（既存86 + 新規4）
- 実ブラウザでスクリーンショットを撮って目視確認: 既定表示（検索欄 + チップが1行）、絞り込み後、該当なし表示

e2e で見ているもの: 部分一致で件数が減ること / 大小文字無視 / slug だけに含まれる断片（`k-qu`）/ 非 ASCII タイトル（`顧`）/ クリアで全件復帰 / Data チップとの AND / 該当なしリンクが両方クリアすること。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2837 つぎこれ。小さい検索欄をつけて、部分一致で絞り込めれば良い？
- （スコープの確認に対して）検索欄だけ

work in mulmoclaude2

## Summary by Sourcery

Add a client-side search box to the collections index that narrows the installed collections grid by title/slug and integrates with existing Editable/Data filters.

New Features:
- Introduce a search field on the collections index that filters installed collections by case-insensitive substring match over title and slug.
- Show an empty-state message with a clear action when no collections match the current search and chip filters.

Enhancements:
- Extract shared collections index filtering logic into a dedicated helper to combine chip and text search filtering.
- Extend collections i18n strings across all supported locales for the new search placeholder and no-match message.
- Document the new collections index search behavior in the changelog and add an implementation plan document.

Tests:
- Add unit tests for the collections index filtering helper to cover chip/query combinations and matching rules.
- Add end-to-end tests validating collections index search behavior, including case-insensitive matching, slug-only matches, non-ASCII titles, empty states, and joint behavior with the Data chip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collection search by title or slug with case-insensitive, partial matching.
  * Search works alongside Editable, Data, and All filters.
  * Added localized search prompts and no-results messages across supported languages.
  * Added a clear action to reset search and filters when no collections match.

* **Tests**
  * Added unit and end-to-end coverage for filtering, multilingual text, combined filters, empty states, and reset behavior.

* **Documentation**
  * Added an Unreleased changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->