### PR TITLE
fix(logging): MCP ブローカー子プロセスのログに発生源を付ける

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -33,9 +33,12 @@ incidents. `server/system/logs/` is git-ignored.
 2026-04-13T07:12:45.812Z INFO  [agent] request completed sessionId=abc durationMs=512
 ```
 
-Fields: `<ISO-timestamp> <PADDED-LEVEL> [<prefix>] <message> [k=v ...]`
+Fields: `<ISO-timestamp> <PADDED-LEVEL> [<source>] [<prefix>] <message> [k=v ...]`
 
 Strings with whitespace are auto-quoted; nested objects are serialized as JSON.
+
+`[<source>]` is present only for processes that are not the main server — see
+[Who wrote this line](#who-wrote-this-line).
 
 ### JSON (`format: "json"`)
 
@@ -45,7 +48,37 @@ One JSON object per line (JSONL):
 {"ts":"2026-04-13T07:12:45.123Z","level":"info","prefix":"agent","message":"request received","data":{"sessionId":"abc","roleId":"general","messageLen":42}}
 ```
 
-The `data` key is omitted when no structured payload was supplied.
+The `data` key is omitted when no structured payload was supplied. So is
+`source` — see below.
+
+## Who wrote this line
+
+More than one process writes to the same log file. The **MCP broker**
+(`server/agent/mcp-server.ts`) is spawned fresh **once per turn** and shares the
+parent server's file sink, so its boot-time lines repeat all day:
+
+```text
+2026-08-14T09:00:47.172Z INFO  [mcp-broker] [plugins/preset] loaded requested=3 succeeded=3
+2026-08-14T09:00:51.004Z INFO  [plugins/preset] loaded requested=3 succeeded=3
+```
+
+The first line is a broker spawn (one per turn — normal). The second has no
+source, so it is the **main server booting** (once). Without the tag the two are
+byte-identical, and 34 broker spawns a day read as 34 server restarts — which is
+how #2886 came to be filed.
+
+Rules of thumb when reading a log:
+
+- **no `[source]` / no `"source"` field** → the main server.
+- **`[mcp-broker]`** → a per-turn broker child. Repetition is expected; count
+  turns, not restarts.
+- To count actual broker spawns and their cold-boot cost, grep the
+  `[mcp] broker ready` lines instead — each carries `bootMs`, `initializeMs`,
+  `kind` and a unique `spawnId`.
+
+Any process that shares the log file should name itself via `LOG_SOURCE`. The
+logger treats it as an opaque label; composing the value is the spawning code's
+job (`BROKER_LOG_SOURCE` in `server/agent/config.ts`).
 
 ## Log levels
 
@@ -74,6 +107,7 @@ All are optional; omitted values fall back to the defaults table above.
 | `LOG_TELEMETRY_ENABLED` | boolean | telemetry sink (currently a no-op stub) |
 | `LOG_TELEMETRY_LEVEL` | level | telemetry |
 | `LOG_TELEMETRY_FORMAT` | `text` / `json` | telemetry |
+| `LOG_SOURCE` | any label (e.g. `mcp-broker`) | every sink — stamps which process emitted the record. Unset (the default) means the main server; empty / whitespace-only is treated as unset |
 
 Invalid values (e.g. `LOG_LEVEL=chatty`) are silently ignored — the
 logger falls back to the default for that knob rather than crashing

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -107,7 +107,7 @@ All are optional; omitted values fall back to the defaults table above.
 | `LOG_TELEMETRY_ENABLED` | boolean | telemetry sink (currently a no-op stub) |
 | `LOG_TELEMETRY_LEVEL` | level | telemetry |
 | `LOG_TELEMETRY_FORMAT` | `text` / `json` | telemetry |
-| `LOG_SOURCE` | a short printable label (e.g. `mcp-broker`) | every sink — stamps which process emitted the record. Unset (the default) means the main server; empty / whitespace-only is treated as unset. Control characters are stripped and the label is capped at 32 chars, so a value cannot break the one-record-per-line shape of the text log |
+| `LOG_SOURCE` | a short label from `A-Z a-z 0-9 . _ : / -` (e.g. `mcp-broker`) | every sink — stamps which process emitted the record. Unset (the default) means the main server. Any other character is dropped and the label is capped at 32 chars, so a value cannot break the one-record-per-line shape of the text log (control characters, Unicode line separators and bidi overrides included); a value with nothing left is treated as unset |
 
 Invalid values (e.g. `LOG_LEVEL=chatty`) are silently ignored — the
 logger falls back to the default for that knob rather than crashing

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -107,7 +107,7 @@ All are optional; omitted values fall back to the defaults table above.
 | `LOG_TELEMETRY_ENABLED` | boolean | telemetry sink (currently a no-op stub) |
 | `LOG_TELEMETRY_LEVEL` | level | telemetry |
 | `LOG_TELEMETRY_FORMAT` | `text` / `json` | telemetry |
-| `LOG_SOURCE` | any label (e.g. `mcp-broker`) | every sink — stamps which process emitted the record. Unset (the default) means the main server; empty / whitespace-only is treated as unset |
+| `LOG_SOURCE` | a short printable label (e.g. `mcp-broker`) | every sink — stamps which process emitted the record. Unset (the default) means the main server; empty / whitespace-only is treated as unset. Control characters are stripped and the label is capped at 32 chars, so a value cannot break the one-record-per-line shape of the text log |
 
 Invalid values (e.g. `LOG_LEVEL=chatty`) are silently ignored — the
 logger falls back to the default for that knob rather than crashing

