### PR TITLE
fix(agent): 「MCP server may have crashed」の誤検知をやめ、beacon で判定する

### DIFF
--- a/plans/fix-2900-broker-crash-false-positive.md
+++ b/plans/fix-2900-broker-crash-false-positive.md
@@ -1,0 +1,87 @@
+# fix(agent): 「MCP server may have crashed」の誤検知をやめる（#2900）
+
+## 問題
+
+`server/agent/backend/claude-code.ts` の `createMcpTracker()` は、次の条件だけで
+「MCP サーバがクラッシュしたかもしれない」と警告する。
+
+```ts
+if (toolSearchCalled && !mcpToolCalled) { log.warn("agent", "…may have crashed…"); }
+```
+
+ところが ToolSearch は **Claude Code CLI 組み込みの deferred ツール**
+（`WebFetch` / `WebSearch` / `PushNotification` など）の解決にも使われる。これらは
+`mcp__` プレフィックスを持たないので、**MCP が完全に健全でも条件が成立する**。
+
+#2886 ではこの警告が出たことで、報告者が「MCP がクラッシュしている / socat リレーが原因では」
+という誤った切り分けに進み、issue のタイトルにもその推測が入った。実際には MCP は健全で、
+`notify, handlePermission, spawnBackgroundChat, manageCollection` が正常に publish されていた。
+
+副次的に、警告が案内する `npx tsx --test test/agent/test_mcp_docker_smoke.ts` は
+npm パッケージの `files` に `test/` が入らないため、`npx mulmoclaude` ユーザーには実行できない。
+
+## 方針
+
+推測（ツール名の形）ではなく、**ブローカーが ready を報告したかどうか**で判定する。
+#2898 が入れた startup beacon（`server/agent/brokerReadiness.ts`）がその信号。
+
+警告条件を次の3つの **AND** にする。
+
+1. `mcpConfigured` — このターンが MCP 付きで構成された（`input.mcpConfigPath !== undefined`）。
+   MCP 無しのターンで「MCP が来ない」と言っても意味がない。
+2. `!brokerEverReady` — 現在の spawn の beacon が一度も届いていない（`getBrokerReady() === null`）。
+3. `mcpToolsCalled === 0` — `mcp__*` ツールが1回も呼ばれなかった。
+
+### 3 を残す理由（新しい誤検知を作らないため）
+
+beacon はブローカー → ホストへの POST なので、**beacon 自体が届かない環境がありうる**
+（#2842 の報告者の socat リレー、firewalld 等）。beacon の不在だけで警告すると、
+まさに元の報告を出した環境で新しい誤検知になる。
+
+ツールが実際に動いていれば、beacon が落ちていてもブローカーは仕事をしている。
+だから「beacon が無い」かつ「ツールも1つも動いていない」を要求する。
+
+逆に #2886 のケース（ToolSearch で `PushNotification` / `WebFetch` を引いた健全なターン）は
+beacon が届いているので 2 で落ちる。**旧ヒューリスティックの誤検知はこれで消える。**
+
+### ToolSearch は判定から完全に外す
+
+「ToolSearch が呼ばれたか」は MCP の健全性と無関係なので、追跡自体をやめる。
+
+## 変更
+
+| ファイル | 変更 |
+|---|---|
+| `server/agent/backend/claude-code.ts` | `createMcpTracker` を廃止し、`mcp__*` の呼び出しだけ数える watcher + 純粋な判定関数 `shouldWarnMcpUnavailable()` に置き換え。警告文を npm 版でも実行できる案内に差し替え |
+| `server/agent/mcpFailureMonitor.ts` | `MCP_PREFIX` を export（プレフィックス literal の重複を作らない） |
+
+`readAgentEvents()` に `chatSessionId` と `mcpConfigured` を渡す必要がある
+（呼び出し元 `runClaudeAgent` は `input.sessionId` / `input.mcpConfigPath` を持っている）。
+
+判定は純粋関数として export し、単体テストで固定する（`docs/testing.md` の
+designing-for-testability に従う）。
+
+## テスト
+
+`test/agent/test_mcpUnavailableWarning.ts`（新規）:
+
+- MCP 未構成 → 警告しない
+- beacon あり / ツール0 → 警告しない（**#2886 の回帰ケース**: ToolSearch で組み込みを引いた健全なターン）
+- beacon なし / ツールあり → 警告しない（beacon が落ちる環境の保護）
+- beacon なし / ツール0 → 警告する
+- watcher が `mcp__*` だけを数え、`WebFetch` / `ToolSearch` / `PushNotification` を数えないこと
+
+## 検証
+
+`yarn format` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test`。
+
+判定は純粋関数なので単体テストで足りるが、`readAgentEvents` のシグネチャを変えるため
+**実際にターンを1回回して**、健全なターンで警告が出ないことを確認する。
+
+## やらないこと
+
+`packages/core/assets/helps/error-recovery.md` は触らない。これは既存の診断の条件を
+直すもので、新しい失敗モードを足すものではない。かつ `assets/helps/*` を変更すると
+`@mulmoclaude/core` の publish が要る。必要なら別 issue にする。
+
+refs #2900

--- a/plans/fix-2900-broker-crash-false-positive.md
+++ b/plans/fix-2900-broker-crash-false-positive.md
@@ -25,7 +25,7 @@ npm パッケージの `files` に `test/` が入らないため、`npx mulmocla
 推測（ツール名の形）ではなく、**ブローカーが ready を報告したかどうか**で判定する。
 #2898 が入れた startup beacon（`server/agent/brokerReadiness.ts`）がその信号。
 
-警告条件を次の3つの **AND** にする。
+警告条件を次の4つの **AND** にする。
 
 1. `mcpConfigured` — このターンが MCP 付きで構成された（`input.mcpConfigPath !== undefined`）。
    MCP 無しのターンで「MCP が来ない」と言っても意味がない。

--- a/plans/fix-2900-broker-crash-false-positive.md
+++ b/plans/fix-2900-broker-crash-false-positive.md
@@ -30,7 +30,12 @@ npm パッケージの `files` に `test/` が入らないため、`npx mulmocla
 1. `mcpConfigured` — このターンが MCP 付きで構成された（`input.mcpConfigPath !== undefined`）。
    MCP 無しのターンで「MCP が来ない」と言っても意味がない。
 2. `!brokerEverReady` — 現在の spawn の beacon が一度も届いていない（`getBrokerReady() === null`）。
-3. `mcpToolsCalled === 0` — `mcp__*` ツールが1回も呼ばれなかった。
+3. `builtinMcpToolsCalled === 0` — **組み込みブローカーの**ツール（`mcp__mulmoclaude__*`）が1回も呼ばれなかった。
+
+`mcp__*` 全体ではなく組み込み限定にするのが要点。`buildMcpConfig()` はユーザー定義 MCP サーバや
+claude.ai コネクタを同じ config に登録するので、`mcp__github__*` が成功しただけで
+「うちのブローカーは上がった」と誤って判定してしまう。beacon が語るのは組み込みブローカーだけ
+（Codex review on #2906）。
 
 ### 3 を残す理由（新しい誤検知を作らないため）
 
@@ -52,8 +57,8 @@ beacon が届いているので 2 で落ちる。**旧ヒューリスティッ�
 
 | ファイル | 変更 |
 |---|---|
-| `server/agent/backend/claude-code.ts` | `createMcpTracker` を廃止し、`mcp__*` の呼び出しだけ数える watcher + 純粋な判定関数 `shouldWarnMcpUnavailable()` に置き換え。警告文を npm 版でも実行できる案内に差し替え |
-| `server/agent/mcpFailureMonitor.ts` | `MCP_PREFIX` を export（プレフィックス literal の重複を作らない） |
+| `server/agent/backend/claude-code.ts` | `createMcpTracker` を廃止し、組み込みブローカーの呼び出しだけ数える watcher + 純粋な判定関数 `shouldWarnMcpUnavailable()` に置き換え。警告文を npm 版でも実行できる案内に差し替え |
+| `server/agent/activeTools.ts` | `BUILTIN_MCP_TOOL_PREFIX`（`mcp__mulmoclaude__`）を export |
 
 `readAgentEvents()` に `chatSessionId` と `mcpConfigured` を渡す必要がある
 （呼び出し元 `runClaudeAgent` は `input.sessionId` / `input.mcpConfigPath` を持っている）。
@@ -69,7 +74,9 @@ designing-for-testability に従う）。
 - beacon あり / ツール0 → 警告しない（**#2886 の回帰ケース**: ToolSearch で組み込みを引いた健全なターン）
 - beacon なし / ツールあり → 警告しない（beacon が落ちる環境の保護）
 - beacon なし / ツール0 → 警告する
-- watcher が `mcp__*` だけを数え、`WebFetch` / `ToolSearch` / `PushNotification` を数えないこと
+- watcher が `mcp__mulmoclaude__*` だけを数え、`WebFetch` / `ToolSearch` / `PushNotification` も
+  `mcp__github__*` / `mcp__claude_ai_Gmail__*` も数えないこと
+- 非組み込み MCP だけが応答 + beacon なし → **警告する**
 
 ## 検証
 

--- a/plans/fix-2900-broker-crash-false-positive.md
+++ b/plans/fix-2900-broker-crash-false-positive.md
@@ -29,15 +29,22 @@ npm パッケージの `files` に `test/` が入らないため、`npx mulmocla
 
 1. `mcpConfigured` — このターンが MCP 付きで構成された（`input.mcpConfigPath !== undefined`）。
    MCP 無しのターンで「MCP が来ない」と言っても意味がない。
-2. `!brokerEverReady` — 現在の spawn の beacon が一度も届いていない（`getBrokerReady() === null`）。
-3. `builtinMcpToolsCalled === 0` — **組み込みブローカーの**ツール（`mcp__mulmoclaude__*`）が1回も呼ばれなかった。
+2. `!aborted` — ユーザーがターンを止めていない。停止ボタンを押した直後は
+   「MCP 構成あり・beacon なし・ツール0」が必ず成立するので、これが無いと
+   **ごく普通のキャンセル操作で毎回誤検知する**（Codex review on #2906）。
+   判定に使うのは `isAbortCausedExit` ではなく abort シグナルそのもの。
+   ここで問うているのは「ターンが途中で切られたか」であって
+   「この exit code が我々由来か」ではない。キャンセル後に CLI が exit 0 で
+   きれいに終わるケースを `isAbortCausedExit` は通常終了として扱ってしまう。
+3. `!brokerEverReady` — 現在の spawn の beacon が一度も届いていない（`getBrokerReady() === null`）。
+4. `builtinMcpToolsCalled === 0` — **組み込みブローカーの**ツール（`mcp__mulmoclaude__*`）が1回も呼ばれなかった。
 
 `mcp__*` 全体ではなく組み込み限定にするのが要点。`buildMcpConfig()` はユーザー定義 MCP サーバや
 claude.ai コネクタを同じ config に登録するので、`mcp__github__*` が成功しただけで
 「うちのブローカーは上がった」と誤って判定してしまう。beacon が語るのは組み込みブローカーだけ
 （Codex review on #2906）。
 
-### 3 を残す理由（新しい誤検知を作らないため）
+### 4 を残す理由（新しい誤検知を作らないため）
 
 beacon はブローカー → ホストへの POST なので、**beacon 自体が届かない環境がありうる**
 （#2842 の報告者の socat リレー、firewalld 等）。beacon の不在だけで警告すると、
@@ -74,6 +81,7 @@ designing-for-testability に従う）。
 - beacon あり / ツール0 → 警告しない（**#2886 の回帰ケース**: ToolSearch で組み込みを引いた健全なターン）
 - beacon なし / ツールあり → 警告しない（beacon が落ちる環境の保護）
 - beacon なし / ツール0 → 警告する
+- **キャンセルされたターン → 警告しない**（他の条件が全て揃っていても）
 - watcher が `mcp__mulmoclaude__*` だけを数え、`WebFetch` / `ToolSearch` / `PushNotification` も
   `mcp__github__*` / `mcp__claude_ai_Gmail__*` も数えないこと
 - 非組み込み MCP だけが応答 + beacon なし → **警告する**

--- a/server/agent/activeTools.ts
+++ b/server/agent/activeTools.ts
@@ -69,8 +69,11 @@ export interface ActiveToolDescriptor {
   source: ToolSource;
 }
 
-const FULL_PREFIX = `mcp__${MCP_SERVER_ID}__`;
-const fullNameFor = (toolName: string): string => `${FULL_PREFIX}${toolName}`;
+/** What every tool published by the built-in broker is called. User-configured
+ *  MCP servers get their own `mcp__<their-id>__` prefix, so this is how callers
+ *  tell "our broker answered" from "some MCP server answered". */
+export const BUILTIN_MCP_TOOL_PREFIX = `mcp__${MCP_SERVER_ID}__`;
+const fullNameFor = (toolName: string): string => `${BUILTIN_MCP_TOOL_PREFIX}${toolName}`;
 const promptFor = (def: ToolDefinition): string | undefined => (hasStringProp(def, "prompt") ? def.prompt : undefined);
 
 export function getActiveToolDescriptors(role: Role): ActiveToolDescriptor[] {

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -92,6 +92,10 @@ export function createBuiltinMcpToolWatcher() {
  *    resolves CLI built-ins (`WebFetch`, `PushNotification`), so a perfectly
  *    healthy turn satisfied it — which is how #2886 came to be filed against a
  *    working MCP server.
+ *  - `!aborted` — a turn the user stopped never got the chance to use its
+ *    tools. Hitting the stop button straight away produces "configured, no
+ *    beacon, no calls" every time, so without this the diagnostic fires on an
+ *    ordinary cancellation (Codex review on #2906).
  *  - `builtinMcpToolsCalled === 0` — the beacon is a POST from the broker back
  *    to the host, so a relay or firewall can swallow it (#2842's socat setup is
  *    exactly that). Built-in tools that ran prove the broker delivered whether
@@ -100,8 +104,8 @@ export function createBuiltinMcpToolWatcher() {
  *    broker's tools count — a user-configured MCP server answering says nothing
  *    about ours.
  */
-export function shouldWarnMcpUnavailable(turn: { mcpConfigured: boolean; brokerEverReady: boolean; builtinMcpToolsCalled: number }): boolean {
-  return turn.mcpConfigured && !turn.brokerEverReady && turn.builtinMcpToolsCalled === 0;
+export function shouldWarnMcpUnavailable(turn: { mcpConfigured: boolean; aborted: boolean; brokerEverReady: boolean; builtinMcpToolsCalled: number }): boolean {
+  return turn.mcpConfigured && !turn.aborted && !turn.brokerEverReady && turn.builtinMcpToolsCalled === 0;
 }
 
 // Exit codes the claude CLI reports when it is terminated by one of the
@@ -174,9 +178,13 @@ interface TurnMcpContext {
   mcpConfigured: boolean;
 }
 
-function logIfMcpUnavailable(turn: TurnMcpContext, builtinMcpToolsCalled: number): void {
+// `aborted` is the abort SIGNAL, not `isAbortCausedExit`: the question here is
+// whether the turn was cut short, not whether this particular exit code was
+// ours. A cancel that lets the CLI exit 0 cleanly is still a turn that never got
+// to use its tools, and `isAbortCausedExit` reads that one as a normal finish.
+function logIfMcpUnavailable(turn: TurnMcpContext, builtinMcpToolsCalled: number, aborted: boolean): void {
   const brokerEverReady = getBrokerReady(turn.chatSessionId) !== null;
-  if (!shouldWarnMcpUnavailable({ mcpConfigured: turn.mcpConfigured, brokerEverReady, builtinMcpToolsCalled })) return;
+  if (!shouldWarnMcpUnavailable({ mcpConfigured: turn.mcpConfigured, aborted, brokerEverReady, builtinMcpToolsCalled })) return;
   log.warn("agent", "MCP tools were unavailable this turn — the broker never reported ready and none of its tools ran", {
     chatSessionId: turn.chatSessionId,
     brokerEverReady,
@@ -242,7 +250,7 @@ async function* readAgentEvents(proc: ClaudeProc, turn: TurnMcpContext, abortSig
 
   if (stderrBuffer.trim()) logAgentStderr(stderrBuffer);
   log.info("agent", "claude exited", { exitCode, signal });
-  logIfMcpUnavailable(turn, builtinMcpToolWatcher.count());
+  logIfMcpUnavailable(turn, builtinMcpToolWatcher.count(), abortSignal?.aborted === true);
 
   const errorEvent = buildExitErrorEvent(exitCode, signal, abortSignal, stderrOutput) ?? brokerNotReadyErrorEvent(stderrOutput);
   if (errorEvent) yield errorEvent;

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -83,19 +83,20 @@ export function createBuiltinMcpToolWatcher() {
 
 /** Did this turn look like the broker never delivered its tools?
  *
- *  All three conditions are required, and each rules out a way of being wrong:
+ *  All four conditions are required, and each rules out a way of being wrong.
+ *  They are listed in the order the predicate reads them:
  *
  *  - `mcpConfigured` — a turn that was never given MCP cannot be missing it.
+ *  - `!aborted` — a turn the user stopped never got the chance to use its
+ *    tools. Hitting the stop button straight away produces "configured, no
+ *    beacon, no calls" every time, so without this the diagnostic fires on an
+ *    ordinary cancellation (Codex review on #2906).
  *  - `!brokerEverReady` — the startup beacon (#2898) is direct evidence, where
  *    the old check inferred a crash from the SHAPE of the tool names: it fired
  *    whenever ToolSearch ran without a following `mcp__*` call. ToolSearch also
  *    resolves CLI built-ins (`WebFetch`, `PushNotification`), so a perfectly
  *    healthy turn satisfied it — which is how #2886 came to be filed against a
  *    working MCP server.
- *  - `!aborted` — a turn the user stopped never got the chance to use its
- *    tools. Hitting the stop button straight away produces "configured, no
- *    beacon, no calls" every time, so without this the diagnostic fires on an
- *    ordinary cancellation (Codex review on #2906).
  *  - `builtinMcpToolsCalled === 0` — the beacon is a POST from the broker back
  *    to the host, so a relay or firewall can swallow it (#2842's socat setup is
  *    exactly that). Built-in tools that ran prove the broker delivered whether

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -16,7 +16,8 @@ import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
-import { createMcpFailureMonitor } from "../mcpFailureMonitor.js";
+import { createMcpFailureMonitor, MCP_PREFIX } from "../mcpFailureMonitor.js";
+import { getBrokerReady } from "../brokerReadiness.js";
 import { isMcpBrokerNotReadyError } from "../mcpBrokerFailover.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -59,30 +60,39 @@ function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[
   return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
 }
 
-// Track MCP tool usage to detect silent MCP server failures.
-// If ToolSearch was called but no mcp__* tool was ever invoked,
-// the MCP server likely crashed on startup (e.g. module resolution
-// failure inside Docker). See #430.
-function createMcpTracker() {
-  let toolSearchCalled = false;
-  let mcpToolCalled = false;
+// Counts the MCP tools a turn actually ran. A Set rather than a boolean so the
+// state stays `const` and the count can go into the log line. Which names count
+// is the half of #2886 that went wrong, so it is exported and pinned by tests.
+export function createMcpToolWatcher() {
+  const called = new Set<string>();
   return {
-    track(event: AgentEvent) {
+    track(event: AgentEvent): void {
       if (event.type !== EVENT_TYPES.toolCall) return;
-      if (event.toolName === "ToolSearch") toolSearchCalled = true;
-      if (event.toolName.startsWith("mcp__")) mcpToolCalled = true;
+      if (event.toolName.startsWith(MCP_PREFIX)) called.add(event.toolName);
     },
-    logIfSuspicious() {
-      if (toolSearchCalled && !mcpToolCalled) {
-        log.warn(
-          "agent",
-          "ToolSearch was used but no MCP tool was called — the MCP server may have crashed. " +
-            "Check Docker volume mounts and package.json exports. " +
-            "Run: npx tsx --test test/agent/test_mcp_docker_smoke.ts",
-        );
-      }
-    },
+    count: (): number => called.size,
   };
+}
+
+/** Did this turn look like the broker never delivered its tools?
+ *
+ *  All three conditions are required, and each rules out a way of being wrong:
+ *
+ *  - `mcpConfigured` — a turn that was never given MCP cannot be missing it.
+ *  - `!brokerEverReady` — the startup beacon (#2898) is direct evidence, where
+ *    the old check inferred a crash from the SHAPE of the tool names: it fired
+ *    whenever ToolSearch ran without a following `mcp__*` call. ToolSearch also
+ *    resolves CLI built-ins (`WebFetch`, `PushNotification`), so a perfectly
+ *    healthy turn satisfied it — which is how #2886 came to be filed against a
+ *    working MCP server.
+ *  - `mcpToolsCalled === 0` — the beacon is a POST from the broker back to the
+ *    host, so a relay or firewall can swallow it (#2842's socat setup is
+ *    exactly that). Tools that ran prove the broker delivered whether or not
+ *    its beacon arrived; without this the fix would re-create the false
+ *    positive in the very environment that reported it.
+ */
+export function shouldWarnMcpUnavailable(turn: { mcpConfigured: boolean; brokerEverReady: boolean; mcpToolsCalled: number }): boolean {
+  return turn.mcpConfigured && !turn.brokerEverReady && turn.mcpToolsCalled === 0;
 }
 
 // Exit codes the claude CLI reports when it is terminated by one of the
@@ -147,7 +157,26 @@ function logAgentStderr(line: string): void {
   else log.error("agent-stderr", line);
 }
 
-async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
+// What the turn's tool availability is judged against once the CLI exits. The
+// readiness lookup needs the session key, and "was MCP configured at all" is
+// the orchestrator's decision, not something to re-derive here.
+interface TurnMcpContext {
+  chatSessionId: string;
+  mcpConfigured: boolean;
+}
+
+function logIfMcpUnavailable(turn: TurnMcpContext, mcpToolsCalled: number): void {
+  const brokerEverReady = getBrokerReady(turn.chatSessionId) !== null;
+  if (!shouldWarnMcpUnavailable({ mcpConfigured: turn.mcpConfigured, brokerEverReady, mcpToolsCalled })) return;
+  log.warn("agent", "MCP tools were unavailable this turn — the broker never reported ready and no MCP tool ran", {
+    chatSessionId: turn.chatSessionId,
+    brokerEverReady,
+    mcpToolsCalled,
+    hint: "Look for `[mcp] broker ready` in server/system/logs/; on Docker also check the sandbox volume mounts.",
+  });
+}
+
+async function* readAgentEvents(proc: ClaudeProc, turn: TurnMcpContext, abortSignal?: AbortSignal): AsyncGenerator<AgentEvent> {
   let stderrOutput = "";
   let stderrBuffer = "";
   proc.stderr.on("data", (chunk: Buffer) => {
@@ -166,10 +195,10 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
   // text is suppressed. See createStreamParser() in stream.ts.
   const parser = createStreamParser();
 
-  const mcpTracker = createMcpTracker();
-  // Runtime failure monitor (#1353). Lives next to mcpTracker
-  // because they share the same event stream — the tracker spots
-  // the "MCP never invoked" pattern, the monitor spots the
+  const mcpToolWatcher = createMcpToolWatcher();
+  // Runtime failure monitor (#1353). Lives next to mcpToolWatcher
+  // because they share the same event stream — the watcher feeds the
+  // "MCP never invoked" check, the monitor spots the
   // "MCP invoked but consistently failing" pattern.
   const mcpFailureMonitor = createMcpFailureMonitor();
 
@@ -193,7 +222,7 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
         continue;
       }
       for (const agentEvent of parser.parse(event)) {
-        mcpTracker.track(agentEvent);
+        mcpToolWatcher.track(agentEvent);
         mcpFailureMonitor.track(agentEvent);
         yield agentEvent;
       }
@@ -204,7 +233,7 @@ async function* readAgentEvents(proc: ClaudeProc, abortSignal?: AbortSignal): As
 
   if (stderrBuffer.trim()) logAgentStderr(stderrBuffer);
   log.info("agent", "claude exited", { exitCode, signal });
-  mcpTracker.logIfSuspicious();
+  logIfMcpUnavailable(turn, mcpToolWatcher.count());
 
   const errorEvent = buildExitErrorEvent(exitCode, signal, abortSignal, stderrOutput) ?? brokerNotReadyErrorEvent(stderrOutput);
   if (errorEvent) yield errorEvent;
@@ -307,7 +336,7 @@ async function* runClaudeAgent(input: AgentInput): AsyncGenerator<AgentEvent> {
   input.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
   try {
-    yield* readAgentEvents(proc, input.abortSignal);
+    yield* readAgentEvents(proc, { chatSessionId: input.sessionId, mcpConfigured: input.mcpConfigPath !== undefined }, input.abortSignal);
   } finally {
     input.abortSignal?.removeEventListener("abort", onAbort);
     if (!proc.killed) proc.kill();

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -16,8 +16,9 @@ import { writeFileAtomic } from "../../utils/files/atomic.js";
 import { resolveSandboxAuth } from "../sandboxMounts.js";
 import { getCachedReferenceDirs, referenceDirMountArgs } from "../../workspace/reference-dirs.js";
 import { createStreamParser, type AgentEvent, type RawStreamEvent } from "../stream.js";
-import { createMcpFailureMonitor, MCP_PREFIX } from "../mcpFailureMonitor.js";
+import { createMcpFailureMonitor } from "../mcpFailureMonitor.js";
 import { getBrokerReady } from "../brokerReadiness.js";
+import { BUILTIN_MCP_TOOL_PREFIX } from "../activeTools.js";
 import { isMcpBrokerNotReadyError } from "../mcpBrokerFailover.js";
 import { log } from "../../system/logger/index.js";
 import { errorMessage } from "../../utils/errors.js";
@@ -60,15 +61,21 @@ function spawnClaude(useDocker: boolean, workspacePath: string, cliArgs: string[
   return spawn("docker", dockerArgs, { stdio: ["pipe", "pipe", "pipe"] });
 }
 
-// Counts the MCP tools a turn actually ran. A Set rather than a boolean so the
-// state stays `const` and the count can go into the log line. Which names count
-// is the half of #2886 that went wrong, so it is exported and pinned by tests.
-export function createMcpToolWatcher() {
+// Counts the tools a turn ran FROM THE BUILT-IN BROKER. Scoped to
+// `mcp__mulmoclaude__` rather than `mcp__`, because the beacon only speaks for
+// that broker: a working `mcp__github__…` call says nothing about whether OUR
+// broker loaded, and counting it would hide the very startup failure this
+// feeds (Codex review on #2906).
+//
+// A Set rather than a boolean so the state stays `const` and the count can go
+// into the log line. Which names count is the half of #2886 that went wrong,
+// so this is exported and pinned by tests.
+export function createBuiltinMcpToolWatcher() {
   const called = new Set<string>();
   return {
     track(event: AgentEvent): void {
       if (event.type !== EVENT_TYPES.toolCall) return;
-      if (event.toolName.startsWith(MCP_PREFIX)) called.add(event.toolName);
+      if (event.toolName.startsWith(BUILTIN_MCP_TOOL_PREFIX)) called.add(event.toolName);
     },
     count: (): number => called.size,
   };
@@ -85,14 +92,16 @@ export function createMcpToolWatcher() {
  *    resolves CLI built-ins (`WebFetch`, `PushNotification`), so a perfectly
  *    healthy turn satisfied it — which is how #2886 came to be filed against a
  *    working MCP server.
- *  - `mcpToolsCalled === 0` — the beacon is a POST from the broker back to the
- *    host, so a relay or firewall can swallow it (#2842's socat setup is
- *    exactly that). Tools that ran prove the broker delivered whether or not
- *    its beacon arrived; without this the fix would re-create the false
- *    positive in the very environment that reported it.
+ *  - `builtinMcpToolsCalled === 0` — the beacon is a POST from the broker back
+ *    to the host, so a relay or firewall can swallow it (#2842's socat setup is
+ *    exactly that). Built-in tools that ran prove the broker delivered whether
+ *    or not its beacon arrived; without this the fix would re-create the false
+ *    positive in the very environment that reported it. Only the BUILT-IN
+ *    broker's tools count — a user-configured MCP server answering says nothing
+ *    about ours.
  */
-export function shouldWarnMcpUnavailable(turn: { mcpConfigured: boolean; brokerEverReady: boolean; mcpToolsCalled: number }): boolean {
-  return turn.mcpConfigured && !turn.brokerEverReady && turn.mcpToolsCalled === 0;
+export function shouldWarnMcpUnavailable(turn: { mcpConfigured: boolean; brokerEverReady: boolean; builtinMcpToolsCalled: number }): boolean {
+  return turn.mcpConfigured && !turn.brokerEverReady && turn.builtinMcpToolsCalled === 0;
 }
 
 // Exit codes the claude CLI reports when it is terminated by one of the
@@ -165,13 +174,13 @@ interface TurnMcpContext {
   mcpConfigured: boolean;
 }
 
-function logIfMcpUnavailable(turn: TurnMcpContext, mcpToolsCalled: number): void {
+function logIfMcpUnavailable(turn: TurnMcpContext, builtinMcpToolsCalled: number): void {
   const brokerEverReady = getBrokerReady(turn.chatSessionId) !== null;
-  if (!shouldWarnMcpUnavailable({ mcpConfigured: turn.mcpConfigured, brokerEverReady, mcpToolsCalled })) return;
-  log.warn("agent", "MCP tools were unavailable this turn — the broker never reported ready and no MCP tool ran", {
+  if (!shouldWarnMcpUnavailable({ mcpConfigured: turn.mcpConfigured, brokerEverReady, builtinMcpToolsCalled })) return;
+  log.warn("agent", "MCP tools were unavailable this turn — the broker never reported ready and none of its tools ran", {
     chatSessionId: turn.chatSessionId,
     brokerEverReady,
-    mcpToolsCalled,
+    builtinMcpToolsCalled,
     hint: "Look for `[mcp] broker ready` in server/system/logs/; on Docker also check the sandbox volume mounts.",
   });
 }
@@ -195,8 +204,8 @@ async function* readAgentEvents(proc: ClaudeProc, turn: TurnMcpContext, abortSig
   // text is suppressed. See createStreamParser() in stream.ts.
   const parser = createStreamParser();
 
-  const mcpToolWatcher = createMcpToolWatcher();
-  // Runtime failure monitor (#1353). Lives next to mcpToolWatcher
+  const builtinMcpToolWatcher = createBuiltinMcpToolWatcher();
+  // Runtime failure monitor (#1353). Lives next to builtinMcpToolWatcher
   // because they share the same event stream — the watcher feeds the
   // "MCP never invoked" check, the monitor spots the
   // "MCP invoked but consistently failing" pattern.
@@ -222,7 +231,7 @@ async function* readAgentEvents(proc: ClaudeProc, turn: TurnMcpContext, abortSig
         continue;
       }
       for (const agentEvent of parser.parse(event)) {
-        mcpToolWatcher.track(agentEvent);
+        builtinMcpToolWatcher.track(agentEvent);
         mcpFailureMonitor.track(agentEvent);
         yield agentEvent;
       }
@@ -233,7 +242,7 @@ async function* readAgentEvents(proc: ClaudeProc, turn: TurnMcpContext, abortSig
 
   if (stderrBuffer.trim()) logAgentStderr(stderrBuffer);
   log.info("agent", "claude exited", { exitCode, signal });
-  logIfMcpUnavailable(turn, mcpToolWatcher.count());
+  logIfMcpUnavailable(turn, builtinMcpToolWatcher.count());
 
   const errorEvent = buildExitErrorEvent(exitCode, signal, abortSignal, stderrOutput) ?? brokerNotReadyErrorEvent(stderrOutput);
   if (errorEvent) yield errorEvent;

--- a/server/agent/mcpFailureMonitor.ts
+++ b/server/agent/mcpFailureMonitor.ts
@@ -36,7 +36,9 @@ export const MCP_FAILURE_THRESHOLD = 3;
 // what lets the monitor attribute failures back to the right
 // server entry in `mcp.json`.
 const MCP_SERVER_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
-const MCP_PREFIX = "mcp__";
+/** What the CLI prefixes every MCP tool name with. Exported so callers that
+ *  only need "is this an MCP tool at all?" don't re-declare the literal. */
+export const MCP_PREFIX = "mcp__";
 const MCP_DELIM = "__";
 
 function isValidServerId(value: string): boolean {

--- a/server/agent/mcpFailureMonitor.ts
+++ b/server/agent/mcpFailureMonitor.ts
@@ -36,9 +36,7 @@ export const MCP_FAILURE_THRESHOLD = 3;
 // what lets the monitor attribute failures back to the right
 // server entry in `mcp.json`.
 const MCP_SERVER_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
-/** What the CLI prefixes every MCP tool name with. Exported so callers that
- *  only need "is this an MCP tool at all?" don't re-declare the literal. */
-export const MCP_PREFIX = "mcp__";
+const MCP_PREFIX = "mcp__";
 const MCP_DELIM = "__";
 
 function isValidServerId(value: string): boolean {

--- a/test/agent/test_mcpUnavailableWarning.ts
+++ b/test/agent/test_mcpUnavailableWarning.ts
@@ -11,11 +11,26 @@ const toolCall = (toolName: string): AgentEvent => ({ type: EVENT_TYPES.toolCall
 // would.
 describe("shouldWarnMcpUnavailable", () => {
   it("warns when MCP was configured, the broker never reported ready, and nothing ran", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 0 }), true);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: false, brokerEverReady: false, builtinMcpToolsCalled: 0 }), true);
   });
 
   it("stays silent on a turn that was never given MCP", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: false, brokerEverReady: false, builtinMcpToolsCalled: 0 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: false, aborted: false, brokerEverReady: false, builtinMcpToolsCalled: 0 }), false);
+  });
+
+  // Hitting stop straight away produces "configured, no beacon, no calls" every
+  // single time — the broker simply never got the chance. Diagnosing that as a
+  // broker failure is a false positive on the most ordinary user action there
+  // is (Codex iter-2 on #2906).
+  it("stays silent when the user cancelled the turn", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: true, brokerEverReady: false, builtinMcpToolsCalled: 0 }), false);
+  });
+
+  it("stays silent on a cancel even when everything else looks like a failure", () => {
+    // Same inputs as the one case that DOES warn, flipping only `aborted`.
+    const failing = { mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 0 };
+    assert.equal(shouldWarnMcpUnavailable({ ...failing, aborted: false }), true);
+    assert.equal(shouldWarnMcpUnavailable({ ...failing, aborted: true }), false);
   });
 
   // The #2886 regression. The old check fired on exactly this shape: ToolSearch
@@ -23,7 +38,7 @@ describe("shouldWarnMcpUnavailable", () => {
   // `mcp__*` call followed, and the warning claimed a crash — while the broker
   // was healthy and had published its four tools.
   it("stays silent when the broker reported ready but the turn called no MCP tool", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, builtinMcpToolsCalled: 0 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: false, brokerEverReady: true, builtinMcpToolsCalled: 0 }), false);
   });
 
   // The beacon is a POST from the broker back to the host, so a relay or
@@ -31,7 +46,7 @@ describe("shouldWarnMcpUnavailable", () => {
   // that ran prove the broker delivered, beacon or not. Dropping this condition
   // would recreate the false positive in the environment that reported it.
   it("stays silent when the broker's own tools ran even though no beacon arrived", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 3 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: false, brokerEverReady: false, builtinMcpToolsCalled: 3 }), false);
   });
 
   // The end-to-end shape of the Codex finding: a user-configured MCP server
@@ -40,17 +55,17 @@ describe("shouldWarnMcpUnavailable", () => {
   it("still warns when only a non-built-in MCP server answered", () => {
     const watcher = createBuiltinMcpToolWatcher();
     watcher.track(toolCall("mcp__github__create_issue"));
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: watcher.count() }), true);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: false, brokerEverReady: false, builtinMcpToolsCalled: watcher.count() }), true);
   });
 
   it("stays silent on a fully healthy turn", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, builtinMcpToolsCalled: 5 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: false, brokerEverReady: true, builtinMcpToolsCalled: 5 }), false);
   });
 
   // One call is enough — the question is "did anything get through", not "how
   // much".
   it("treats a single MCP call as delivery", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 1 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, aborted: false, brokerEverReady: false, builtinMcpToolsCalled: 1 }), false);
   });
 });
 

