### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.13.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+## [1.13.2] - 2026-08-15
+
+**Google sign-in on the remote host works again, and the plugin family that had
+been sitting unpublished since June finally reaches npm.**
+
 ### Added
 
 #### An `enum` field can declare the value a new record starts on (#2839)
@@ -169,6 +174,25 @@ Design: mulmoterminal `plans/refactor-shared-app-module.md`.
 Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ### Fixed
+
+#### Remote host: Google sign-in failed with `Database is closing/hidden` (#2835, #2912)
+
+Pressing **Sign in with Google** left the remote host offline behind a red
+`Database is closing/hidden`, reproducibly, in both Chrome and Safari on macOS.
+Nothing in MulmoClaude was wrong: `@firebase/auth` 1.13.4 added a
+`visibilitychange` listener to `IndexedDBLocalPersistence` that treats a hidden
+document as page teardown. The sign-in popup backgrounds the opener, so the
+credential write `signInWithPopup` performs on return hits `_openDb()` while the
+database is closed and throws. Reads degrade to an empty result; writes are
+fatal and `_withRetries` does not retry them, so there is no recovery path — the
+idToken is never handed back and `/connect` is never reached.
+
+Upstream fixed it in firebase-js-sdk#10300 but has not published it, and
+`firebase@12.17.1` still carries the broken auth. `firebase` is therefore pinned
+to an exact `12.16.0` — the newest 12.x on `@firebase/auth` 1.13.3 — in the root
+and in the launcher alike, since `server/remoteHost/` resolves `firebase` from
+the launcher at runtime. The caret is deliberately gone so nothing floats back
+to 12.17.x; #2835 stays open until a fixed release lets the pin be lifted.
 
 #### A Web Push that does not arrive now says why in the log (#2903)
 
@@ -484,10 +508,6 @@ is people.
   instead of a permission denial that says nothing about identity. **Breaking
   for a host that calls `setFirestoreAccessor`**; MulmoClaude's binding is
   updated here, and MulmoTerminal binds no accessor.
-
-### Package releases
-
-Ships `@mulmoclaude/core@3.13.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/accounting-plugin@2.2.0`, `@mulmoclaude/chart-plugin@2.1.0`, `@mulmoclaude/collection-plugin@3.1.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@2.2.0`, `@mulmoclaude/html-plugin@3.0.0`, `@mulmoclaude/markdown-plugin@3.0.0`, `@mulmoclaude/mulmoscript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.1] - 2026-08-10
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.13.1",
+  "version": "1.13.2",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,6 +1890,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
+
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
@@ -4379,6 +4386,11 @@ chokidar@^5.0.0:
   integrity sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==
   dependencies:
     readdirp "^5.0.0"
+
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chromium-bidi@17.0.2:
   version "17.0.2"
@@ -7947,10 +7959,17 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mitt@^3.0.1:
   version "3.0.1"
@@ -9854,6 +9873,17 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
+tar@7.5.22:
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
+
 teeny-request@^10.0.0:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/teeny-request/-/teeny-request-10.1.2.tgz#13aa65d98dce099a85bfc6ef77760b536e3cc040"
@@ -10156,20 +10186,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.28.0, undici@^7.25.0:
+undici@7.28.0, undici@^6.27.0, undici@^7.25.0, undici@^7.29.0:
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
-
-undici@^6.27.0:
-  version "6.28.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
-  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
-
-undici@^7.29.0:
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
-  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 unenv@2.0.0-rc.24:
   version "2.0.0-rc.24"
@@ -10297,20 +10317,10 @@ utrie@^1.0.2:
   dependencies:
     base64-arraybuffer "^1.0.2"
 
-uuid@*, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1:
+uuid@*, uuid@14.0.1, uuid@^10.0.0, "uuid@^11.1.0 || ^12 || ^13 || ^14.0.0", uuid@^14.0.1, uuid@^8.3.0:
   version "14.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
   integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
-
-uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vary@^1, vary@^1.1.2:
   version "1.1.2"
@@ -10736,6 +10746,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yaml-eslint-parser@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

`mulmoclaude@1.13.2` を npm に出すためのリリース PR です。ルートとランチャーの version を 1.13.2 に揃え、`docs/CHANGELOG.md` の `[Unreleased]` を `## [1.13.2] - 2026-08-15` に確定させます。

**このリリースの主目的は #2835（リモートホストの Google サインインが `Database is closing/hidden` で失敗）の修正を npm 利用者に届けることです。** 修正自体は #2912 で main に入っていますが、`firebase` のピンは `packages/mulmoclaude/package.json` の依存レンジなので、ランチャーを publish しない限り npm 経由の利用者には届きません（npm の `mulmoclaude@1.13.1` は今も `firebase: ^12.17.0` を宣言しています）。

### 先行して publish した6プラグイン（この PR の前提）

