### PR TITLE
chore(release): @mulmoclaude/core@4.0.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -134,7 +134,7 @@ Design: mulmoterminal `plans/refactor-shared-app-module.md`.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.0.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.0.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.0.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.0.1`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ### Fixed
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.0.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -40,7 +40,7 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "express": "^5.2.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/express": "^5.0.6",
     "@types/node": "^26.1.2",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,14 +35,14 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,12 +31,12 @@
     "lint": "eslint src test"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "gui-chat-protocol": "^2.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@types/node": "^26.1.2",
     "tsx": "^4.23.5",
     "typescript": "^6.0.3",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -38,14 +38,14 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -43,13 +43,13 @@
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "@mulmocast/deck-web": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "mulmocast": "^2.9.0",
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.0.0",
+    "@mulmoclaude/core": "^4.0.1",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.1.2",
     "@typescript-eslint/eslint-plugin": "^8.66.0",


### PR DESCRIPTION
## Summary

`@mulmoclaude/core` を **4.0.1** に上げ、宣言側のレンジを揃える。publish のための PR。

npm の `core@4.0.0` は今日 #2894 の直後（04:16 JST）に公開されたもので、**その後 #2842 が `packages/core/assets/helps/error-recovery.md` を書き換えている**。この asset は `files: ["dist", "assets"]` で npm 配布物に入り、エージェントがツール失敗時に**実行時に読む**（`server/prompts/system/system.md` の "When a tool call fails"）ので、公開しない限り npm 利用者には届かない。CLAUDE.md の「`assets/helps/*` が変わったら core を bump する」に該当する。

API の変更は無いので **patch**。

レンジは CLAUDE.md の「内部依存レンジは常に最新の公開版を指す」に従い、7プラグイン + launcher の **15箇所**を `^4.0.0` → `^4.0.1` に揃えた（`dependencies` / `devDependencies` / `peerDependencies` すべて）。

`@mulmoclaude/collection-plugin` は version 4.0.0 のまま（bump 済み・未公開）。この PR がマージされたら **core → collection-plugin の順**で publish する。

## Items to Confirm / Review

- **patch で良いか**。差分は shipped asset（ヘルプ文書）1本のみで、`dist` の API は変わらない
- **collection-plugin の version を触っていないこと**。4.0.0 は既に手元にあり npm が 3.1.0 なので、publish するだけで今日の3件（embed の fail-soft 修正 / 並び順 / 検索）が届く
- **launcher（`mulmoclaude`）の `version` は触っていない**。CLAUDE.md の「`chore(release)` で launcher の version を先回りで上げない」に従い、`@mulmoclaude/core` のレンジだけ上げた

## 検証

- `yarn check:launcher-sync` → OK（root ↔ launcher 同期、peer 違反なし）
- `yarn check:changelog-ships` → OK（Unreleased が 13 依存すべてを列挙）
- `yarn install` で `yarn.lock` に差分なし（workspace 内部レンジのため）
- `yarn lint`（error 0）/ `yarn typecheck`（0）/ `yarn build` 通過

## User Prompt

- 今日のわたしの変更で publish 必要なのを教えて
- @mulmoclaude/collection-plugin と @mulmoclaude/core だね / もしそうなら、その2つを publish して

work in mulmoclaude2

## Summary by Sourcery

Release @mulmoclaude/core@4.0.1 and align internal dependency ranges with the new patch version.

Enhancements:
- Bump @mulmoclaude/core package version from 4.0.0 to 4.0.1 for a patch release.
- Update all plugin and launcher dependencies/peerDependencies to require @mulmoclaude/core^4.0.1 instead of ^4.0.0.
- Adjust changelog package release entry to reflect shipping @mulmoclaude/core@4.0.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the core package to version 4.0.1.
  * Updated the unreleased changelog entry to reflect the new version.

* **Compatibility**
  * Updated plugin and package requirements to support core version 4.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->