--- a/plans/fix-2904-log-source.md
+++ b/plans/fix-2904-log-source.md
@@ -9,7 +9,7 @@
 
 両者は同じログファイルに、**完全に同一の行**を書く。
 
-```
+```json
 {"time":"…","level":"info","prefix":"plugins/preset","message":"loaded","data":{"requested":3,"succeeded":3}}
 ```
 
@@ -46,7 +46,7 @@ source は `mcp-broker` 固定でよい。
 
 出力例（text）:
 
-```
+```text
 2026-08-14T09:00:47.172Z INFO  [mcp-broker] [plugins/preset] loaded requested=3 succeeded=3
 2026-08-14T09:00:47.180Z INFO  [plugins/preset] loaded requested=3 succeeded=3
 ```

--- a/plans/fix-2904-log-source.md
+++ b/plans/fix-2904-log-source.md
@@ -1,0 +1,68 @@
+# fix(logging): MCP ブローカー子プロセスのログに発生源を付ける（#2904）
+
+## 問題
+
+`loadPresetPlugins()` の呼び出し元は2箇所ある。
+
+- `server/index.ts` — 親サーバの起動時に1回
+- `server/agent/mcp-server.ts` — MCP ブローカーの子プロセス（**ターンごとに spawn**）
+
+両者は同じログファイルに、**完全に同一の行**を書く。
+
+```
+{"time":"…","level":"info","prefix":"plugins/preset","message":"loaded","data":{"requested":3,"succeeded":3}}
+```
+
+`plugins/preset loaded` に限らず、ブローカー子プロセスが出す**すべての行**が親サーバのものと区別できない。#2886 では報告者がこれを「サーバが数分おきに再起動している」と読み、バグ報告の主要な根拠の1つになった。実際は40分で9ターン実行されただけだった。
+
+## 方針
+
+ログレコードに **発生源（source）** を持たせ、親サーバ以外のプロセスが自分を名乗る。
+
+- ロガーは source を**不透明な文字列として運ぶだけ**にする。MCP を知らせない（層の分離）。
+- 発生源の合成は、spawn 元の `server/agent/config.ts` が行う。
+- 親サーバは source を持たない（既存の全行のシェイプを変えない）。非デフォルトのプロセスだけが名乗る。
+
+env 経由で渡す。ブローカーの env には既に `LOG_CONSOLE_STREAM: "stderr"` が同じ理由（stdout が JSON-RPC）で入っているので、その隣に置く。
+
+### spawn id を source に含めない判断
+
+`MCP_SPAWN_ID` は `makeUuid()` の 36 文字。これを全行に付けると text ログが読めなくなる。
+かつ「40分に9回 = 9 spawn か1プロセスのループか」の判別は、#2898 が入れた
+`log.info("mcp", "broker ready", { …, spawnId })`（`server/api/routes/mcpBrokerReady.ts:74`）が
+spawn ごとに1行出すので既に可能。この issue の残課題は**親と子の区別**なので、
+source は `mcp-broker` 固定でよい。
+
+## 変更
+
+| ファイル | 変更 |
+|---|---|
+| `server/system/logger/types.ts` | `LogRecord.source?: string` |
+| `server/system/logger/config.ts` | `LoggerConfig.source?: string`、`resolveConfig` が `env.LOG_SOURCE` を読む（trim して空なら undefined） |
+| `server/system/logger/index.ts` | `createLogger` が全レコードに `source` を載せる |
+| `server/system/logger/formatters.ts` | text: level と prefix の間に `[source]`／json: `source` フィールド（どちらも source が無ければ従来どおり） |
+| `server/agent/config.ts` | ブローカーの env に `LOG_SOURCE: "mcp-broker"` |
+| `docs/logging.md` | `LOG_SOURCE` と、ブローカー子プロセスの行の読み方 |
+
+出力例（text）:
+
+```
+2026-08-14T09:00:47.172Z INFO  [mcp-broker] [plugins/preset] loaded requested=3 succeeded=3
+2026-08-14T09:00:47.180Z INFO  [plugins/preset] loaded requested=3 succeeded=3
+```
+
+## テスト
+
+- `test/logger/test_formatters.ts` — text / json / color 各フォーマットで source あり・なし
+- `test/logger/test_logger.ts` — `createLogger({ source })` が全レコードに載せること
+- `test/logger/test_loggerConfig.ts`（既存があればそこに追記） — `LOG_SOURCE` のパース（未設定 / 空文字 / 空白のみ / 通常値）
+- `test/agent/` のブローカー env テスト — `LOG_SOURCE: "mcp-broker"` が env に入ること
+
+## 検証
+
+`yarn format` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test`。
+
+加えて **実際にターンを回して**、同じログファイルに `[mcp-broker]` 付きの行と付かない行が
+両方現れることを確認する（build が通っただけでは、broker の env に届いたことを保証しない）。
+
+refs #2904

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -420,6 +420,9 @@ export interface McpStdioServerSpec {
   alwaysLoad: boolean;
 }
 
+/** What broker lines call themselves in the shared log file (`LOG_SOURCE`). */
+export const BROKER_LOG_SOURCE = "mcp-broker";
+
 export function buildMulmoclaudeServer(params: {
   chatSessionId: string;
   port: number;
@@ -481,6 +484,11 @@ export function buildMulmoclaudeServer(params: {
       // line lands between protocol messages — or, once a response is
       // large enough to be split across writes, inside one.
       LOG_CONSOLE_STREAM: "stderr",
+      // The broker writes to the SAME log file as the parent server and
+      // respawns once per turn, so its untagged lines read as server restarts
+      // — "plugins/preset loaded" 34x/day was reported as a reload loop
+      // (#2904). Tagging the source is what separates the two.
+      LOG_SOURCE: BROKER_LOG_SOURCE,
       ...authEnv,
       ...dockerEnv,
     },

--- a/server/system/logger/config.ts
+++ b/server/system/logger/config.ts
@@ -35,6 +35,8 @@ export interface TelemetrySinkConfig {
 }
 
 export interface LoggerConfig {
+  // Stamped onto every record this logger emits. See `LogRecord.source`.
+  source?: string;
   sinks: {
     console: ConsoleSinkConfig;
     file: FileSinkConfig;
@@ -91,6 +93,16 @@ function parseBool(raw: string | undefined): boolean | undefined {
   return undefined;
 }
 
+// Returns a spreadable fragment rather than `string | undefined` so the branch
+// lives here instead of in `resolveConfig`, which is already at its complexity
+// ceiling. A whitespace-only value is a shell accident (`LOG_SOURCE=$UNSET`),
+// not a process claiming to be called " " — treat it as unset so the record
+// stays untagged rather than gaining an empty bracket.
+function sourceField(raw: string | undefined): { source?: string } {
+  const trimmed = raw?.trim();
+  return trimmed ? { source: trimmed } : {};
+}
+
 function parsePositiveInt(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;
   const num = Number(raw);
@@ -105,6 +117,7 @@ export function resolveConfig(env: Env): LoggerConfig {
   const fileLevel = parseLevel(env.LOG_FILE_LEVEL) ?? coarseLevel;
 
   return {
+    ...sourceField(env.LOG_SOURCE),
     sinks: {
       console: {
         enabled: parseBool(env.LOG_CONSOLE_ENABLED) ?? DEFAULT_CONFIG.sinks.console.enabled,

--- a/server/system/logger/config.ts
+++ b/server/system/logger/config.ts
@@ -93,14 +93,36 @@ function parseBool(raw: string | undefined): boolean | undefined {
   return undefined;
 }
 
+/** A process label is one short printable run. C0 controls, DEL and C1 are
+ *  excluded by code point rather than a regex, so the `no-control-regex` lint
+ *  rule has nothing to trip on. */
+function isLabelChar(char: string): boolean {
+  const code = char.codePointAt(0) ?? 0;
+  return code > 0x1f && (code < 0x7f || code > 0x9f);
+}
+
+/** Longest label kept. A source names a process; anything longer is a mistake,
+ *  and bounding it also bounds what a bad value can push into every line. */
+const SOURCE_MAX = 32;
+
 // Returns a spreadable fragment rather than `string | undefined` so the branch
 // lives here instead of in `resolveConfig`, which is already at its complexity
-// ceiling. A whitespace-only value is a shell accident (`LOG_SOURCE=$UNSET`),
-// not a process claiming to be called " " — treat it as unset so the record
-// stays untagged rather than gaining an empty bracket.
+// ceiling.
+//
+// The text formatter interpolates the label verbatim, so a newline inside it
+// would end the line early and let the remainder pose as a second record —
+// `mcp-broker\n2026-01-01T00:00:00Z ERROR [auth] forged` reads as two entries
+// in the file (the JSON sink escapes it, so only text logs forge). Dropping
+// every control character removes that, and dropping rather than rejecting the
+// whole value keeps the attribution this field exists for: a mangled
+// LOG_SOURCE must not make a broker's lines read as the parent server's.
+//
+// A whitespace-only value is a shell accident (`LOG_SOURCE=$UNSET`), not a
+// process claiming to be called " " — it ends up unset, and the record stays
+// untagged rather than gaining an empty bracket.
 function sourceField(raw: string | undefined): { source?: string } {
-  const trimmed = raw?.trim();
-  return trimmed ? { source: trimmed } : {};
+  const label = [...(raw ?? "")].filter(isLabelChar).join("").trim().slice(0, SOURCE_MAX);
+  return label ? { source: label } : {};
 }
 
 function parsePositiveInt(raw: string | undefined): number | undefined {

--- a/server/system/logger/config.ts
+++ b/server/system/logger/config.ts
@@ -93,13 +93,13 @@ function parseBool(raw: string | undefined): boolean | undefined {
   return undefined;
 }
 
-/** A process label is one short printable run. C0 controls, DEL and C1 are
- *  excluded by code point rather than a regex, so the `no-control-regex` lint
- *  rule has nothing to trip on. */
-function isLabelChar(char: string): boolean {
-  const code = char.codePointAt(0) ?? 0;
-  return code > 0x1f && (code < 0x7f || code > 0x9f);
-}
+/** What a process label may contain. An ALLOWLIST, because the denylist form
+ *  kept losing to characters nobody thinks of: C0 and DEL first, then C1, then
+ *  the Unicode line/paragraph separators (U+2028 / U+2029) and the bidi
+ *  overrides (U+202E), each of which can make one record render as several — or
+ *  in reversed order — in a Unicode-aware viewer. A name for a process needs
+ *  none of them, so enumerate what it does need and drop the rest. */
+const LABEL_CHAR = /[A-Za-z0-9._:/-]/;
 
 /** Longest label kept. A source names a process; anything longer is a mistake,
  *  and bounding it also bounds what a bad value can push into every line. */
@@ -109,19 +109,23 @@ const SOURCE_MAX = 32;
 // lives here instead of in `resolveConfig`, which is already at its complexity
 // ceiling.
 //
-// The text formatter interpolates the label verbatim, so a newline inside it
+// The text formatter interpolates the label verbatim, so a line break inside it
 // would end the line early and let the remainder pose as a second record —
 // `mcp-broker\n2026-01-01T00:00:00Z ERROR [auth] forged` reads as two entries
-// in the file (the JSON sink escapes it, so only text logs forge). Dropping
-// every control character removes that, and dropping rather than rejecting the
-// whole value keeps the attribution this field exists for: a mangled
-// LOG_SOURCE must not make a broker's lines read as the parent server's.
+// in the file (the JSON sink escapes it, so only text logs forge). Keeping only
+// `LABEL_CHAR` removes that whole class, and dropping the stray characters
+// rather than rejecting the whole value keeps the attribution this field exists
+// for: a mangled LOG_SOURCE must not make a broker's lines read as the parent
+// server's.
 //
-// A whitespace-only value is a shell accident (`LOG_SOURCE=$UNSET`), not a
-// process claiming to be called " " — it ends up unset, and the record stays
-// untagged rather than gaining an empty bracket.
+// Whitespace is not in the allowlist, so a whitespace-only value — a shell
+// accident like `LOG_SOURCE=$UNSET` rather than a process called " " — ends up
+// unset, and the record stays untagged rather than gaining an empty bracket.
 function sourceField(raw: string | undefined): { source?: string } {
-  const label = [...(raw ?? "")].filter(isLabelChar).join("").trim().slice(0, SOURCE_MAX);
+  const label = [...(raw ?? "")]
+    .filter((char) => LABEL_CHAR.test(char))
+    .join("")
+    .slice(0, SOURCE_MAX);
   return label ? { source: label } : {};
 }
 

--- a/server/system/logger/formatters.ts
+++ b/server/system/logger/formatters.ts
@@ -59,16 +59,24 @@ export const formatText: Formatter = (record: LogRecord): string => formatTextLi
  */
 export const formatTextColor: Formatter = (record: LogRecord): string => formatTextLine(record, true);
 
+// Its own bracket ahead of the prefix, so a reader scanning the left edge sees
+// which process wrote the line before reading what the line says. Empty for the
+// main server, keeping its lines byte-identical to before.
+function formatSource(source: string | undefined): string {
+  return source ? `[${source}] ` : "";
+}
+
 function formatTextLine(record: LogRecord, color: boolean): string {
   const levelText = record.level.toUpperCase().padEnd(5);
   const colorCode = LEVEL_COLOR[record.level];
+  const source = formatSource(record.source);
   if (color && WHOLE_LINE_COLOR.has(record.level)) {
     // Whole-row wrap. Avoid double-wrapping the level slot — one
     // colour code at the start + reset at the end is enough.
-    return `${colorCode}${record.time} ${levelText} [${record.prefix}] ${record.message}${formatData(record.data)}${ANSI_RESET}`;
+    return `${colorCode}${record.time} ${levelText} ${source}[${record.prefix}] ${record.message}${formatData(record.data)}${ANSI_RESET}`;
   }
   const level = color ? `${colorCode}${levelText}${ANSI_RESET}` : levelText;
-  return `${record.time} ${level} [${record.prefix}] ${record.message}${formatData(record.data)}`;
+  return `${record.time} ${level} ${source}[${record.prefix}] ${record.message}${formatData(record.data)}`;
 }
 
 export const formatJson: Formatter = (record: LogRecord): string => {
@@ -78,6 +86,7 @@ export const formatJson: Formatter = (record: LogRecord): string => {
     prefix: record.prefix,
     message: record.message,
   };
+  if (record.source) payload.source = record.source;
   if (record.data) payload.data = record.data;
   return JSON.stringify(payload);
 };

--- a/server/system/logger/index.ts
+++ b/server/system/logger/index.ts
@@ -24,6 +24,7 @@ export function createLogger(config: LoggerConfig): Logger {
       level,
       prefix,
       message,
+      ...(config.source ? { source: config.source } : {}),
       ...(data ? { data } : {}),
     };
     const recordPriority = LEVEL_PRIORITY[level];

--- a/server/system/logger/types.ts
+++ b/server/system/logger/types.ts
@@ -15,6 +15,11 @@ export interface LogRecord {
   level: LogLevel;
   prefix: string;
   message: string;
+  // Which process emitted this. Absent for the main server; set by processes
+  // that share its log file and would otherwise be indistinguishable from it
+  // — the MCP broker respawns once per turn, so its lines read as server
+  // restarts to anyone holding only the log (#2904).
+  source?: string;
   data?: Record<string, unknown>;
 }
 

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -9,6 +9,7 @@ import {
   buildDockerSpawnArgs,
   brokerSpawn,
   buildMulmoclaudeServer,
+  BROKER_LOG_SOURCE,
   dockerUserCapArgs,
   dockerBindMountArgs,
   buildMcpConfig,
@@ -1209,6 +1210,16 @@ describe("MCP child wiring (regression guard for #2052)", () => {
     for (const useDocker of [false, true]) {
       const spec = buildMulmoclaudeServer({ chatSessionId: "s", port: 1, activePlugins: [], useDocker });
       assert.equal(spec.env.LOG_CONSOLE_STREAM, "stderr", `missing for useDocker=${useDocker}`);
+    }
+  });
+
+  // The broker shares the parent's log FILE and respawns once per turn, so
+  // untagged lines read as server restarts — 34 "plugins/preset loaded" a day
+  // was filed as a reload loop (#2904). Only the parent can name the child.
+  it("names the broker as the log source in both modes", () => {
+    for (const useDocker of [false, true]) {
+      const spec = buildMulmoclaudeServer({ chatSessionId: "s", port: 1, activePlugins: [], useDocker });
+      assert.equal(spec.env.LOG_SOURCE, BROKER_LOG_SOURCE, `missing for useDocker=${useDocker}`);
     }
   });
 

--- a/test/logger/test_config.ts
+++ b/test/logger/test_config.ts
@@ -140,9 +140,35 @@ describe("resolveConfig", () => {
     const C1_CSI = String.fromCharCode(0x9b);
     assert.equal(resolveConfig({ LOG_SOURCE: `a\rb` }).source, "ab");
     assert.equal(resolveConfig({ LOG_SOURCE: `a\tb` }).source, "ab");
-    assert.equal(resolveConfig({ LOG_SOURCE: `a${ESC}[31mb` }).source, "a[31mb");
+    // The brackets go too — they are not label characters, and a `[` inside the
+    // label would make the text line's bracket structure ambiguous.
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${ESC}[31mb` }).source, "a31mb");
     assert.equal(resolveConfig({ LOG_SOURCE: `a${DEL}b` }).source, "ab");
     assert.equal(resolveConfig({ LOG_SOURCE: `a${C1_CSI}b` }).source, "ab");
