### PR TITLE
fix(web-push): 届かなかった push の理由をログに残す

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -138,6 +138,31 @@ Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`,
 
 ### Fixed
 
+#### A Web Push that does not arrive now says why in the log (#2903)
+
+`sendWebPush` answered `null` for every failure — not signed in, non-2xx,
+offline, timeout, unparseable body — and wrote nothing. Its caller logged only
+the case where the push succeeded and reached zero devices. So the two answers a
+reader actually needs, "tried and failed" and "never tried", were the same
+observation from outside: #2886's reporter grepped the log for `web-push` and
+got no lines at all, and settling it took reading the source.
+
+Never throwing is the right design for a push fired from a turn-end hook, and
+that has not changed. What changed is that failing is no longer invisible:
+`SendWebPushOptions` takes an `onFailure` callback carrying a typed reason
+(`not-signed-in` / `http-error` with its status / `network` with the thrown
+message / `bad-response`), and the host logs it. The return type is untouched,
+so this is not a breaking change for anything already calling it.
+
+The caller now accounts for all three outcomes rather than one: a warn when the
+push did not deliver, an info with the delivery counts when it did, and a debug
+line when push is simply disabled in settings. That last one is deliberately
+debug — the file sink records debug while the console starts at info, so it
+lands in `server/system/logs/` where the search was run, without a line per turn
+on anyone's terminal.
+
+Ships as `@mulmobridge/web-push@1.1.0`.
+
 #### An embed whose optional `idField` is empty reads as unset, not as a broken link (#2863)
 
 `embedTargetId()` resolves an absent or empty `idField` to `""`, and the schema

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -31,7 +31,7 @@
     "@mulmobridge/chat-service": "^1.0.3",
     "@mulmobridge/client": "^1.0.2",
     "@mulmobridge/protocol": "^1.0.1",
-    "@mulmobridge/web-push": "^1.0.1",
+    "@mulmobridge/web-push": "^1.1.0",
     "@mulmocast/types": "^2.9.0",
     "@mulmochat-plugin/quiz": "^2.0.0",
     "@mulmochat-plugin/ui-image": "^0.4.1",

--- a/packages/web-push/package.json
+++ b/packages/web-push/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/web-push",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Auth-agnostic sender for the mulmoserver Web Push (sendPush) Cloud Function",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/web-push/src/index.ts
+++ b/packages/web-push/src/index.ts
@@ -134,12 +134,19 @@ export async function sendWebPush(title: string, body: string, options: SendWebP
       signal: controller.signal,
     });
     if (!res.ok) return reportFailure(options.onFailure, { reason: "http-error", status: res.status });
-    const result = parseSendPushResult(await res.json());
-    return result ?? reportFailure(options.onFailure, { reason: "bad-response" });
+    let json: unknown;
+    try {
+      json = await res.json();
+    } catch (error) {
+      // A 2xx whose body will not parse is the endpoint answering something
+      // unexpected — the request itself completed, so it is not a transport
+      // failure. Unless the timeout fired while the body was still streaming:
+      // that abort IS the transport, so let the outer catch name it.
+      if (controller.signal.aborted) throw error;
+      return reportFailure(options.onFailure, { reason: "bad-response" });
+    }
+    return parseSendPushResult(json) ?? reportFailure(options.onFailure, { reason: "bad-response" });
   } catch (error) {
-    // The JSON parse above lands here too: a 2xx whose body isn't JSON at all
-    // is the endpoint answering something else, which reads as a transport
-    // problem more than a shape one.
     return reportFailure(options.onFailure, { reason: "network", message: error instanceof Error ? error.message : String(error) });
   } finally {
     clearTimeout(timer);

--- a/packages/web-push/src/index.ts
+++ b/packages/web-push/src/index.ts
@@ -18,11 +18,38 @@ export interface SendPushResult {
   targets: number;
 }
 
+// Why a push was not delivered. `null` alone made "tried and failed" and
+// "never tried" indistinguishable from the outside, which is what turned a
+// missing push into a code-reading exercise (#2903).
+export type SendPushFailureReason =
+  // No ID token — the host isn't signed in, so nothing was sent and no request
+  // was made. Also covers an auth SDK that threw.
+  | "not-signed-in"
+  // The endpoint answered non-2xx.
+  | "http-error"
+  // The request never completed: offline, DNS, or the timeout aborted it.
+  | "network"
+  // 2xx, but the body wasn't the onCall result envelope.
+  | "bad-response";
+
+export interface SendPushFailure {
+  reason: SendPushFailureReason;
+  /** HTTP status, for `"http-error"` only. */
+  status?: number;
+  /** The thrown error's message, for `"network"` only. */
+  message?: string;
+}
+
 export interface SendWebPushOptions {
   // Resolve the caller's Firebase Auth ID token, or null when not signed in
   // (→ the push is skipped without a network call). May reject; a rejection is
   // treated as "not signed in".
   getIdToken: () => Promise<string | null>;
+  // Called once when the push is not delivered. The return value is `null`
+  // either way — this exists so the host can LOG the reason, since this package
+  // has no logger of its own and must not grow a dependency on one. Exceptions
+  // it throws are swallowed: reporting a failure must not become one.
+  onFailure?: (failure: SendPushFailure) => void;
   // sendPush endpoint. Defaults to the mulmoserver production URL.
   url?: string;
   // Abort the request after this many ms. Defaults to 8000.
@@ -70,13 +97,24 @@ async function resolveIdToken(getIdToken: () => Promise<string | null>): Promise
   }
 }
 
+// A reporter that cannot itself fail the send. `sendWebPush` promises never to
+// throw, and that promise must survive a host handler that does.
+function reportFailure(onFailure: SendWebPushOptions["onFailure"], failure: SendPushFailure): null {
+  try {
+    onFailure?.(failure);
+  } catch {
+    // Nothing to escalate to — this IS the error path.
+  }
+  return null;
+}
+
 // POST { title, body, data? } to sendPush as the signed-in user. Returns the
 // delivery result, or null when nothing was sent (not signed in / network /
-// timeout / non-2xx / bad JSON). Never throws — a failed push must not disturb
-// its trigger.
+// timeout / non-2xx / bad JSON) — with `options.onFailure` told which of those
+// it was. Never throws — a failed push must not disturb its trigger.
 export async function sendWebPush(title: string, body: string, options: SendWebPushOptions): Promise<SendPushResult | null> {
   const idToken = await resolveIdToken(options.getIdToken);
-  if (!idToken) return null; // not signed in → nothing to send with
+  if (!idToken) return reportFailure(options.onFailure, { reason: "not-signed-in" });
   const url = options.url ?? DEFAULT_SEND_PUSH_URL;
   const timeout_ms = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const doFetch = options.fetchImpl ?? globalThis.fetch;
@@ -89,10 +127,14 @@ export async function sendWebPush(title: string, body: string, options: SendWebP
       body: buildSendPushBody(title, body, options.data),
       signal: controller.signal,
     });
-    if (!res.ok) return null;
-    return parseSendPushResult(await res.json());
-  } catch {
-    return null; // offline / aborted / bad JSON — silently skip
+    if (!res.ok) return reportFailure(options.onFailure, { reason: "http-error", status: res.status });
+    const result = parseSendPushResult(await res.json());
+    return result ?? reportFailure(options.onFailure, { reason: "bad-response" });
+  } catch (error) {
+    // The JSON parse above lands here too: a 2xx whose body isn't JSON at all
+    // is the endpoint answering something else, which reads as a transport
+    // problem more than a shape one.
+    return reportFailure(options.onFailure, { reason: "network", message: error instanceof Error ? error.message : String(error) });
   } finally {
     clearTimeout(timer);
   }

--- a/packages/web-push/src/index.ts
+++ b/packages/web-push/src/index.ts
@@ -99,9 +99,15 @@ async function resolveIdToken(getIdToken: () => Promise<string | null>): Promise
 
 // A reporter that cannot itself fail the send. `sendWebPush` promises never to
 // throw, and that promise must survive a host handler that does.
+//
+// Both shapes of "the handler failed" have to be absorbed. TypeScript accepts
+// an `async` function where a `void` return is declared, so a handler can hand
+// back a Promise this call never awaits — and its rejection would surface as an
+// unhandled rejection, which Node's default terminates the process on. That is
+// a worse outcome than the undelivered push it was reporting.
 function reportFailure(onFailure: SendWebPushOptions["onFailure"], failure: SendPushFailure): null {
   try {
-    onFailure?.(failure);
+    void Promise.resolve(onFailure?.(failure)).catch(() => {});
   } catch {
     // Nothing to escalate to — this IS the error path.
   }

--- a/packages/web-push/test/test_web-push.ts
+++ b/packages/web-push/test/test_web-push.ts
@@ -246,3 +246,21 @@ test("sendWebPush works with no onFailure supplied (back-compat)", async () => {
   const { fetchImpl } = makeFetch(() => ({ ok: false, status: 500, json: async () => ({}) }));
   assert.equal(await sendWebPush("t", "b", okOpts({ fetchImpl })), null);
 });
+
+// TypeScript accepts an `async` handler where `void` is declared, so this is a
+// shape a host will pass eventually. Its rejection is not observed by the
+// synchronous try/catch, and an unhandled rejection terminates the process
+// under Node's default — the opposite of what the never-throw guarantee is for.
+// node:test fails the run on an unhandled rejection, so this case IS the assert
+// (Codex review on #2907).
+test("sendWebPush survives an async onFailure that rejects", async () => {
+  const result = await sendWebPush("t", "b", {
+    getIdToken: async () => null,
+    onFailure: (async () => {
+      throw new Error("async logger exploded");
+    }) as () => void,
+  });
+  assert.equal(result, null);
+  // Give the rejected promise a turn to surface if it were unhandled.
+  await new Promise((resolve) => setTimeout(resolve, 10));
+});

--- a/packages/web-push/test/test_web-push.ts
+++ b/packages/web-push/test/test_web-push.ts
@@ -208,7 +208,9 @@ test("sendWebPush reports bad-response for a 2xx that isn't a result envelope", 
   assert.deepEqual(failures, [{ reason: "bad-response" }]);
 });
 
-test("sendWebPush reports network when the body isn't JSON at all", async () => {
+// The request completed with a 2xx — only the body is unusable — so this is a
+// shape failure, not a transport one (Codex review on #2907).
+test("sendWebPush reports bad-response when the body isn't JSON at all", async () => {
   const { failures, onFailure } = collectFailures();
   const { fetchImpl } = makeFetch(() => ({
     ok: true,
@@ -217,6 +219,22 @@ test("sendWebPush reports network when the body isn't JSON at all", async () => 
     },
   }));
   const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure }));
+  assert.equal(result, null);
+  assert.deepEqual(failures, [{ reason: "bad-response" }]);
+});
+
+// ...but a timeout that fires while the body is still streaming is the
+// transport, and must keep saying so rather than blaming the payload.
+test("sendWebPush reports network when the timeout aborts mid-body", async () => {
+  const { failures, onFailure } = collectFailures();
+  const { fetchImpl } = makeFetch(() => ({
+    ok: true,
+    json: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      throw new Error("The operation was aborted");
+    },
+  }));
+  const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure, timeoutMs: 1 }));
   assert.equal(result, null);
   assert.equal(failures.length, 1);
   assert.equal(failures[0]?.reason, "network");

--- a/packages/web-push/test/test_web-push.ts
+++ b/packages/web-push/test/test_web-push.ts
@@ -1,9 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildSendPushBody, parseSendPushResult, sendWebPush, DEFAULT_SEND_PUSH_URL, type SendWebPushOptions } from "../src/index.js";
+import { buildSendPushBody, parseSendPushResult, sendWebPush, DEFAULT_SEND_PUSH_URL, type SendPushFailure, type SendWebPushOptions } from "../src/index.js";
 
 // A fetch stub that records its call and returns a scripted Response-like object.
-const makeFetch = (impl: (url: string, init: RequestInit) => { ok: boolean; json: () => Promise<unknown> }) => {
+const makeFetch = (impl: (url: string, init: RequestInit) => { ok: boolean; status?: number; json: () => Promise<unknown> }) => {
   const calls: Array<{ url: string; init: RequestInit }> = [];
   const fetchImpl = (async (url: string, init: RequestInit) => {
     calls.push({ url, init });
@@ -146,4 +146,103 @@ test("sendWebPush omits data when the caller passes none (back-compat)", async (
   await sendWebPush("done", "ok", okOpts({ fetchImpl }));
   const sent = JSON.parse(String(calls[0].init.body)) as { data: Record<string, unknown> };
   assert.ok(!("data" in sent.data), `no routing block expected, got: ${JSON.stringify(sent)}`);
+});
+
+// ── onFailure: why a push was not delivered (#2903) ──────────────────
+//
+// Returning null for every failure made "tried and failed" and "never tried"
+// the same observation from outside — so a missing push could only be
+// diagnosed by reading this file. Each case below is one of the answers a
+// reader needs, and the return value stays null throughout: the reason is
+// reported, never thrown.
+
+const collectFailures = () => {
+  const failures: SendPushFailure[] = [];
+  return { failures, onFailure: (failure: SendPushFailure) => failures.push(failure) };
+};
+
+test("sendWebPush reports not-signed-in when there is no id token", async () => {
+  const { failures, onFailure } = collectFailures();
+  const result = await sendWebPush("t", "b", { getIdToken: async () => null, onFailure });
+  assert.equal(result, null);
+  assert.deepEqual(failures, [{ reason: "not-signed-in" }]);
+});
+
+test("sendWebPush reports not-signed-in when the auth SDK throws", async () => {
+  const { failures, onFailure } = collectFailures();
+  const result = await sendWebPush("t", "b", {
+    getIdToken: async () => {
+      throw new Error("auth/internal-error");
+    },
+    onFailure,
+  });
+  assert.equal(result, null);
+  assert.deepEqual(failures, [{ reason: "not-signed-in" }]);
+});
+
+test("sendWebPush reports http-error with the status", async () => {
+  const { failures, onFailure } = collectFailures();
+  const { fetchImpl } = makeFetch(() => ({ ok: false, status: 503, json: async () => ({}) }));
+  const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure }));
+  assert.equal(result, null);
+  assert.deepEqual(failures, [{ reason: "http-error", status: 503 }]);
+});
+
+test("sendWebPush reports network with the thrown message (offline / timeout abort)", async () => {
+  const { failures, onFailure } = collectFailures();
+  const fetchImpl = (async () => {
+    throw new Error("fetch failed");
+  }) as unknown as typeof fetch;
+  const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure }));
+  assert.equal(result, null);
+  assert.deepEqual(failures, [{ reason: "network", message: "fetch failed" }]);
+});
+
+// A 2xx whose body parses but isn't the onCall envelope: the endpoint answered
+// something, so this is a shape problem, not a transport one.
+test("sendWebPush reports bad-response for a 2xx that isn't a result envelope", async () => {
+  const { failures, onFailure } = collectFailures();
+  const { fetchImpl } = makeFetch(() => ({ ok: true, json: async () => ({ unexpected: true }) }));
+  const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure }));
+  assert.equal(result, null);
+  assert.deepEqual(failures, [{ reason: "bad-response" }]);
+});
+
+test("sendWebPush reports network when the body isn't JSON at all", async () => {
+  const { failures, onFailure } = collectFailures();
+  const { fetchImpl } = makeFetch(() => ({
+    ok: true,
+    json: async () => {
+      throw new Error("Unexpected token < in JSON");
+    },
+  }));
+  const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure }));
+  assert.equal(result, null);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0]?.reason, "network");
+});
+
+test("sendWebPush does not report a failure on a delivered push", async () => {
+  const { failures, onFailure } = collectFailures();
+  const { fetchImpl } = makeFetch(() => ({ ok: true, json: async () => ({ result: { sent: 1, failed: 0, targets: 1 } }) }));
+  const result = await sendWebPush("t", "b", okOpts({ fetchImpl, onFailure }));
+  assert.deepEqual(result, { sent: 1, failed: 0, targets: 1 });
+  assert.deepEqual(failures, []);
+});
+
+// The never-throws contract is the reason this package can be called from a
+// turn-end hook. A host handler that throws must not take that away.
+test("sendWebPush still resolves null when onFailure itself throws", async () => {
+  const result = await sendWebPush("t", "b", {
+    getIdToken: async () => null,
+    onFailure: () => {
+      throw new Error("logger exploded");
+    },
+  });
+  assert.equal(result, null);
+});
+
+test("sendWebPush works with no onFailure supplied (back-compat)", async () => {
+  const { fetchImpl } = makeFetch(() => ({ ok: false, status: 500, json: async () => ({}) }));
+  assert.equal(await sendWebPush("t", "b", okOpts({ fetchImpl })), null);
 });

--- a/plans/fix-2903-web-push-silent-failures.md
+++ b/plans/fix-2903-web-push-silent-failures.md
@@ -1,0 +1,57 @@
+# push の失敗を観測可能にする (#2903)
+
+## 症状
+
+「push が届かない」を調べた報告者が、サーバログを `web-push` / `webpush` / `push` で grep して
+**1件もヒットしなかった**。その結果、次の2つが区別できなかった。
+
+- push を送ろうとして失敗した（未サインイン / タイムアウト / 非2xx …）
+- そもそも送ろうとしていない
+
+実際は後者だったが、判定にコード読解が要った。#2886 の調査が長引いた直接の原因。
+
+## 原因
+
+`packages/web-push/src/index.ts` の `sendWebPush()` は、あらゆる失敗を `null` で返して何も記録しない。
+呼び出し側（`server/agent/webPush.ts`）がログを出すのは **成功して届け先が0台のときだけ**。
+`isPushEnabled` が false のときの早期 return も無音。
+
+## 直し方
+
+**never throw は正しい設計なので変えない。** 変えるのは「失敗が観測不能」の方だけ。
+
+戻り値の型は変えない。`@mulmobridge/web-push` は npm 公開パッケージで、型を変えると major +
+mulmoterminal 側の追従が要る。issue が挙げているもう一方の案（渡されたロガーに書く）を採る。
+
+- `SendWebPushOptions` に `onFailure?: (failure: SendPushFailure) => void` を追加
+- `SendPushFailure` = `{ reason: "not-signed-in" | "http-error" | "network" | "bad-response"; status?; message? }`
+- 各 `return null` の前に理由を report する。`onFailure` が throw しても握る
+  （never throw の契約は、ホスト側のハンドラが壊れても維持されなければ意味が無い）
+- 既存の戻り値（`SendPushResult | null`）は不変 → **非破壊**。既存テストはそのまま通る
+
+呼び出し側は3方向すべてを記録する。
+
+- 失敗 → `log.warn("web-push", "sendPush did not deliver", { chatSessionId, ...failure })`
+- 成功 → `log.info` で `sent` / `failed` / `targets`（0台のときは従来の文言のまま）
+- 設定で無効 → `log.debug("web-push", "skipped — push is disabled in settings")`
+
+**debug で十分な理由**: ファイルシンクの既定レベルが `debug`（`server/system/logger/config.ts`）で、
+コンソールが `info`。つまり debug 行は `server/system/logs/` に残る —— 報告者が grep した先そのもの。
+毎ターン出る行をコンソールに出さずに、grep には残せる。
+
+## バージョン
+
+`@mulmobridge/web-push` に runtime の export（型のみだが options の契約が増える）を足すので
+1.0.1 → **1.1.0**。launcher の宣言レンジも `^1.1.0` に揃える。マージ後に publish が必要
+（publish しないと npm 経由のホストには届かない）。
+
+## テスト
+
+`packages/web-push/test/test_web-push.ts` に9ケース追加（既存17は無改変で通る）。
+理由ごとの report、成功時に report しないこと、`onFailure` が throw しても null を返すこと、
+`onFailure` 無しでも動くこと（後方互換）。
+
+## 関連
+
+- #2886 — 起点
+- #2901 — 完了 push の本文が固定（別軸、未着手）

--- a/server/agent/webPush.ts
+++ b/server/agent/webPush.ts
@@ -38,11 +38,23 @@ export function buildTaskFinishedPush(firstUserMessage: string | undefined, didE
 // Notify the user's registered devices that a visible agent turn finished.
 // No-op when push is disabled or RemoteHost isn't connected. Never throws.
 export async function notifyTaskFinished(chatSessionId: string, didError: boolean): Promise<void> {
-  if (!isPushEnabled(loadSettings())) return;
+  // Logged, quietly: "push is off" and "push failed" are the two answers a
+  // reader is choosing between, and a silent return leaves `grep web-push`
+  // empty for both (#2903).
+  if (!isPushEnabled(loadSettings())) {
+    log.debug("web-push", "skipped — push is disabled in settings", { chatSessionId });
+    return;
+  }
   const meta = await readSessionMeta(chatSessionId);
   const { title, body } = buildTaskFinishedPush(meta?.firstUserMessage, didError);
-  const result = await sendWebPush(title, body, { getIdToken: currentIdToken });
-  if (result?.targets === 0) {
+  const result = await sendWebPush(title, body, {
+    getIdToken: currentIdToken,
+    onFailure: (failure) => log.warn("web-push", "sendPush did not deliver", { chatSessionId, ...failure }),
+  });
+  if (!result) return; // already reported by onFailure
+  if (result.targets === 0) {
     log.info("web-push", "sendPush reached no registered devices", { chatSessionId });
+    return;
   }
+  log.info("web-push", "sendPush delivered", { chatSessionId, ...result });
 }


### PR DESCRIPTION
## Summary

`sendWebPush` はあらゆる失敗（未サインイン / 非2xx / オフライン / タイムアウト / 壊れた body）を `null` で返して**何も記録しない**。呼び出し側がログを出すのは「成功して届け先が0台」のときだけ。結果、読み手が本当に必要な2つの答え —— **「送って失敗した」と「そもそも送っていない」** —— が外から同じ観測になっていた。#2886 の報告者はログを `web-push` で grep して1件も出ず、切り分けにコード読解が必要になった。

**never throw は正しい設計なので変えない**（ターン終了フックから撃つので、push の失敗が引き金を壊してはいけない）。変えるのは「失敗が観測不能」の方だけ。

- `SendWebPushOptions` に `onFailure?: (failure: SendPushFailure) => void` を追加。理由は型で渡す —— `not-signed-in` / `http-error`（+`status`）/ `network`（+`message`）/ `bad-response`
- **戻り値の型は変えない**（`SendPushResult | null` のまま）。`@mulmobridge/web-push` は npm 公開パッケージで、型を変えると major + mulmoterminal 側の追従が要る。issue が挙げていたもう一方の案（渡されたロガーに書く）を採った → **非破壊**
- 呼び出し側は3方向すべて記録: 失敗は `warn`、成功は `info`（`sent`/`failed`/`targets`）、設定で無効なら `debug`

## Items to Confirm / Review

- **戻り値の型を変えず callback にしたこと。** issue は discriminated union 案を先に挙げていますが、公開パッケージの major と mulmoterminal の追従を避けたい判断です。情報量は同じ（理由 + status/message）
- **「設定で無効」を `debug` にしたこと。** ファイルシンクの既定レベルが `debug`、コンソールが `info`（`server/system/logger/config.ts`）なので、**毎ターン端末を汚さずに `server/system/logs/` には残ります** —— 報告者が grep した先そのものです。info に上げるべきならご指摘ください
- **`onFailure` が throw しても握っていること。** never throw の契約は、ホスト側のハンドラが壊れても維持されないと意味がないためです（テストで固定）
- **`@mulmobridge/web-push` を 1.1.0 に bump し、launcher のレンジも `^1.1.0` に揃えた。** マージ後に publish が必要です（publish しないと npm 経由のホストには届きません）

## 検証（実機）

このリポジトリのサーバを実際に起動して、修正前後を同じ設定・同じ操作で比べました。

| | 観測 |
|---|---|
| **修正前** | `pushEnabled: true` のまま、今日のログ **31,396 行に `web-push` が 0 件** —— #2886 の症状がこのマシンで再現 |
| **修正後** | 同じ設定で1ターン流すと `WARN [web-push] sendPush did not deliver chatSessionId=… reason=not-signed-in` が**コンソールとファイルシンクの両方**に出る |

つまり「送ろうとして、未サインインで送れなかった」が grep 1回で分かる状態になりました。

その他: `yarn format` / `lint`（error 0）/ `typecheck`（0）/ `build` / `yarn test`（exit 0）/ `check:launcher-sync` OK。パッケージ単体テストは **26件 green**（既存17件は無改変で通過 = 非破壊の裏付け、新規9件）。

新規テストが押さえているもの: 理由ごとの report（4種）、2xx で JSON でない body、成功時に report しないこと、`onFailure` が throw しても `null` を返すこと、`onFailure` 無しでも動くこと。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2904 未着手ならこれ
- （#2904 は PR #2905 で着手済みのため、未着手の2件から選択）#2903 失敗の握りつぶし

work in mulmoclaude2

## Summary by Sourcery

Make Web Push delivery failures observable without changing the public return type, and ensure server-side logging distinguishes between disabled push, attempted-but-failed deliveries, and successful deliveries.

Bug Fixes:
- Expose structured failure reasons from sendWebPush so hosts can log why a push was not delivered instead of silently returning null.
- Log when push is disabled in settings, so missing pushes can be distinguished from delivery failures in server logs.

Enhancements:
- Extend sendWebPush options with an optional onFailure callback carrying a typed SendPushFailure payload while preserving the never-throw contract.
- Update server Web Push notifications to log warnings for failed deliveries and info-level summaries for successful deliveries, including target counts.
- Add comprehensive tests covering all failure modes, success behavior, and onFailure robustness in the web-push package.

Build:
- Bump @mulmobridge/web-push to version 1.1.0 and align mulmoclaude’s dependency range to ^1.1.0.

Documentation:
- Document the new Web Push failure reporting and logging behavior in the changelog, including the non-breaking nature of the API change.

Chores:
- Add a plan document describing the motivation, design, and testing strategy for making Web Push failures observable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web Push delivery failures now provide typed reasons, including authentication, HTTP, network, and invalid-response errors.
  * Added optional failure notifications for applications integrating Web Push.
  * Delivery outcomes now include clearer success, failure, and disabled-status logging.
* **Bug Fixes**
  * Push failures remain non-throwing while becoming observable through callbacks and logs.
  * Improved distinction between unavailable delivery results and pushes with no registered devices.
* **Chores**
  * Updated the Web Push package to version 1.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->