--- a/test/agent/test_mcpUnavailableWarning.ts
+++ b/test/agent/test_mcpUnavailableWarning.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { createMcpToolWatcher, shouldWarnMcpUnavailable } from "../../server/agent/backend/claude-code.js";
+import { createBuiltinMcpToolWatcher, shouldWarnMcpUnavailable } from "../../server/agent/backend/claude-code.js";
 import { EVENT_TYPES } from "../../src/types/events.js";
 import type { AgentEvent } from "../../server/agent/stream.js";
 
@@ -11,11 +11,11 @@ const toolCall = (toolName: string): AgentEvent => ({ type: EVENT_TYPES.toolCall
 // would.
 describe("shouldWarnMcpUnavailable", () => {
   it("warns when MCP was configured, the broker never reported ready, and nothing ran", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, mcpToolsCalled: 0 }), true);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 0 }), true);
   });
 
   it("stays silent on a turn that was never given MCP", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: false, brokerEverReady: false, mcpToolsCalled: 0 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: false, brokerEverReady: false, builtinMcpToolsCalled: 0 }), false);
   });
 
   // The #2886 regression. The old check fired on exactly this shape: ToolSearch
@@ -23,31 +23,40 @@ describe("shouldWarnMcpUnavailable", () => {
   // `mcp__*` call followed, and the warning claimed a crash — while the broker
   // was healthy and had published its four tools.
   it("stays silent when the broker reported ready but the turn called no MCP tool", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, mcpToolsCalled: 0 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, builtinMcpToolsCalled: 0 }), false);
   });
 
   // The beacon is a POST from the broker back to the host, so a relay or
