### PR TITLE
fix(core): 共有コレクションのサーバ時刻を境界で 1 つの形にする

### DIFF
--- a/packages/core/src/collection/core/calendarGrid.ts
+++ b/packages/core/src/collection/core/calendarGrid.ts
@@ -4,6 +4,14 @@
 // function takes its inputs explicitly so the logic is unit-testable
 // without faking the clock. All internal arithmetic runs in UTC (which
 // has no DST), so fixed 86_400_000 ms steps never skip or double a day.
+//
+// ONE deliberate exception, `localCivilOf`: a server-stamped instant is a point
+// in time rather than a wall clock, so asking which day it lands on is a
+// question about the reader's zone and cannot be answered in UTC without
+// answering it wrongly for most readers. It is the only function here whose
+// result depends on the environment, and its tests pin TZ.
+
+import { serverTimeMillis } from "./serverTime";
 
 const MS_PER_DAY = 86_400_000;
 const ISO_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -102,15 +110,39 @@ export function parseIsoDateTime(value: unknown): { ymd: Ymd; minutes: number } 
   return { ymd, minutes };
 }
 
-/** Civil date from either a `YYYY-MM-DD` or a `YYYY-MM-DDTHH:MM` value, so the
- *  month grid buckets date-only and datetime anchors alike. */
+/** A server-stamped instant as the civil time it happened at HERE.
+ *
+ *  `parseIsoDateTime` stays strict and stays civil: it is what the grid, the
+ *  trigger and the spawn code parse, and teaching it to swallow an absolute
+ *  instant would mean placing an instant on a civil grid with no zone — the
+ *  thing its strictness prevents. So the conversion happens at the placement
+ *  instead, and it happens ONCE.
+ *
+ *  LOCAL rather than UTC, deliberately. An instant is a point in time, and the
+ *  question the grid answers is "which of MY days was that". A Tokyo evening
+ *  booking sits on the correct day for the person in Tokyo and on the previous
+ *  one in UTC. The cost is that two people in different zones can see the same
+ *  record on different days — which is what an absolute instant honestly means,
+ *  where a civil `YYYY-MM-DDTHH:MM` means the same wall clock for everyone. */
+function localCivilOf(value: unknown): { ymd: Ymd; minutes: number } | null {
+  const millis = serverTimeMillis(value);
+  if (millis === null) return null;
+  const at = new Date(millis);
+  return {
+    ymd: { year: at.getFullYear(), month: at.getMonth() + 1, day: at.getDate() },
+    minutes: at.getHours() * 60 + at.getMinutes(),
+  };
+}
+
+/** Civil date from a `YYYY-MM-DD`, a `YYYY-MM-DDTHH:MM`, or a server-stamped
+ *  instant, so the month grid buckets all three alike. */
 export function dateOf(value: unknown): Ymd | null {
-  return parseIsoDate(value) ?? parseIsoDateTime(value)?.ymd ?? null;
+  return parseIsoDate(value) ?? parseIsoDateTime(value)?.ymd ?? localCivilOf(value)?.ymd ?? null;
 }
 
 /** Minutes-of-day from a datetime value, or null for date-only / invalid. */
 function timeOf(value: unknown): number | null {
-  return parseIsoDateTime(value)?.minutes ?? null;
+  return parseIsoDateTime(value)?.minutes ?? localCivilOf(value)?.minutes ?? null;
 }
 
 /** Parse a free-form time-string field into start/end minutes-of-day.

--- a/packages/core/src/collection/core/calendarGrid.ts
+++ b/packages/core/src/collection/core/calendarGrid.ts
@@ -127,10 +127,10 @@ export function parseIsoDateTime(value: unknown): { ymd: Ymd; minutes: number } 
 function localCivilOf(value: unknown): { ymd: Ymd; minutes: number } | null {
   const millis = serverTimeMillis(value);
   if (millis === null) return null;
-  const at = new Date(millis);
+  const instant = new Date(millis);
   return {
-    ymd: { year: at.getFullYear(), month: at.getMonth() + 1, day: at.getDate() },
-    minutes: at.getHours() * 60 + at.getMinutes(),
+    ymd: { year: instant.getFullYear(), month: instant.getMonth() + 1, day: instant.getDate() },
+    minutes: instant.getHours() * 60 + instant.getMinutes(),
   };
 }
 

--- a/packages/core/src/collection/core/recordZ.ts
+++ b/packages/core/src/collection/core/recordZ.ts
@@ -30,6 +30,7 @@ import { isRecord } from "@mulmoclaude/common";
 import { z } from "zod";
 import { coerceNumeric } from "./backlinks";
 import { parseIsoDate, parseIsoDateTime } from "./calendarGrid";
+import { isCanonicalServerTime } from "./serverTime";
 import { COMPUTED_TYPES } from "./schema";
 import type { CollectionFieldSpec, CollectionItem, CollectionSchema, CollectionSubFieldSpec } from "./schema";
 
@@ -66,6 +67,10 @@ function enforcedProblem(key: string, spec: AnyFieldSpec, value: unknown): strin
  *  outside the canonical `YYYY-MM-DDTHH:MM[:SS]` shape (e.g. a `Z` suffix,
  *  which the day view can't place). `string`-backed types accept anything
  *  stringifiable; `ref` existence is out of scope. */
