### PR TITLE
feat(collections): enum フィールドに default を持たせる

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### An `enum` field can declare the value a new record starts on (#2839)
+
+```jsonc
+"status": { "type": "enum", "values": ["todo","doing","done"], "required": true, "default": "todo" }
+```
+
+The Add form opens on it, and a `putItems` row in `create` mode that omits the
+field gets it — both paths, because a default the form fills but the tool
+ignores is worse than none. `required: true` and a `default` go together: the
+requirement is already satisfied, so the user just saves. `upsert` and `merge`
+do NOT re-apply it; those edit a record that already carries an answer.
+
+Only `enum` for now. Literals for the scalar types and `today` / `now`
+sentinels for dates are the same request's later tiers, deliberately left until
+this one has been used.
+
+**Note for anyone who already wrote `default`.** The key parsed but did nothing
+before this change, so a schema may carry one that is not among its `values`.
+Two deliberate choices keep that harmless:
+
+- **Nothing that loads today stops loading.** Membership is checked when
+  `putSchema` WRITES a schema, not when discovery parses one. Rejecting at parse
+  time would drop the whole collection out of the index over one cosmetic key —
+  it would vanish from the UI with a log line as the only clue.
+- **A stale value is treated as no default.** The Add form starts blank rather
+  than on a value the `<select>` cannot offer, which would otherwise fail the
+  save for a reason nothing on screen explains.
+
+So a pre-existing `default` either starts working as written, or goes on being
+ignored exactly as before. The only new refusal is at authoring time, where the
+error names the offending field and lists the allowed values.
+
 #### The collections index has a search box (#2837)
 
 A substring over title and slug, case-insensitive, ANDed with the existing

--- a/e2e/tests/collection-field-default.spec.ts
+++ b/e2e/tests/collection-field-default.spec.ts
@@ -85,3 +85,42 @@ test.describe("collection enum field default", () => {
     await expect(page.getByTestId("collections-input-priority")).toHaveValue("low");
   });
 });
+
+// `primary` lives on every field type, so an enum can be the primary key. The
+// id pre-fill must not stomp its default: a generated UUID is not one of the
+// enum's values, so the form would open blank on a field that cannot be saved
+// (Codex review on #2910).
+test.describe("enum primary key", () => {
+  const PHASES_DETAIL = {
+    collection: {
+      slug: "phases",
+      title: "Phases",
+      icon: "list",
+      source: "user",
+      schema: {
+        title: "Phases",
+        icon: "list",
+        dataPath: "data/phases/items",
+        primaryKey: "phase",
+        fields: {
+          phase: { type: "enum", label: "Phase", values: ["intake", "review"], primary: true, required: true, default: "intake" },
+          note: { type: "string", label: "Note" },
+        },
+      },
+    },
+    items: [{ phase: "review", note: "existing" }],
+  };
+
+  test("the Add form opens on the declared default, not a generated id", async ({ page }) => {
+    await mockAllApis(page);
+    await page.route(
+      (url) => url.pathname === "/api/collections/phases",
+      (route) => route.fulfill({ json: PHASES_DETAIL }),
+    );
+    await page.goto("/collections/phases");
+    await page.getByTestId("collections-row-review").waitFor();
+
+    await page.getByTestId("collections-add-item").click();
+    await expect(page.getByTestId("collections-input-phase")).toHaveValue("intake");
+  });
+});

--- a/e2e/tests/collection-field-default.spec.ts
+++ b/e2e/tests/collection-field-default.spec.ts
@@ -163,3 +163,44 @@ test("a field named __proto__ gets its default like any other", async ({ page })
   // The ordinary primary key still gets its generated id.
   await expect(page.getByTestId("collections-input-id")).not.toHaveValue("");
 });
+
+// The edit path builds its own draft maps, and without a slot the field cannot
+// be edited at all — the form would show the record as empty and a save would
+// drop what it stores (CodeRabbit on #2910).
+test("a field named __proto__ is editable, showing what the record stores", async ({ page }) => {
+  const PROTO_KEY = "__proto__";
+  const detail = {
+    collection: {
+      slug: "odd",
+      title: "Odd",
+      icon: "list",
+      source: "user",
+      schema: {
+        title: "Odd",
+        icon: "list",
+        dataPath: "data/odd/items",
+        primaryKey: "id",
+        fields: {
+          id: { type: "string", label: "ID", primary: true, required: true },
+          [PROTO_KEY]: { type: "enum", label: "Proto", values: ["todo", "done"], default: "todo" },
+        },
+      },
+    },
+    items: [
+      Object.fromEntries([
+        ["id", "o1"],
+        [PROTO_KEY, "done"],
+      ]),
+    ],
+  };
+  await mockAllApis(page);
+  await page.route(
+    (url) => url.pathname === "/api/collections/odd",
+    (route) => route.fulfill({ json: detail }),
+  );
+  await page.goto("/collections/odd?selected=o1");
+  await expect(page.getByTestId("collections-detail")).toBeVisible();
+
+  await page.getByTestId("collections-detail-edit").click();
+  await expect(page.getByTestId(`collections-input-${PROTO_KEY}`)).toHaveValue("done");
+});

--- a/e2e/tests/collection-field-default.spec.ts
+++ b/e2e/tests/collection-field-default.spec.ts
@@ -1,0 +1,87 @@
+// E2E for a field-level `default` on an enum. The Add form is the primary
+// payoff of the feature: a task collection whose status is almost always
+// "todo" should open on it, so adding a record is one click rather than the
+// same two picks every time.
+
+import { test, expect, type Page } from "@playwright/test";
+import { mockAllApis } from "../fixtures/api";
+
+const TASKS_DETAIL = {
+  collection: {
+    slug: "tasks",
+    title: "Tasks",
+    icon: "task_alt",
+    source: "user",
+    schema: {
+      title: "Tasks",
+      icon: "task_alt",
+      dataPath: "data/tasks/items",
+      primaryKey: "id",
+      fields: {
+        id: { type: "string", label: "ID", primary: true, required: true },
+        title: { type: "string", label: "Title", required: true },
+        // Required AND defaulted: the default satisfies the requirement.
+        status: { type: "enum", label: "Status", values: ["todo", "doing", "done"], required: true, default: "todo" },
+        priority: { type: "enum", label: "Priority", values: ["high", "low"], default: "low" },
+        // No default — must stay blank, so the pre-fill is provably per-field.
+        assignee: { type: "enum", label: "Assignee", values: ["ada", "grace"] },
+      },
+    },
+  },
+  items: [{ id: "t1", title: "Existing", status: "doing", priority: "high", assignee: "ada" }],
+};
+
+async function mockTasks(page: Page, detail: unknown = TASKS_DETAIL): Promise<void> {
+  await page.route(
+    (url) => url.pathname === "/api/collections/tasks",
+    (route) => route.fulfill({ json: detail }),
+  );
+}
+
+test.describe("collection enum field default", () => {
+  test("the Add form opens on the declared defaults, and leaves undeclared fields blank", async ({ page }) => {
+    await mockAllApis(page);
+    await mockTasks(page);
+    await page.goto("/collections/tasks");
+    await page.getByTestId("collections-row-t1").waitFor();
+
+    await page.getByTestId("collections-add-item").click();
+    await expect(page.getByTestId("collections-edit-title")).toBeVisible();
+
+    await expect(page.getByTestId("collections-input-status")).toHaveValue("todo");
+    await expect(page.getByTestId("collections-input-priority")).toHaveValue("low");
+    await expect(page.getByTestId("collections-input-assignee")).toHaveValue("");
+  });
+
+  // Opening an existing record must show what it stores, not what a new one
+  // would start on — a default that leaked into the edit form would rewrite
+  // the record on the next save.
+  test("editing an existing record still shows its own values", async ({ page }) => {
+    await mockAllApis(page);
+    await mockTasks(page);
+    // Deep link rather than a row click: a row cell can carry its own link,
+    // and the click target is not what this test is about.
+    await page.goto("/collections/tasks?selected=t1");
+    await expect(page.getByTestId("collections-detail")).toBeVisible();
+
+    await page.getByTestId("collections-detail-edit").click();
+    await expect(page.getByTestId("collections-input-status")).toHaveValue("doing");
+    await expect(page.getByTestId("collections-input-priority")).toHaveValue("high");
+  });
+
+  // A file written before the feature existed can carry a default the values
+  // no longer offer. The collection must still load, and the form starts blank
+  // rather than on an impossible value that would fail the save.
+  test("a stale default outside the values leaves the field blank, collection intact", async ({ page }) => {
+    const stale = JSON.parse(JSON.stringify(TASKS_DETAIL)) as typeof TASKS_DETAIL;
+    stale.collection.schema.fields.status.default = "未着手";
+    await mockAllApis(page);
+    await mockTasks(page, stale);
+    await page.goto("/collections/tasks");
+
+    await expect(page.getByTestId("collections-row-t1")).toBeVisible();
+    await page.getByTestId("collections-add-item").click();
+    await expect(page.getByTestId("collections-input-status")).toHaveValue("");
+    await expect(page.getByTestId("collections-input-priority")).toHaveValue("low");
+  });
+});