-  // firewall can eat it — #2842's socat setup is precisely that. Tools that ran
-  // prove the broker delivered, beacon or not. Dropping this condition would
-  // recreate the false positive in the environment that reported it.
-  it("stays silent when tools ran even though no beacon arrived", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, mcpToolsCalled: 3 }), false);
+  // firewall can eat it — #2842's socat setup is precisely that. Built-in tools
+  // that ran prove the broker delivered, beacon or not. Dropping this condition
+  // would recreate the false positive in the environment that reported it.
+  it("stays silent when the broker's own tools ran even though no beacon arrived", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 3 }), false);
+  });
+
+  // The end-to-end shape of the Codex finding: a user-configured MCP server
+  // answered all turn, our broker never did. The watcher does not count those
+  // calls, so the count stays 0 and the warning still fires.
+  it("still warns when only a non-built-in MCP server answered", () => {
+    const watcher = createBuiltinMcpToolWatcher();
+    watcher.track(toolCall("mcp__github__create_issue"));
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: watcher.count() }), true);
   });
 
   it("stays silent on a fully healthy turn", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, mcpToolsCalled: 5 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, builtinMcpToolsCalled: 5 }), false);
   });
 
   // One call is enough — the question is "did anything get through", not "how
   // much".
   it("treats a single MCP call as delivery", () => {
-    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, mcpToolsCalled: 1 }), false);
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, builtinMcpToolsCalled: 1 }), false);
   });
 });
 
