### PR TITLE
fix(remote-host): firebase を 12.16.0 にピン留めして Google サインインを直す (#2835)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "exifr": "^7.1.3",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.10.1",
-    "firebase": "^12.17.0",
+    "firebase": "12.16.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "heic-convert": "^2.1.0",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -54,7 +54,7 @@
     "exifr": "^7.1.3",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.10.1",
-    "firebase": "^12.17.0",
+    "firebase": "12.16.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "heic-convert": "^2.1.0",

--- a/plans/fix-2835-pin-firebase-12.16.md
+++ b/plans/fix-2835-pin-firebase-12.16.md
@@ -1,0 +1,98 @@
+# fix(remote-host): firebase を 12.16.0 にピン留めして Google サインインを直す（#2835）
+
+## 問題
+
+リモートホストの「Google でサインイン」が `Database is closing/hidden` で失敗し、
+オフラインのまま繋がらない。macOS の Chrome / Safari の両方で、複数の利用者が再現している。
+
+MulmoClaude 側のロジックの誤りではなく、**`@firebase/auth` 1.13.4 のリグレッション**
+（上流 [firebase-js-sdk#10264](https://github.com/firebase/firebase-js-sdk/issues/10264)）。
+
+## 原因
+
+1.13.4 は `IndexedDBLocalPersistence` に `visibilitychange` リスナを追加し、
+`document.visibilityState === 'hidden'` を**ページ teardown と同じ扱い**にした。
+
+```js
+// @firebase/auth 1.13.4 dist
+this.onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') { this.onPageHide(); }  // isHiding = true, IndexedDB を close
+    else if (document.visibilityState === 'visible') { this.onPageShow(); }
+};
+async _openDb() {
+    if (this.isHiding) { throw new Error('Database is closing/hidden'); }
+```
+
+サインインのポップアップが元ウィンドウを背面に回すと `hidden` になり、
+ポップアップから認証情報が戻ってきた時点の永続化で `_openDb()` が throw する。到達経路:
+
+```
+signInWithPopup → PopupOperation → _signIn
+  → _signInWithCredential(auth, IdpCredential, bypassAuthState=false)
+  → auth._updateCurrentUser → directlySetCurrentUser
+  → assertedPersistence.setCurrentUser → IndexedDBLocalPersistence._set
+  → _withRetries → _openDb → throw
+```
+
+`_withRetries()` は `isHiding` のときリトライせず rethrow するため回復経路が無い。
+**読み取りは握りつぶすのに書き込みだけ致命的**という非対称がこの不具合の芯で、
+`_poll()` は `isHiding` を見て `[]` を返すのに、`_set` / `_remove` は例外を上げる。
+
+`signInWithPopup` が reject するので idToken を取得できず `/connect` に到達しない。
+`errorMessage(err, fallback)` は Error の `message` を返すため、i18n フォールバックには
+届かず SDK の生文字列がそのまま画面に出る。
+
+## 調査で確定させたこと
+
+| 確認 | 方法 | 結果 |
+|---|---|---|
+| エラー文字列の出どころ | SDK 全文検索 | `_openDb()` の1箇所のみ。出た時点で `isHiding === true` が確定 |
+| リグレッションかどうか | 1.13.3 / 1.13.4 の tarball 差分 | `isHiding` / `visibilitychange` / 当該文字列は 1.13.3 に **0件**、1.13.4 で新規追加 |
+| 実際に落ちるか | Playwright + Chromium で実 SDK を実行 | `indexedDBLocalPersistence` は hidden で throw、`inMemoryPersistence` は通る |
+| 上流の状態 | GitHub API | PR #10300 が 2026-08-13 に merge 済み。ただし **npm 未公開** |
+| 上げれば直るか | npm registry | `@firebase/auth` の latest は 1.13.4 のまま。`firebase@12.17.1`（最新）も 1.13.4 を同梱 |
+
+## 方針: ピン留め
+
+`firebase` を **12.16.0 に完全固定**する（`@firebase/auth` 1.13.3 を同梱する最新の 12.x）。
+
+- `^12.16.0` ではなく `12.16.0`。キャレットだと 12.17.x に浮いて 1.13.4 に戻ってしまう。
+- 対象は **2箇所**。ルートの `package.json` だけでは npm 利用者に届かない:
+  - `package.json` — 開発・ビルド時に解決される。ブラウザ束は build 時に焼き込まれる
+  - `packages/mulmoclaude/package.json` — ランチャーの runtime 依存。`server/` が
+    `firebase/storage` を実行時に import するので、ここが `^12.17.0` のままだと
+    npm 利用者側で 12.17.x が解決される
+- `packages/core` は `firebase: ^12.0.0` を optional peer で宣言しており 12.16.0 で満たされる。変更不要。
+
+### 却下した案
+
+**`setPersistence(auth, inMemoryPersistence)` に切り替える**（issue の提案） — 回避としては
+正しく、この Auth インスタンスは `signInWithPopup` で idToken を1回取るためだけに存在し、
+`onAuthStateChanged` / `currentUser` / `getIdToken` は `src/` 全体に0件なので persistence
+自体が不要、という前提も正しい。ただし `setPersistence()` は内部で**古い（IndexedDB）
+persistence に対して `_get` + `_remove` を実行してから**切り替えるため、起動時にページが
+hidden だとその呼び出し自体が同じエラーで reject し、投げっぱなしだと persistence は
+IndexedDB のまま残って再発する。採るなら `getAuth` をやめて
+`initializeAuth(app, { persistence: inMemoryPersistence, popupRedirectResolver: browserPopupRedirectResolver })`
+にすべきだが、**上流が既に直しており公開待ちなだけ**なので、アプリ側の認証初期化を
+書き換えるより依存を固定して待つほうが差し戻しが容易と判断した。
+
+**上流リリースを待つ** — 現時点では不可。1.13.3 → 1.13.4 は約6週間空いており、
+修正版がいつ出るか読めない。
+
+## 解除の手順
+
+`@firebase/auth` が 1.13.5 以上（= PR #10300 を含む `firebase` リリース）を同梱したら:
+
+1. `npm view firebase@latest dependencies.@firebase/auth` で 1.13.5 以上を確認
+2. `yarn add firebase@^<新バージョン> -W` と `yarn workspace mulmoclaude add firebase@^<新バージョン>`
+3. #2835 をクローズ
+
+issue #2835 は**この PR では閉じない**。ピン留めは回避であって原因の除去ではなく、
+上流版に戻すまでが完了だから。
+
+### ピンが外れうる経路
+
+`.github/dependabot.yml` は npm の version update を意図的に対象外にしている（#2875）ので
+Dependabot が勝手に上げることはない。ただし**リポジトリ設定の npm security update と、
+手動の `yarn upgrade --latest` はこのピンを外し得る**。外れたときの症状は #2835 そのもの。

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,26 +818,26 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.0.tgz#54479e0f406cbad024d6fe1c3190ecca4468df3b"
   integrity sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==
 
-"@firebase/ai@2.14.0":
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/@firebase/ai/-/ai-2.14.0.tgz#292789b4dfa817ac17c25fef36bc7b7ffd710c31"
-  integrity sha512-TYEQqCQUTyVHuG/HVi9vau6F9kvEaS49o/hmdn/yUuN6ZXQkwIml2nNJTIBfjNl/r9LOxwUNILgcOY16nxObug==
+"@firebase/ai@2.13.1":
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/@firebase/ai/-/ai-2.13.1.tgz#15dc946a793bc8ea35e1aba03ec3cf50c9443ba9"
+  integrity sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.4"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/analytics-compat@0.2.29":
-  version "0.2.29"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.2.29.tgz#9a13c73db2c6ad63a854a5ce3a7b16ff74cd7630"
-  integrity sha512-allztvCvCUlItZzD97TiRAtGoFJzR1FQFmLxbaLc6PvgscqD9cl5NdKPTtka6keShVYXvCZJpzWcRoH4TME8rw==
+"@firebase/analytics-compat@0.2.28":
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz#fb8f18e40a019dd9ea005859fe71ccf3d0867ee9"
+  integrity sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==
   dependencies:
-    "@firebase/analytics" "0.10.23"
+    "@firebase/analytics" "0.10.22"
     "@firebase/analytics-types" "0.8.4"
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/analytics-types@0.8.4":
@@ -845,27 +845,27 @@
   resolved "https://registry.yarnpkg.com/@firebase/analytics-types/-/analytics-types-0.8.4.tgz#194ee289e7293e47b1bd6221147f0dcc02f92e3d"
   integrity sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==
 
-"@firebase/analytics@0.10.23":
-  version "0.10.23"
-  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.10.23.tgz#ec92235e1b35ef0f22b286194e458f5640570b00"
-  integrity sha512-34ALWXzWA6PTRUA5hipZmsm1RKzeecw5J1+qTCXsiMzwLqONC+GuTIQSdmm91MmTAEA+wG1Q5t0IFahcYQOqAA==
+"@firebase/analytics@0.10.22":
+  version "0.10.22"
+  resolved "https://registry.yarnpkg.com/@firebase/analytics/-/analytics-0.10.22.tgz#20f3a6431ed51c4590cf898455de7fd40b2163f0"
+  integrity sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/app-check-compat@0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.4.6.tgz#78af8bcd3cbbbf857541926d0dc63f899b22f037"
-  integrity sha512-2pzNEZEkX84jSqy6TH6FI1HSLA1lc7kakRUybBbKjg9YhIttPlW/XX3N9CDtChji2PTTPWVPZiWhB10exHfA+A==
+"@firebase/app-check-compat@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz#f136a07e5bcdef81aaad1b82b49557d5d1329ee8"
+  integrity sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==
   dependencies:
-    "@firebase/app-check" "0.13.0"
+    "@firebase/app-check" "0.12.0"
     "@firebase/app-check-types" "0.5.4"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/app-check-interop-types@0.3.4":
@@ -878,25 +878,25 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-check-types/-/app-check-types-0.5.4.tgz#8001732e81332dd77d898d82fe773761cf2f023b"
   integrity sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==
 
-"@firebase/app-check@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.13.0.tgz#de1d1e4671172b55eda2ad6b0a6182d763926b73"
-  integrity sha512-AbMttBKazQvGVXBZhQdVAdPzRhwHyJAY3Ghu5y2C7IZKIDIppzNYz0shTZ1mP4FBJa+28BuC4t+5h1Q6pT3Asg==
+"@firebase/app-check@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@firebase/app-check/-/app-check-0.12.0.tgz#8fb9bdfa426b110169efc7446f84a9c54ef5bdd0"
+  integrity sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.5.16":
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.5.16.tgz#2c2f87fb29f298dd220b66b7b28493ff9f2e7ff7"
-  integrity sha512-shQq37O8qELDzvsVwYPlDXwD1zlcrZ0m2bpBF5ov2HSbY8x+AHsnL5TtJ2e1JAfkQN05qHao1AfabS69PN6GiA==
+"@firebase/app-compat@0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.5.15.tgz#6db6d3a5cc35dba7c4fbcc985c5a8bff4f2fab01"
+  integrity sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==
   dependencies:
-    "@firebase/app" "0.16.0"
-    "@firebase/component" "0.7.4"
+    "@firebase/app" "0.15.1"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/app-types@0.9.5":
@@ -906,26 +906,26 @@
   dependencies:
     "@firebase/logger" "0.5.1"
 
-"@firebase/app@0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.16.0.tgz#9521de87efb74eed879f201be1abc8df92364b37"
-  integrity sha512-G+ZGEyVP8YTb3ay6A+XpcYgFH3sTESHcnHU/EyTktodqhz2BHkLq+QEP7IVwjiMX0cxYwpVKip0/wC0KZcn9vQ==
+"@firebase/app@0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.15.1.tgz#2d5eb26abf388dc32aea5763eb26e0698d5401ca"
+  integrity sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     idb "7.1.1"
     tslib "^2.1.0"
 
-"@firebase/auth-compat@0.6.9":
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.6.9.tgz#16db5b6f14f4a09c861aa643310e421db488e528"
-  integrity sha512-/hHeTBmQ61+N5J1RECls+WfskZTY78JXr7aO5EMOfUpqJvDqvoS+568k0rp6Ss/4UWwBjadILs+H+SGy1zCS3A==
+"@firebase/auth-compat@0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.6.8.tgz#09d828421a9ec1edcde60cd86785a29cad9b5720"
+  integrity sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==
   dependencies:
-    "@firebase/auth" "1.13.4"
+    "@firebase/auth" "1.13.3"
     "@firebase/auth-types" "0.13.1"
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/auth-interop-types@0.2.5":
@@ -938,77 +938,77 @@
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.13.1.tgz#eb5abafdaa40dd3b6badfab111dd94f7e196ea66"
   integrity sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==
 
-"@firebase/auth@1.13.4":
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.13.4.tgz#440862edc7782cbd28ce6606cb31249e009efff9"
-  integrity sha512-s+NS1aV0DDyyfoIMeSz53HXnVTv7ufJjJfrP63XyaWHweJ5vOoxKWrTm5tO7S7PDqvyOa/Wi3oP0dgAo6JTMMA==
+"@firebase/auth@1.13.3":
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.13.3.tgz#5cad74ce656c9b4f8ffb2a026fab98d4b40c4a96"
+  integrity sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/component@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.7.4.tgz#1c7942806ba03334e5ef432e088a07efad787cf3"
-  integrity sha512-tLpOaaCol9ugUIYp2R3CbWPPA8Ajg/papX/XHEy8U52b/QXH3BbX8tTJX9aShDCjp+9sMAxMLD94i7lresdugQ==
+"@firebase/component@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@firebase/component/-/component-0.7.3.tgz#900c9720f7e5abb2a23975f90f96366d62d085b9"
+  integrity sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==
   dependencies:
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/data-connect@0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@firebase/data-connect/-/data-connect-0.7.2.tgz#1333edc262b30a4104d892840d471a091e392e83"
-  integrity sha512-Z64TRTp5KsvZtuCS1BhEg0H63TTDIi6k7idGG+z1ImAnP2qHv+xt0S5rzAONpiO7Z1geldWhpu1iY/ju+l3a3w==
+"@firebase/data-connect@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@firebase/data-connect/-/data-connect-0.7.1.tgz#3ae9235525b5b0438968c4bf1ea1afc8816944b3"
+  integrity sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==
   dependencies:
     "@firebase/auth-interop-types" "0.2.5"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/database-compat@2.1.5":
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-2.1.5.tgz#59d29bfb62aa6e71ea1cd7de45b2cf77648210ce"
-  integrity sha512-m2KZDNXrg8DBzXWQNbbrjOhsJnM+ctsSFaDYKrqj1gEetQ8BSAwRuMUdeWLM9a6qPBgOvOA+o09j1BSEzdFqOg==
+"@firebase/database-compat@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@firebase/database-compat/-/database-compat-2.1.4.tgz#8ea753bef91d2dfbd81853479799f3ab17ddbbbe"
+  integrity sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/database" "1.1.4"
-    "@firebase/database-types" "1.0.21"
+    "@firebase/component" "0.7.3"
+    "@firebase/database" "1.1.3"
+    "@firebase/database-types" "1.0.20"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/database-types@1.0.21":
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-1.0.21.tgz#a571c6491bb7d2e0b71b8eac0511acf7f87d5a24"
-  integrity sha512-SX1jUqhttKgg/m9dYRTvqU9QvucBooziWfA986r4cpsbi4zlsvewe424j3Vpduwd6DG1MSAMfBVT2VqA61FnkA==
+"@firebase/database-types@1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@firebase/database-types/-/database-types-1.0.20.tgz#2050c3c13a4b71d92797e1475a297c0b5e0c9f5d"
+  integrity sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==
   dependencies:
     "@firebase/app-types" "0.9.5"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
 
-"@firebase/database@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-1.1.4.tgz#af9ada837b44e5b65b93d185ce950a1501877172"
-  integrity sha512-D+j4+8uhGtNd1tVD+X+c8JrC4ppStGJKyujSQt2NPwdN26QcCk0BeIxue+UqspHkHiFHyQOimwlzjLewGq6S+A==
+"@firebase/database@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@firebase/database/-/database-1.1.3.tgz#ae3b1c906c45d70381359e61b4add6fc4beaa51e"
+  integrity sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.4"
     "@firebase/auth-interop-types" "0.2.5"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     faye-websocket "0.11.4"
     tslib "^2.1.0"
 
-"@firebase/firestore-compat@0.4.12":
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.4.12.tgz#bfe962327a06ddb7df2d7262ebb045d6ed976ca3"
-  integrity sha512-k2uX81Ao/S0jnFcWGPOQpKK1cPlJHvD9WIqh/RE1XBDP2yg5zhE4rHhSg1rtB11k39q3nKon9XLNDDrPjGclag==
+"@firebase/firestore-compat@0.4.11":
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz#f382491377bad53e0aec888c62dfe400865266b5"
+  integrity sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/firestore" "4.17.0"
+    "@firebase/component" "0.7.3"
+    "@firebase/firestore" "4.16.0"
     "@firebase/firestore-types" "3.0.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/firestore-types@3.0.4":
@@ -1016,29 +1016,29 @@
   resolved "https://registry.yarnpkg.com/@firebase/firestore-types/-/firestore-types-3.0.4.tgz#a7205638195de1d356fbd39a620fd2d93c11d792"
   integrity sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==
 
-"@firebase/firestore@4.17.0":
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.17.0.tgz#5bc6c8ed1bbf9c30c91bb3df2ae143faede78d15"
-  integrity sha512-P9tof6pyO1bnLlMWbux+5O7WFJqlb7OTPMKxxOiXKYiQl7mxykAvxr1BFCgWeEXUU7DZxQncyJ040B0IhFVZCg==
+"@firebase/firestore@4.16.0":
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/@firebase/firestore/-/firestore-4.16.0.tgz#502b35d7ed4cdc61d62a02311a67145192c804f6"
+  integrity sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     "@firebase/webchannel-wrapper" "1.0.6"
     "@grpc/grpc-js" "~1.9.0"
     "@grpc/proto-loader" "^0.7.8"
-    re2js "^2.8.3"
+    re2js "^0.4.2"
     tslib "^2.1.0"
 
-"@firebase/functions-compat@0.4.6":
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.4.6.tgz#97a2c833d4a772694fa4a2c4e7358443bd98f4c2"
-  integrity sha512-dj9sOet+FIU91jeU4A3vGJoXHty7NqkSfjRLCwLgJXPDk1m72KFuxD3nlFgw/yXx/Fr7UjqzbxZ0LrIOdpx7+w==
+"@firebase/functions-compat@0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@firebase/functions-compat/-/functions-compat-0.4.5.tgz#5e22c71c5b11c7d49177fd7b0ff62d8583567604"
+  integrity sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/functions" "0.13.6"
+    "@firebase/component" "0.7.3"
+    "@firebase/functions" "0.13.5"
     "@firebase/functions-types" "0.6.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/functions-types@0.6.4":
@@ -1046,27 +1046,27 @@
   resolved "https://registry.yarnpkg.com/@firebase/functions-types/-/functions-types-0.6.4.tgz#bb73ed93aa396419f907967202572ea55a605a40"
   integrity sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==
 
-"@firebase/functions@0.13.6":
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.13.6.tgz#72d19d9b7d5a4136505333cd731a5f5aa8bbb59f"
-  integrity sha512-9obLnzeQUivK5lmtGFOU2ucQ38BjTp+jpPtbfFp/mDsdVCvEpRqdWNvMMQ6aQwR4vcVc/utsvngm5BRkXbc7ZA==
+"@firebase/functions@0.13.5":
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/@firebase/functions/-/functions-0.13.5.tgz#a4e099c072d7eac32b0f835438c45fa29a531e93"
+  integrity sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==
   dependencies:
     "@firebase/app-check-interop-types" "0.3.4"
     "@firebase/auth-interop-types" "0.2.5"
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/messaging-interop-types" "0.2.5"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/installations-compat@0.2.23":
-  version "0.2.23"
-  resolved "https://registry.yarnpkg.com/@firebase/installations-compat/-/installations-compat-0.2.23.tgz#4eeeb1c14c1bd193c802a1b0d161d1dfbf76ff5f"
-  integrity sha512-isaXmjb9roM83eVeXAe+ZRNKYNsSo2s0aNM+cy04AAGEyVL/d8Aa11GwEXovRFeYjl9+1yRAOxRDTOukZRwTxA==
+"@firebase/installations-compat@0.2.22":
+  version "0.2.22"
+  resolved "https://registry.yarnpkg.com/@firebase/installations-compat/-/installations-compat-0.2.22.tgz#d8287cef67879b3d3e796fc7e81256e1b75c8c8a"
+  integrity sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/installations-types" "0.5.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/installations-types@0.5.4":
@@ -1074,13 +1074,13 @@
   resolved "https://registry.yarnpkg.com/@firebase/installations-types/-/installations-types-0.5.4.tgz#3b1e41ae7d1b89eb3b4a1c9cc583a12bed83aa27"
   integrity sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==
 
-"@firebase/installations@0.6.23":
-  version "0.6.23"
-  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.6.23.tgz#687c03a51e8d30936d7673f879c388e8ac3593c8"
-  integrity sha512-MBkbcQfd+3qHjW+slsH4s7jH5qTdGlYpwqmxEZ7QcIpgDxu1SKyU0f+mCZhCt1BCacLNiOWF5L0R06N0LtlfMg==
+"@firebase/installations@0.6.22":
+  version "0.6.22"
+  resolved "https://registry.yarnpkg.com/@firebase/installations/-/installations-0.6.22.tgz#f5e7d2f51e58d22f8fd5c44901e56e3555d58837"
+  integrity sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     idb "7.1.1"
     tslib "^2.1.0"
 
@@ -1091,14 +1091,14 @@
   dependencies:
     tslib "^2.1.0"
 
-"@firebase/messaging-compat@0.2.28":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.28.tgz#f623183ca7ad1dddc50a1d4ab623b2bf937974bb"
-  integrity sha512-/AmMqHRnSQhPsdeED3ocs+s30/tpFvZDiiwIYY2uXFRvLujo1fnbPOeCFoe4Y+dRy1LCSjpvJf+dy5ZTsxi1yg==
+"@firebase/messaging-compat@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz#55a5d0754f54ecf9befac7c0574a2c8f6899b208"
+  integrity sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/messaging" "0.13.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/messaging" "0.13.0"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/messaging-interop-types@0.2.5":
@@ -1106,28 +1106,28 @@
   resolved "https://registry.yarnpkg.com/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz#078657f9be789bfaa31156a969630ecc4c0d5e16"
   integrity sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==
 
-"@firebase/messaging@0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.13.1.tgz#32beaa0d6967067ea589fc72f18a6156321ec5d9"
-  integrity sha512-kL8fdjbNBI7hprlXJrUjktDWosrpT4JtfwXtVVevImPF/rBRAsC+LS/jIs+kgQVuotnvMhaBCgAFipBoY9YU9g==
+"@firebase/messaging@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@firebase/messaging/-/messaging-0.13.0.tgz#40b0c9a564759c963527c8aef9038c438397c3c7"
+  integrity sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/messaging-interop-types" "0.2.5"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     idb "7.1.1"
     tslib "^2.1.0"
 
-"@firebase/performance-compat@0.2.26":
-  version "0.2.26"
-  resolved "https://registry.yarnpkg.com/@firebase/performance-compat/-/performance-compat-0.2.26.tgz#559a397ee5d0d0d50268d257198c8d2094cd5906"
-  integrity sha512-jgoocXLN6ao26xWQ8pzosmzQ33uLzGBJQPNK0NTbVy1XvIHr5pfgBf9hWLOxsWe+R7sJq5bjD+8ybXprmt61mA==
+"@firebase/performance-compat@0.2.25":
+  version "0.2.25"
+  resolved "https://registry.yarnpkg.com/@firebase/performance-compat/-/performance-compat-0.2.25.tgz#2c23654e67d974b0679b39a18a7672bf886d0bb5"
+  integrity sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/performance" "0.7.13"
+    "@firebase/performance" "0.7.12"
     "@firebase/performance-types" "0.2.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/performance-types@0.2.4":
@@ -1135,28 +1135,28 @@
   resolved "https://registry.yarnpkg.com/@firebase/performance-types/-/performance-types-0.2.4.tgz#9aa9e531f974f4b5e5a09bffff12406e0dc11e1f"
   integrity sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==
 
-"@firebase/performance@0.7.13":
-  version "0.7.13"
-  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.7.13.tgz#59cd61dd9edcb61b241e353118acfabd007a7030"
-  integrity sha512-1u6fuXP9cj0s+lkTFAspr/ttfPebPbEdpx+5Wdr4mPZbp8qH2KCMxOddEAR1ZMRa5GI0E7hDYSnolEmbqOFOAg==
+"@firebase/performance@0.7.12":
+  version "0.7.12"
+  resolved "https://registry.yarnpkg.com/@firebase/performance/-/performance-0.7.12.tgz#7d46c91f4942df365669dbb32492c100d069bad6"
+  integrity sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
     web-vitals "^4.2.4"
 
-"@firebase/remote-config-compat@0.2.28":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@firebase/remote-config-compat/-/remote-config-compat-0.2.28.tgz#4d26f630b2462b09ee1bf0c57f2d254bbd58da8d"
-  integrity sha512-kEO9Gn6fbmVj7eNUtZ6d59mLgUDUD0qo7aCicGOWNfuRWTaUv3CF9DMYychO61zaEQ3cfA+CEny4V1E8A1gRGA==
+"@firebase/remote-config-compat@0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz#19d05eb72deaf6f7205021c896f290c9426c13f1"
+  integrity sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==
   dependencies:
-    "@firebase/component" "0.7.4"
+    "@firebase/component" "0.7.3"
     "@firebase/logger" "0.5.1"
-    "@firebase/remote-config" "0.9.1"
+    "@firebase/remote-config" "0.9.0"
     "@firebase/remote-config-types" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/remote-config-types@0.5.1":
@@ -1164,26 +1164,26 @@
   resolved "https://registry.yarnpkg.com/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz#2bc52831f8b52aff2b1b434158b4f7803e05f86e"
   integrity sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==
 
-"@firebase/remote-config@0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.9.1.tgz#62cf8c305b8cd94f07fda5c8d531204b7175dab8"
-  integrity sha512-nzQUSJnk1zAZEl2Q5O3I7Z61cYLK5JI4H6wyyOiHkVZ+bmgy1YXNNMptNbVjixMQ/eCzgA6nZRaC+1eBcJGUFA==
+"@firebase/remote-config@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@firebase/remote-config/-/remote-config-0.9.0.tgz#f3d2b1a86c56a6f9da17602e8f4f347b4edee297"
+  integrity sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/installations" "0.6.23"
+    "@firebase/component" "0.7.3"
+    "@firebase/installations" "0.6.22"
     "@firebase/logger" "0.5.1"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/storage-compat@0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.4.4.tgz#7ddc6769047fbc276cbf08ddd1fc24f533c391a1"
-  integrity sha512-qSRgCB9f2R/nCp8t/8OC101cIFBFeUazlRInOMdzbnLzvrQBzEfx19SrR4pvdj/0+M+P/y8AK/a2s+3EB+B1Pw==
+"@firebase/storage-compat@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@firebase/storage-compat/-/storage-compat-0.4.3.tgz#85a01de8fbd0ef4cad261d39beea5e6391e5a051"
+  integrity sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/storage" "0.14.4"
+    "@firebase/component" "0.7.3"
+    "@firebase/storage" "0.14.3"
     "@firebase/storage-types" "0.8.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
 "@firebase/storage-types@0.8.4":
@@ -1191,19 +1191,19 @@
   resolved "https://registry.yarnpkg.com/@firebase/storage-types/-/storage-types-0.8.4.tgz#88d72c80eb9a1167da33e8c551fd3b703c2422ec"
   integrity sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==
 
-"@firebase/storage@0.14.4":
-  version "0.14.4"
-  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.14.4.tgz#110afe6d6256e2b339d690e36578abcc12ccc8ce"
-  integrity sha512-jfzEWZb3Fpsq3FwAB2ifoc8mcSh935qXdDou3TpyjDWa45hhNcZUv8/w28/10njByhfK7snbakKN30nwnzQ3/w==
+"@firebase/storage@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@firebase/storage/-/storage-0.14.3.tgz#df93f895ff6f296e9305933cfe6c387d19fa4f93"
+  integrity sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==
   dependencies:
-    "@firebase/component" "0.7.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/component" "0.7.3"
+    "@firebase/util" "1.15.1"
     tslib "^2.1.0"
 
-"@firebase/util@1.15.2":
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.15.2.tgz#0650ace6fa8b98c772910e9fe50e20e61f4093f4"
-  integrity sha512-974pWIZVLDMc5GW5YAsj8y0XxULxIy/sPUy7tsxmWbF93KRIyh9xpuHlh0zDL+shUcf5nHDjFOg9YLiQ763eiA==
+"@firebase/util@1.15.1":
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/@firebase/util/-/util-1.15.1.tgz#7efaf8903f50b601c06afbaffbeb48ed2ba7aab8"
+  integrity sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==
   dependencies:
     tslib "^2.1.0"
 
@@ -1889,13 +1889,6 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
-
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -4387,11 +4380,6 @@ chokidar@^5.0.0:
   dependencies:
     readdirp "^5.0.0"
 
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
-
 chromium-bidi@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-17.0.2.tgz#921a586deecd0c2d8b9242c4c1b73c3aa39ff77c"
@@ -6059,39 +6047,39 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
-firebase@^12.17.0:
-  version "12.17.0"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-12.17.0.tgz#44c43984a50ce6ace7fcd9b8c67ec1f2d23a9aad"
-  integrity sha512-8iENFg2/k7asnybijN3ZrmTag0BuyiihUXrRZkX+yCW+YocknpzPZ4DUkdbyA/rdrdaCssBqHH8zpdDliv+4ng==
+firebase@12.16.0:
+  version "12.16.0"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-12.16.0.tgz#d94f3827626314e310c434c55a50542495b6151f"
+  integrity sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==
   dependencies:
-    "@firebase/ai" "2.14.0"
-    "@firebase/analytics" "0.10.23"
-    "@firebase/analytics-compat" "0.2.29"
-    "@firebase/app" "0.16.0"
-    "@firebase/app-check" "0.13.0"
-    "@firebase/app-check-compat" "0.4.6"
-    "@firebase/app-compat" "0.5.16"
+    "@firebase/ai" "2.13.1"
+    "@firebase/analytics" "0.10.22"
+    "@firebase/analytics-compat" "0.2.28"
+    "@firebase/app" "0.15.1"
+    "@firebase/app-check" "0.12.0"
+    "@firebase/app-check-compat" "0.4.5"
+    "@firebase/app-compat" "0.5.15"
     "@firebase/app-types" "0.9.5"
-    "@firebase/auth" "1.13.4"
-    "@firebase/auth-compat" "0.6.9"
-    "@firebase/data-connect" "0.7.2"
-    "@firebase/database" "1.1.4"
-    "@firebase/database-compat" "2.1.5"
-    "@firebase/firestore" "4.17.0"
-    "@firebase/firestore-compat" "0.4.12"
-    "@firebase/functions" "0.13.6"
-    "@firebase/functions-compat" "0.4.6"
-    "@firebase/installations" "0.6.23"
-    "@firebase/installations-compat" "0.2.23"
-    "@firebase/messaging" "0.13.1"
-    "@firebase/messaging-compat" "0.2.28"
-    "@firebase/performance" "0.7.13"
-    "@firebase/performance-compat" "0.2.26"
-    "@firebase/remote-config" "0.9.1"
-    "@firebase/remote-config-compat" "0.2.28"
-    "@firebase/storage" "0.14.4"
-    "@firebase/storage-compat" "0.4.4"
-    "@firebase/util" "1.15.2"
+    "@firebase/auth" "1.13.3"
+    "@firebase/auth-compat" "0.6.8"
+    "@firebase/data-connect" "0.7.1"
+    "@firebase/database" "1.1.3"
+    "@firebase/database-compat" "2.1.4"
+    "@firebase/firestore" "4.16.0"
+    "@firebase/firestore-compat" "0.4.11"
+    "@firebase/functions" "0.13.5"
+    "@firebase/functions-compat" "0.4.5"
+    "@firebase/installations" "0.6.22"
+    "@firebase/installations-compat" "0.2.22"
+    "@firebase/messaging" "0.13.0"
+    "@firebase/messaging-compat" "0.2.27"
+    "@firebase/performance" "0.7.12"
+    "@firebase/performance-compat" "0.2.25"
+    "@firebase/remote-config" "0.9.0"
+    "@firebase/remote-config-compat" "0.2.27"
+    "@firebase/storage" "0.14.3"
+    "@firebase/storage-compat" "0.4.3"
+    "@firebase/util" "1.15.1"
 
 flat-cache@^4.0.0:
   version "4.0.1"
@@ -7959,17 +7947,10 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
-
-minizlib@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
-  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
-  dependencies:
-    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -8917,10 +8898,10 @@ raw-body@^3.0.0, raw-body@^3.0.2:
     iconv-lite "~0.7.0"
     unpipe "~1.0.0"
 
-re2js@^2.8.3:
-  version "2.8.6"
-  resolved "https://registry.yarnpkg.com/re2js/-/re2js-2.8.6.tgz#acbd17a1ad0e98c1f2ee0a2adc17ba0903d9ca95"
-  integrity sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==
+re2js@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/re2js/-/re2js-0.4.3.tgz#1318cd0c12aa6ed3ba56d5e012311ffbfb2aef35"
+  integrity sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==
 
 readable-stream@>=4.0.0, readable-stream@^4.0.0:
   version "4.7.0"
@@ -9873,17 +9854,6 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.22:
-  version "7.5.22"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
-  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -10186,7 +10156,17 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.28.0, undici@7.29.0, undici@^6.27.0, undici@^7.25.0, undici@^7.29.0:
+undici@7.28.0, undici@^7.25.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+
+undici@^6.27.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
+
+undici@^7.29.0:
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
   integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
@@ -10317,10 +10297,20 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, uuid@14.0.1, uuid@^10.0.0, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1, uuid@^8.3.0:
+uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -10746,11 +10736,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

リモートホストの「Google でサインイン」が `Database is closing/hidden` で失敗する #2835 の回避として、
**`firebase` を 12.16.0 に完全固定**します。アプリのコードは変更していません。

原因は `@firebase/auth` 1.13.4 のリグレッション（上流 [firebase-js-sdk#10264](https://github.com/firebase/firebase-js-sdk/issues/10264)）。
1.13.4 が `IndexedDBLocalPersistence` に `visibilitychange` リスナを足し、
`document.visibilityState === 'hidden'` をページ teardown と同じ扱いにしたため、
サインインのポップアップが元ウィンドウを背面に回した状態で認証情報を永続化しようとすると
`_openDb()` が throw します。

```
signInWithPopup → PopupOperation → _signIn
  → _signInWithCredential(auth, IdpCredential, bypassAuthState=false)
  → auth._updateCurrentUser → directlySetCurrentUser
  → assertedPersistence.setCurrentUser → IndexedDBLocalPersistence._set
  → _withRetries → _openDb → throw new Error('Database is closing/hidden')
```

`_withRetries()` は `isHiding` のときリトライせず rethrow するので回復経路がありません。
**読み取り（`_poll()`）は `isHiding` を見て `[]` を返して握りつぶすのに、書き込み（`_set` / `_remove`）だけ
例外を上げる**という非対称が芯です。`signInWithPopup` が reject するため idToken を取得できず
`/connect` に到達せず、`errorMessage()` が Error の `message` を返すので SDK の生文字列が画面に出ます。

### なぜピン留めか

上流は **PR [#10300](https://github.com/firebase/firebase-js-sdk/pull/10300) で修正済み（2026-08-13 merge、listener 完全削除）ですが、まだ npm に出ていません**。
`@firebase/auth` の latest は 1.13.4 のままで、`firebase@12.17.1`（最新）も 1.13.4 を同梱しています。
つまり**上げても直らず、待つ手も今は使えません**。12.16.0 は `@firebase/auth` 1.13.3 を同梱する最新の 12.x です。

`^12.16.0` ではなく **`12.16.0`（キャレット無し）**にしています。キャレットだと 12.17.x に浮いて 1.13.4 に戻ります。

**2箇所を変更しています。** ルートだけでは npm 利用者に届きません:

| ファイル | 役割 |
|---|---|
| `package.json` | 開発・ビルド時の解決。ブラウザ束は build 時に焼き込まれる |
| `packages/mulmoclaude/package.json` | ランチャーの runtime 依存。`server/remoteHost/*` が `firebase/storage` を実行時に import するので、ここが `^12.17.0` のままだと npm 利用者側で 12.17.x が解決される |

`packages/core` は `firebase: ^12.0.0` を optional peer で宣言しており 12.16.0 で満たされるため変更不要です。

### 検証

| 確認 | 方法 | 結果 |
|---|---|---|
| エラー文字列の出どころ | SDK 全文検索 | `_openDb()` の1箇所のみ。出た時点で `isHiding === true` が確定 |
| リグレッションか | 1.13.3 / 1.13.4 の tarball 差分 | `isHiding` / `visibilitychange` / 当該文字列は 1.13.3 に **0件**、1.13.4 で新規追加 |
| 実際に落ちるか | Playwright + Chromium で実 SDK を実行し、visibility 遷移をまたいで永続化書き込みを走らせた | 1.13.4 + `indexedDBLocalPersistence` は hidden で `THREW: Database is closing/hidden`、`inMemoryPersistence` は通る |
| ピン留めで直るか | 同じハーネスを 12.16.0 install 後に再実行 | hidden でも OK（下記の実行結果を参照） |
| lockfile の健全性 | `rm -rf node_modules && yarn install --frozen-lockfile` | 落ちた推移的依存なし |

lockfile の差分は `@firebase/*` 一族の 12.17.0 → 12.16.0 一括ダウングレードのほかに、
**孤児だった `tar@7.5.22` と `@isaacs/fs-minipass@4.0.1` の stanza が GC されています**。
`tar` は `resolutions` にだけ書かれていて依存グラフ上どこからも要求されておらず（変更前の lockfile でも同じ）、
`yarn add` が今回まとめて刈り取ったものです。`resolutions` のエントリ自体は触っていません。

## Items to Confirm / Review

- **`firebase` を完全固定（キャレット無し）にした判断。** キャレットのままだと 12.17.x に浮いて
  不具合が再発するため、意図的にレンジを外しています。**解除は手動**になります。
  なお `.github/dependabot.yml` は npm の version update を意図的に対象外にしている（#2875）ので
  Dependabot が勝手に上げることはありませんが、**リポジトリ設定の npm security update と、
  手動の `yarn upgrade --latest` はこのピンを外し得ます**。
- **#2835 をこの PR では閉じていません**（`Closes` を書いていません）。ピン留めは回避であって
  原因の除去ではなく、上流版に戻すまでが完了だからです。issue は open のまま残します。
- **ランチャー側も固定した点。** ブラウザ束は build 時に焼き込まれるので #2835 の症状自体は
  ルートの固定で消えますが、`server/` が runtime で `firebase/storage` を引くため、
  版ズレを避けて両方を揃えています。
- **実際の Google アカウントでのサインイン通しは未確認**です。手元に検証用アカウントが無いため、
  1.13.3 で永続化書き込みが hidden 状態でも通ることをハーネスで確認するに留めています。
- ダウングレードにより `@firebase/*` 一族が一段古くなります（`firestore` 4.17.0 → 4.16.0、
  `storage` 0.14.4 → 0.14.3 など）。リモートホスト以外の Firebase 利用箇所への影響は見ていません。

## 解除の手順

`@firebase/auth` が 1.13.5 以上（= PR #10300 を含む `firebase` リリース）を同梱したら:

1. `npm view firebase@latest dependencies.@firebase/auth` で 1.13.5 以上を確認
2. `yarn add firebase@^<新バージョン> -W` と `yarn workspace mulmoclaude add firebase@^<新バージョン>`
3. #2835 をクローズ

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2835 の原因を調べてほしい。pin でのダウングレードはしたくない。
- （調査結果を確認したうえで）では一旦ダウングレードして、issue は open のままにして更新版が出たら上げる、とする。ピン留めで。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude5

## Summary by Sourcery

Pin Firebase dependency to version 12.16.0 to work around a regression in @firebase/auth that breaks Google sign-in on the remote host, and document the investigation and pinning strategy.

Bug Fixes:
- Prevent remote host Google sign-in failures caused by the @firebase/auth 1.13.4 IndexedDB persistence regression by downgrading Firebase.

Enhancements:
- Align root and mulmoclaude workspace Firebase versions to avoid runtime mismatches for npm users while the pin is in effect.

Documentation:
- Add an internal plan document describing the root cause of issue #2835, the decision to pin Firebase to 12.16.0, and the conditions and procedure for lifting the pin in a future release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google sign-in failures caused by a Firebase authentication regression.
  * Improved authentication reliability when the app is hidden or switched away from.
* **Chores**
  * Pinned Firebase to version 12.16.0 for consistent authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->