+  });
+
+  // The denylist form of this filter passed the ASCII cases above and still let
+  // these through: U+2028/U+2029 break a line in Unicode-aware viewers, and
+  // U+202E reverses the rendering of everything after it. (Codex iter-2 on
+  // #2905 — the reason the filter became an allowlist.)
+  it("strips Unicode line/paragraph separators and bidi overrides", () => {
+    const LINE_SEP = "\u2028";
+    const PARA_SEP = "\u2029";
+    const RLO = "\u202e";
+    const ZWJ = "\u200d";
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${LINE_SEP}b` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${PARA_SEP}b` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${RLO}b` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${ZWJ}b` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `mcp-broker${LINE_SEP}ERROR [auth] forged` }).source, "mcp-brokerERRORauthforged");
+  });
+
+  it("keeps only the allowlisted label characters", () => {
+    assert.equal(resolveConfig({ LOG_SOURCE: "mcp-broker_2.worker:a/b" }).source, "mcp-broker_2.worker:a/b");
+    // Non-ASCII is dropped: the field is a machine-readable process tag, and an
+    // allowlist that admits arbitrary scripts is back to guessing which of them
+    // render as a line break.
+    assert.equal(resolveConfig({ LOG_SOURCE: "ワーカー" }).source, undefined);
   });
 
   it("treats an all-control-character LOG_SOURCE as unset", () => {

--- a/test/logger/test_config.ts
+++ b/test/logger/test_config.ts
@@ -107,4 +107,19 @@ describe("resolveConfig", () => {
     assert.equal(config.sinks.telemetry.enabled, true);
     assert.equal(config.sinks.telemetry.level, "warn");
   });
+
+  it("reads LOG_SOURCE and leaves it unset by default (#2904)", () => {
+    assert.equal(resolveConfig({ LOG_SOURCE: "mcp-broker" }).source, "mcp-broker");
+    assert.equal(resolveConfig({}).source, undefined);
+  });
+
+  it("treats an empty or whitespace-only LOG_SOURCE as unset", () => {
+    // `LOG_SOURCE=$UNSET_VAR` is a shell accident, not a process named " ".
+    assert.equal(resolveConfig({ LOG_SOURCE: "" }).source, undefined);
+    assert.equal(resolveConfig({ LOG_SOURCE: "   " }).source, undefined);
+  });
+
+  it("trims surrounding whitespace off a real LOG_SOURCE", () => {
+    assert.equal(resolveConfig({ LOG_SOURCE: "  mcp-broker\n" }).source, "mcp-broker");
+  });
 });