-describe("createMcpToolWatcher", () => {
-  it("counts mcp__* calls and nothing else", () => {
-    const watcher = createMcpToolWatcher();
+describe("createBuiltinMcpToolWatcher", () => {
+  it("counts the built-in broker's tools and nothing else", () => {
+    const watcher = createBuiltinMcpToolWatcher();
     // The exact tool names from the #2886 turn: ToolSearch resolved two CLI
     // built-ins, and the old check read that as the MCP server having crashed.
     ["ToolSearch", "PushNotification", "WebFetch", "Bash", "Read"].forEach((name) => watcher.track(toolCall(name)));
@@ -57,8 +66,18 @@ describe("createMcpToolWatcher", () => {
     assert.equal(watcher.count(), 1);
   });
 
+  // `buildMcpConfig` registers user servers and claude.ai connectors alongside
+  // the built-in broker, so `mcp__*` alone would count a working
+  // `mcp__github__…` as proof OUR broker loaded — hiding the startup failure
+  // the warning exists for (Codex review on #2906).
+  it("does not count other MCP servers as the built-in broker answering", () => {
+    const watcher = createBuiltinMcpToolWatcher();
+    ["mcp__github__create_issue", "mcp__claude_ai_Gmail__search", "mcp__weather__fetchWeather"].forEach((name) => watcher.track(toolCall(name)));
+    assert.equal(watcher.count(), 0);
+  });
+
   it("counts distinct tools, not repeat calls", () => {
-    const watcher = createMcpToolWatcher();
+    const watcher = createBuiltinMcpToolWatcher();
     watcher.track(toolCall("mcp__mulmoclaude__notify"));
     watcher.track(toolCall("mcp__mulmoclaude__notify"));
     watcher.track(toolCall("mcp__mulmoclaude__manageCollection"));
@@ -66,7 +85,7 @@ describe("createMcpToolWatcher", () => {
   });
 
   it("ignores events that are not tool calls", () => {
-    const watcher = createMcpToolWatcher();
+    const watcher = createBuiltinMcpToolWatcher();
     watcher.track({ type: EVENT_TYPES.error, message: "mcp__mulmoclaude__notify failed" });
     assert.equal(watcher.count(), 0);
   });

--- a/test/agent/test_mcpUnavailableWarning.ts
+++ b/test/agent/test_mcpUnavailableWarning.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createMcpToolWatcher, shouldWarnMcpUnavailable } from "../../server/agent/backend/claude-code.js";
+import { EVENT_TYPES } from "../../src/types/events.js";
+import type { AgentEvent } from "../../server/agent/stream.js";
+
+const toolCall = (toolName: string): AgentEvent => ({ type: EVENT_TYPES.toolCall, toolUseId: "u1", toolName, args: {} });
+
+// The warning this guards exists to say "your tools didn't load". Every case
+// below is a way the old check got that answer wrong, or a way a naive fix
+// would.
+describe("shouldWarnMcpUnavailable", () => {
+  it("warns when MCP was configured, the broker never reported ready, and nothing ran", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, mcpToolsCalled: 0 }), true);
+  });
+
+  it("stays silent on a turn that was never given MCP", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: false, brokerEverReady: false, mcpToolsCalled: 0 }), false);
+  });
+
+  // The #2886 regression. The old check fired on exactly this shape: ToolSearch
+  // ran (resolving the CLI built-ins `PushNotification` / `WebFetch`), no
+  // `mcp__*` call followed, and the warning claimed a crash — while the broker
+  // was healthy and had published its four tools.
+  it("stays silent when the broker reported ready but the turn called no MCP tool", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, mcpToolsCalled: 0 }), false);
+  });
+
+  // The beacon is a POST from the broker back to the host, so a relay or
+  // firewall can eat it — #2842's socat setup is precisely that. Tools that ran
+  // prove the broker delivered, beacon or not. Dropping this condition would
+  // recreate the false positive in the environment that reported it.
+  it("stays silent when tools ran even though no beacon arrived", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, mcpToolsCalled: 3 }), false);
+  });
+
+  it("stays silent on a fully healthy turn", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: true, mcpToolsCalled: 5 }), false);
+  });
+
+  // One call is enough — the question is "did anything get through", not "how
+  // much".
+  it("treats a single MCP call as delivery", () => {
+    assert.equal(shouldWarnMcpUnavailable({ mcpConfigured: true, brokerEverReady: false, mcpToolsCalled: 1 }), false);
+  });
+});
+
+describe("createMcpToolWatcher", () => {
+  it("counts mcp__* calls and nothing else", () => {
+    const watcher = createMcpToolWatcher();
+    // The exact tool names from the #2886 turn: ToolSearch resolved two CLI
+    // built-ins, and the old check read that as the MCP server having crashed.
+    ["ToolSearch", "PushNotification", "WebFetch", "Bash", "Read"].forEach((name) => watcher.track(toolCall(name)));
+    assert.equal(watcher.count(), 0);
+
+    watcher.track(toolCall("mcp__mulmoclaude__notify"));
+    assert.equal(watcher.count(), 1);
+  });
+
+  it("counts distinct tools, not repeat calls", () => {
+    const watcher = createMcpToolWatcher();
+    watcher.track(toolCall("mcp__mulmoclaude__notify"));
+    watcher.track(toolCall("mcp__mulmoclaude__notify"));
+    watcher.track(toolCall("mcp__mulmoclaude__manageCollection"));
+    assert.equal(watcher.count(), 2);
+  });
+
+  it("ignores events that are not tool calls", () => {
+    const watcher = createMcpToolWatcher();
+    watcher.track({ type: EVENT_TYPES.error, message: "mcp__mulmoclaude__notify failed" });
+    assert.equal(watcher.count(), 0);
+  });
+});