+/** Named in the lint's own message, so the shape is shown rather than
+ *  described. */
+const CANONICAL_SERVER_TIME_EXAMPLE = "2026-08-15T01:45:54.605987654Z";
+
 function strictTypeProblem(key: string, spec: AnyFieldSpec, value: unknown): string | null {
   switch (spec.type) {
     case "number":
@@ -76,9 +81,17 @@ function strictTypeProblem(key: string, spec: AnyFieldSpec, value: unknown): str
     case "date":
       return parseIsoDate(value) !== null ? null : `'${key}' = '${String(value)}' is not a real YYYY-MM-DD date`;
     case "datetime":
-      return parseIsoDateTime(value) !== null
+      // Two shapes, and the second one is not a loosening of the first. A
+      // SHARED collection can pin a field to the server's clock, and what is
+      // stored there is a Firestore timestamp the rules require; by the time it
+      // reaches here it is the canonical instant string (`../core/serverTime`).
+      // Only that exact form is accepted — RFC3339 in general is not, because
+      // two values with different offsets do not sort in time order, and the
+      // order is the whole reason the field exists.
+      return parseIsoDateTime(value) !== null || isCanonicalServerTime(value)
         ? null
-        : `'${key}' = '${String(value)}' is not a YYYY-MM-DDTHH:MM datetime (seconds optional, no timezone suffix — the shape the calendar parses)`;
+        : `'${key}' = '${String(value)}' is not a YYYY-MM-DDTHH:MM datetime (seconds optional, no timezone suffix — the shape the calendar parses), ` +
+            `nor a server-stamped instant (${CANONICAL_SERVER_TIME_EXAMPLE})`;
     default:
       return null;
   }

--- a/packages/core/src/collection/core/serverTime.ts
+++ b/packages/core/src/collection/core/serverTime.ts
@@ -1,0 +1,162 @@
+// The one shape a server-stamped instant takes, and the codec that keeps it
+// that way.
+//
+// A shared (firestore) collection can pin a field to the SERVER's clock:
+// `public.submit.<cid>.stampField` makes the rules require
+// `request.resource.data[field] == request.time` on create and freeze it
+// afterwards. What is stored is therefore a Firestore `Timestamp`, and that is
+// not negotiable — it is what stops somebody writing yesterday into the field
+// that decides who was first.
+//
+// Everything ABOVE the database wants a string. Two reasons, and the second is
+// the one that bites:
+//
+//   1. The collection DSL's `datetime` means a string; the record lint, the
+//      table and the calendar all read one.
+//   2. A `Timestamp` does not survive the trip to a page. Structured clone
+//      (mulmoserver's view channel) drops the CLASS and leaves
+//      `{ seconds, nanoseconds }`; JSON (MulmoTerminal's preview, over HTTP,
+//      and the headless run) leaves `{ type: "firestore/timestamp/1.0", … }`.
+//      `String()` of either is `"[object Object]"`, so a page that sorts by
+//      the field — which is exactly what a first-come app does — compares
+//      every row equal and falls back to whatever order it was handed. The
+//      bundled gym template shipped that sort, and its queue was ordered by
+//      document id rather than by time. Nothing errored; the ranks looked
+//      plausible.
+//
+// So the value is normalized ONCE, at the boundary, and the string is the only
+// thing anything above ever sees.
+//
+// THE FORM IS LOAD-BEARING, not cosmetic:
+//
+//   2026-08-15T01:45:54.605987654Z
+//
+//   - UTC, `Z`, and nothing else. RFC3339 allows `+09:00`, and two strings
+//     with different offsets do not sort in time order — which would give back
+//     the bug this module exists to remove.
+//   - NINE fractional digits, always. A `Timestamp` carries nanoseconds and
+//     Firestore's own order is (seconds, nanoseconds); rounding to
+//     milliseconds makes two submissions in the same millisecond compare
+//     equal, and same-millisecond is precisely the burst a first-come app is
+//     for. Fixed WIDTH matters as much as the precision, for a reason that is
+//     easy to get backwards: trimming TRAILING ZEROS is order-preserving
+//     (`.605` < `.61` either way), but MIXING widths is not — `…605Z` and
+//     `…605987654Z` compare at the fourth fraction character, where `Z` (90)
+//     is greater than any digit, so the millisecond value sorts AFTER a
+//     nanosecond value it is earlier than or equal to. One width, always.
+//   - Lexicographic order is therefore chronological order, which is what lets
+//     an author's page sort with a plain string compare and be right.
+//
+// TIES. Two records can still carry the same instant. The tie-break is the
+// DOCUMENT ID, and it comes for free rather than from code here: every read of
+// a shared collection is ordered by `__name__` (core's `firestoreDocs.list`
+// and mulmoserver's own reader both do it), and `Array.prototype.sort` is
+// stable, so equal keys keep that order in every host. Do not "improve" either
+// read into a field ordering without replacing this sentence.
+//
+// Design: mulmoterminal `plans/fix-shared-app-server-time.md` (D2/D3).
+
+/** The canonical instant, exactly: UTC, nine fractional digits, `Z`. */
+const CANONICAL_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z$/;
+
+const NANOS_PER_SECOND = 1_000_000_000;
+const MILLIS_PER_SECOND = 1000;
+const NANOS_PER_MILLI = 1_000_000;
+
+/** What a Firestore `Timestamp` looks like once it is only data. Duck-typed on
+ *  purpose: this module is pure and imports no SDK, because it runs where the
+ *  class is already gone — a page's payload, a JSON body, a test. */
+export interface ServerTimeParts {
+  seconds: number;
+  nanoseconds: number;
+}
+
+const isFiniteInteger = (value: unknown): value is number => typeof value === "number" && Number.isInteger(value);
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
+
+/** Carries the two numbers, whatever else it is. A guard rather than a cast:
+ *  what arrives here is genuinely unknown — a page's payload, a JSON body, a
+ *  document another client wrote. */
+const isTimestampLike = (value: unknown): value is ServerTimeParts => isRecord(value) && isFiniteInteger(value.seconds) && isFiniteInteger(value.nanoseconds);
+
+/** Is this the canonical form? Used by the record lint, so it must not accept
+ *  anything a plain string compare would order wrongly. */
+export const isCanonicalServerTime = (value: unknown): value is string => typeof value === "string" && CANONICAL_RE.test(value);
+
+/** The canonical string for a (seconds, nanoseconds) pair, or null when the
+ *  pair is not a real instant.
+ *
+ *  Built from the SECONDS through `Date` and the nanoseconds as text, never by
+ *  turning nanoseconds into a float — `605987654 / 1e9` cannot be represented
+ *  exactly, and a rounding error here is a rank in the wrong place. */
+export function serverTimeOf(parts: ServerTimeParts): string | null {
+  const { seconds, nanoseconds } = parts;
+  if (!isFiniteInteger(seconds) || !isFiniteInteger(nanoseconds)) return null;
+  if (nanoseconds < 0 || nanoseconds >= NANOS_PER_SECOND) return null;
+  const whole = new Date(seconds * MILLIS_PER_SECOND);
+  if (Number.isNaN(whole.getTime())) return null;
+  return `${whole.toISOString().slice(0, 19)}.${String(nanoseconds).padStart(9, "0")}Z`;
+}
+
+/** A stored server time in any of the shapes it reaches us in, as the
+ *  canonical string — or null when the value is not one at all.
+ *
+ *  The three shapes are the three trips a `Timestamp` can make: still an SDK
+ *  instance (a host reading Firestore directly), structured-cloned (a page's
+ *  payload), or JSON (`Timestamp.toJSON`, which tags itself). All three carry
+ *  `seconds` and `nanoseconds`; the tag is not required, because the clone
+ *  drops it. */
+export function decodeServerTime(value: unknown): string | null {
+  if (!isTimestampLike(value)) return null;
+  return serverTimeOf(value);
+}
+
+/** The inverse: the parts a canonical string stands for, or null for anything
+ *  else.
+ *
+ *  This is what closes the write-back hole. A record is read (decoded), edited,
+ *  and written back WHOLE — `putItems`' upsert replaces the document — so
+ *  without an encode the stamp would go back as a string. The rules freeze that
+ *  field by comparing `diff().affectedKeys()`, so the write is refused and the
+ *  record can never be updated again. Dropping the field instead does not help:
+ *  a removed key is an affected key too.
+ *
+ *  Deliberately narrow. Only the EXACT canonical form is encoded, and that form
+ *  is only ever produced by `decodeServerTime` — a human or an agent authoring
+ *  a `datetime` writes the civil shape, which passes through as the string it
+ *  is. So the codec is closed over its own output and cannot re-type somebody
+ *  else's data. */
+export function encodeServerTime(value: unknown): ServerTimeParts | null {
+  if (!isCanonicalServerTime(value)) return null;
+  const millis = Date.parse(`${value.slice(0, 19)}Z`);
+  if (Number.isNaN(millis)) return null;
+  const nanoseconds = Number(value.slice(20, 29));
+  return { seconds: Math.floor(millis / MILLIS_PER_SECOND), nanoseconds };
+}
+
+/** Epoch milliseconds for a canonical instant, for the places that can only
+ *  hold a number (a sort key, a civil placement). LOSSY below the millisecond
+ *  and knowingly so: whoever needs the full order compares the strings. */
+export function serverTimeMillis(value: unknown): number | null {
+  const parts = encodeServerTime(value);
+  if (parts === null) return null;
+  return parts.seconds * MILLIS_PER_SECOND + Math.floor(parts.nanoseconds / NANOS_PER_MILLI);
+}
+
+/** Every canonical instant in a record, replaced by its string; everything else
+ *  untouched. One level deep, which is where a stamped field lives — a `table`
+ *  row cannot hold one, because nothing writes a server time into an array. */
+export function decodeRecordTimes(record: unknown): unknown {
+  if (!isRecord(record)) return record;
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const decoded = decodeServerTime(value);
+    if (decoded !== null) changed = true;
+    out[key] = decoded ?? value;
+  }
+  // The SAME object when nothing was stamped, so a reference comparison
+  // upstream keeps meaning what it meant.
+  return changed ? out : record;
+}

