### PR TITLE
chore(release): @mulmoclaude/core 4.1.1 — publish 済み 4.1.0 とのドリフト修復

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Fixed
+
+#### `@mulmoclaude/core@4.1.0` on npm is not the 4.1.0 in this tree — republished as 4.1.1
+
+npm's 4.1.0 was published at 2026-08-14 18:56 UTC. PR #2915 merged at 23:16 UTC
+and added `putItems`' `itemsFile` to the SAME version number, so two different
+builds of `@mulmoclaude/core` now answer to 4.1.0: the published one has zero
+occurrences of `itemsFile` in `dist/`, and zero in `assets/` — neither the code
+nor the `collection-skills.md` / `error-recovery.md` text that documents it.
+The tree's 4.1.0 carries 345 more lines across those three files.
+
+A version is a promise about bits, so the repair is a new number rather than a
+re-publish of the old one: nothing that already resolved 4.1.0 would fetch it
+again, and a `^` range that picked up the drifted copy would keep it forever.
+4.1.1 gives every consumer one copy to converge on.
+
+Only `core`'s version and the launcher's DEP RANGE move. The plugins keep
+`^4.1.0` — a caret floats across patches, so they resolve 4.1.1 on their own,
+and ratcheting them here would force a publish cascade for no gain. The
+launcher's own `version` stays at 1.13.2: that field is the `/publish-mulmoclaude`
+flow's to move, and 1.13.2 already declares `^4.1.0`, which floats to 4.1.1 too.
+
+Note for whoever publishes: this delivers the core half only. The host half of
+#2915 — `server/agent/containerPaths.ts` and the `mcp-tools` binding that
+supplies `sandboxWorkspacePath` — lives under `server/`, which reaches npm users
+ONLY through a `mulmoclaude` publish. Until that happens, an npm-installed
+sandboxed agent gets the `itemsFile` argument without the container-path
+translation behind it.
+
+### Package releases
+
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.1.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.1.1`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ## [1.13.2] - 2026-08-15
 
 **Google sign-in on the remote host works again, and the plugin family that had

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.1.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.1.0",
+    "@mulmoclaude/core": "^4.1.1",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",


### PR DESCRIPTION
`@mulmoclaude/core` を 4.1.0 → **4.1.1** に上げ、ランチャーの dep range を追随させます。

## なぜ

npm の 4.1.0 と、この tree の 4.1.0 は**別物**です。

| | |
|---|---|
| npm が 4.1.0 を publish | 2026-08-14 **18:56** UTC |
| PR #2915（`itemsFile`）が main にマージ | 2026-08-14 **23:16** UTC |

PR #2915 は同じバージョン番号のまま `putItems` の `itemsFile` を足したので、`@mulmoclaude/core@4.1.0` という 1 つの名前に 2 つのビルドが答える状態になっています。

確認した内容:

- タグ `@mulmoclaude/core@4.1.0` の `manageTool.ts` に `itemsFile` は **0 件**
- npm から取得した 4.1.0 の tarball — `dist/` **0 件**、`assets/` **0 件**（コードも、それを説明する `collection-skills.md` / `error-recovery.md` の記述も入っていない）
- タグからの差分: `packages/core` の 3 ファイルに **345 行**（`manageTool.ts` +275、helps 2 ファイル）

つまり npm 経由の利用者は、`itemsFile` のコードもドキュメントも受け取れていません。

## なぜ再 publish ではなく新しい番号か

バージョンはビットに対する約束だからです。同じ 4.1.0 を publish し直しても、既にそれを解決したものは取り直しませんし、ドリフトしたコピーを掴んだ `^` レンジはそれを持ち続けます。4.1.1 なら全ての consumer が 1 つのコピーに収束します。

## 変更範囲

- `packages/core/package.json` — `version: 4.1.1`
- `packages/mulmoclaude/package.json` — `@mulmoclaude/core: ^4.1.1`（launcherSync の workspace-lockstep 不変条件のため）
- `docs/CHANGELOG.md` — `[Unreleased]` に Fixed エントリと Ships 行

**動かしていないもの:**

- **プラグインの range は `^4.1.0` のまま。** caret は patch を跨いで浮くので自力で 4.1.1 を解決します。core の patch bump でプラグインを ratchet すると無駄な publish カスケードになります。
- **ランチャー自身の `version` は 1.13.2 のまま。** CLAUDE.md の `chore(release)` ルール通り、このフィールドは `/publish-mulmoclaude` が動かすものです。1.13.2 は既に `^4.1.0` を宣言しており、これも 4.1.1 に浮きます。
- **`[1.13.2]` セクションの Ships 行は書き換えていません。** 出荷済みの記録なので、新しい `[Unreleased]` セクションを立てました（ships gate は `[Unreleased]` があればそちらを見ます）。

## publish する人への注意

これで届くのは **core の半分だけ**です。#2915 のホスト側 — `server/agent/containerPaths.ts` と `sandboxWorkspacePath` を供給する `mcp-tools` バインディング — は `server/` 配下にあり、**`mulmoclaude` の publish 経由でしか npm 利用者に届きません**。それまでは、npm でインストールされた sandbox 内エージェントは `itemsFile` 引数を受け取るものの、その裏にあるコンテナパス翻訳が無い状態になります。

## 検証

`yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn test`（0 fail）/ `yarn check:launcher-sync` / `check-changelog-ships` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Bump @mulmoclaude/core to 4.1.1 and align the launcher dependency range to repair a version drift between the npm-published 4.1.0 and the repository’s 4.1.0, documenting the fix and updated shipped package set in the changelog.

Enhancements:
- Update @mulmoclaude/core package version from 4.1.0 to 4.1.1 to unify consumers on a single correct build.
- Adjust the mulmoclaude launcher’s dependency on @mulmoclaude/core to ^4.1.1 while leaving plugin ranges at ^4.1.0 to avoid unnecessary publishes.

Documentation:
- Add an Unreleased changelog entry explaining the 4.1.0 npm drift and its correction via 4.1.1, plus a Ships line listing the current package releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Republished `@mulmoclaude/core` as version 4.1.1 to resolve inconsistent package contents from version 4.1.0.
  * Updated the launcher to use the corrected core package version.

* **Documentation**
  * Added changelog details covering the package release and related version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->