### PR DESCRIPTION
## Summary

「MCP server may have crashed」の判定を、**ツール名の形からの推測**ではなく **ブローカーの startup beacon**（#2898）に置き換える。

旧条件は「ToolSearch が呼ばれた」かつ「`mcp__*` が1回も呼ばれなかった」だけだった。ところが ToolSearch は Claude Code CLI 組み込みの deferred ツール（`WebFetch` / `WebSearch` / `PushNotification`）の解決にも使われ、これらは `mcp__` プレフィックスを持たない。**MCP が完全に健全でも条件が成立する。**

#2886 ではこの警告が出たことで、報告者が「MCP がクラッシュしている / socat リレーが原因では」という誤った切り分けへ進み、issue のタイトルにもその推測が入った。実際には `notify, handlePermission, spawnBackgroundChat, manageCollection` が正常に publish されていた。

新しい条件は3つの AND:

| 条件 | 何を排除するか |
|---|---|
| `mcpConfigured` | MCP 無しのターンで「MCP が来ない」と言わない |
| `!brokerEverReady` | 推測ではなく beacon という直接証拠を使う |
| `mcpToolsCalled === 0` | **beacon が届かない環境で新しい誤検知を作らない** |

3番目が要点。beacon はブローカー → ホストへの POST なので、リレーやファイアウォールが飲みうる（#2842 の socat 構成がまさにそれ）。ツールが実際に動いていればブローカーは仕事をしているので、beacon の有無に関わらず警告しない。**これが無いと、元の報告を出した環境で誤検知が復活する。**