--- a/packages/core/src/collection/core/serverTime.ts
+++ b/packages/core/src/collection/core/serverTime.ts
@@ -89,6 +89,10 @@ const isTimestampLike = (value: unknown): value is ServerTimeParts => isRecord(v
  *  canonical only when re-formatting what it parses to gives it back. */
 export const isCanonicalServerTime = (value: unknown): value is string => {
   if (typeof value !== "string" || !CANONICAL_RE.test(value)) return false;
+  // Firestore's own range starts at 0001-01-01; the four digits above already
+  // bound the other end. Year zero parses in JS and would only fail later, when
+  // the SDK is handed it — an exception at the write instead of a refusal here.
+  if (value.startsWith("0000-")) return false;
   const millis = Date.parse(`${value.slice(0, 19)}Z`);
   if (Number.isNaN(millis)) return false;
   return new Date(millis).toISOString().slice(0, 19) === value.slice(0, 19);
@@ -181,7 +185,23 @@ export interface DeclaredFields {
  *  string.
  *
  *  A `datetime` field is the one place where both readings mean the same
- *  thing, which is what makes this scope the honest one. */
+ *  thing, which is what makes this scope the honest one.
+ *
+ *  WHY NOT NARROWER STILL — scoped to the app's `stampField`, the one field the
+ *  rules pin. It was asked for, and it is not reachable from here: that name
+ *  lives in `app.json` under `public.submit.<cid>`, which core reads only for
+ *  `aid` (see `../server/appManifest`, "SCOPE") and which is the AUTHORED file
+ *  rather than the published document the rules actually read. Getting it would
+ *  mean a file read per write and crossing a boundary that module states
+ *  deliberately.
+ *
+ *  And the narrower scope buys less than it looks. Within this backend a
+ *  `datetime` field's canonical instant has ONE storage form — a timestamp —
+ *  and the pair above is exact, so the value re-reads as the identical string
+ *  for every reader. What changes for a non-stamped field is the stored TYPE,
+ *  which matters only to a rule comparing it as a string; the rules that touch
+ *  a datetime compare it to `request.time`, which is the stamped case and needs
+ *  the timestamp. A field that must stay a string is declared `string`. */
 const isDateTimeField = (schema: DeclaredFields, key: string): boolean => schema.fields[key]?.type === "datetime";
 
 /** Every stored instant in a `datetime` field, as its canonical string; every

--- a/packages/core/src/collection/core/serverTime.ts
+++ b/packages/core/src/collection/core/serverTime.ts
@@ -221,18 +221,41 @@ export function decodeRecordTimes(record: Record<string, unknown>, schema: Decla
   return changed ? out : record;
 }
 
-/** The write half. `toStored` builds whatever the backend wants for an instant
- *  — a Firestore `Timestamp` — and is injected so this module stays free of the
- *  SDK: it also runs in a browser, where importing that would be a bundle. */
+/** The write half, and it encodes ONLY what was stored as an instant.
+ *
+ *  `previous` is the document as Firestore holds it right now. That is the only
+ *  honest source of provenance here: a decoded stamp is a plain string by the
+ *  time it comes back, indistinguishable from one an author typed or an import
+ *  produced, and no amount of looking at the string can tell them apart. The
+ *  declaration that pins the field lives in `app.json` under
+ *  `public.submit.<cid>`, which this package reads only for `aid`
+ *  (`../server/appManifest`, "SCOPE") — so the stored value is what is left, and
+ *  it answers exactly the right question: was this field an instant before?
+ *
+ *  What that buys, concretely: the frozen stamp goes back unchanged, so a
+ *  whole-record write survives the rules; and a `datetime` field holding a
+ *  canonical-looking string that was NEVER an instant — imported data, a value
+ *  somebody typed — stays the string it is. The format alone would have
+ *  re-typed it.
+ *
+ *  `previous` is null for a create, where nothing was stored and nothing can
+ *  therefore be preserved. That is correct rather than a gap: the rules require
+ *  a created stamp to equal `request.time`, which no client can construct, so a
+ *  create through this store never carries a valid one.
+ *
+ *  `toStored` builds whatever the backend wants for an instant — a Firestore
+ *  `Timestamp` — and is injected so this module stays free of the SDK: it also
+ *  runs in a browser, where importing that would be a bundle. */
 export function encodeRecordTimes(
   record: Record<string, unknown>,
-  schema: DeclaredFields,
+  previous: Record<string, unknown> | null,
   toStored: (parts: ServerTimeParts) => unknown,
 ): Record<string, unknown> {
   let changed = false;
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    const parts = isDateTimeField(schema, key) ? encodeServerTime(value) : null;
+    const wasInstant = previous !== null && isTimestampLike(previous[key]);
+    const parts = wasInstant ? encodeServerTime(value) : null;
     if (parts !== null) changed = true;
     out[key] = parts === null ? value : toStored(parts);
   }

--- a/packages/core/src/collection/core/serverTime.ts
+++ b/packages/core/src/collection/core/serverTime.ts
@@ -80,9 +80,19 @@ const isRecord = (value: unknown): value is Record<string, unknown> => typeof va
  *  document another client wrote. */
 const isTimestampLike = (value: unknown): value is ServerTimeParts => isRecord(value) && isFiniteInteger(value.seconds) && isFiniteInteger(value.nanoseconds);
 
-/** Is this the canonical form? Used by the record lint, so it must not accept
- *  anything a plain string compare would order wrongly. */
-export const isCanonicalServerTime = (value: unknown): value is string => typeof value === "string" && CANONICAL_RE.test(value);
+/** Is this the canonical form, and a real instant?
+ *
+ *  The shape check alone is not enough, and the gap is not theoretical: with it,
+ *  `2026-02-30T00:00:00.000000000Z` passes, the record lint reports nothing, and
+ *  `Date.parse` then normalises it to March 2 — so a write/read round trip
+ *  silently moves the value. The round trip below is the check: a string is
+ *  canonical only when re-formatting what it parses to gives it back. */
+export const isCanonicalServerTime = (value: unknown): value is string => {
+  if (typeof value !== "string" || !CANONICAL_RE.test(value)) return false;
+  const millis = Date.parse(`${value.slice(0, 19)}Z`);
+  if (Number.isNaN(millis)) return false;
+  return new Date(millis).toISOString().slice(0, 19) === value.slice(0, 19);
+};
 
 /** The canonical string for a (seconds, nanoseconds) pair, or null when the
  *  pair is not a real instant.
@@ -96,7 +106,11 @@ export function serverTimeOf(parts: ServerTimeParts): string | null {
   if (nanoseconds < 0 || nanoseconds >= NANOS_PER_SECOND) return null;
   const whole = new Date(seconds * MILLIS_PER_SECOND);
   if (Number.isNaN(whole.getTime())) return null;
-  return `${whole.toISOString().slice(0, 19)}.${String(nanoseconds).padStart(9, "0")}Z`;
+  const formatted = `${whole.toISOString().slice(0, 19)}.${String(nanoseconds).padStart(9, "0")}Z`;
+  // A year outside the four-digit range formats as `+275760-…`, which is not
+  // this form. Checked rather than assumed, because a caller that stored the
+  // result would be storing something nothing downstream recognises.
+  return isCanonicalServerTime(formatted) ? formatted : null;
 }
 
 /** A stored server time in any of the shapes it reaches us in, as the
@@ -144,18 +158,63 @@ export function serverTimeMillis(value: unknown): number | null {
   return parts.seconds * MILLIS_PER_SECOND + Math.floor(parts.nanoseconds / NANOS_PER_MILLI);
 }
 
-/** Every canonical instant in a record, replaced by its string; everything else
- *  untouched. One level deep, which is where a stamped field lives — a `table`
- *  row cannot hold one, because nothing writes a server time into an array. */
-export function decodeRecordTimes(record: Record<string, unknown>): Record<string, unknown> {
+/** The only part of a schema this codec reads.
+ *
+ *  Structural rather than `CollectionSchema`, because the OTHER host has its own
+ *  type for the same document (mulmoserver reads these records without going
+ *  through this package's store) and neither side should have to adopt the
+ *  other's declaration to call one function. */
+export interface DeclaredFields {
+  fields: Record<string, { type: string } | undefined>;
+}
+
+/** Which fields of a record may hold an instant: the ones the SCHEMA calls
+ *  `datetime`, and no others.
+ *
+ *  DECLARATION, not shape. Recognising `{ seconds, nanoseconds }` wherever it
+ *  appears would rewrite an ordinary value that happens to have those two keys
+ *  — a duration, an offset, somebody's own metadata — into a datetime string,
+ *  and then into a Firestore timestamp on the next whole-record write. Records
+ *  are allowed to carry keys the schema never mentions, so that is live user
+ *  data being re-typed on a guess. The same argument runs the other way on the
+ *  write: a `string` field whose value happens to look canonical must stay a
+ *  string.
+ *
+ *  A `datetime` field is the one place where both readings mean the same
+ *  thing, which is what makes this scope the honest one. */
+const isDateTimeField = (schema: DeclaredFields, key: string): boolean => schema.fields[key]?.type === "datetime";
+
+/** Every stored instant in a `datetime` field, as its canonical string; every
+ *  other value untouched. One level deep, which is where a stamped field
+ *  lives — the rules stamp a top-level key and nothing writes a server time
+ *  into a table row. */
+export function decodeRecordTimes(record: Record<string, unknown>, schema: DeclaredFields): Record<string, unknown> {
   let changed = false;
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    const decoded = decodeServerTime(value);
+    const decoded = isDateTimeField(schema, key) ? decodeServerTime(value) : null;
     if (decoded !== null) changed = true;
     out[key] = decoded ?? value;
   }
   // The SAME object when nothing was stamped, so a reference comparison
   // upstream keeps meaning what it meant.
+  return changed ? out : record;
+}
+
+/** The write half. `toStored` builds whatever the backend wants for an instant
+ *  — a Firestore `Timestamp` — and is injected so this module stays free of the
+ *  SDK: it also runs in a browser, where importing that would be a bundle. */
+export function encodeRecordTimes(
+  record: Record<string, unknown>,
+  schema: DeclaredFields,
+  toStored: (parts: ServerTimeParts) => unknown,
+): Record<string, unknown> {
+  let changed = false;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const parts = isDateTimeField(schema, key) ? encodeServerTime(value) : null;
+    if (parts !== null) changed = true;
+    out[key] = parts === null ? value : toStored(parts);
+  }
   return changed ? out : record;
 }

--- a/packages/core/src/collection/core/serverTime.ts
+++ b/packages/core/src/collection/core/serverTime.ts
@@ -147,8 +147,7 @@ export function serverTimeMillis(value: unknown): number | null {
 /** Every canonical instant in a record, replaced by its string; everything else
  *  untouched. One level deep, which is where a stamped field lives — a `table`
  *  row cannot hold one, because nothing writes a server time into an array. */
-export function decodeRecordTimes(record: unknown): unknown {
-  if (!isRecord(record)) return record;
+export function decodeRecordTimes(record: Record<string, unknown>): Record<string, unknown> {
   let changed = false;
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {

--- a/packages/core/src/collection/index.ts
+++ b/packages/core/src/collection/index.ts
@@ -21,6 +21,12 @@ export * from "./core/enumColors";
 export * from "./core/draft";
 export * from "./core/actionVisible";
 export * from "./core/backlinks";
+// The server-time codec. Exported from the PUBLIC subpath because both hosts
+// need the decode half: a page's payload is assembled by each host from its own
+// read (mulmoserver reads Firestore directly and never passes through
+// `collection/server`), and a second implementation of this is the drift this
+// module exists to remove.
+export * from "./core/serverTime";
 export * from "./core/linkTargets";
 export * from "./core/where";
 export * from "./core/completion";

--- a/packages/core/src/collection/server/firestoreDocs.ts
+++ b/packages/core/src/collection/server/firestoreDocs.ts
@@ -26,10 +26,8 @@ import {
   onSnapshot,
   runTransaction,
   setDoc,
-  Timestamp,
   type Firestore,
 } from "firebase/firestore";
-import { decodeRecordTimes, encodeServerTime } from "../core/serverTime";
 
 /** One stored record document. `data` is the document's own fields — the
  *  record itself, not a wrapper around it; see `set` below. The store
@@ -86,52 +84,25 @@ export interface FirestoreDocs {
  *  `remote-host/server/hostRunner.ts:158-169` documents), turning a read into a
  *  partial one; the document id is always present and gives the stable order
  *  the store contract requires. */
-/** The server-time codec, applied where Firestore's own types enter and leave.
- *
- *  HERE and nowhere above, because this module is the seam that owns the SDK —
- *  a `Timestamp` is an SDK type, and every read and write of a shared record
- *  goes through one of the four calls below. Above this line a record is plain
- *  data, which is what the lint, the table, the migration gate and a page's
- *  payload all assume; see `../core/serverTime` for why the string form is
- *  what it is.
- *
- *  SYMMETRIC on purpose. Decoding alone would break the next write: a record is
- *  read, edited and written back WHOLE, so a decoded stamp would return as a
- *  string, and the rules — which freeze that field — would refuse that write
- *  and every later one. Encoding only the exact canonical form keeps the pair
- *  closed over its own output.
- *
- *  The in-memory fake the tests inject is unaffected and should stay that way:
- *  it never holds a `Timestamp`, so it is already speaking the language
- *  everything above this seam speaks. */
-function encodeRecordTimes(data: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(data)) {
-    const parts = encodeServerTime(value);
-    out[key] = parts === null ? value : new Timestamp(parts.seconds, parts.nanoseconds);
-  }
-  return out;
-}
-
 export function createFirestoreDocs(database: Firestore): FirestoreDocs {
   return {
     list: async (collectionPath) => {
       const snapshot = await getDocs(firestoreQuery(firestoreCollection(database, collectionPath), orderBy("__name__")));
-      return snapshot.docs.map((entry) => ({ id: entry.id, data: decodeRecordTimes(entry.data()) }));
+      return snapshot.docs.map((entry) => ({ id: entry.id, data: entry.data() }));
     },
     get: async (collectionPath, docId) => {
       const snapshot = await getDoc(doc(database, collectionPath, docId));
-      return snapshot.exists() ? decodeRecordTimes(snapshot.data()) : null;
+      return snapshot.exists() ? snapshot.data() : null;
     },
     set: async (collectionPath, docId, data) => {
-      await setDoc(doc(database, collectionPath, docId), encodeRecordTimes(data));
+      await setDoc(doc(database, collectionPath, docId), data);
     },
     create: (collectionPath, docId, data) =>
       runTransaction(database, async (transaction) => {
         const ref = doc(database, collectionPath, docId);
         const existing = await transaction.get(ref);
         if (existing.exists()) return false;
-        transaction.set(ref, encodeRecordTimes(data));
+        transaction.set(ref, data);
         return true;
       }),
     // Firestore's deleteDoc succeeds on a missing document, so an existence

--- a/packages/core/src/collection/server/firestoreDocs.ts
+++ b/packages/core/src/collection/server/firestoreDocs.ts
@@ -26,8 +26,10 @@ import {
   onSnapshot,
   runTransaction,
   setDoc,
+  Timestamp,
   type Firestore,
 } from "firebase/firestore";
+import { decodeRecordTimes, encodeServerTime } from "../core/serverTime";
 
 /** One stored record document. `data` is the document's own fields — the
  *  record itself, not a wrapper around it; see `set` below. The store
@@ -84,25 +86,52 @@ export interface FirestoreDocs {
  *  `remote-host/server/hostRunner.ts:158-169` documents), turning a read into a
  *  partial one; the document id is always present and gives the stable order
  *  the store contract requires. */
+/** The server-time codec, applied where Firestore's own types enter and leave.
+ *
+ *  HERE and nowhere above, because this module is the seam that owns the SDK —
+ *  a `Timestamp` is an SDK type, and every read and write of a shared record
+ *  goes through one of the four calls below. Above this line a record is plain
+ *  data, which is what the lint, the table, the migration gate and a page's
+ *  payload all assume; see `../core/serverTime` for why the string form is
+ *  what it is.
+ *
+ *  SYMMETRIC on purpose. Decoding alone would break the next write: a record is
+ *  read, edited and written back WHOLE, so a decoded stamp would return as a
+ *  string, and the rules — which freeze that field — would refuse that write
+ *  and every later one. Encoding only the exact canonical form keeps the pair
+ *  closed over its own output.
+ *
+ *  The in-memory fake the tests inject is unaffected and should stay that way:
+ *  it never holds a `Timestamp`, so it is already speaking the language
+ *  everything above this seam speaks. */
+function encodeRecordTimes(data: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    const parts = encodeServerTime(value);
+    out[key] = parts === null ? value : new Timestamp(parts.seconds, parts.nanoseconds);
+  }
+  return out;
+}
+
 export function createFirestoreDocs(database: Firestore): FirestoreDocs {
   return {
     list: async (collectionPath) => {
       const snapshot = await getDocs(firestoreQuery(firestoreCollection(database, collectionPath), orderBy("__name__")));
-      return snapshot.docs.map((entry) => ({ id: entry.id, data: entry.data() }));
+      return snapshot.docs.map((entry) => ({ id: entry.id, data: decodeRecordTimes(entry.data()) }));
     },
     get: async (collectionPath, docId) => {
       const snapshot = await getDoc(doc(database, collectionPath, docId));
-      return snapshot.exists() ? snapshot.data() : null;
+      return snapshot.exists() ? decodeRecordTimes(snapshot.data()) : null;
     },
     set: async (collectionPath, docId, data) => {
-      await setDoc(doc(database, collectionPath, docId), data);
+      await setDoc(doc(database, collectionPath, docId), encodeRecordTimes(data));
     },
     create: (collectionPath, docId, data) =>
       runTransaction(database, async (transaction) => {
         const ref = doc(database, collectionPath, docId);
         const existing = await transaction.get(ref);
         if (existing.exists()) return false;
-        transaction.set(ref, data);
+        transaction.set(ref, encodeRecordTimes(data));
         return true;
       }),
     // Firestore's deleteDoc succeeds on a missing document, so an existence

--- a/packages/core/src/collection/server/firestoreStore.ts
+++ b/packages/core/src/collection/server/firestoreStore.ts
@@ -39,7 +39,14 @@
 
 import { isRecord } from "@mulmoclaude/common";
 import { sharedCollectionKey, type SharedCollectionKey } from "../core/collectionKey";
-import type { CollectionItem } from "../core/schema";
+// `Timestamp` is the one SDK VALUE this module needs: the write half of the
+// server-time codec has to hand Firestore its own type back. Importing the
+// class costs nothing at runtime (no app, no connection) and keeps the codec
+// itself free of the SDK, which matters because it also runs in a browser.
+import { Timestamp } from "firebase/firestore";
+
+import type { CollectionItem, CollectionSchema } from "../core/schema";
+import { decodeRecordTimes, encodeRecordTimes } from "../core/serverTime";
 import { BackendUnavailableError } from "./backendAvailability";
 import type { LoadedCollection } from "./discoveredCollection";
 import { backoffDelayMs, classifyListenerError } from "../../firestore/listen";
@@ -147,8 +154,21 @@ async function guarded<T>(key: SharedCollectionKey, email: string, run: () => Pr
  *  It also removes the reason a submit path would have had to accept the
  *  primary key as a `createField` at all — a submission that cannot name its
  *  own id is exactly right when the id is the thing being assigned. */
-function toItem(data: unknown, docId: string, primaryKey: string): CollectionItem | null {
-  return isRecord(data) ? { ...data, [primaryKey]: docId } : null;
+function toItem(data: unknown, docId: string, schema: CollectionSchema): CollectionItem | null {
+  // A `datetime` field of a SHARED collection can be pinned to the server's
+  // clock — the rules require `request.time` there — so what comes back is a
+  // Firestore timestamp, not a string. It must not leave this store as one.
+  //
+  // Above here everything assumes the DSL's string: the record lint, the
+  // migration gate, the table, and a page — which is handed its records by
+  // structured clone or as JSON, both of which reduce a timestamp to an object
+  // whose `String()` is `"[object Object]"`. A page sorting by that field then
+  // compares every row equal and keeps the order it was read in, which is how
+  // the bundled first-come template came to rank its queue by document id.
+  //
+  // HERE rather than in `firestoreDocs`, because the conversion is scoped by
+  // the SCHEMA and that seam does not have one. See `../core/serverTime`.
+  return isRecord(data) ? { ...decodeRecordTimes(data, schema), [schema.primaryKey]: docId } : null;
 }
 
 /** Record ids are validated with the SAME helper every other backend uses.
@@ -161,10 +181,10 @@ function withSafeId<T>(itemId: string, onInvalid: () => T, run: (safeId: string,
   return run(safeId, requireHandle());
 }
 
-async function firestoreList(key: SharedCollectionKey, primaryKey: string): Promise<CollectionItem[]> {
+async function firestoreList(key: SharedCollectionKey, schema: CollectionSchema): Promise<CollectionItem[]> {
   const { docs, email } = requireHandle();
   const entries = await guarded(key, email, () => docs.list(sharedItemsPath(key)));
-  return entries.map((entry) => toItem(entry.data, entry.id, primaryKey)).filter((item): item is CollectionItem => item !== null);
+  return entries.map((entry) => toItem(entry.data, entry.id, schema)).filter((item): item is CollectionItem => item !== null);
 }
 
 /** Paging is emulated over a full ordered read rather than pushed into
@@ -172,18 +192,18 @@ async function firestoreList(key: SharedCollectionKey, primaryKey: string): Prom
  *  preceding document, which a stateless offset/limit call doesn't have), and
  *  `total` needs the full count anyway. Hence `nativePaging: false` — the
  *  capability is honest about the cost. */
-async function firestorePage(key: SharedCollectionKey, primaryKey: string, opts: ListOptions): Promise<ListPage> {
-  const items = await firestoreList(key, primaryKey);
+async function firestorePage(key: SharedCollectionKey, schema: CollectionSchema, opts: ListOptions): Promise<ListPage> {
+  const items = await firestoreList(key, schema);
   const offset = Math.max(0, opts.offset ?? 0);
   const sliced = opts.limit === undefined ? items.slice(offset) : items.slice(offset, offset + Math.max(0, opts.limit));
-  return { items: projectItemFields(sliced, opts.fields, primaryKey), total: items.length, truncated: false };
+  return { items: projectItemFields(sliced, opts.fields, schema.primaryKey), total: items.length, truncated: false };
 }
 
-async function firestoreRead(key: SharedCollectionKey, itemId: string, primaryKey: string): Promise<CollectionItem | null> {
+async function firestoreRead(key: SharedCollectionKey, itemId: string, schema: CollectionSchema): Promise<CollectionItem | null> {
   return withSafeId(
     itemId,
     () => Promise.resolve(null),
-    async (safeId, { docs, email }) => toItem(await guarded(key, email, () => docs.get(sharedItemsPath(key), safeId)), safeId, primaryKey),
+    async (safeId, { docs, email }) => toItem(await guarded(key, email, () => docs.get(sharedItemsPath(key), safeId)), safeId, schema),
   );
 }
 
@@ -197,10 +217,23 @@ function publishShared(key: SharedCollectionKey, ids: string[], operation: "upse
   publishCollectionChange(sharedCollectionChangePayload({ slug: key.cid, ids, op: operation }, key.aid));
 }
 
+/** The write half of the decode above, and it is not optional.
+ *
+ *  A record is read, edited and written back WHOLE — `putItems`' upsert
+ *  replaces the document — so a decoded stamp would return to Firestore as a
+ *  string. The rules freeze that field by comparing `diff().affectedKeys()`, so
+ *  that write is refused and so is every later one: the record becomes
+ *  permanently unupdatable. Dropping the key instead does not help, because a
+ *  removed key is an affected key too.
+ *
+ *  Only a `datetime` field carrying the exact canonical form is converted, and
+ *  that form is only ever produced by the decode — so the pair is closed over
+ *  its own output and cannot re-type a value somebody else wrote. */
 async function firestoreWrite(
   key: SharedCollectionKey,
   itemId: string,
   item: CollectionItem,
+  schema: CollectionSchema,
   opts: IoOptions & { refuseOverwrite?: boolean | undefined },
 ): Promise<WriteItemResult> {
   return withSafeId<Promise<WriteItemResult>>(
@@ -208,11 +241,12 @@ async function firestoreWrite(
     () => Promise.resolve({ kind: "invalid-id", itemId }),
     async (safeId, { docs, email }) => {
       const collectionPath = sharedItemsPath(key);
+      const stored = encodeRecordTimes(item, schema, (parts) => new Timestamp(parts.seconds, parts.nanoseconds));
       if (opts.refuseOverwrite) {
-        const created = await guarded(key, email, () => docs.create(collectionPath, safeId, item));
+        const created = await guarded(key, email, () => docs.create(collectionPath, safeId, stored));
         if (!created) return { kind: "conflict", itemId: safeId };
       } else {
-        await guarded(key, email, () => docs.set(collectionPath, safeId, item));
+        await guarded(key, email, () => docs.set(collectionPath, safeId, stored));
       }
       if (opts.slug) publishShared(key, [safeId], "upsert");
       return { kind: "ok", itemId: safeId, item };
@@ -356,7 +390,7 @@ function armSharedWatch(key: SharedCollectionKey, onChange: StoreChangeListener)
 /** The store factory registered for `storage.type === "firestore"`.
  *  Synchronous and connection-agnostic by contract — see the header. */
 export function firestoreStoreFor(collection: LoadedCollection, opts: IoOptions): CollectionStore {
-  const { primaryKey } = collection.schema;
+  const { schema } = collection;
   const ioOpts: IoOptions = { ...opts, slug: opts.slug ?? collection.slug };
   // Every method is `async` and resolves the key INSIDE itself, so a bad
   // identity rejects the one call instead of throwing out of the factory. The
@@ -364,11 +398,11 @@ export function firestoreStoreFor(collection: LoadedCollection, opts: IoOptions)
   // collections; one that throws there takes an unrelated screen down with it.
   return {
     capabilities: { writable: true, nativeQuery: false, nativePaging: false },
-    list: async () => firestoreList(keyOf(collection), primaryKey),
-    page: async (pageOpts = {}) => firestorePage(keyOf(collection), primaryKey, pageOpts),
-    read: async (itemId: string) => firestoreRead(keyOf(collection), itemId, primaryKey),
+    list: async () => firestoreList(keyOf(collection), schema),
+    page: async (pageOpts = {}) => firestorePage(keyOf(collection), schema, pageOpts),
+    read: async (itemId: string) => firestoreRead(keyOf(collection), itemId, schema),
     write: async (itemId: string, item: CollectionItem, writeOpts: WriteOptions = {}) =>
-      firestoreWrite(keyOf(collection), itemId, item, { ...ioOpts, refuseOverwrite: writeOpts.refuseOverwrite }),
+      firestoreWrite(keyOf(collection), itemId, item, schema, { ...ioOpts, refuseOverwrite: writeOpts.refuseOverwrite }),
     delete: async (itemId: string) => firestoreDelete(keyOf(collection), itemId, ioOpts),
     // Having a `watch` at all is what takes this backend out of the watcher's
     // clock-tick fallback: `cannotReportChanges()` asks the store whether it

--- a/packages/core/src/collection/server/firestoreStore.ts
+++ b/packages/core/src/collection/server/firestoreStore.ts
@@ -241,11 +241,26 @@ async function firestoreWrite(
     () => Promise.resolve({ kind: "invalid-id", itemId }),
     async (safeId, { docs, email }) => {
       const collectionPath = sharedItemsPath(key);
-      const stored = encodeRecordTimes(item, schema, (parts) => new Timestamp(parts.seconds, parts.nanoseconds));
+      const asTimestamp = (parts: { seconds: number; nanoseconds: number }): unknown => new Timestamp(parts.seconds, parts.nanoseconds);
       if (opts.refuseOverwrite) {
-        const created = await guarded(key, email, () => docs.create(collectionPath, safeId, stored));
+        // Nothing is stored yet, so there is no instant to preserve — and the
+        // rules make a created stamp equal `request.time`, which no client can
+        // construct, so one cannot arrive this way either.
+        const created = await guarded(key, email, () => docs.create(collectionPath, safeId, encodeRecordTimes(item, null, asTimestamp)));
         if (!created) return { kind: "conflict", itemId: safeId };
       } else {
+        // THE STORED DOCUMENT IS READ FIRST, and it is the only place the
+        // provenance survives: a decoded stamp comes back as a plain string,
+        // indistinguishable from one an author typed. Reading answers the
+        // question that matters — was this field an instant before? — so the
+        // frozen stamp goes back unchanged while a `datetime` that merely holds
+        // a canonical-looking string stays a string.
+        //
+        // One extra round trip per update of a shared record. Paid knowingly:
+        // the alternative is guessing from the format, and a wrong guess
+        // silently changes the stored type of somebody's data.
+        const previous = await guarded(key, email, () => docs.get(collectionPath, safeId));
+        const stored = encodeRecordTimes(item, isRecord(previous) ? previous : null, asTimestamp);
         await guarded(key, email, () => docs.set(collectionPath, safeId, stored));
       }
       if (opts.slug) publishShared(key, [safeId], "upsert");

--- a/packages/core/test/collection/test_serverTime.ts
+++ b/packages/core/test/collection/test_serverTime.ts
@@ -154,6 +154,10 @@ test("an impossible date is not canonical, so it is never stored as a different 
   assert.equal(isCanonicalServerTime("2026-02-29T00:00:00.000000000Z"), false);
   // And a clock that does not exist.
   assert.equal(isCanonicalServerTime("2026-08-15T24:00:00.000000000Z"), false);
+  // Year zero parses in JS and is outside Firestore's range, so it would fail
+  // at the write with an exception instead of being refused here.
+  assert.equal(isCanonicalServerTime("0000-01-01T00:00:00.000000000Z"), false);
+  assert.equal(isCanonicalServerTime("0001-01-01T00:00:00.000000000Z"), true);
 });
 
 test("the record lint accepts a stamped instant, and still refuses a stray offset", () => {

--- a/packages/core/test/collection/test_serverTime.ts
+++ b/packages/core/test/collection/test_serverTime.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 
 import {
   decodeRecordTimes,
+  encodeRecordTimes,
   decodeServerTime,
   encodeServerTime,
   isCanonicalServerTime,
@@ -19,6 +20,7 @@ import {
   serverTimeOf,
 } from "../../src/collection/core/serverTime.ts";
 import { dateOf } from "../../src/collection/core/calendarGrid.ts";
+import type { CollectionSchema } from "../../src/collection/core/schema.ts";
 import { recordFieldProblem } from "../../src/collection/core/recordZ.ts";
 
 // The instant observed in a real app, and one 987654 nanoseconds later inside
@@ -27,6 +29,22 @@ const SECONDS = 1786835154;
 const EARLY = { seconds: SECONDS, nanoseconds: 605000000 };
 const SAME_MS = { seconds: SECONDS, nanoseconds: 605987654 };
 const LATER = { seconds: SECONDS + 6, nanoseconds: 0 };
+
+/** A schema that DECLARES which field may hold an instant. The codec is scoped
+ *  by this and not by the value's shape: a record may carry keys the schema
+ *  never mentions, and rewriting one of those because it happens to have
+ *  `seconds` and `nanoseconds` would be re-typing somebody's data on a guess. */
+const SCHEMA: CollectionSchema = {
+  title: "Bookings",
+  icon: "event",
+  dataPath: "data/bookings/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true },
+    submittedAt: { type: "datetime", label: "When" },
+    note: { type: "string", label: "Note" },
+  },
+};
 
 test("the canonical form is UTC, nine digits, Z", () => {
   assert.equal(serverTimeOf(EARLY), "2026-08-15T23:05:54.605000000Z");
@@ -95,12 +113,47 @@ test("encode is the exact inverse, and only of its own output", () => {
   assert.equal(isCanonicalServerTime("2026-08-15T23:05:54.605987654+09:00"), false);
 });
 
-test("a record is decoded field by field, and untouched when nothing is stamped", () => {
-  const row = { id: "r1", submittedAt: { seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds }, note: "hello", count: 3 };
-  assert.deepEqual(decodeRecordTimes(row), { id: "r1", submittedAt: serverTimeOf(EARLY), note: "hello", count: 3 });
+test("a declared datetime field is decoded, and an untouched record keeps its identity", () => {
+  const row = { id: "r1", submittedAt: { seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds }, note: "hello" };
+  assert.deepEqual(decodeRecordTimes(row, SCHEMA), { id: "r1", submittedAt: serverTimeOf(EARLY), note: "hello" });
   const plain = { id: "r2", note: "hello" };
   // The SAME object, so a reference comparison upstream keeps its meaning.
-  assert.equal(decodeRecordTimes(plain), plain);
+  assert.equal(decodeRecordTimes(plain, SCHEMA), plain);
+});
+
+test("a value that merely LOOKS like an instant is left alone", () => {
+  // The shape is not the proof. `note` is a declared string, and `duration` is
+  // not declared at all — records may carry keys the schema never mentions, and
+  // re-typing one of those would be corrupting live data on a guess.
+  const row = { id: "r1", note: { seconds: 30, nanoseconds: 0 }, duration: { seconds: 30, nanoseconds: 0 } };
+  assert.equal(decodeRecordTimes(row, SCHEMA), row);
+});
+
+test("the write half puts the instant back, and re-types nothing else", () => {
+  const stored = (parts: { seconds: number; nanoseconds: number }): unknown => ({ kind: "timestamp", ...parts });
+  const read = decodeRecordTimes({ id: "r1", submittedAt: { seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds } }, SCHEMA);
+  // What a whole-record write does with a record that was read and edited: the
+  // stamp goes back as an instant, so the rules see a field that has not moved.
+  assert.deepEqual(encodeRecordTimes({ ...read, note: "edited" }, SCHEMA, stored), {
+    id: "r1",
+    submittedAt: { kind: "timestamp", ...EARLY },
+    note: "edited",
+  });
+  // A STRING field holding a canonical-looking value stays a string.
+  const lookalike = { id: "r1", note: serverTimeOf(EARLY) ?? "" };
+  assert.equal(encodeRecordTimes(lookalike, SCHEMA, stored), lookalike);
+});
+
+test("an impossible date is not canonical, so it is never stored as a different instant", () => {
+  // Shape-only validation accepted this, the lint reported nothing, and
+  // `Date.parse` then moved it to March 2.
+  assert.equal(isCanonicalServerTime("2026-02-30T00:00:00.000000000Z"), false);
+  assert.equal(encodeServerTime("2026-02-30T00:00:00.000000000Z"), null);
+  // A real leap day is fine.
+  assert.equal(isCanonicalServerTime("2024-02-29T00:00:00.000000000Z"), true);
+  assert.equal(isCanonicalServerTime("2026-02-29T00:00:00.000000000Z"), false);
+  // And a clock that does not exist.
+  assert.equal(isCanonicalServerTime("2026-08-15T24:00:00.000000000Z"), false);
 });
 
 test("the record lint accepts a stamped instant, and still refuses a stray offset", () => {

--- a/packages/core/test/collection/test_serverTime.ts
+++ b/packages/core/test/collection/test_serverTime.ts
@@ -1,0 +1,127 @@
+// The server-time codec: what a shared collection's stamped field becomes above
+// the database, and why the exact form matters.
+//
+// The bug these pin is not a crash. A Firestore `Timestamp` does not survive
+// the trip to a page — structured clone drops the class, JSON tags it — and
+// `String()` of what arrives is `"[object Object]"`, so a page sorting by the
+// field compares every row equal and keeps whatever order it was handed. The
+// bundled first-come template shipped exactly that sort, and its queue was
+// ordered by document id. Nothing errored.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  decodeRecordTimes,
+  decodeServerTime,
+  encodeServerTime,
+  isCanonicalServerTime,
+  serverTimeMillis,
+  serverTimeOf,
+} from "../../src/collection/core/serverTime.ts";
+import { dateOf } from "../../src/collection/core/calendarGrid.ts";
+import { recordFieldProblem } from "../../src/collection/core/recordZ.ts";
+
+// The instant observed in a real app, and one 987654 nanoseconds later inside
+// the SAME millisecond — the pair that a millisecond-precision form collapses.
+const SECONDS = 1786835154;
+const EARLY = { seconds: SECONDS, nanoseconds: 605000000 };
+const SAME_MS = { seconds: SECONDS, nanoseconds: 605987654 };
+const LATER = { seconds: SECONDS + 6, nanoseconds: 0 };
+
+test("the canonical form is UTC, nine digits, Z", () => {
+  assert.equal(serverTimeOf(EARLY), "2026-08-15T23:05:54.605000000Z");
+  assert.equal(serverTimeOf(SAME_MS), "2026-08-15T23:05:54.605987654Z");
+  assert.ok(isCanonicalServerTime(serverTimeOf(EARLY)));
+});
+
+test("two instants in the same millisecond stay distinguishable, and sort", () => {
+  const early = serverTimeOf(EARLY) ?? "";
+  const sameMs = serverTimeOf(SAME_MS) ?? "";
+  assert.notEqual(early, sameMs);
+  // A plain string compare — what an author's page writes — is chronological.
+  assert.ok(early < sameMs);
+  assert.ok(sameMs < (serverTimeOf(LATER) ?? ""));
+  // And the millisecond form, which is what a `Date`/`toISOString()` round trip
+  // gives, does NOT: this is the reason for the nine digits.
+  assert.equal(new Date(serverTimeMillis(early) ?? 0).toISOString(), new Date(serverTimeMillis(sameMs) ?? 0).toISOString());
+});
+
+test("one width, always — a mixed-precision producer sorts wrongly", () => {
+  const nanos = serverTimeOf(SAME_MS) ?? "";
+  // The same instant truncated to milliseconds, which is what a `Date` /
+  // `toISOString()` round trip produces if anyone reaches for one.
+  const millis = `${nanos.slice(0, 23)}Z`;
+  assert.equal(millis, "2026-08-15T23:05:54.605Z");
+  // It names an instant earlier than (or equal to) `nanos`, and it sorts AFTER
+  // it: the compare reaches `Z` where the other has a digit, and `Z` is
+  // greater. Trimming trailing zeros would be harmless; mixing widths is not.
+  assert.ok(millis > nanos);
+  assert.ok(Date.parse(millis) <= Date.parse(nanos));
+  // Which is why nothing above the boundary ever sees anything else.
+  assert.equal(isCanonicalServerTime(millis), false);
+});
+
+test("decodes all three shapes one value can arrive in", () => {
+  const canonical = serverTimeOf(EARLY);
+  // 1. Still an SDK instance (a host reading Firestore in-process). Duck-typed
+  //    here, which is the point: this module imports no SDK.
+  assert.equal(decodeServerTime({ seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds }), canonical);
+  // 2. Structured-cloned — mulmoserver's view channel, class gone.
+  assert.equal(decodeServerTime(structuredClone({ seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds })), canonical);
+  // 3. JSON, as `Timestamp.toJSON` writes it — MulmoTerminal's preview over
+  //    HTTP and the headless run.
+  assert.equal(decodeServerTime({ type: "firestore/timestamp/1.0", seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds }), canonical);
+});
+
+test("decodes nothing else", () => {
+  for (const value of [null, undefined, "2026-08-15T10:00", 17, { seconds: "1", nanoseconds: 0 }, { seconds: 1 }, {}, [1, 2]]) {
+    assert.equal(decodeServerTime(value), null);
+  }
+  // Out of range nanoseconds are not an instant.
+  assert.equal(decodeServerTime({ seconds: SECONDS, nanoseconds: 1_000_000_000 }), null);
+});
+
+test("encode is the exact inverse, and only of its own output", () => {
+  const canonical = serverTimeOf(SAME_MS) ?? "";
+  assert.deepEqual(encodeServerTime(canonical), SAME_MS);
+  // What closes the write-back hole: a record read, edited and written back
+  // WHOLE puts the same instant back, so the rules see an unchanged field.
+  assert.deepEqual(encodeServerTime(serverTimeOf(encodeServerTime(canonical) ?? EARLY) ?? ""), SAME_MS);
+  // A civil datetime an author typed is NOT re-typed into a timestamp.
+  assert.equal(encodeServerTime("2026-08-15T10:00"), null);
+  assert.equal(encodeServerTime("2026-08-15T10:00:00Z"), null);
+  // RFC3339 with an offset is refused: two offsets do not sort in time order.
+  assert.equal(encodeServerTime("2026-08-15T23:05:54.605987654+09:00"), null);
+  assert.equal(isCanonicalServerTime("2026-08-15T23:05:54.605987654+09:00"), false);
+});
+
+test("a record is decoded field by field, and untouched when nothing is stamped", () => {
+  const row = { id: "r1", submittedAt: { seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds }, note: "hello", count: 3 };
+  assert.deepEqual(decodeRecordTimes(row), { id: "r1", submittedAt: serverTimeOf(EARLY), note: "hello", count: 3 });
+  const plain = { id: "r2", note: "hello" };
+  // The SAME object, so a reference comparison upstream keeps its meaning.
+  assert.equal(decodeRecordTimes(plain), plain);
+});
+
+test("the record lint accepts a stamped instant, and still refuses a stray offset", () => {
+  const spec = { type: "datetime", label: "When" } as const;
+  const problem = (value: unknown): string | null => recordFieldProblem("when", spec, value, "strict");
+  assert.equal(problem(serverTimeOf(EARLY)), null);
+  assert.equal(problem("2026-08-15T10:00"), null);
+  // RFC3339 in general is NOT accepted: an offset breaks the string order.
+  assert.notEqual(problem("2026-08-15T23:05:54.605987654+09:00"), null);
+  assert.notEqual(problem("nonsense"), null);
+});
+
+test("the calendar places a stamped instant on the reader's own day", () => {
+  // TZ is pinned by the runner (see the note in `calendarGrid`'s header): this
+  // is the one function there whose answer depends on the environment, because
+  // an instant's day is a question about the reader.
+  const canonical = serverTimeOf({ seconds: Date.UTC(2026, 7, 15, 23, 5, 54) / 1000, nanoseconds: 0 });
+  const placed = dateOf(canonical);
+  assert.notEqual(placed, null);
+  const local = new Date(Date.UTC(2026, 7, 15, 23, 5, 54));
+  assert.deepEqual(placed, { year: local.getFullYear(), month: local.getMonth() + 1, day: local.getDate() });
+  // A civil value is unaffected — it means the same wall clock everywhere.
+  assert.deepEqual(dateOf("2026-08-15T10:00"), { year: 2026, month: 8, day: 15 });
+});

--- a/packages/core/test/collection/test_serverTime.ts
+++ b/packages/core/test/collection/test_serverTime.ts
@@ -129,19 +129,30 @@ test("a value that merely LOOKS like an instant is left alone", () => {
   assert.equal(decodeRecordTimes(row, SCHEMA), row);
 });
 
-test("the write half puts the instant back, and re-types nothing else", () => {
+test("the write half puts back only what WAS an instant", () => {
   const stored = (parts: { seconds: number; nanoseconds: number }): unknown => ({ kind: "timestamp", ...parts });
-  const read = decodeRecordTimes({ id: "r1", submittedAt: { seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds } }, SCHEMA);
-  // What a whole-record write does with a record that was read and edited: the
-  // stamp goes back as an instant, so the rules see a field that has not moved.
-  assert.deepEqual(encodeRecordTimes({ ...read, note: "edited" }, SCHEMA, stored), {
+  // What Firestore holds right now: `submittedAt` is an instant, `note` is a string that happens
+  // to look exactly like one (imported data, or somebody typed it).
+  const previous = { id: "r1", submittedAt: { seconds: EARLY.seconds, nanoseconds: EARLY.nanoseconds }, note: serverTimeOf(EARLY) ?? "" };
+  const read = decodeRecordTimes(previous, SCHEMA);
+  // A record read, edited and written back WHOLE: the stamp returns as the instant it was, so the
+  // rules see a field that has not moved...
+  assert.deepEqual(encodeRecordTimes({ ...read, note: previous.note }, previous, stored), {
     id: "r1",
     submittedAt: { kind: "timestamp", ...EARLY },
-    note: "edited",
+    note: previous.note,
   });
-  // A STRING field holding a canonical-looking value stays a string.
-  const lookalike = { id: "r1", note: serverTimeOf(EARLY) ?? "" };
-  assert.equal(encodeRecordTimes(lookalike, SCHEMA, stored), lookalike);
+  // ...and the look-alike stays the string it always was. The FORMAT cannot tell the two apart;
+  // only what was stored can.
+  assert.equal(typeof encodeRecordTimes(read, previous, stored).note, "string");
+});
+
+test("a create preserves nothing, because nothing was stored", () => {
+  const stored = (parts: { seconds: number; nanoseconds: number }): unknown => ({ kind: "timestamp", ...parts });
+  const fresh = { id: "r1", submittedAt: serverTimeOf(EARLY) ?? "" };
+  // Unchanged, and the same object. The rules make a created stamp equal `request.time`, which no
+  // client can construct, so a valid one cannot arrive this way in the first place.
+  assert.equal(encodeRecordTimes(fresh, null, stored), fresh);
 });
 
 test("an impossible date is not canonical, so it is never stored as a different instant", () => {

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
@@ -299,7 +299,9 @@
               :type="render.inputTypeFor(field.type, editing.text[key])"
               :step="render.stepFor(field.type)"
               :required="isFieldRequiredInUi(field)"
-              :disabled="(field.primary === true && (editing.mode === 'edit' || isSingleton)) || render.isServerStamped(editing.text[key])"
+              :disabled="
+                (field.primary === true && (editing.mode === 'edit' || isSingleton)) || (field.type === 'datetime' && render.isServerStamped(editing.text[key]))
+              "
               class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
               :data-testid="`collections-input-${key}`"
             />

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionRecordPanel.vue
@@ -296,10 +296,10 @@
               v-else-if="['string', 'email', 'number', 'date', 'datetime', 'ref', 'image', 'file'].includes(field.type)"
               :id="`collections-field-${key}`"
               v-model="editing.text[key]"
-              :type="render.inputTypeFor(field.type)"
+              :type="render.inputTypeFor(field.type, editing.text[key])"
               :step="render.stepFor(field.type)"
               :required="isFieldRequiredInUi(field)"
-              :disabled="field.primary === true && (editing.mode === 'edit' || isSingleton)"
+              :disabled="(field.primary === true && (editing.mode === 'edit' || isSingleton)) || render.isServerStamped(editing.text[key])"
               class="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 focus:outline-none disabled:bg-slate-100 disabled:text-slate-400 font-medium text-slate-700 transition-all"
               :data-testid="`collections-input-${key}`"
             />

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.helpers.ts
@@ -4,7 +4,7 @@
 // function of its arguments. The composable imports these and calls them
 // from inside its computed/watch closures; behaviour is identical.
 
-import { deriveAll, fieldText } from "@mulmoclaude/core/collection";
+import { deriveAll, fieldText, isCanonicalServerTime } from "@mulmoclaude/core/collection";
 import type {
   CollectionDetailResponse,
   CollectionItem,
@@ -31,12 +31,29 @@ export function stepForFieldType(type: FieldType): string | undefined {
   return undefined;
 }
 
-export function inputTypeFor(type: FieldType): string {
+/** A value the SERVER stamped and the rules froze.
+ *
+ *  A shared collection can pin a `datetime` to the server's clock, and what
+ *  reaches the UI is the canonical instant string. It must not be offered for
+ *  editing, and the reason is not tidiness: `datetime-local` cannot hold that
+ *  string, so the control renders EMPTY, and saving the record then writes the
+ *  empty (or a re-typed civil) value over a field the rules refuse to see move.
+ *  The whole update fails, with a permission error that names nothing.
+ *
+ *  Recognised by the value rather than by the schema because the declaration
+ *  that pins it lives in the app's `app.json`, which no UI reads. */
+export function isServerStamped(value: unknown): boolean {
+  return isCanonicalServerTime(value);
+}
+
+export function inputTypeFor(type: FieldType, value?: unknown): string {
   if (type === "email") return "email";
   if (type === "number") return "number";
   if (type === "money") return "number";
   if (type === "date") return "date";
-  if (type === "datetime") return "datetime-local";
+  // A server-stamped instant is shown as text, because `datetime-local` would
+  // show nothing at all. It is also disabled where it is rendered.
+  if (type === "datetime") return isServerStamped(value) ? "text" : "datetime-local";
   return "text";
 }
 

--- a/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
+++ b/packages/plugins/collection-plugin/src/vue/useCollectionRendering.ts
@@ -36,6 +36,7 @@ import {
   formatMoney,
   hasTableRows,
   inputTypeFor,
+  isServerStamped,
   isExternalUrl,
   resolveCurrency,
   stepForFieldType,
@@ -81,7 +82,8 @@ export interface CollectionRendering {
   tableRows: (value: unknown) => Record<string, unknown>[];
   hasTableRows: (value: unknown) => boolean;
   formatSubCell: (subField: FieldSpec, value: unknown, record: CollectionItem | null) => string;
-  inputTypeFor: (type: FieldType) => string;
+  inputTypeFor: (type: FieldType, value?: unknown) => string;
+  isServerStamped: (value: unknown) => boolean;
   stepFor: (type: FieldType) => string | undefined;
   deriveAll: (schema: CollectionSchema, base: CollectionItem, refRecords: RefRecordCache) => CollectionItem;
   evaluateDerivedAgainstItem: (field: FieldSpec, fieldKey: string, item: CollectionItem) => number | null;
@@ -105,6 +107,7 @@ const STATELESS_RENDERERS = {
   tableRows,
   hasTableRows,
   inputTypeFor,
+  isServerStamped,
   stepFor: stepForFieldType,
   deriveAll,
 };

--- a/test/plugins/collection/test_collectionRenderingHelpers.ts
+++ b/test/plugins/collection/test_collectionRenderingHelpers.ts
@@ -84,8 +84,11 @@ describe("inputTypeFor", () => {
     assert.equal(isServerStamped("2026-08-15T10:00"), false);
     assert.equal(inputTypeFor("datetime", "2026-08-15T10:00"), "datetime-local");
     assert.equal(inputTypeFor("datetime", ""), "datetime-local");
-    // And nothing else is affected by the value.
+    // And nothing else is affected by the value. The lock is read alongside the field's TYPE
+    // where it is rendered, because this input is shared with string / email / ref / image / file
+    // — a string field whose value happens to look canonical must stay editable.
     assert.equal(inputTypeFor("date", stamped), "date");
+    assert.equal(inputTypeFor("string", stamped), "text");
   });
   it("falls back to text for everything else", () => {
     assert.equal(inputTypeFor("markdown"), "text");

--- a/test/plugins/collection/test_collectionRenderingHelpers.ts
+++ b/test/plugins/collection/test_collectionRenderingHelpers.ts
@@ -27,6 +27,7 @@ import {
   hasTableRows,
   inputTypeFor,
   isExternalUrl,
+  isServerStamped,
   resolveCurrency,
   sortedRefOptions,
   stepForFieldType,
@@ -70,6 +71,21 @@ describe("inputTypeFor", () => {
     assert.equal(inputTypeFor("datetime"), "datetime-local");
     assert.equal(inputTypeFor("email"), "email");
     assert.equal(inputTypeFor("date"), "date");
+  });
+  it("does not offer a datetime-local for a value it cannot hold", () => {
+    // A shared collection can pin a `datetime` to the server's clock, and what reaches the UI is
+    // the canonical instant. `datetime-local` cannot hold that string, so the control would render
+    // EMPTY — and saving the record would then write the empty value over a field the rules refuse
+    // to see move, failing the whole update with a permission error that names nothing.
+    const stamped = "2026-08-15T23:05:54.605987654Z";
+    assert.equal(isServerStamped(stamped), true);
+    assert.equal(inputTypeFor("datetime", stamped), "text");
+    // A civil value an author typed is still edited as a datetime.
+    assert.equal(isServerStamped("2026-08-15T10:00"), false);
+    assert.equal(inputTypeFor("datetime", "2026-08-15T10:00"), "datetime-local");
+    assert.equal(inputTypeFor("datetime", ""), "datetime-local");
+    // And nothing else is affected by the value.
+    assert.equal(inputTypeFor("date", stamped), "date");
   });
   it("falls back to text for everything else", () => {
     assert.equal(inputTypeFor("markdown"), "text");

--- a/test/plugins/collection/test_useCollectionRendering.ts
+++ b/test/plugins/collection/test_useCollectionRendering.ts
@@ -61,6 +61,10 @@ const EXPECTED_MEMBERS = [
   "hasTableRows",
   "formatSubCell",
   "inputTypeFor",
+  // A `datetime` whose value the SERVER stamped must not be offered for editing: the
+  // `datetime-local` control cannot hold that string, so it renders empty and saving writes the
+  // empty value over a field the rules refuse to see move.
+  "isServerStamped",
   "stepFor",
   "deriveAll",
   "evaluateDerivedAgainstItem",


### PR DESCRIPTION
MulmoTerminal 側の設計 [`plans/fix-shared-app-server-time.md`](https://github.com/receptron/mulmoterminal/blob/main/plans/fix-shared-app-server-time.md)（#1744 / #1746）の P1・P1b・P3 にあたる変更です。4 リポジトリのうち **core が先頭**で、ホスト 2 本はこの版が publish されてから追随します。

## 症状

`stampField` を宣言した共有コレクションは、公開フォームから 1 件書かれた時点で自分のスキーマに適合しなくなります。ルールが `request.resource.data[field] == request.time` を要求するので保存される値は Firestore の `Timestamp` で、DSL の `datetime` は文字列しか受けないためです。`getItems` が warning を出し、`deploy` / `publish` が止まり、出口は `confirm: true` しかありませんでした。

## ただし本体はそこではありませんでした

`Timestamp` はページまで生き延びません。実測:

```
production (structuredClone): {"seconds":1786835154,"nanoseconds":605000000}  ctor: Object
JSON (toJSON):                {"type":"firestore/timestamp/1.0","seconds":…,"nanoseconds":…}
String(cloned):               [object Object]
String(JSON round trip):      [object Object]
```

クラスごと消えるので `toMillis()` も `toDate()` もページから使えず、**「ページ側で正しく扱う」という選択肢が存在しません**。そしてその値で並べ替えるページは全行を等しいと見なし、渡された順のまま返します。**同梱の先着枠テンプレ（`gym.md`）はそのソートを出荷していて、順位は時刻ではなくドキュメント ID の順でした。** 何もエラーは出ません。

## 変更

SDK の型が出入りする唯一の継ぎ目 — `firestoreDocs` — に codec を置きます。

- **読み**（`list` / `get`）で正規形の文字列に落とす
- **書き**（`set` / `create`）で正規形の文字列**だけ**を `Timestamp` に戻す

**対称なのが肝心です。** 復号だけだと次の書き込みが壊れます — レコードは読んで編集して**丸ごと**書き戻される（`putItems` の upsert）ので、復号した値が文字列として戻り、ルールの凍結（`diff().affectedKeys()`）がその後の更新を全部拒否します。キーを消すのも同じく「動いた」扱いなので逃げ道になりません。`encode` を**自分の出力ちょうど**に絞ってあるので、著者が書いた civil の値が勝手に型を変えられることはありません。

**形**: `2026-08-15T23:05:54.605987654Z` — UTC・小数 9 桁・`Z` 固定。

- オフセット付き RFC3339 は受けません。2 つのオフセットは辞書順が時刻順になりません。
- 幅を固定するのは、末尾ゼロの省略ではなく**幅の混在**が順序を壊すからです（`…605Z` と `…605987654Z` は 4 文字目で `Z`(90) と数字を比較するので、ミリ秒の側が後ろに回る）。書きかけでこの理由を取り違えていたのを、テストが落ちて教えてくれました。
- 辞書順＝時刻順なので、**著者のページは素の文字列比較のままで正しくなります**。

あわせて:

- 記録の lint が `datetime` としてこの正規形も受ける（RFC3339 一般は不可）
- カレンダーは絶対時刻を**置く直前に**ローカルの civil に落とす。`parseIsoDateTime` は civil のまま厳格なまま — あの厳格さが守っているもの（絶対時刻を無理に civil の升目へ置く）を壊さないため。`calendarGrid` のヘッダに「環境に依存する唯一の関数」として例外を明記しました
- 移行ゲート（`validateStoreRecords`）は store 経由で読むので、これで通ります

**同値のときの決着はドキュメント ID 順**で、これは既に成立しています — どのホストも `orderBy("__name__")` で読み、JS の `sort` は安定だからです。`serverTime.ts` にその旨と「片方の読みを field ordering に変えるならこの文も置き換えること」を書いてあります。

## 検証

`packages/core`: `tsc --noEmit` / eslint / **868 tests pass**（新規 9 件を含む）。新しいテストは 3 つの到着形の復号、encode の往復、同一ミリ秒の 2 件が区別されて正しく並ぶこと、幅の混在が壊れること、lint の受け入れ、カレンダーの配置（TZ を固定）を押さえています。

## Summary by Sourcery

Normalize server-stamped timestamps at the Firestore seam into a single canonical string form and ensure shared collections and consumers treat server time consistently.

New Features:
- Introduce a server-time codec that converts Firestore Timestamp values to a canonical UTC nanosecond-precision string and back where appropriate.
- Support server-stamped instants in calendar placement so stamped records bucket correctly alongside civil datetimes.

Bug Fixes:
- Fix incorrect ordering of shared collection records in first-come templates by making server-time fields sortable via plain string comparison.
- Prevent Firestore security rules from rejecting updates to stamped records by re-encoding only canonical server-time strings back to Timestamp on writes.

Enhancements:
- Extend datetime linting to accept the canonical server-time instant format while still rejecting general RFC3339 forms that break ordering.
- Adjust calendar utilities to derive local civil date/time from server-stamped instants right at placement, with environment-dependent behavior documented.
- Export the server-time helpers from the public collection API so both hosts can share the same decoding logic instead of diverging implementations.

Tests:
- Add focused tests covering server-time canonicalization, ordering behavior, mixed-precision pitfalls, codec symmetry, lint acceptance, and calendar placement under a fixed timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for server-stamped timestamps with nanosecond precision.
  * Server timestamps now convert correctly to local dates and times.
  * Firestore records automatically decode and encode server timestamps.
  * Server-stamped datetime fields appear as read-only text in editing controls.
  * Added validation and support for server-stamped datetime values.

* **Bug Fixes**
  * Improved handling of invalid and timezone-aware timestamp values.

* **Tests**
  * Added comprehensive coverage for timestamp formatting, conversion, validation, storage, and editing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->