--- a/test/logger/test_config.ts
+++ b/test/logger/test_config.ts
@@ -122,4 +122,35 @@ describe("resolveConfig", () => {
   it("trims surrounding whitespace off a real LOG_SOURCE", () => {
     assert.equal(resolveConfig({ LOG_SOURCE: "  mcp-broker\n" }).source, "mcp-broker");
   });
+
+  // The text formatter interpolates the label verbatim, so a newline inside it
+  // would close the line early and let the rest pose as its own log entry.
+  // (Codex review on #2905.)
+  it("strips control characters so a label cannot forge a second log line", () => {
+    const forged = "mcp-broker\n2026-01-01T00:00:00.000Z ERROR [auth] forged";
+    const source = resolveConfig({ LOG_SOURCE: forged }).source ?? "";
+    assert.ok(!source.includes("\n"), `newline survived: ${JSON.stringify(source)}`);
+    assert.ok(!source.includes("\r"));
+    assert.ok(source.startsWith("mcp-broker"));
+  });
+
+  it("strips CR, tab, ESC and DEL as well as LF", () => {
+    const ESC = String.fromCharCode(0x1b);
+    const DEL = String.fromCharCode(0x7f);
+    const C1_CSI = String.fromCharCode(0x9b);
+    assert.equal(resolveConfig({ LOG_SOURCE: `a\rb` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a\tb` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${ESC}[31mb` }).source, "a[31mb");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${DEL}b` }).source, "ab");
+    assert.equal(resolveConfig({ LOG_SOURCE: `a${C1_CSI}b` }).source, "ab");
+  });
+
+  it("treats an all-control-character LOG_SOURCE as unset", () => {
+    assert.equal(resolveConfig({ LOG_SOURCE: "\n\r\t" }).source, undefined);
+  });
+
+  it("caps the label so a bad value cannot pad every line", () => {
+    const source = resolveConfig({ LOG_SOURCE: "x".repeat(200) }).source ?? "";
+    assert.equal(source.length, 32);
+  });
 });

--- a/test/logger/test_formatters.ts
+++ b/test/logger/test_formatters.ts
@@ -50,13 +50,13 @@ describe("formatText", () => {
   });
 });
 
-describe("formatTextColor", () => {
-  // Build the ANSI patterns from String.fromCharCode so the lint rule
-  // `no-control-regex` doesn't trip on a literal ESC byte in the source.
-  const ESC = String.fromCharCode(27);
-  const ANY_ANSI = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
-  const FIRST_CODE = new RegExp(`${ESC}\\[([0-9;]+)m`);
+// Build the ANSI patterns from String.fromCharCode so the lint rule
+// `no-control-regex` doesn't trip on a literal ESC byte in the source.
+const ESC = String.fromCharCode(27);
+const ANY_ANSI = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
+const FIRST_CODE = new RegExp(`${ESC}\\[([0-9;]+)m`);
 
+describe("formatTextColor", () => {
   it("wraps the entire line for error and warn (whole-row colour)", () => {
     for (const level of ["error", "warn"] as const) {
       const colored = formatTextColor(record({ level }));
@@ -92,6 +92,47 @@ describe("formatTextColor", () => {
       seen.add(match[1] ?? "");
     }
     assert.equal(seen.size, 4, "every level should map to a distinct ANSI code");
+  });
+});
+
+describe("source tagging (#2904)", () => {
+  it("puts the source in its own bracket ahead of the prefix", () => {
+    assert.equal(formatText(record({ source: "mcp-broker" })), "2026-04-13T07:12:45.123Z INFO  [mcp-broker] [agent] request received");
+  });
+
+  it("leaves an untagged line byte-identical to before", () => {
+    assert.equal(formatText(record()), "2026-04-13T07:12:45.123Z INFO  [agent] request received");
+  });
+
+  it("keeps a tagged line greppable per process, which is the point", () => {
+    const broker = formatText(record({ source: "mcp-broker", prefix: "plugins/preset", message: "loaded" }));
+    const parent = formatText(record({ prefix: "plugins/preset", message: "loaded" }));
+    // The exact pair that read as a server restart in #2886.
+    assert.notEqual(broker, parent);
+    assert.ok(broker.includes("[mcp-broker]"));
+    assert.ok(!parent.includes("[mcp-broker]"));
+  });
+
+  it("survives the whole-row colour wrap without extra escapes", () => {
+    for (const level of ["error", "warn"] as const) {
+      const colored = formatTextColor(record({ level, source: "mcp-broker" }));
+      const escapeCount = (colored.match(ANY_ANSI) ?? []).length;
+      assert.equal(escapeCount, 2, `expected exactly two SGR codes for ${level}, got ${escapeCount}`);
+      assert.equal(colored.replaceAll(ANY_ANSI, ""), formatText(record({ level, source: "mcp-broker" })));
+    }
+  });
+
+  it("survives the level-only colour wrap", () => {
+    for (const level of ["info", "debug"] as const) {
+      const colored = formatTextColor(record({ level, source: "mcp-broker" }));
+      assert.equal(colored.replaceAll(ANY_ANSI, ""), formatText(record({ level, source: "mcp-broker" })));
+    }
+  });
+
+  it("emits source as a JSON field, omitted when absent", () => {
+    const tagged: { source?: string } = JSON.parse(formatJson(record({ source: "mcp-broker" })));
+    assert.equal(tagged.source, "mcp-broker");
+    assert.ok(!formatJson(record()).includes('"source"'));
   });
 });
 

--- a/test/logger/test_logger.ts
+++ b/test/logger/test_logger.ts
@@ -95,9 +95,10 @@ describe("createLogger level filtering", () => {
 });
 
 describe("createLogger source stamping (#2904)", () => {
-  function captureJsonRecords(config: Parameters<typeof createLogger>[0]): { source?: string; message: string }[] {
-    const originalOut = process.stdout.write.bind(process.stdout);
-    const originalErr = process.stderr.write.bind(process.stderr);
+  // Both console streams are captured because `stream: "split"` sends
+  // info to stdout and error to stderr.
+  function withCapturedStreams(run: () => void): string[] {
+    const originals = { out: process.stdout.write.bind(process.stdout), err: process.stderr.write.bind(process.stderr) };
     const lines: string[] = [];
     const recordWrite = (chunk: string | Uint8Array) => {
       lines.push(typeof chunk === "string" ? chunk : chunk.toString());
@@ -106,13 +107,20 @@ describe("createLogger source stamping (#2904)", () => {
     process.stdout.write = recordWrite as typeof process.stdout.write;
     process.stderr.write = recordWrite as typeof process.stderr.write;
     try {
+      run();
+    } finally {
+      process.stdout.write = originals.out;
+      process.stderr.write = originals.err;
+    }
+    return lines;
+  }
+
+  function captureJsonRecords(config: Parameters<typeof createLogger>[0]): { source?: string; message: string }[] {
+    const lines = withCapturedStreams(() => {
       const logger = createLogger(config);
       logger.info("plugins/preset", "loaded");
       logger.error("plugins/preset", "boom");
-    } finally {
-      process.stdout.write = originalOut;
-      process.stderr.write = originalErr;
-    }
+    });
     return lines.map((line) => JSON.parse(line.trim()));
   }
 

--- a/test/logger/test_logger.ts
+++ b/test/logger/test_logger.ts
@@ -93,3 +93,51 @@ describe("createLogger level filtering", () => {
     }
   });
 });
+
+describe("createLogger source stamping (#2904)", () => {
+  function captureJsonRecords(config: Parameters<typeof createLogger>[0]): { source?: string; message: string }[] {
+    const originalOut = process.stdout.write.bind(process.stdout);
+    const originalErr = process.stderr.write.bind(process.stderr);
+    const lines: string[] = [];
+    const recordWrite = (chunk: string | Uint8Array) => {
+      lines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+    process.stdout.write = recordWrite as typeof process.stdout.write;
+    process.stderr.write = recordWrite as typeof process.stderr.write;
+    try {
+      const logger = createLogger(config);
+      logger.info("plugins/preset", "loaded");
+      logger.error("plugins/preset", "boom");
+    } finally {
+      process.stdout.write = originalOut;
+      process.stderr.write = originalErr;
+    }
+    return lines.map((line) => JSON.parse(line.trim()));
+  }
+
+  const consoleOnlyJson = (source?: string): Parameters<typeof createLogger>[0] => ({
+    ...(source ? { source } : {}),
+    sinks: {
+      console: { enabled: true, level: "debug", format: "json", stream: "split" },
+      file: { enabled: false, level: "debug", format: "json", dir: "/tmp", rotation: { kind: "daily", maxFiles: 1 } },
+      telemetry: { enabled: false, level: "error", format: "json" },
+    },
+  });
+
+  it("stamps every record, at every level", () => {
+    const records = captureJsonRecords(consoleOnlyJson("mcp-broker"));
+    assert.equal(records.length, 2);
+    for (const rec of records) {
+      assert.equal(rec.source, "mcp-broker");
+    }
+  });
+
+  it("leaves records unstamped when no source is configured", () => {
+    const records = captureJsonRecords(consoleOnlyJson());
+    assert.equal(records.length, 2);
+    for (const rec of records) {
+      assert.equal(rec.source, undefined);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

ログレコードに発生源（`source`）を持たせ、MCP ブローカー子プロセスの行を親サーバの行と区別できるようにする。

ブローカーは親サーバと**同じログファイル**に書き、**ターンごとに spawn** される。これまで両者の行は完全に同一だったため、`plugins/preset loaded` が1日34回出るのを見た #2886 の報告者は「サーバが数分おきに再起動している」と結論し、それがバグ報告の主要な根拠の1つになった。実際は40分で9ターン実行されただけだった。

```text
2026-08-14T09:00:47.172Z INFO  [mcp-broker] [plugins/preset] loaded requested=3 succeeded=3
2026-08-14T09:00:51.004Z INFO  [plugins/preset] loaded requested=3 succeeded=3
```

- ロガーは `source` を**不透明な文字列として運ぶだけ**。MCP を知らない（層の分離）。値の合成は spawn 元の `server/agent/config.ts` が持つ（`BROKER_LOG_SOURCE`）。
- `LOG_SOURCE` 未設定＝親サーバ。**既存の全行のシェイプは変わらない**（text はバイト一致、json は `source` キーが増えない）。
- spawn ごとの識別子（`MCP_SPAWN_ID`）は source に含めていない。`makeUuid()` の36文字を全行に付けると text ログが読めなくなるうえ、spawn 回数の把握は #2898 が入れた `[mcp] broker ready`（`spawnId` / `bootMs` / `initializeMs` 付き、spawn ごとに1行）で既に可能なため。この issue の残課題は親と子の区別。

| ファイル | 変更 |
|---|---|
| `server/system/logger/types.ts` | `LogRecord.source?: string` |
| `server/system/logger/config.ts` | `LoggerConfig.source?: string`、`resolveConfig` が `LOG_SOURCE` を読む |
| `server/system/logger/index.ts` | `createLogger` が全レコードに載せる |
| `server/system/logger/formatters.ts` | text: level と prefix の間に `[source]`／json: `source` フィールド |
| `server/agent/config.ts` | ブローカーの env に `LOG_SOURCE: BROKER_LOG_SOURCE` |
| `docs/logging.md` | 「Who wrote this line」節と `LOG_SOURCE` の行 |

## Items to Confirm / Review

1. **`[source]` の置き場所** — level と prefix の間に独立したブラケットで置いた。`[mcp-broker] [plugins/preset]` とブラケットが2つ並ぶ。`data` の末尾に `source=mcp-broker` として付ける案もあったが、行末だと目視で拾いにくく、呼び出し側が `data.source` を渡したときに衝突するので避けた。左端を眺めて発生源が分かる形を優先している。**好みが割れるところなので見てほしい。**

2. **`resolveConfig` の複雑度回避** — `complexity: max 15` に既に張り付いていたため、`...(source ? { source } : {})` を直接書くと 16 になって落ちる。分岐を `sourceField()` ヘルパー（spreadable な断片を返す）に逃がして `resolveConfig` の構造を変えずに済ませた。**本筋は `resolveConfig` を sink ごとに分割することだと思うが、挙動保存のリファクタになるのでこの PR のスコープ外にした**（`resolveConfig` は35行あり、20行ルールにも違反している）。別 issue にすべきなら言ってほしい。

3. **`exactOptionalPropertyTypes: true`** — `source?: string` に `undefined` を明示代入できないため、条件付きスプレッドが必須。`LoggerConfig` / `LogRecord` の両方でこの形にしている。

4. **既存ログの互換性** — `source` 未設定時に text がバイト一致することはテストで固定した（`formatText(record())` の完全一致 assert）。json も `"source"` キーが現れないことを assert している。**外部のログコレクタが json をパースしている場合、キーが1つ増えることになる**（増えるのはブローカー由来の行だけ）。問題があれば指摘してほしい。

## 検証

`yarn format` → `yarn lint`（0 errors、warning 37 は変更前と同数）→ `yarn typecheck` → `yarn build` → `yarn test`（27 スイート全て fail 0）。

加えて、**build が通っただけでは env がブローカー子プロセスに届いた保証がない**ので、使い捨てハーネスで実プロセスを確認した（実行後に削除済み）。`buildMulmoclaudeServer()` が返す実際の spec の env で本物のブローカーを spawn し、親のロガーと同じログファイルへ書かせて、ファイルの中身を読んだ結果:

```
spec.env.LOG_SOURCE = "mcp-broker"
total lines: 3  tagged(mcp-broker): 2  untagged(parent): 1

=== the exact #2886 pair ===
parent: {"time":"…","level":"info","prefix":"plugins/preset","message":"loaded","data":{"requested":3,"succeeded":3}}
broker: {"time":"…","level":"info","prefix":"plugins/preset","message":"loaded","source":"mcp-broker","data":{"requested":5,"succeeded":5}}
```

#2886 で読み違いを生んだ当のペアが、同一ファイル内で区別できるようになっている。

**未確認**: 実際のエージェントターンを最後まで回してはいない（Docker サンドボックス経路での確認を含む）。上の確認はブローカーを直接 spawn したもの。ただし env は `buildMulmoclaudeServer()` の実際の戻り値をそのまま使っており、`useDocker` の両方で `LOG_SOURCE` が入ることは unit test で固定している。

## User Prompt

- 「awaiting-response 報告者からの回答待ち　をissueのラベルに追加して」→ ラベル作成
- 「ラベルつけて」→ #2842 に付与
- 「https://github.com/receptron/mulmoclaude/issues/2886 は閉じれるかな？ここからissue化できものある？」→ #2886 をクローズし、そこから #2900〜#2904 を切り出し
- 「簡単なのからやろう」→ 切り出した5件のうち最も小さい #2904 から着手（この PR）

Closes #2904

work in mulmoclaude3

## Summary by Sourcery

Tag log records with a per-process source label so MCP broker child processes can be distinguished from the main server in shared logs.

New Features:
- Add an optional source field to logger configuration and records to label which process emitted each log line.
- Introduce LOG_SOURCE environment support so non-main processes can name themselves in all sinks.
- Configure the MCP broker to set LOG_SOURCE to a fixed label when spawned from the agent.

Enhancements:
- Extend text and JSON log formatters to include the source label while preserving byte-identical output when no source is set.
- Document how to interpret source-tagged log lines and the LOG_SOURCE environment variable in the logging guide.

Tests:
- Add formatter tests covering source tagging in text, colored, and JSON outputs, including compatibility of untagged lines.
- Add logger tests ensuring configured sources are stamped on all emitted records and omitted when unset.
- Add config tests for LOG_SOURCE parsing, including trimming and handling of empty or whitespace-only values.
- Add agent wiring tests verifying that MCP broker spawn specs include the configured LOG_SOURCE label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional process source labels to log records.
  * Text logs now display sources as `[source]`; JSON logs include a `source` field when configured.
  * Broker processes are automatically identified as `mcp-broker`, making their logs easier to distinguish and filter.

* **Documentation**
  * Added guidance for configuring `LOG_SOURCE` and identifying server versus broker logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->