--- a/e2e/tests/collection-field-default.spec.ts
+++ b/e2e/tests/collection-field-default.spec.ts
@@ -124,3 +124,42 @@ test.describe("enum primary key", () => {
     await expect(page.getByTestId("collections-input-phase")).toHaveValue("intake");
   });
 });
+
+// A field may be named `__proto__` — JSON.parse gives it as an own key, so it
+// reaches the form like any other. Building the draft by assignment would run
+// the prototype setter for that one name and the field would have no slot at
+// all: blank, and un-typeable (Codex review on #2910).
+test("a field named __proto__ gets its default like any other", async ({ page }) => {
+  const PROTO_KEY = "__proto__";
+  const detail = {
+    collection: {
+      slug: "odd",
+      title: "Odd",
+      icon: "list",
+      source: "user",
+      schema: {
+        title: "Odd",
+        icon: "list",
+        dataPath: "data/odd/items",
+        primaryKey: "id",
+        fields: {
+          id: { type: "string", label: "ID", primary: true, required: true },
+          [PROTO_KEY]: { type: "enum", label: "Proto", values: ["todo", "done"], default: "todo" },
+        },
+      },
+    },
+    items: [{ id: "o1" }],
+  };
+  await mockAllApis(page);
+  await page.route(
+    (url) => url.pathname === "/api/collections/odd",
+    (route) => route.fulfill({ json: detail }),
+  );
+  await page.goto("/collections/odd");
+  await page.getByTestId("collections-row-o1").waitFor();
+
+  await page.getByTestId("collections-add-item").click();
+  await expect(page.getByTestId(`collections-input-${PROTO_KEY}`)).toHaveValue("todo");
+  // The ordinary primary key still gets its generated id.
+  await expect(page.getByTestId("collections-input-id")).not.toHaveValue("");
+});

--- a/packages/core/assets/helps/collection-skills.md
+++ b/packages/core/assets/helps/collection-skills.md
@@ -200,7 +200,12 @@ Every field spec needs a `type` and a `label`. Extra keys by type:
   "date column + separate time column" shape, keep `date` and point
   `calendarTimeField` at the time string instead.
 - **`enum`** — `values: ["draft", "sent", "paid"]` (non-empty strings). Renders
-  a `<select>`; stored as a plain string.
+  a `<select>`; stored as a plain string. Optional `default: "draft"` pre-fills
+  a NEW record — the Add form opens on it, and a `putItems` row in `create` mode
+  that omits the field gets it. The value must be one of `values` (`putSchema`
+  refuses otherwise). `default` pairs with `required: true`: the requirement is
+  already satisfied, so the user just saves. It is NOT re-applied by `upsert` or
+  `merge` — those edit a record that already carries an answer.
 - **`money`** — `currency: "USD"` (ISO 4217, defaults to USD). Stored as a plain
   decimal; currency is display-only.
 - **`ref`** — `to: "<target-slug>"`. Stores the target record's primary-key

--- a/packages/core/src/collection/core/draft.ts
+++ b/packages/core/src/collection/core/draft.ts
@@ -81,15 +81,16 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
   return row;
 }
 
