### PR TITLE
chore(deps): bump github/codeql-action from v4.37.6 to v4.37.7

### DIFF
--- a/.github/workflows/duplication-scan.yaml
+++ b/.github/workflows/duplication-scan.yaml
@@ -123,7 +123,7 @@ jobs:
       - name: Upload SARIF to Code Scanning
         # Hash-pinned: .github/zizmor.yml grants a tag-pin exemption to
         # `actions/*` only, and codeql-action lives under `github/*`.
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
         with:
           sarif_file: report/jscpd-report.sarif
           # Distinct category keeps these alerts from colliding with the


### PR DESCRIPTION
## Summary

`duplication-scan.yaml` の `github/codeql-action/upload-sarif` のハッシュピンを **v4.37.6 → v4.37.7** に更新します。

```diff
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
```

SHA の解決手順（annotated tag なので commit まで deref した）:

| 参照 | 値 |
|---|---|
| `refs/tags/v4.37.7` (tag object) | `faaa5d804fc648d0fdb28822a8e36cf7d0a6132c` |
| deref した commit | `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd` (2026-08-13) |
| 浮動タグ `v4` の指す commit | 同上 — v4 系の最新であることを確認 |

## Items to Confirm / Review

- **実質的な挙動変更は無いはず。** v4.37.7 のリリース内容は "Update default CodeQL bundle version to 2.26.3" のみで、このジョブが使う `upload-sarif` は CodeQL バンドルを消費しない。つまり SARIF アップロードの動作には影響しないという読みです。ここが合っているかを確認してほしい。
- **`.github/dependabot.yml` (#2875) と重複する可能性。** `github-actions` の version update は weekly・グループ1PR で回っており、v4.37.6 もそれが入れたもの。次回の実行でこれと同じ bump が提案される可能性があります。手で先出しする価値があるかは判断してほしい（無ければクローズで構いません）。
- ピンは 40 桁 SHA のままなので `.github/zizmor.yml` の `"*": hash-pin` ポリシーは満たしています（`actions/*` の ref-pin 例外は `github/*` には効かない、というコード内コメントの前提も変わっていません）。

## 検証

- `actionlint` 1.7.12 相当をローカル実行 → **exit 0**（全ワークフロー対象）
- zizmor はローカル未インストールのため実行できていません。**CI の `workflow-lint` ジョブでの確認が必要**です。
- 変更は 1 ファイル 1 行のみで、`run:` ブロックやジョブ構成には触れていません。

## User Prompt

> knip clean（exit 0）。codeql-action は mulmoterminal の v3.37.1 からメジャーが1つ進んで v4.37.7 が最新なので、そちらの commit SHA を解決してピンします。

補足: 依頼時点のローカル `main` は古く、v3.37.1 が見えていました。`origin/main` は既に v4.37.6 まで進んでいた（dependabot 由来）ため、実際の差分はメジャー1つではなくパッチ1つです。

work in mulmoclaude4

## Summary by Sourcery

CI:
- Bump github/codeql-action/upload-sarif in duplication-scan.yaml from v4.37.6 to v4.37.7 while retaining SHA pinning for workflow security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use the latest pinned CodeQL upload action version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->