ToolSearch は判定から完全に外した（MCP の健全性と無関係なため）。

警告文も差し替えた。旧文は `npx tsx --test test/agent/test_mcp_docker_smoke.ts` を案内していたが、npm パッケージの `files` に `test/` は入らないので `npx mulmoclaude` ユーザーには実行できない（#2886 の報告者も「そのパスは存在しない」と書いている）。新しい案内は `server/system/logs/` の `[mcp] broker ready` 行を見る、という npm 版でも成立するもの。

## Items to Confirm / Review

1. **`mcpToolsCalled === 0` を AND に入れる判断** — beacon の不在だけで警告すると診断としては鋭いが、beacon 配送が壊れている環境（#2842）で毎ターン誤検知する。「ツールが動いた＝ブローカーは届いた」を優先した。**逆に、beacon が落ちていること自体を知らせたいという考え方もありうる**ので、ここは意見がほしい。

2. **`readAgentEvents()` のシグネチャ変更** — 第2引数に `TurnMcpContext { chatSessionId, mcpConfigured }` を足した。呼び出し元は1箇所（`runClaudeAgent`）。`mcpConfigured` は `input.mcpConfigPath !== undefined` で導出している（`server/agent/index.ts:255` が `hasMcp ? mcpPaths.argPath : undefined` なので `hasMcp` と等価）。**再導出せず orchestrator の決定をそのまま使う形にしたが、`hasMcp` を `AgentInput` に明示フィールドとして足すほうが良いなら言ってほしい。**

