### PR TITLE
fix(dev): Tailwind の走査範囲を絞り、ドキュメント書き込みによるフルリロードを止める

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,17 @@
-@import "tailwindcss";
+/* Tailwind v4 auto-detects content by scanning the whole Vite root minus
+   `.gitignore`. With the workspace inside the checkout (the default —
+   `MULMOCLAUDE_WORKSPACE_PATH` is `~/mulmoclaude`), that pulls in every
+   tracked non-code file: `plans/`, `docs/`, `outputs/`, `.claude/`, root
+   `*.md`. `@tailwindcss/vite`'s `hotUpdate` has no HMR boundary for those,
+   so it broadcasts a bare `{"type":"full-reload"}` on each write — and the
+   documented workflow writes a plan record plus a CHANGELOG entry per task.
+   One session's agent turn then reloads every open tab, destroying staged
+   attachments in whichever composer the user is typing in (#2919).
+   #1940 / #2632 pruned the workspace RUNTIME dirs from the dev watcher;
+   scoping the scan here closes the class instead of enumerating dirs. */
+@import "tailwindcss" source(none);
+@source "../src";
+@source "../packages/plugins";
 
 @layer base {
   /* Tailwind v4 removed the default `cursor: pointer` on <button>


### PR DESCRIPTION
Closes #2919

## 何が起きていたか

Tailwind v4 の自動 content 検出は、**Vite root 全体（`.gitignore` を除く）** を走査入力として登録します。ワークスペースがチェックアウトの内側にある既定構成（`MULMOCLAUDE_WORKSPACE_PATH` の既定値が `~/mulmoclaude`）では、これがリポジトリの追跡下ドキュメントを全部拾います。`plans/`、`docs/`、`outputs/`、`todo/`、`batch/`、`test/`、`e2e/`、`.claude/`、ルートの `CLAUDE.md` / `README*.md`。

`@tailwindcss/vite` はそれらに HMR 境界を持たないので、1回の書き込みごとに裸の `{"type":"full-reload"}` を投げます。`[vite] page reload <file>` のログが出ないため、原因不明の再読み込みに見えます。

そして CLAUDE.md の作業フローは、ほぼ全てのタスクで plan の記録と CHANGELOG への追記を要求します。**手順どおり作業することが引き金**でした。

## なぜ「ちらつき」で済まないか

裏のセッションでターンが走っている間、リロードはユーザーが入力中の composer に着弾します。

- **添付ファイルが破棄される**（設計上メモリ保持のみ。30MB の data URL は sessionStorage のクォータを飛ばすので、この設計自体は妥当）
- フォーカスが失われる
- IME の変換中文字列が未変換のかなで下書きに固定される

下書きのテキストは生き残ります（1打鍵ごとに同期ミラー）。ただし複数セッションの並行利用は実質不可能になります。**ユーザーがリロードを要求していない**点が本質です。

## なぜ watcher の prune を延ばさないか

#1940 / #2632 はワークスペースの**実行時**ディレクトリを dev watcher から prune しました（`WORKSPACE_RUNTIME_ENTRIES`）。`conversations/` への書き込みが無音なのはそのためです。

しかしリストを延ばす対処は、次にトップレベルのドキュメントディレクトリが増えたときに同じ穴を再び開けます。ディレクトリを数え上げるのではなく、走査範囲そのものを絞りました。

## 検証

**dev — リロードが止まる**

新規に起動した dev server に対し、HMR ソケット（`ws://…`, subprotocol `vite-hmr`）を直接購読して計測。

| 操作 | 修正前 | 修正後 |
|---|---|---|
| `docs/CHANGELOG.md` を書き換え ×2 | full-reload 2 | **0** |
| `plans/*.md` を書き換え ×2 | full-reload 2 | **0** |
| `CLAUDE.md` を書き換え ×2 | full-reload 2 | **0** |

> **注意（レビュー時にハマります）**：**起動済みの dev server には効きません。** 走っているサーバは古い Tailwind の状態を保持するため、`source(none)` は再起動して初めて反映されます。最初この修正を「効かない」と誤判定しました。

**dev — スキャンは生きている**

実コンポーネントに `bg-fuchsia-500`（今回 purge された側のクラス）を足すと、dev の CSS に出現します。

**production CSS — 削除されたクラスの全数確認**

```
1438 -> 1327 classes / 152,804 -> 147,051 bytes / 追加 0
```

削除された111件の内訳を1件ずつ確認しました。

- 36件：正規表現の誤検出（CSS 中の数値）
- 10件：`[build:hooks]` `[mulmoclaude:deps]` 等、`package.json` のスクリプト名由来の文字列
- 65件：実クラスに見えるもの

65件については、`src/**` と `packages/plugins/**` の `.ts` / `.vue` / `.html` に literal で出現するか個別に照合し、**該当ゼロ**でした。

安全性の根拠として追加で確認した点：

- `bg-${...}` のような**動的クラス生成は両ツリーに一切存在しない**（0件）。これがあれば doc の文字列が偶然クラスを生かしていた可能性があり危険でしたが、該当なし
- ルート `index.html` に `class` 属性なし。走査対象外の HTML は他に存在しない
- `.vue` は `src/**` と `packages/plugins/*/src/**` にのみ存在

`bg-cyan-100` / `border-cyan-200` / `text-cyan-600` のように色がセットで消えているのは目を引きますが、実ソースが使っているのは別のシェード（`text-teal-700`、`bg-violet-600` など）で、消えた側はドキュメントのコード例由来です。

## 影響範囲

`yarn dev` のみ。production serve では `@tailwindcss/vite` の `hotUpdate` 自体が存在しないため、npm / npx のユーザーには影響しません（#1940 の記述と整合）。

## 補足

`docs/CHANGELOG.md` はこのブランチでは更新していません。作業ツリーに無関係な未コミット変更が同ファイルに乗っていたため、巻き込みを避けました。必要であれば別途追記します。

## Summary by Sourcery

Restrict Tailwind v4 content scanning to application source directories to prevent unintended full page reloads during development and reduce unused CSS in the dev build.

Bug Fixes:
- Stop dev server full reloads triggered by writes to non-code documentation and workspace files when using Tailwind v4 auto content detection.

Enhancements:
- Reduce the number of generated Tailwind CSS classes by excluding non-code files from the content scan, trimming unused styles from the bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CSS source scanning for more predictable styling behavior.
  * Limited style detection to the application and plugin source directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->