-/** Convert a full edit draft to the record to persist. */
+/** Convert a full edit draft to the record to persist.
+ *
+ *  Collected as entries rather than assigned into an accumulator: a field may
+ *  be named `__proto__` (JSON.parse hands that over as an own key, so it
+ *  reaches here like any other), and `record[key] = value` would run the
+ *  prototype setter for that one name — the user's value would vanish between
+ *  the form and the save, with nothing to see. `fromEntries` defines an own
+ *  property whatever the name is. The read side of this file already guards the
+ *  same hazard with `ownFlag` (Codex review on #2910). */
 export function draftToRecord(state: EditState, schema: CollectionSchema): CollectionItem {
-  // Collected as entries rather than assigned into an accumulator: a field may
-  // be named `__proto__` (JSON.parse hands that over as an own key, so it
-  // reaches here like any other), and `record[key] = value` would run the
-  // prototype setter for that one name — the user's value would vanish between
-  // the form and the save, with nothing to see. `fromEntries` defines an own
-  // property whatever the name is. The read side of this file already guards
-  // the same hazard with `ownFlag` (Codex review on #2910).
   const entries: [string, unknown][] = [];
   for (const [key, field] of Object.entries(schema.fields)) {
     if (COMPUTED_TYPES.has(field.type)) continue; // never persisted (toggle projects an enum field)

--- a/packages/core/src/collection/core/draft.ts
+++ b/packages/core/src/collection/core/draft.ts
@@ -83,22 +83,29 @@ function rowDraftToRecord(rowDraft: TableRowDraft, subFields: Record<string, Fie
 
 /** Convert a full edit draft to the record to persist. */
 export function draftToRecord(state: EditState, schema: CollectionSchema): CollectionItem {
-  const record: CollectionItem = {};
+  // Collected as entries rather than assigned into an accumulator: a field may
+  // be named `__proto__` (JSON.parse hands that over as an own key, so it
+  // reaches here like any other), and `record[key] = value` would run the
+  // prototype setter for that one name — the user's value would vanish between
+  // the form and the save, with nothing to see. `fromEntries` defines an own
+  // property whatever the name is. The read side of this file already guards
+  // the same hazard with `ownFlag` (Codex review on #2910).
+  const entries: [string, unknown][] = [];
   for (const [key, field] of Object.entries(schema.fields)) {
     if (COMPUTED_TYPES.has(field.type)) continue; // never persisted (toggle projects an enum field)
     if (field.type === "boolean") {
-      if (shouldEmitBoolean(state, key, field)) record[key] = ownFlag(state.bool, key);
+      if (shouldEmitBoolean(state, key, field)) entries.push([key, ownFlag(state.bool, key)]);
       continue;
     }
     if (field.type === "table" && field.of) {
       const subFields = field.of;
-      record[key] = (state.table[key] ?? []).map((rowDraft) => rowDraftToRecord(rowDraft, subFields));
+      entries.push([key, (state.table[key] ?? []).map((rowDraft) => rowDraftToRecord(rowDraft, subFields))]);
       continue;
     }
     const value = scalarDraftToValue(state.text[key], field.type);
-    if (value !== undefined) record[key] = value;
+    if (value !== undefined) entries.push([key, value]);
   }
-  return record;
+  return Object.fromEntries(entries);
 }
 
 /** Normalise a raw inline-edit input (table-cell checkbox/select) to its

--- a/packages/core/src/collection/core/fieldDefaults.ts
+++ b/packages/core/src/collection/core/fieldDefaults.ts
@@ -20,14 +20,19 @@ export function fieldDefaultValue(field: CollectionFieldSpec): string | null {
   return field.values.includes(field.default) ? field.default : null;
 }
 
-/** Every applicable default in a schema, keyed by field. */
+/** Every applicable default in a schema, keyed by field.
+ *
+ *  Built through `Object.fromEntries` rather than by assigning into an
+ *  accumulator, because a field may legitimately be named `__proto__` —
+ *  `JSON.parse` hands that over as an OWN key, so it survives into the parsed
+ *  schema (the same reason the primary-field resolver reaches for
+ *  `Object.hasOwn`). `out[key] = value` on a plain object would run the
+ *  prototype setter for that one name and drop the default with no error
+ *  anywhere; `fromEntries` defines an own property either way (Codex review on
+ *  #2910). */
 export function schemaDefaults(schema: CollectionSchema): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [key, field] of Object.entries(schema.fields)) {
-    const value = fieldDefaultValue(field);
-    if (value !== null) out[key] = value;
-  }
-  return out;
+  const entries = Object.entries(schema.fields).map(([key, field]): [string, string | null] => [key, fieldDefaultValue(field)]);
+  return Object.fromEntries(entries.filter((entry): entry is [string, string] => entry[1] !== null));
 }
 
 /** The first `default` that names something `values` does not offer, for the

--- a/packages/core/src/collection/core/fieldDefaults.ts
+++ b/packages/core/src/collection/core/fieldDefaults.ts
@@ -1,0 +1,42 @@
+// What a NEW record starts on (#2839). Shared so the Add form and
+// `putItems mode:"create"` agree — a default the UI pre-fills but the tool
+// ignores is worse than none, because only one of the two paths gets it.
+//
+// Only `enum` declares a `default` today. The other types are a separate
+// question (literals for scalars, `today` / `now` sentinels for dates) and
+// deliberately not modelled yet.
+
+import type { CollectionFieldSpec, CollectionSchema } from "./schema.js";
+
+/** The starting value for a field, or null when it declares none.
+ *
+ *  A `default` outside `values` resolves to null rather than being handed on.
+ *  `putSchema` refuses to write one, but the key was silently ignored before
+ *  #2839, so a stale value may already sit in a file that discovery still
+ *  loads — and putting an impossible value into a form yields a rejected save
+ *  the author cannot explain from what they see. */
+export function fieldDefaultValue(field: CollectionFieldSpec): string | null {
+  if (field.type !== "enum" || field.default === undefined) return null;
+  return field.values.includes(field.default) ? field.default : null;
+}
+
+/** Every applicable default in a schema, keyed by field. */
+export function schemaDefaults(schema: CollectionSchema): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, field] of Object.entries(schema.fields)) {
+    const value = fieldDefaultValue(field);
+    if (value !== null) out[key] = value;
+  }
+  return out;
+}
+
+/** The first `default` that names something `values` does not offer, for the
+ *  WRITE path to refuse. Kept out of the parse so a file already carrying one
+ *  keeps loading — see `fieldDefaultValue`. */
+export function firstUnknownDefault(schema: CollectionSchema): { key: string; value: string; values: string[] } | null {
+  for (const [key, field] of Object.entries(schema.fields)) {
+    if (field.type !== "enum" || field.default === undefined) continue;
+    if (!field.values.includes(field.default)) return { key, value: field.default, values: field.values };
+  }
+  return null;
+}

--- a/packages/core/src/collection/core/schemaZ.ts
+++ b/packages/core/src/collection/core/schemaZ.ts
@@ -198,11 +198,23 @@ const MoneyFieldZ = z
   .refine(hasCurrencySource, currencyMessage);
 
 /** A closed set of allowed string values. The form renders a `<select>`
- *  populated from `values`; storage is a plain string. */
+ *  populated from `values`; storage is a plain string.
+ *
+ *  `default` pre-fills a NEW record — the Add form starts on it, and a
+ *  `putItems` row in `create` mode that omits the field gets it. Never applied
+ *  on `merge` / `upsert`: those edit a record that already answered this.
+ *
+ *  Membership in `values` is NOT checked here on purpose. This schema is what
+ *  discovery parses on every load, and a rejection there drops the whole
+ *  collection out of the index (`discovery.ts`) — too steep a price for a
+ *  cosmetic key, and the key was silently ignored before #2839, so a stale one
+ *  may already sit in someone's file. `putSchema` refuses a non-member instead,
+ *  where the author is present to read the reason. */
 const EnumFieldZ = z.object({
   type: z.literal("enum"),
   ...fieldBase,
   values: z.array(z.string().trim().min(1)).min(1),
+  default: z.string().trim().min(1).optional(),
 });
 
 // Sub-fields inside a `table.of` map: the regular field types minus `table`