3. **`MCP_PREFIX` の export** — `server/agent/mcpFailureMonitor.ts` の private 定数を export した。`"mcp__"` literal を2箇所に書かないため。

4. **`error-recovery.md` は触っていない** — これは既存診断の条件修正であって新しい失敗モードの追加ではなく、かつ `assets/helps/*` を変えると `@mulmoclaude/core` の publish が要る。**必要なら別 issue にする。**

## 検証

`yarn format` → `yarn lint`（0 errors、warning 37 は変更前と同数）→ `yarn typecheck` → `yarn build` → `yarn test`（27 スイート全て fail 0）。

判定は純粋関数 `shouldWarnMcpUnavailable()` として export し、`test/agent/test_mcpUnavailableWarning.ts` で全分岐を固定。`createMcpToolWatcher` も export して「`ToolSearch` / `PushNotification` / `WebFetch` / `Bash` / `Read` を数えず `mcp__*` だけ数える」ことを固定した。

**加えて、実サーバで #2886 の症状そのものを踏ませた。** 隔離ワークスペース（`MULMOCLAUDE_WORKSPACE_PATH`）でサーバを起動し、実ターンを2回。

ターン2（`Fetch https://example.com with WebFetch …`）のログ:

```
tool calls:  ToolSearch × 1,  WebFetch × 1        <- mcp__* はゼロ
[mcp] broker ready  chatSessionId=verify2900b-…  bootMs=…  kind=bundle
warnings:    (none)
```