`/publish-mulmoclaude` の §6 チェックで、**ランチャーの依存6本がローカルだけ major を上げて npm 未公開**であることを検出しました。ランチャーの宣言レンジはすでに新 major を指しているため、このまま publish すると `npx mulmoclaude@1.13.2` が ETARGET で**インストール不能**になります（実際に npm で解決を試して確認）。

| プラグイン | publish 前の npm | 今回 publish |
|---|---|---|
| `@mulmoclaude/accounting-plugin` | 2.2.0 | **3.0.0** |
| `@mulmoclaude/chart-plugin` | 2.1.0 | **3.0.0** |
| `@mulmoclaude/google-plugin` | 2.2.0 | **3.0.0** |
| `@mulmoclaude/html-plugin` | 3.0.0 | **4.0.0** |
| `@mulmoclaude/markdown-plugin` | 3.0.0 | **4.0.0** |
| `@mulmoclaude/mulmoscript-plugin` | 2.1.0 | **3.0.0** |

major になっている理由は正当です。各プラグインが `@mulmoclaude/core` を `dependencies` から外して `peerDependencies` のみに移し（CLAUDE.md の「host が供給するものは peer + dev、`dependencies` には絶対に書かない」ルール）、peer レンジを `^4.1.0` に上げています。consumer にとって破壊的変更なので major が正しい semver です。6本とも `@scope/name@X.Y.Z` タグと `--latest=false` の GH リリースを作成済みです。

### publish 前チェックの結果

| 項目 | 結果 |
|---|---|
| §1 依存監査 (`deps.mjs`) | ✅ 不足なし |
| §2 workspace drift (`drift.mjs`) | ✅ `@mulmobridge/*` 4本とも `src == published` |
| §3 build | ✅ `yarn install` / `yarn build` とも exit 0 |
| §3.5 README | ✅ 185行、CLI フラグ・env var・ブリッジ一覧が実装と一致 |
| §4 tarball smoke | ✅ pack → clean install → 起動 → HTTP 200 |
| §6 内部依存の公開状況 | ✅ 6本 publish 後、13本すべて解決 |
| `check:changelog-ships` | ✅ `[1.13.2]` が 13 依存すべてを列挙 |

## Items to Confirm / Review

- **1.13.2（patch）にした判断。** v1.13.1 以降に 38 本の PR がマージされており、コレクションの検索・ソート、共有アプリ、broker observability など**機能追加が多数含まれます**。semver としては minor が素直で、私は 1.14.0 を推奨しましたが、今回のリリースの主目的が #2835 のバグ修正であることを重視して patch を選ぶ判断がなされています。CHANGELOG の `[1.13.2]` セクションには `### Added` が2ブロック分入っているので、番号と中身の食い違いは残ります。
- **プラグイン6本を major で publish したこと。** 破壊的変更なので、`@mulmoclaude/core` 3.x をピンしている外部の利用者がいれば影響します（peer が `^4.1.0` になるため）。
- **CHANGELOG の重複 `Ships` 行を1本削除しました。** `[Unreleased]` に古い版（core@3.13.0 等）と新しい版（core@4.1.0 等）の2本が入っていて、1つのリリースセクションとして矛盾していたため、ランチャーの実際の依存と一致する新しい方を残しています。
- **`yarn.lock` の差分**は `tar@7.5.22` と `@isaacs/fs-minipass@4.0.1` の孤児 stanza が戻っただけです（`resolutions` にあるだけで依存グラフ上どこからも要求されていない。`yarn add` が刈り取り、`yarn install` が復元する往復）。
- **#2835 は open のまま**です。ピン留めは回避なので、`@firebase/auth` >= 1.13.5 を同梱する `firebase` リリースが出たら解除してクローズします。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2835 の原因を調べてほしい。pin でのダウングレードはしたくない。
- （調査結果を確認したうえで）では一旦ダウングレードして、issue は open のままにして更新版が出たら上げる、とする。ピン留めで。
- コミットして。PR を作って。
- （マージ後）`/publish-mulmoclaude` を実行。未公開の6プラグインは major で publish し、ランチャーは 1.13.2（patch）で出す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude5

## Summary by Sourcery

Prepare the 1.13.2 MulmoClaude release, documenting the Google sign-in fix and aligning package versions for publishing.

Bug Fixes:
- Document the remote-host Google sign-in failure and its mitigation via pinning firebase to a fixed version.

Enhancements:
- Clarify changelog entries by finalizing the 1.13.2 release section and removing a conflicting older package release line.

Build:
- Bump the monorepo root and launcher package versions from 1.13.1 to 1.13.2 for release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored Google sign-in when accessing the application from remote hosts.
  * Corrected a Firebase authentication regression.

* **New Features**
  * Previously unpublished plugins are now available through npm.

* **Chores**
  * Released version 1.13.2 with updated changelog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->