--- a/packages/core/src/collection/index.ts
+++ b/packages/core/src/collection/index.ts
@@ -13,6 +13,7 @@ export type { CollectionQuery, CollectionQueryAggregate, CollectionQueryOrder, C
 export * from "./core/ids";
 export * from "./core/collectionKey";
 export * from "./core/fieldText";
+export * from "./core/fieldDefaults";
 export * from "./core/project";
 export * from "./core/uiTypes";
 export * from "./core/presentCollection";

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -602,8 +602,13 @@ async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCol
   // discovery accepts, so it cannot hide a collection (#2839).
   const unknownDefault = firstUnknownDefault(parsed.data);
   if (unknownDefault) {
-    const { key, value, values } = unknownDefault;
-    return `manageCollection: schema rejected — field '${key}' has default '${value}', which is not one of its values (${values.join(", ")}).`;
+    // Every piece of this message came from the submitted schema, so it is
+    // caller-controlled text on its way back into the agent's context — defanged
+    // like every other echo in this file (CodeRabbit on #2910).
+    const key = defangForPrompt(unknownDefault.key);
+    const value = defangForPrompt(unknownDefault.value);
+    const values = unknownDefault.values.map(defangForPrompt).join(", ");
+    return `manageCollection: schema rejected — field '${key}' has default '${value}', which is not one of its values (${values}).`;
   }
   // Run the SAME post-Zod gates discovery applies, so a write can't pass
   // here yet be silently skipped on the next load (hiding the collection).

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -324,20 +324,22 @@ async function putOneItem(
   deps: ManageCollectionDeps,
 ): Promise<{ written?: string; rejected?: RejectedRow }> {
   const { schema } = collection;
-  const itemId = resolveCreateItemId(schema, record);
+  // Schema defaults fill only what the row left out, and only on create:
+  // "upsert" and "merge" edit a record that already answered this question, so
+  // re-applying a default there would overwrite the answer (#2839). Applied
+  // BEFORE the id is resolved — an `enum` is a legal primary key, so a default
+  // can be what supplies the id (Codex review on #2910).
+  const created = mode === "create" ? { ...schemaDefaults(schema), ...record } : record;
+  const itemId = resolveCreateItemId(schema, created);
   const reject = (about: string, problem: string): { rejected: RejectedRow } => ({
     rejected: { id: defangForPrompt(about), problem: defangForPrompt(problem) },
   });
   if (itemId === null) return reject("(no id)", `record has no '${schema.primaryKey}' value — set it (it doubles as the filename)`);
+  // Against the row as the caller wrote it: a default never introduces a
+  // computed key, and the message should name what they sent.
   const computed = computedKeyProblem(record, schema);
   if (computed) return reject(itemId, computed);
-  let toWrite = record;
-  if (mode === "create") {
-    // Schema defaults fill only what the row left out, and only here: "upsert"
-    // and "merge" edit a record that already answered this question, so
-    // re-applying a default there would overwrite the answer (#2839).
-    toWrite = { ...schemaDefaults(schema), ...record };
-  }
+  let toWrite = created;
   if (mode === "merge") {
     const merged = await mergeWithExisting(collection, store, record, itemId);
     if (typeof merged === "string") return reject(itemId, merged);

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -51,6 +51,7 @@ import type { CollectionItem, CollectionSchema } from "../core/schema";
 import { CollectionSchemaZ } from "../core/schemaZ";
 import { CollectionQueryZ } from "../core/queryZ";
 import { defangForPrompt } from "../core/promptSafety";
+import { firstUnknownDefault, schemaDefaults } from "../core/fieldDefaults";
 import { loadCollection, resolvePrimaryField, type DiscoveryOptions } from "./discovery";
 import type { LoadedCollection } from "./discoveredCollection";
 import { resolveCreateItemId } from "./io";
@@ -331,6 +332,12 @@ async function putOneItem(
   const computed = computedKeyProblem(record, schema);
   if (computed) return reject(itemId, computed);
   let toWrite = record;
+  if (mode === "create") {
+    // Schema defaults fill only what the row left out, and only here: "upsert"
+    // and "merge" edit a record that already answered this question, so
+    // re-applying a default there would overwrite the answer (#2839).
+    toWrite = { ...schemaDefaults(schema), ...record };
+  }
   if (mode === "merge") {
     const merged = await mergeWithExisting(collection, store, record, itemId);
     if (typeof merged === "string") return reject(itemId, merged);
@@ -587,6 +594,15 @@ async function handlePutSchema(slug: string, schemaArg: unknown, deps: ManageCol
   if (refusal) return refusal;
   const parsed = CollectionSchemaZ.safeParse(schemaArg);
   if (!parsed.success) return formatSchemaIssues(parsed.error.issues);
+  // Write-only, and deliberately not part of the parse: discovery runs that on
+  // every load, and rejecting there would drop the whole collection out of the
+  // index over one bad key. Refusing the WRITE is strictly narrower than what
+  // discovery accepts, so it cannot hide a collection (#2839).
+  const unknownDefault = firstUnknownDefault(parsed.data);
+  if (unknownDefault) {
+    const { key, value, values } = unknownDefault;
+    return `manageCollection: schema rejected — field '${key}' has default '${value}', which is not one of its values (${values.join(", ")}).`;
+  }
   // Run the SAME post-Zod gates discovery applies, so a write can't pass
   // here yet be silently skipped on the next load (hiding the collection).
   const gate = schemaDiscoveryGate(parsed.data, resolveBase(deps));

--- a/packages/core/test/collection/test_draft.ts
+++ b/packages/core/test/collection/test_draft.ts
@@ -60,3 +60,24 @@ test("omits an untouched boolean table sub-field named after a prototype member"
   const record = draftToRecord(emptyState({ table: { rows: [row] } }), schema);
   assert.deepEqual(record.rows, [{}]);
 });
+
+// The WRITE side of the same hazard: the value reached the draft, but building
+// the record by assignment ran the prototype setter for this one name, so the
+// user's choice disappeared between the form and the save — on create AND on
+// edit, where it also removed a value the record already had (Codex review on
+// #2910).
+test("saves the value of a field named __proto__ as an own property", () => {
+  const PROTO_KEY = "__proto__";
+  const schema = schemaWith({
+    id: { type: "string", label: "Id", primary: true },
+    [PROTO_KEY]: { type: "enum", label: "Proto", values: ["todo", "done"] } satisfies CollectionFieldSpec,
+  });
+  const text = Object.fromEntries([
+    ["id", "x1"],
+    [PROTO_KEY, "done"],
+  ]);
+  const record = draftToRecord(emptyState({ text }), schema);
+  assert.equal(Object.hasOwn(record, PROTO_KEY), true, "the value must survive the save");
+  assert.equal(record[PROTO_KEY], "done");
+  assert.deepEqual(Object.keys(record).sort(), ["__proto__", "id"]);
+});

--- a/packages/core/test/collection/test_fieldDefaults.ts
+++ b/packages/core/test/collection/test_fieldDefaults.ts
@@ -46,6 +46,20 @@ describe("schemaDefaults", () => {
     assert.deepEqual(schemaDefaults(schemaOf({ id: field("string"), name: field("string") })), {});
   });
 
+  // A field may legitimately be named `__proto__` — JSON.parse hands it over as
+  // an OWN key, and the schema keeps it. Assigning that name into a plain
+  // object would run the prototype setter and drop the default silently
+  // (Codex review on #2910). Held in a const so the lookups read as data
+  // rather than as the deprecated `__proto__` accessor.
+  it("keeps a default on a field named __proto__", () => {
+    const PROTO_KEY = "__proto__";
+    const fields: Record<string, CollectionFieldSpec> = { [PROTO_KEY]: field("enum", { values: ["todo", "done"], default: "todo" }) };
+    const defaults = schemaDefaults(schemaOf(fields));
+    assert.equal(Object.hasOwn(defaults, PROTO_KEY), true, "must be an own property, not a prototype write");
+    assert.equal(defaults[PROTO_KEY], "todo");
+    assert.deepEqual(Object.keys(defaults), [PROTO_KEY]);
+  });
+
   it("skips a default the values do not offer", () => {
     const schema = schemaOf({ status: field("enum", { values: ["todo"], default: "gone" }) });
     assert.deepEqual(schemaDefaults(schema), {});

--- a/packages/core/test/collection/test_fieldDefaults.ts
+++ b/packages/core/test/collection/test_fieldDefaults.ts
@@ -1,0 +1,70 @@
+// Field-level `default` (#2839): what a NEW record starts on, shared by the
+// Add form and `putItems mode:"create"` so the two cannot disagree.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { fieldDefaultValue, schemaDefaults, firstUnknownDefault } from "../../src/collection/core/fieldDefaults";
+import type { CollectionFieldSpec, CollectionSchema } from "../../src/collection/core/schema";
+
+const field = (type: string, extra: Record<string, unknown> = {}): CollectionFieldSpec => ({ type, label: type, ...extra }) as CollectionFieldSpec;
+
+const STATUS = field("enum", { values: ["todo", "doing", "done"], default: "todo", required: true });
+const PRIORITY = field("enum", { values: ["high", "low"], default: "low" });
+
+const schemaOf = (fields: Record<string, CollectionFieldSpec>): CollectionSchema =>
+  ({ title: "T", icon: "list", dataPath: "data/t", primaryKey: "id", fields }) as CollectionSchema;
+
+describe("fieldDefaultValue", () => {
+  it("returns the declared default of an enum field", () => {
+    assert.equal(fieldDefaultValue(STATUS), "todo");
+  });
+
+  it("returns null for an enum without a default, and for non-enum types", () => {
+    assert.equal(fieldDefaultValue(field("enum", { values: ["a"] })), null);
+    assert.equal(fieldDefaultValue(field("string")), null);
+    assert.equal(fieldDefaultValue(field("boolean")), null);
+    assert.equal(fieldDefaultValue(field("number", { default: 3 })), null);
+  });
+
+  // A file written before #2839 could carry a default the schema no longer
+  // offers — the key was silently ignored then, and discovery still loads it.
+  // Handing an impossible value to the form would make the save fail for a
+  // reason the author cannot see.
+  it("returns null when the default is not one of the values", () => {
+    assert.equal(fieldDefaultValue(field("enum", { values: ["todo", "done"], default: "未着手" })), null);
+  });
+});
+
+describe("schemaDefaults", () => {
+  it("collects every applicable default, and only those", () => {
+    const schema = schemaOf({ id: field("string"), status: STATUS, priority: PRIORITY, note: field("text") });
+    assert.deepEqual(schemaDefaults(schema), { status: "todo", priority: "low" });
+  });
+
+  it("is empty when no field declares one", () => {
+    assert.deepEqual(schemaDefaults(schemaOf({ id: field("string"), name: field("string") })), {});
+  });
+
+  it("skips a default the values do not offer", () => {
+    const schema = schemaOf({ status: field("enum", { values: ["todo"], default: "gone" }) });
+    assert.deepEqual(schemaDefaults(schema), {});
+  });
+});
+
+describe("firstUnknownDefault", () => {
+  // The WRITE-path check. Deliberately separate from the parse: rejecting at
+  // parse time would drop the whole collection out of discovery's index.
+  it("names the offending field, its value, and what was allowed", () => {
+    const schema = schemaOf({ status: field("enum", { values: ["todo", "done"], default: "未着手" }) });
+    assert.deepEqual(firstUnknownDefault(schema), { key: "status", value: "未着手", values: ["todo", "done"] });
+  });
+
+  it("returns null for a schema whose defaults are all members", () => {
+    assert.equal(firstUnknownDefault(schemaOf({ status: STATUS, priority: PRIORITY })), null);
+  });
+
+  it("returns null when no default is declared at all", () => {
+    assert.equal(firstUnknownDefault(schemaOf({ status: field("enum", { values: ["todo"] }) })), null);
+  });
+});

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1074,24 +1074,35 @@ function generateUniqueItemId(primaryKey: string): string {
  *  would run the prototype setter for that one name — the field would silently
  *  have no slot. `fromEntries` defines an own property whatever the name is
  *  (Codex review on #2910). */
-function draftSlots<T>(fields: [string, FieldSpec][], keep: (field: FieldSpec) => boolean, valueOf: (field: FieldSpec) => T): Record<string, T> {
-  return Object.fromEntries(fields.filter(([, field]) => keep(field)).map(([key, field]): [string, T] => [key, valueOf(field)]));
+function draftSlots<T>(fields: [string, FieldSpec][], keep: (field: FieldSpec) => boolean, valueOf: (key: string, field: FieldSpec) => T): Record<string, T> {
+  return Object.fromEntries(fields.filter(([, field]) => keep(field)).map(([key, field]): [string, T] => [key, valueOf(key, field)]));
 }
+
+/** A stored `table` value as editable row drafts: anything that isn't a list of
+ *  plain objects has no rows to edit. */
+function tableRowsFromItem(raw: unknown, field: FieldSpec): TableRowDraft[] {
+  const sub = field.type === "table" ? field.of : undefined;
+  if (!sub || !Array.isArray(raw)) return [];
+  return raw
+    .filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row))
+    .map((row) => rowFromItem(row, sub));
+}
+
+const isBoolField = (field: FieldSpec): boolean => field.type === "boolean";
+const isTableField = (field: FieldSpec): boolean => field.type === "table";
+/** Everything else that gets a text slot — the computed/projected kinds
+ *  (COMPUTED_TYPES: derived, embed, backlinks, rollup, toggle) have none. */
+const isTextField = (field: FieldSpec): boolean => !isBoolField(field) && !isTableField(field) && !COMPUTED_TYPES.has(field.type);
 
 function openCreate(): void {
   if (!collection.value) return;
-  // The computed/projected kinds (COMPUTED_TYPES: derived, embed, backlinks,
-  // rollup, toggle) have no draft slot.
   const fields = Object.entries(collection.value.schema.fields);
-  const isBool = (field: FieldSpec) => field.type === "boolean";
-  const isTable = (field: FieldSpec) => field.type === "table";
-  const isText = (field: FieldSpec) => !isBool(field) && !isTable(field) && !COMPUTED_TYPES.has(field.type);
-  const text = draftSlots(fields, isText, (field) => fieldDefaultValue(field) ?? "");
-  const bool = draftSlots(fields, isBool, () => false);
+  const text = draftSlots(fields, isTextField, (_key, field) => fieldDefaultValue(field) ?? "");
+  const bool = draftSlots(fields, isBoolField, () => false);
   // New record — no boolean was originally present.
-  const boolOriginallyPresent = draftSlots(fields, isBool, () => false);
-  const boolTouched = draftSlots(fields, isBool, () => false);
-  const table = draftSlots(fields, isTable, (): TableRowDraft[] => []);
+  const boolOriginallyPresent = draftSlots(fields, isBoolField, () => false);
+  const boolTouched = draftSlots(fields, isBoolField, () => false);
+  const table = draftSlots(fields, isTableField, (): TableRowDraft[] => []);
   // Singleton collections fix the primary key to the schema-declared
   // value (e.g. "me") so the first Add can't pick an arbitrary id.
   // Otherwise pre-fill a unique, editable id so the user doesn't have to
@@ -1116,33 +1127,19 @@ function openCreate(): void {
 
 function openEdit(item: CollectionItem): void {
   if (!collection.value) return;
-  const text: Record<string, string> = {};
-  const bool: Record<string, boolean> = {};
-  const boolOriginallyPresent: Record<string, boolean> = {};
-  const boolTouched: Record<string, boolean> = {};
-  const table: Record<string, TableRowDraft[]> = {};
-  for (const [key, field] of Object.entries(collection.value.schema.fields)) {
-    const raw = item[key];
-    if (field.type === "boolean") {
-      bool[key] = raw === true;
-      // Track whether the key was present in the source record so
-      // we can preserve "omitted" through a save that doesn't
-      // touch this field. `typeof raw === "boolean"` is more
-      // defensive than `key in item` because a wrong-typed value
-      // (e.g. `billable: "yes"`) shouldn't be treated as a real
-      // existing boolean state.
-      boolOriginallyPresent[key] = typeof raw === "boolean";
-      boolTouched[key] = false;
-    } else if (field.type === "table" && field.of) {
-      const sub = field.of;
-      const rows = Array.isArray(raw) ? raw : [];
-      table[key] = rows
-        .filter((row): row is Record<string, unknown> => Boolean(row) && typeof row === "object" && !Array.isArray(row))
-        .map((row) => rowFromItem(row, sub));
-    } else if (!COMPUTED_TYPES.has(field.type)) {
-      text[key] = raw === undefined || raw === null ? "" : String(raw);
-    }
-  }
+  // Same `draftSlots` construction as the create path, and for the same
+  // reason: a field may be named `__proto__`, which an assignment would send
+  // to the prototype setter instead of a draft slot (Codex/CodeRabbit on
+  // #2910). Without a slot the field cannot be edited at all.
+  const fields = Object.entries(collection.value.schema.fields);
+  const text = draftSlots(fields, isTextField, (key) => (item[key] === undefined || item[key] === null ? "" : String(item[key])));
+  const bool = draftSlots(fields, isBoolField, (key) => item[key] === true);
+  // Whether the key was present in the source record, so an untouched field
+  // stays omitted through a save. `typeof === "boolean"` is more defensive than
+  // `key in item`: a wrong-typed value (`billable: "yes"`) is not a real state.
+  const boolOriginallyPresent = draftSlots(fields, isBoolField, (key) => typeof item[key] === "boolean");
+  const boolTouched = draftSlots(fields, isBoolField, () => false);
+  const table = draftSlots(fields, isTableField, (key, field): TableRowDraft[] => tableRowsFromItem(item[key], field));
   const primaryRaw = item[collection.value.schema.primaryKey];
   const originalId = typeof primaryRaw === "string" ? primaryRaw : String(primaryRaw ?? "");
   viewing.value = null; // one panel open at a time

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -361,6 +361,7 @@ import { useViewMode } from "../composables/useViewMode";
 import { useLiveCollectionRefresh } from "../composables/useLiveCollectionRefresh";
 import {
   dateOf,
+  fieldDefaultValue,
   itemMatchesQuery,
   snapshotEmptyEnums,
   rowIdOf,
@@ -1083,7 +1084,7 @@ function openCreate(): void {
     } else if (field.type === "table") {
       table[key] = [];
     } else if (!COMPUTED_TYPES.has(field.type)) {
-      text[key] = "";
+      text[key] = fieldDefaultValue(field) ?? "";
     }
     // The computed/projected kinds (COMPUTED_TYPES: derived, embed,
     // backlinks, rollup, toggle) have no draft slot.

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1068,27 +1068,30 @@ function generateUniqueItemId(primaryKey: string): string {
   return nextUniqueItemId(items.value, primaryKey, newItemId);
 }
 
+/** The draft slots for one kind of field, built through `Object.fromEntries`
+ *  rather than by assigning into an accumulator: a field may be named
+ *  `__proto__` (JSON.parse hands that over as an own key), and `draft[key] = v`
+ *  would run the prototype setter for that one name — the field would silently
+ *  have no slot. `fromEntries` defines an own property whatever the name is
+ *  (Codex review on #2910). */
+function draftSlots<T>(fields: [string, FieldSpec][], keep: (field: FieldSpec) => boolean, valueOf: (field: FieldSpec) => T): Record<string, T> {
+  return Object.fromEntries(fields.filter(([, field]) => keep(field)).map(([key, field]): [string, T] => [key, valueOf(field)]));
+}
+
 function openCreate(): void {
   if (!collection.value) return;
-  const text: Record<string, string> = {};
-  const bool: Record<string, boolean> = {};
-  const boolOriginallyPresent: Record<string, boolean> = {};
-  const boolTouched: Record<string, boolean> = {};
-  const table: Record<string, TableRowDraft[]> = {};
-  for (const [key, field] of Object.entries(collection.value.schema.fields)) {
-    if (field.type === "boolean") {
-      bool[key] = false;
-      // New record — no boolean was originally present.
-      boolOriginallyPresent[key] = false;
-      boolTouched[key] = false;
-    } else if (field.type === "table") {
-      table[key] = [];
-    } else if (!COMPUTED_TYPES.has(field.type)) {
-      text[key] = fieldDefaultValue(field) ?? "";
-    }
-    // The computed/projected kinds (COMPUTED_TYPES: derived, embed,
-    // backlinks, rollup, toggle) have no draft slot.
-  }
+  // The computed/projected kinds (COMPUTED_TYPES: derived, embed, backlinks,
+  // rollup, toggle) have no draft slot.
+  const fields = Object.entries(collection.value.schema.fields);
+  const isBool = (field: FieldSpec) => field.type === "boolean";
+  const isTable = (field: FieldSpec) => field.type === "table";
+  const isText = (field: FieldSpec) => !isBool(field) && !isTable(field) && !COMPUTED_TYPES.has(field.type);
+  const text = draftSlots(fields, isText, (field) => fieldDefaultValue(field) ?? "");
+  const bool = draftSlots(fields, isBool, () => false);
+  // New record — no boolean was originally present.
+  const boolOriginallyPresent = draftSlots(fields, isBool, () => false);
+  const boolTouched = draftSlots(fields, isBool, () => false);
+  const table = draftSlots(fields, isTable, (): TableRowDraft[] => []);
   // Singleton collections fix the primary key to the schema-declared
   // value (e.g. "me") so the first Add can't pick an arbitrary id.
   // Otherwise pre-fill a unique, editable id so the user doesn't have to
@@ -1098,10 +1101,12 @@ function openCreate(): void {
   const { singleton, primaryKey } = collection.value.schema;
   if (singleton) {
     text[primaryKey] = singleton;
-  } else if (primaryKey in text && !text[primaryKey]) {
+  } else if (Object.hasOwn(text, primaryKey) && !text[primaryKey]) {
     // Only when nothing filled it: an `enum` is a legal primary key, and a
     // generated UUID is not one of its `values` — the form would open blank on
-    // a field that cannot be saved (Codex review on #2910).
+    // a field that cannot be saved. `hasOwn` rather than `in`, so a primary key
+    // named after something on Object.prototype reads its own slot rather than
+    // an inherited one (Codex review on #2910).
     text[primaryKey] = generateUniqueItemId(primaryKey);
   }
   viewing.value = null; // one panel open at a time

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -1098,7 +1098,10 @@ function openCreate(): void {
   const { singleton, primaryKey } = collection.value.schema;
   if (singleton) {
     text[primaryKey] = singleton;
-  } else if (primaryKey in text) {
+  } else if (primaryKey in text && !text[primaryKey]) {
+    // Only when nothing filled it: an `enum` is a legal primary key, and a
+    // generated UUID is not one of its `values` — the form would open blank on
+    // a field that cannot be saved (Codex review on #2910).
     text[primaryKey] = generateUniqueItemId(primaryKey);
   }
   viewing.value = null; // one panel open at a time

--- a/plans/feat-2839-enum-field-default.md
+++ b/plans/feat-2839-enum-field-default.md
@@ -60,5 +60,10 @@ e2e は **UI の prefill を戻すと2件落ちる**ことを確認済み（プ�
 
 ## publish
 
-`@mulmoclaude/core`（schemaZ / fieldDefaults / manageTool）と `@mulmoclaude/collection-plugin`（UI）の
-両方に差分があるので、npm 利用者に届けるには次の publish 波で両方を出す必要がある。
+`@mulmoclaude/core`（schemaZ / fieldDefaults / draft / manageTool）と
+`@mulmoclaude/collection-plugin`（UI）の両方に差分があるので、npm 利用者に届けるには次の publish 波で
+両方を出す必要がある。順序は依存の下から **core → collection-plugin**。
+
+各 publish には git タグ（`@mulmoclaude/core@X.Y.Z` / `@mulmoclaude/collection-plugin@X.Y.Z`、`v` 接頭辞なし）と
+GitHub リリース（`--latest=false` —— このリポジトリには `v*` のアプリリリースがあるため）を必ず付ける。
+あわせて宣言側のレンジを新バージョンに掃く。手順は `/publish` skill。

--- a/plans/feat-2839-enum-field-default.md
+++ b/plans/feat-2839-enum-field-default.md
@@ -1,0 +1,64 @@
+# enum フィールドの `default`（Tier 1） (#2839)
+
+## 何を作るか
+
+`schema.json` の enum フィールドに `default` を書けるようにし、**新規レコードの初期値**にする。
+
+```json
+"status": { "type": "enum", "values": ["todo","doing","done"], "required": true, "default": "todo" }
+```
+
+- UI の「+ 追加」がその値で開く
+- `putItems mode:"create"` で、行がそのフィールドを持たなければ埋まる
+- `upsert` / `merge` では**適用しない**（既に答えを持つレコードの編集だから）
+
+issue の Tier 2（全型のリテラル）と Tier 3（`today` / `now`）はやらない。動機になっている実例は
+enum 2つ（`status` / `priority`）で、Tier 1 で満たされる。
+
+## 既存ユーザーへの影響をゼロにする設計
+
+`default` は**今まで Zod の既定（strip）で黙って捨てられていた**。つまり既に書いている人が居る
+（issue の報告者がまさにそれ）。素朴に「Zod で `values` の一員かを検証」すると:
+
+`discovery.ts` は検証に落ちたスキーマを **warn 1行でスキップする**（コレクションが一覧から丸ごと消える）。
+typo の `default` が残っているだけで、ユーザーのコレクションが消える。
+
+そこで検証を**書き込み側だけ**に置く。
+
+| 層 | 扱い |
+| --- | --- |
+| Zod（読み書き共通） | `default: z.string().optional()` のみ。**membership を見ない** → 読みで既存スキーマを落とさない |
+| `putSchema`（書きのみ） | `values` の一員でなければ拒否。理由と許容値をメッセージに載せる |
+| 実行時（`fieldDefaultValue`） | 範囲外なら「default 無し」として扱う |
+
+`manageTool.ts` には「putSchema が通したものが discovery で落ちてはならない（コレクションが隠れる）」
+という不変条件がコメントで明記されている。**書きが読みより厳しい**のはこの向きに反しないので安全。
+
+実行時の fail-soft は1行。無くても「UI の select が空で描画され、保存時に行が弾かれる」で
+一応転ぶが、**画面に説明が無いエラー**になるので入れる価値がある（#2863 と同型の配慮）。
+
+## 実装
+
+| ファイル | 変更 |
+| --- | --- |
+| `core/schemaZ.ts` | `EnumFieldZ` に `default` を optional 追加（membership は見ない、理由をコメント） |
+| `core/fieldDefaults.ts` | 新規。`fieldDefaultValue` / `schemaDefaults` / `firstUnknownDefault` |
+| `server/manageTool.ts` | putSchema に write-only チェック、putItems の `create` で `{...schemaDefaults, ...row}` |
+| `CollectionView.vue` `openCreate()` | 空文字の代わりに default |
+| `assets/helps/collection-skills.md` | enum の項に `default` の説明（エージェントが発見できないと機能しない） |
+
+## テスト
+
+- unit 9件（`fieldDefaults`）
+- ツール経由 7件（create で埋まる / 行の値を上書きしない / upsert・merge では適用しない /
+  putSchema が範囲外を拒否 / 正しい default は書ける / **範囲外の default を持つコレクションが
+  読み込めること** ＝ 互換性の保証）
+- e2e 3件（Add フォームが default で開く・default 無しの列は空のまま / 既存レコードの編集は
+  自分の値を出す / 範囲外の default は空で開きコレクションは無事）
+
+e2e は **UI の prefill を戻すと2件落ちる**ことを確認済み（プラグインと app を再ビルドして実測）。
+
+## publish
+
+`@mulmoclaude/core`（schemaZ / fieldDefaults / manageTool）と `@mulmoclaude/collection-plugin`（UI）の
+両方に差分があるので、npm 利用者に届けるには次の publish 波で両方を出す必要がある。

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -692,6 +692,27 @@ describe("manageCollection — enum field defaults", () => {
     assert.equal(storedTask("t1").priority, "low");
   });
 
+  // An `enum` is a legal primary key (`primary` lives on every field type), so
+  // a default can be what supplies the record id — which means the merge has to
+  // happen before the id is resolved, not after (Codex review on #2910).
+  it("supplies the id when the primary key is an enum with a default", async () => {
+    writeSkill("phases", {
+      title: "Phases",
+      icon: "list",
+      dataPath: "data/phases/items",
+      primaryKey: "phase",
+      fields: {
+        phase: { type: "enum", label: "Phase", values: ["intake", "review"], primary: true, required: true, default: "intake" },
+        note: { type: "string", label: "Note" },
+      },
+    });
+    const result = await runJson({ action: "putItems", slug: "phases", items: [{ note: "no id given" }], mode: "create" });
+    assert.deepEqual(result.rejected, []);
+    assert.deepEqual(result.written, ["intake"]);
+    const stored = JSON.parse(readFileSync(path.join(workdir, "data/phases/items/intake.json"), "utf-8")) as Record<string, unknown>;
+    assert.equal(stored.phase, "intake");
+  });
+
   it("never overrides a value the row carries", async () => {
     await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t2", title: "Urgent", status: "doing", priority: "high" }], mode: "create" });
     assert.equal(storedTask("t2").status, "doing");

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -665,3 +665,97 @@ describe("manageCollection — deleteItems", () => {
     assert.match(await run({ action: "deleteItems", slug: "students", ids: ["s1"] }), /read-only/);
   });
 });
+
+// Field-level `default` (#2839): a starting value for a NEW record, so the
+// same two values don't have to be typed on every add.
+describe("manageCollection — enum field defaults", () => {
+  const TASKS = {
+    title: "Tasks",
+    icon: "task_alt",
+    dataPath: "data/tasks/items",
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      title: { type: "string", label: "Title", required: true },
+      status: { type: "enum", label: "Status", values: ["todo", "doing", "done"], required: true, default: "todo" },
+      priority: { type: "enum", label: "Priority", values: ["high", "low"], default: "low" },
+    },
+  };
+  const storedTask = (itemId: string) => JSON.parse(readFileSync(path.join(workdir, `data/tasks/items/${itemId}.json`), "utf-8")) as Record<string, unknown>;
+
+  beforeEach(() => writeSkill("tasks", TASKS));
+
+  it("fills the fields a create row omits, satisfying a required enum on its own", async () => {
+    const result = await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t1", title: "Write it" }], mode: "create" });
+    assert.deepEqual(result.rejected, []);
+    assert.equal(storedTask("t1").status, "todo");
+    assert.equal(storedTask("t1").priority, "low");
+  });
+
+  it("never overrides a value the row carries", async () => {
+    await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t2", title: "Urgent", status: "doing", priority: "high" }], mode: "create" });
+    assert.equal(storedTask("t2").status, "doing");
+    assert.equal(storedTask("t2").priority, "high");
+  });
+
+  // An edit is not a create: the record already answered this question, and
+  // re-applying the default would put the answer back to the starting value.
+  it("does not apply on upsert or merge", async () => {
+    await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t3", title: "Done one", status: "done", priority: "high" }], mode: "create" });
+
+    const merged = await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t3", title: "Renamed" }], mode: "merge" });
+    assert.deepEqual(merged.rejected, []);
+    assert.equal(storedTask("t3").status, "done", "merge must keep the stored answer");
+    assert.equal(storedTask("t3").priority, "high");
+
+    const upserted = await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t3", title: "Replaced", status: "doing" }] });
+    assert.deepEqual(upserted.rejected, []);
+    assert.equal(storedTask("t3").status, "doing");
+    assert.equal(storedTask("t3").priority, undefined, "upsert replaces WHOLE — no default sneaks back in");
+  });
+});
+
+describe("manageCollection — putSchema and a stale default", () => {
+  let putTool: ReturnType<typeof makeManageCollectionTool>;
+  const putRun = (args: Record<string, unknown>) => putTool.handler(args);
+  const withStatus = (status: Record<string, unknown>) => ({
+    title: "Tasks",
+    icon: "task_alt",
+    dataPath: "data/tasks/items",
+    primaryKey: "id",
+    fields: { id: { type: "string", label: "ID", primary: true, required: true }, status },
+  });
+
+  beforeEach(() => {
+    putTool = makeManageCollectionTool({ workspaceRoot: workdir, userSkillsDir: emptyUserDir, refreshAfterWrite: async () => {} });
+    writeSkill("tasks", withStatus({ type: "enum", label: "Status", values: ["todo", "done"] }));
+  });
+
+  it("accepts a default that is one of the values", async () => {
+    const schema = withStatus({ type: "enum", label: "Status", values: ["todo", "done"], default: "todo" });
+    const result = JSON.parse(await putRun({ action: "putSchema", slug: "tasks", schema })) as Record<string, unknown>;
+    assert.equal(result.written, true);
+  });
+
+  it("refuses a default the values do not offer, naming what was allowed", async () => {
+    const schema = withStatus({ type: "enum", label: "Status", values: ["todo", "done"], default: "未着手" });
+    const msg = await putRun({ action: "putSchema", slug: "tasks", schema });
+    assert.match(msg, /schema rejected/);
+    assert.match(msg, /未着手/);
+    assert.match(msg, /todo, done/);
+    assert.ok(!existsSync(path.join(workdir, "data/skills/tasks/schema.json")), "no staging file on rejection");
+  });
+
+  // The compatibility guarantee. `default` was silently ignored before #2839,
+  // so a file may already carry one the values no longer offer. Refusing it at
+  // PARSE time would drop the collection out of discovery's index entirely —
+  // the collection would vanish from the UI with only a log line. It must keep
+  // loading, and simply start blank.
+  it("keeps loading a collection whose stored default is not a member", async () => {
+    writeSkill("tasks", withStatus({ type: "enum", label: "Status", values: ["todo", "done"], default: "未着手" }));
+    const created = await runJson({ action: "putItems", slug: "tasks", items: [{ id: "t9" }], mode: "create" });
+    assert.deepEqual(created.rejected, [], "the collection is still discoverable and writable");
+    const stored = JSON.parse(readFileSync(path.join(workdir, "data/tasks/items/t9.json"), "utf-8")) as Record<string, unknown>;
+    assert.equal(stored.status, undefined, "an impossible default is not handed to the record");
+  });
+});


### PR DESCRIPTION
## Summary

enum フィールドに `default` を書けるようにし、**新規レコードの初期値**にする。#2839 の Tier 1（issue が「最小の出荷単位」として切り出したもの）です。

```jsonc
"status": { "type": "enum", "values": ["todo","doing","done"], "required": true, "default": "todo" }
```

- UI の「+ 追加」がその値で開く
- `putItems mode:"create"` で、行がそのフィールドを持たなければ埋まる
- **両方やらないと片手落ち**です（フォームだけ埋まってツールが無視する方が、無いより悪い）
- `upsert` / `merge` では**適用しない** —— 既に答えを持つレコードの編集なので、初期値に戻してしまう
- `required: true` と併用できる（要件は default が満たすので、ユーザーは保存するだけ）

Tier 2（全型のリテラル）と Tier 3（`today` / `now`）はやりません。動機になっている実例は enum 2つ（`status` / `priority`）で、Tier 1 で満たされます。

`Closes #2839`

## ⚠️ 既に `default` と書いている人への注記

**`default` は今まで Zod の既定（strip）で黙って捨てられていました。** つまり「書いたが効かなかった」人が居ます（この issue の報告者がまさにそれ）。なので、その人たちのスキーマが `values` に無い値を持っている可能性があります。

素朴に「Zod で membership を検証」すると事故ります: `discovery.ts` は検証に落ちたスキーマを **warn 1行でスキップ**します —— つまり **typo ひとつでコレクションが一覧から丸ごと消え**、ログを見るまで原因が分かりません。

そこで検証を**書き込み側だけ**に置きました。

| 層 | 扱い | 根拠 |
|---|---|---|
| Zod（読み書き共通） | `default: z.string().optional()` のみ。**membership を見ない** | 読みで既存スキーマを落とさない |
| `putSchema`（書きのみ） | 一員でなければ拒否。フィールド名・値・許容値をメッセージに載せる | `manageTool.ts` の「putSchema が通したものが discovery で落ちてはならない（コレクションが隠れる）」に**反しない向き**（書きが読みより厳しいのは安全） |
| 実行時 | 範囲外の default は「未設定」として扱う | 画面に説明の無い保存エラーにしない（#2863 と同型の配慮） |

**結果として、既存の `default` は「書いたとおりに効き始める」か「今までどおり無視される」かのどちらかで、壊れる経路はありません。** 新しく増える拒否は authoring 時（putSchema）だけです。

## Items to Confirm / Review

- **membership を putSchema にだけ置いた判断。** 上表の理由ですが、「Zod で弾く方が素直では」という意見はあり得ます
- **実行時の fail-soft（1行）を入れたこと。** 事前の議論では「レアだから機構は不要」で合意しましたが、これは機構ではなく `values.includes()` 1回で、入れないと「select は空なのに保存が弾かれる」という説明不能な状態になるため入れました
- **`upsert` で default を適用しないこと。** upsert はレコードを丸ごと置換するので、行が省いたフィールドは消えます（テストで固定）。ここを「create 相当」と見なす読み方もあり得ます
- `@mulmoclaude/core` と `@mulmoclaude/collection-plugin` の**両方に差分**があるので、npm 利用者に届けるには次の publish 波で両方が必要です

## 検証

| 種別 | 件数 | 内容 |
|---|---|---|
| unit | 9 | `fieldDefaultValue` / `schemaDefaults` / `firstUnknownDefault` |
| ツール経由 | 7 | create で埋まる / 行の値を上書きしない / upsert・merge では適用しない / putSchema が範囲外を拒否し何も書かない / 正しい default は書ける / **範囲外の default を持つコレクションが読み込めて書ける**（＝互換性の保証） |
| e2e | 3 | Add フォームが default で開き、default 無しの列は空のまま / 既存レコードの編集は自分の値を出す / 範囲外の default は空で開きコレクションは無事 |

**e2e が空振りでないことを確認済み**です: UI の prefill だけを戻してプラグインと app を再ビルドすると **3件中2件が落ち**、戻すと 3件 green。

その他: `yarn format` / `lint`（error 0）/ `typecheck`（0）/ `build` / `yarn test`（exit 0）/ `collection` 系 e2e **98件 green**。

`collection-skills.md`（schemaDocs が配る authoring リファレンス）にも `default` の項を足しました —— ドキュメントに無い機能はエージェントが発見できないためです。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2839 これってなにかできる？必要？
- Tier 1 やるとどうなる？既存のユーザへは影響内？
- 既に default と書いている人は、レアだからケアしなくてよくない？
- （方針合意ののち）はい / release note と PR だけには注書きを書いておこう

work in mulmoclaude2

## Summary by Sourcery

Support enum field-level defaults that initialize new records while preserving compatibility with existing schemas.

New Features:
- Allow enum fields in collection schemas to declare a `default` value used as the initial value for newly created records via the Add form and `putItems` in `create` mode.

Bug Fixes:
- Ensure collections with previously ignored or stale enum `default` values continue to load and remain writable, treating impossible defaults as unset at runtime.

Enhancements:
- Add shared core helpers to compute field and schema defaults and to validate enum defaults against allowed values on schema writes only.
- Update collection UI to pre-fill enum fields in the Add form from schema defaults without affecting edit forms.
- Document enum field defaults and their behavior in changelog and collection authoring reference.

Tests:
- Add unit, tool-level, and e2e tests covering enum defaults application on create, non-application on upsert/merge, write-time validation of invalid defaults, and runtime handling of stale defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enum fields can now define default values for new records.
  * Defaults populate Add forms and create-mode collection rows.
  * Enum defaults can provide primary-key values when creating records.
* **Bug Fixes**
  * Invalid defaults are rejected when schemas are saved.
  * Existing schemas with stale defaults continue loading safely.
  * Existing record values remain unchanged during edits, updates, and merges.
  * Fields with special names retain their values correctly.
* **Documentation**
  * Added guidance on configuring enum defaults and their behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->