**ToolSearch が呼ばれ、`mcp__*` が1つも呼ばれていない** — 旧条件なら必ず「may have crashed」を出していた形。beacon が届いているので新条件では出ない。ターン1（ツール未使用）でも警告なし。

**未確認**: 「ブローカーが本当に上がらない」ケースをローカルで発生させてはいない（beacon 不在 + ツール0 で警告が出ること自体は純粋関数のテストで固定）。Docker サンドボックス経路では確認済み（上記は `useDocker=true` / `broker=bundle`）。

## User Prompt

- 「awaiting-response 報告者からの回答待ち　をissueのラベルに追加して」→ ラベル作成
- 「ラベルつけて」→ #2842 に付与
- 「https://github.com/receptron/mulmoclaude/issues/2886 は閉じれるかな？ここからissue化できものある？」→ #2886 をクローズし、#2900〜#2904 を切り出し
- 「簡単なのからやろう」→ 小さいものから着手。#2904 が PR #2905、本 PR が #2900

Closes #2900

work in mulmoclaude3

## Summary by Sourcery

Tighten detection of unavailable MCP tools by using broker readiness beacons and actual MCP tool usage instead of ToolSearch heuristics, and update logging accordingly.

Bug Fixes:
- Eliminate false-positive 'MCP server may have crashed' warnings caused by ToolSearch resolving non-MCP built-in tools.
- Ensure MCP unavailability warnings only trigger when MCP was configured, the broker never reported ready, and no MCP tools ran, avoiding misdiagnosis in environments where broker beacons are blocked.

Enhancements:
- Export the MCP tool name prefix constant so MCP-related tooling can consistently identify MCP tools without duplicating literals.
- Refine agent logging to include MCP tool usage counts and provide a more actionable hint that works for npm users by directing them to broker readiness logs.

Tests:
- Add unit tests for MCP tool watcher and MCP unavailability detection to pin the new warning conditions and tool counting behavior.
- Introduce a plan document describing the rationale and approach for fixing the broker crash false-positive warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP availability warnings to reduce false positives.
  * Warnings now account for broker readiness, configured MCP services, cancelled turns, and actual built-in tool activity.
  * Added session and diagnostic details to MCP failure warnings.

* **Tests**
  * Added coverage for broker readiness, cancellation, tool delivery, repeated calls, and unrelated MCP activity.
  * Verified that healthy MCP activity no longer triggers unnecessary warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->