### PR TITLE
feat(settings): チャットのモデルを設定で選べるようにする

### DIFF
--- a/packages/core/assets/helps/bug-report-faq.md
+++ b/packages/core/assets/helps/bug-report-faq.md
@@ -76,6 +76,19 @@ and when it is not enabling a run the archivist short-circuits before the interv
 consulted. Neither the turn-end hook nor the hourly scheduled task will have written anything, so
 an empty journal is not evidence of a scheduler fault.
 
+## MulmoClaude is running on a different model than I picked
+
+configKey: chatModel
+source: server/agent/config.ts
+
+Read `chatModel` first. Unset is the shipping default and means the `--model` flag is omitted, so
+the CLI resolves the model from the user's own `~/.claude/settings.json` — the same file other
+Claude Code clients (VS Code / Cursor) WRITE to when the user picks a model from `/model`. So a
+model switch made in another client silently becomes MulmoClaude's model too, which reads as a bug
+but is the documented unset behaviour. Setting `chatModel` pins MulmoClaude independently of that
+file. Note an already-running turn keeps the model it started with; the change lands on the next
+one.
+
 ## Gmail / Google Calendar / Notion tools don't show up for the agent
 
 configKey: extraAllowedTools

--- a/server/agent/backend/claude-code.ts
+++ b/server/agent/backend/claude-code.ts
@@ -269,6 +269,7 @@ export function cliArgsForInput(input: AgentInput, systemPromptPath: string): Cl
     mcpConfigPath: input.mcpConfigPath,
     extraAllowedTools: input.extraAllowedTools,
     effortLevel: input.effortLevel,
+    chatModel: input.chatModel,
   };
 }
 

--- a/server/agent/backend/types.ts
+++ b/server/agent/backend/types.ts
@@ -9,7 +9,7 @@
 
 import type { Attachment } from "@mulmobridge/protocol";
 import type { Role } from "../../../src/config/roles.js";
-import type { EffortLevel } from "../../system/config.js";
+import type { ChatModel, EffortLevel } from "../../system/config.js";
 import type { AgentEvent } from "../stream.js";
 
 /** Inputs the orchestrator passes to a backend for one user turn.
@@ -40,6 +40,9 @@ export interface AgentInput {
   extraAllowedTools: string[];
   /** Reasoning effort from settings (#1323). Undefined → flag omitted. */
   effortLevel?: EffortLevel | undefined;
+  /** Model alias from settings. Undefined → flag omitted, so the backend
+   *  falls back to whatever the underlying client resolves by itself. */
+  chatModel?: ChatModel | undefined;
   /** When fired, the backend must terminate any in-flight
    *  subprocess / connection. */
   abortSignal?: AbortSignal | undefined;

--- a/server/agent/config.ts
+++ b/server/agent/config.ts
@@ -6,7 +6,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import type { Role } from "../../src/config/roles.js";
 import { mcpTools, isMcpToolEnabled } from "./mcp-tools/index.js";
 import { getActiveToolDescriptors } from "./activeTools.js";
-import type { EffortLevel, McpServerSpec } from "../system/config.js";
+import type { ChatModel, EffortLevel, McpServerSpec } from "../system/config.js";
 import { startStdioHttpShim, type ShimHandle } from "./stdioHttpShim.js";
 import { claudeConfigDir, claudeConfigJson } from "../utils/claudeConfigPath.js";
 import { getCurrentToken } from "../api/auth/token.js";
@@ -561,10 +561,15 @@ export interface CliArgsParams {
   // Reasoning effort (#1323). When undefined, the flag is omitted
   // and Claude picks its own default.
   effortLevel?: EffortLevel | undefined;
+  // Model alias for `--model`. When undefined the flag is omitted and the
+  // CLI resolves the model from the user's `~/.claude/settings.json` —
+  // which other Claude Code clients (VS Code / Cursor) also write to, so
+  // leaving it unset means MulmoClaude follows their `/model` switches.
+  chatModel?: ChatModel | undefined;
 }
 
 export function buildCliArgs(params: CliArgsParams): string[] {
-  const { systemPromptPath, activePlugins, claudeSessionId, mcpConfigPath, extraAllowedTools = [], effortLevel } = params;
+  const { systemPromptPath, activePlugins, claudeSessionId, mcpConfigPath, extraAllowedTools = [], effortLevel, chatModel } = params;
 
   const mcpToolNames = activePlugins.map((pluginName) => `mcp__mulmoclaude__${pluginName}`);
   // DEBUG: also pass the wildcard form `mcp__mulmoclaude` so Claude
@@ -630,6 +635,10 @@ export function buildCliArgs(params: CliArgsParams): string[] {
 
   if (effortLevel) {
     args.push("--effort", effortLevel);
+  }
+
+  if (chatModel) {
+    args.push("--model", chatModel);
   }
 
   return args;

--- a/server/agent/index.ts
+++ b/server/agent/index.ts
@@ -255,6 +255,7 @@ function buildAgentInput(
     mcpConfigPath: hasMcp ? mcpPaths.argPath : undefined,
     extraAllowedTools: [...settings.extraAllowedTools, ...userServerAllowedTools],
     effortLevel: settings.effortLevel,
+    chatModel: settings.chatModel,
     abortSignal,
     userTimezone,
     useDocker,

--- a/server/api/routes/config.ts
+++ b/server/api/routes/config.ts
@@ -182,6 +182,12 @@ router.put(API_ROUTES.config.settings, (req: Request<unknown, unknown, AppSettin
   if (body.effortLevel === null) {
     delete merged.effortLevel;
   }
+  // Chat-model null-sentinel: unset means "follow ~/.claude/settings.json"
+  // (the `--model` flag is omitted), which is the documented default, so
+  // the tab sends `null` rather than a literal "default" value.
+  if (body.chatModel === null) {
+    delete merged.chatModel;
+  }
   // Chat-index null-sentinel (#1944): "off" is the documented default
   // (chatIndexMode() maps undefined → "off"), so the tab sends `null`
   // to drop the field entirely and keep settings.json free of default

--- a/server/system/config.ts
+++ b/server/system/config.ts
@@ -44,6 +44,21 @@ export type ChatIndexMode = (typeof CHAT_INDEX_MODES)[number];
 export const JOURNAL_MODES = ["off", "haiku", "sonnet"] as const;
 export type JournalMode = (typeof JOURNAL_MODES)[number];
 
+// Model the main chat agent runs on, passed through as `claude --model
+// <alias>`. Deliberately family ALIASES rather than pinned ids: an alias
+// tracks the newest model in its family, so a settings file written today
+// keeps working when the next Opus ships.
+//
+// Unset (the default) omits the flag, which makes the CLI fall back to the
+// user's own `~/.claude/settings.json` — the shipping behaviour before this
+// setting existed, and the only safe default given that not every plan can
+// reach every family. Setting it here DECOUPLES MulmoClaude from that shared
+// file, so switching models in another Claude Code client (VS Code / Cursor,
+// which persist `/model` to the same `~/.claude/settings.json`) no longer
+// silently changes the model MulmoClaude runs on.
+export const CHAT_MODELS = ["opus", "sonnet", "haiku"] as const;
+export type ChatModel = (typeof CHAT_MODELS)[number];
+
 export interface AppSettings {
   // Extra tool names appended to BASE_ALLOWED_TOOLS in
   // server/agent/config.ts#buildCliArgs. Typical entries are
@@ -73,6 +88,13 @@ export interface AppSettings {
   // every agent invocation (#1323). Unset → flag is omitted →
   // Claude's own default.
   effortLevel?: EffortLevel;
+
+  // Model the main chat agent runs on, passed through as
+  // `claude --model <alias>` on every agent invocation. Unset → flag
+  // omitted → the CLI resolves the model from the user's own
+  // `~/.claude/settings.json`. Set → MulmoClaude pins its own model and
+  // stops following that shared file (see CHAT_MODELS above).
+  chatModel?: ChatModel;
 
   // Local voice input (whisper.cpp). Ships off. `enabled` is the
   // user's explicit opt-in from Settings → Voice; flipping it true is
@@ -128,6 +150,7 @@ export const APP_SETTINGS_KEYS = [
   "googleMapsApiKey",
   "photoExif",
   "effortLevel",
+  "chatModel",
   "voiceInput",
   "chatIndex",
   "journal",
@@ -145,6 +168,7 @@ export const SAFE_SETTINGS_KEYS = [
   "extraAllowedTools",
   "photoExif",
   "effortLevel",
+  "chatModel",
   "voiceInput",
   "chatIndex",
   "journal",
@@ -197,6 +221,10 @@ function isJournalMode(value: unknown): value is JournalMode {
   return JOURNAL_MODES.some((mode) => mode === value);
 }
 
+function isChatModel(value: unknown): value is ChatModel {
+  return CHAT_MODELS.some((model) => model === value);
+}
+
 function isVoiceInputSettings(value: unknown): value is { enabled: boolean; model?: string } {
   if (!isRecord(value)) return false;
   if (typeof value.enabled !== "boolean") return false;
@@ -209,16 +237,25 @@ function isVoiceInputSettings(value: unknown): value is { enabled: boolean; mode
 // as new optional settings land.
 const isOptionalBoolean = (value: unknown): boolean => value === undefined || typeof value === "boolean";
 
+// Table-driven rather than a chain of `if`s: the chain grew one branch per
+// setting and crossed the cognitive-complexity ceiling when `chatModel`
+// landed. A row per field keeps the next addition a one-liner that costs no
+// complexity, and the `keyof AppSettings` key type makes a renamed field a
+// build error instead of a silently-unvalidated one.
+const OPTIONAL_APP_SETTINGS_GUARDS: readonly (readonly [keyof AppSettings, (value: unknown) => boolean])[] = [
+  ["googleMapsApiKey", (value) => typeof value === "string"],
+  ["photoExif", isPhotoExifSettings],
+  ["effortLevel", isEffortLevel],
+  ["chatModel", isChatModel],
+  ["voiceInput", isVoiceInputSettings],
+  ["chatIndex", isChatIndexMode],
+  ["journal", isJournalMode],
+  ["pushEnabled", (value) => typeof value === "boolean"],
+  ["macosRemindersEnabled", (value) => typeof value === "boolean"],
+];
+
 function hasValidOptionalAppSettings(value: Record<string, unknown>): boolean {
-  if (value.googleMapsApiKey !== undefined && typeof value.googleMapsApiKey !== "string") return false;
-  if (value.photoExif !== undefined && !isPhotoExifSettings(value.photoExif)) return false;
-  if (value.effortLevel !== undefined && !isEffortLevel(value.effortLevel)) return false;
-  if (value.voiceInput !== undefined && !isVoiceInputSettings(value.voiceInput)) return false;
-  if (value.chatIndex !== undefined && !isChatIndexMode(value.chatIndex)) return false;
-  if (value.journal !== undefined && !isJournalMode(value.journal)) return false;
-  if (!isOptionalBoolean(value.pushEnabled)) return false;
-  if (!isOptionalBoolean(value.macosRemindersEnabled)) return false;
-  return true;
+  return OPTIONAL_APP_SETTINGS_GUARDS.every(([key, isValid]) => value[key] === undefined || isValid(value[key]));
 }
 
 export function isAppSettings(value: unknown): value is AppSettings {
@@ -245,8 +282,9 @@ export function isAppSettings(value: unknown): value is AppSettings {
  *  but lets nullable fields carry `null` as a "clear me" sentinel —
  *  callers normalise via `normaliseAppSettingsPatch` before merging
  *  into the storage shape (#1323). */
-export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel" | "chatIndex" | "journal">> & {
+export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel" | "chatModel" | "chatIndex" | "journal">> & {
   effortLevel?: EffortLevel | null;
+  chatModel?: ChatModel | null;
   chatIndex?: ChatIndexMode | null;
   journal?: JournalMode | null;
 };
@@ -254,10 +292,13 @@ export type AppSettingsPatch = Partial<Omit<AppSettings, "effortLevel" | "chatIn
 /** Convert a wire patch to the storage-shape patch by dropping any
  *  `null` sentinels (which mean "clear" for the corresponding field). */
 export function normaliseAppSettingsPatch(patch: AppSettingsPatch): Partial<AppSettings> {
-  const { effortLevel, chatIndex, journal, ...rest } = patch;
+  const { effortLevel, chatModel, chatIndex, journal, ...rest } = patch;
   const out: Partial<AppSettings> = { ...rest };
   if (effortLevel !== null && effortLevel !== undefined) {
     out.effortLevel = effortLevel;
+  }
+  if (chatModel !== null && chatModel !== undefined) {
+    out.chatModel = chatModel;
   }
   if (chatIndex !== null && chatIndex !== undefined) {
     out.chatIndex = chatIndex;
@@ -273,6 +314,7 @@ export function normaliseAppSettingsPatch(patch: AppSettingsPatch): Partial<AppS
 // ceiling as new nullable fields land.
 const isOptionalString = (value: unknown): boolean => value === undefined || typeof value === "string";
 const isOptionalNullableEffortLevel = (value: unknown): boolean => value === undefined || value === null || isEffortLevel(value);
+const isOptionalNullableChatModel = (value: unknown): boolean => value === undefined || value === null || isChatModel(value);
 const isOptionalNullableChatIndexMode = (value: unknown): boolean => value === undefined || value === null || isChatIndexMode(value);
 const isOptionalNullableJournalMode = (value: unknown): boolean => value === undefined || value === null || isJournalMode(value);
 
@@ -282,6 +324,7 @@ export function isAppSettingsPatch(value: unknown): value is AppSettingsPatch {
   if (!isOptionalString(value.googleMapsApiKey)) return false;
   if (value.photoExif !== undefined && !isPhotoExifSettings(value.photoExif)) return false;
   if (!isOptionalNullableEffortLevel(value.effortLevel)) return false;
+  if (!isOptionalNullableChatModel(value.chatModel)) return false;
   if (value.voiceInput !== undefined && !isVoiceInputSettings(value.voiceInput)) return false;
   if (!isOptionalNullableChatIndexMode(value.chatIndex)) return false;
   if (!isOptionalNullableJournalMode(value.journal)) return false;
@@ -313,6 +356,9 @@ function cloneAppSettings(settings: AppSettings): AppSettings {
   }
   if (settings.effortLevel !== undefined) {
     copy.effortLevel = settings.effortLevel;
+  }
+  if (settings.chatModel !== undefined) {
+    copy.chatModel = settings.chatModel;
   }
   if (settings.voiceInput !== undefined) {
     copy.voiceInput = { enabled: settings.voiceInput.enabled };
@@ -407,6 +453,9 @@ export function saveSettings(settings: AppSettings): void {
   }
   if (settings.effortLevel !== undefined) {
     payload.effortLevel = settings.effortLevel;
+  }
+  if (settings.chatModel !== undefined) {
+    payload.chatModel = settings.chatModel;
   }
   if (settings.voiceInput !== undefined) {
     payload.voiceInput = { enabled: settings.voiceInput.enabled };

--- a/src/components/SettingsModelTab.vue
+++ b/src/components/SettingsModelTab.vue
@@ -3,13 +3,31 @@
     <p class="text-sm text-gray-700">{{ t("settingsModal.modelTab.description") }}</p>
 
     <div class="space-y-2">
+      <label class="block text-sm font-medium text-gray-800" for="settings-chat-model">{{ t("settingsModal.modelTab.modelLabel") }}</label>
+      <select
+        id="settings-chat-model"
+        v-model="modelDraft"
+        class="w-full px-3 py-2 text-sm rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        data-testid="settings-chat-model-select"
+        @change="saveModel"
+      >
+        <option value="">{{ t("settingsModal.modelTab.modelUnset") }}</option>
+        <option v-for="model in CHAT_MODELS" :key="model" :value="model">{{ model }}</option>
+      </select>
+      <p class="text-xs text-gray-500">{{ t("settingsModal.modelTab.modelHelperText") }}</p>
+      <p v-if="loaded && !errorMessage" class="text-xs" :class="modelStatusColour" data-testid="settings-chat-model-status">
+        {{ modelStatusText }}
+      </p>
+    </div>
+
+    <div class="space-y-2">
       <label class="block text-sm font-medium text-gray-800" for="settings-model-effort">{{ t("settingsModal.modelTab.effortLabel") }}</label>
       <select
         id="settings-model-effort"
         v-model="effortDraft"
         class="w-full px-3 py-2 text-sm rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500"
         data-testid="settings-model-effort-select"
-        @change="save"
+        @change="saveEffort"
       >
         <option value="">{{ t("settingsModal.modelTab.effortUnset") }}</option>
         <option v-for="level in EFFORT_LEVELS" :key="level" :value="level">{{ level }}</option>
@@ -36,6 +54,11 @@ import { API_ROUTES } from "../config/apiRoutes";
 const EFFORT_LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
 type EffortLevel = (typeof EFFORT_LEVELS)[number];
 
+// Mirrors CHAT_MODELS in server/system/config.ts. Family aliases, not
+// pinned ids, so the choice keeps tracking the newest model in its family.
+const CHAT_MODELS = ["opus", "sonnet", "haiku"] as const;
+type ChatModel = (typeof CHAT_MODELS)[number];
+
 const { t } = useI18n();
 
 const props = defineProps<{
@@ -47,11 +70,13 @@ const emit = defineEmits<{
 }>();
 
 interface SettingsResponse {
-  settings: { extraAllowedTools: string[]; effortLevel?: EffortLevel };
+  settings: { extraAllowedTools: string[]; effortLevel?: EffortLevel; chatModel?: ChatModel };
 }
 
 const effortDraft = ref<EffortLevel | "">("");
 const storedEffort = ref<EffortLevel | "">("");
+const modelDraft = ref<ChatModel | "">("");
+const storedModel = ref<ChatModel | "">("");
 const loaded = ref(false);
 const saving = ref(false);
 const errorMessage = ref("");
@@ -69,6 +94,12 @@ const statusColour = computed(() => {
   return storedEffort.value ? "text-green-600" : "text-gray-500";
 });
 
+const modelStatusText = computed(() =>
+  storedModel.value ? t("settingsModal.modelTab.modelConfigured", { model: storedModel.value }) : t("settingsModal.modelTab.modelNotConfigured"),
+);
+
+const modelStatusColour = computed(() => (storedModel.value ? "text-green-600" : "text-gray-500"));
+
 async function load(): Promise<void> {
   errorMessage.value = "";
   const response = await apiGet<SettingsResponse>(API_ROUTES.config.base);
@@ -78,14 +109,28 @@ async function load(): Promise<void> {
   }
   storedEffort.value = response.data.settings.effortLevel ?? "";
   effortDraft.value = storedEffort.value;
+  storedModel.value = response.data.settings.chatModel ?? "";
+  modelDraft.value = storedModel.value;
   loaded.value = true;
 }
 
-async function save(): Promise<void> {
+/** PUT one settings patch, surfacing failures through `errorMessage`.
+ *  Both selects share this so the "" → `null` clear-sentinel handling
+ *  and the error path stay identical between them. */
+async function persist(payload: Record<string, unknown>): Promise<boolean> {
+  const response = await apiPut<unknown>(API_ROUTES.config.settings, payload);
+  if (!response.ok) {
+    errorMessage.value = response.error || t("settingsModal.modelTab.saveError");
+    return false;
+  }
+  return true;
+}
+
+async function saveEffort(): Promise<void> {
   if (saving.value) return;
   if (effortDraft.value === storedEffort.value) return;
   // Capture the submitted value before awaiting — if the user changes
-  // the select again while this PUT is in flight, the second save()
+  // the select again while this PUT is in flight, the second call
   // would early-return on `saving=true`, and a naive
   // `storedEffort = effortDraft` assignment after await would store
   // the newer (unsaved) draft, masking later saves (codex review).
@@ -95,19 +140,33 @@ async function save(): Promise<void> {
   // Empty selection clears the field. The server merges patches over
   // on-disk state, so omitting effortLevel keeps the previous value —
   // we must send `null` to clear. Use undefined→omitted, "" → null.
-  const payload: Record<string, unknown> = requested === "" ? { effortLevel: null } : { effortLevel: requested };
-  const response = await apiPut<unknown>(API_ROUTES.config.settings, payload);
+  const ok = await persist({ effortLevel: requested === "" ? null : requested });
   saving.value = false;
-  if (!response.ok) {
-    errorMessage.value = response.error || t("settingsModal.modelTab.saveError");
-    return;
-  }
+  if (!ok) return;
   storedEffort.value = requested;
   emit("saved");
   // If the draft moved while we were in flight, re-trigger save so
   // the latest value reaches the server.
   if (effortDraft.value !== requested) {
-    void save();
+    void saveEffort();
+  }
+}
+
+async function saveModel(): Promise<void> {
+  if (saving.value) return;
+  if (modelDraft.value === storedModel.value) return;
+  const requested = modelDraft.value;
+  saving.value = true;
+  errorMessage.value = "";
+  // "" means "follow ~/.claude/settings.json" — the documented default,
+  // stored as key-absent, so it clears via the same null sentinel.
+  const ok = await persist({ chatModel: requested === "" ? null : requested });
+  saving.value = false;
+  if (!ok) return;
+  storedModel.value = requested;
+  emit("saved");
+  if (modelDraft.value !== requested) {
+    void saveModel();
   }
 }
 

--- a/src/lang/de.ts
+++ b/src/lang/de.ts
@@ -352,6 +352,12 @@ const deMessages = {
     },
     modelTab: {
       description: "Steuert den Reasoning-Effort, den Claude Code pro Zug verwendet. Ohne Einstellung wird der Standard von Claude verwendet.",
+      modelLabel: "Modell",
+      modelUnset: "(nicht gesetzt — Standard von Claude Code verwenden)",
+      modelHelperText:
+        "Ohne Einstellung folgt MulmoClaude der Datei ~/.claude/settings.json, die auch andere Claude Code Clients (VS Code / Cursor) beim Modellwechsel schreiben — deren Wechsel ändern also auch MulmoClaude. Wählen Sie hier ein Modell, um MulmoClaude unabhängig festzulegen.",
+      modelConfigured: "Modell: {model}",
+      modelNotConfigured: "Folgt dem Standard von Claude Code",
       effortLabel: "Reasoning-Effort",
       effortUnset: "(nicht gesetzt — Standard von Claude verwenden)",
       helperText: "Höhere Stufen erlauben mehr Denkzeit, erhöhen aber Latenz und Token-Verbrauch.",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -368,6 +368,12 @@ const enMessages = {
     },
     modelTab: {
       description: "Control the reasoning effort Claude Code uses for each turn. Leave unset to use Claude's default.",
+      modelLabel: "Model",
+      modelUnset: "(unset — follow the Claude Code default)",
+      modelHelperText:
+        "Unset means MulmoClaude follows ~/.claude/settings.json, which other Claude Code clients (VS Code / Cursor) also write to when you switch models — so their switches change MulmoClaude too. Pick a model here to pin MulmoClaude independently.",
+      modelConfigured: "Model: {model}",
+      modelNotConfigured: "Following the Claude Code default",
       effortLabel: "Reasoning effort",
       effortUnset: "(unset — use Claude's default)",
       helperText: "Higher levels allow more thinking time but increase latency and token usage.",

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -354,6 +354,12 @@ const esMessages = {
     },
     modelTab: {
       description: "Controla el esfuerzo de razonamiento que Claude Code usa en cada turno. Déjalo sin configurar para usar el valor por defecto de Claude.",
+      modelLabel: "Modelo",
+      modelUnset: "(sin configurar — seguir el valor por defecto de Claude Code)",
+      modelHelperText:
+        "Sin configurar, MulmoClaude sigue ~/.claude/settings.json, un archivo que otros clientes de Claude Code (VS Code / Cursor) también escriben al cambiar de modelo, por lo que sus cambios afectan también a MulmoClaude. Elige aquí un modelo para fijar MulmoClaude de forma independiente.",
+      modelConfigured: "Modelo: {model}",
+      modelNotConfigured: "Siguiendo el valor por defecto de Claude Code",
       effortLabel: "Esfuerzo de razonamiento",
       effortUnset: "(sin configurar — usar valor por defecto de Claude)",
       helperText: "Niveles más altos permiten más tiempo de pensamiento pero aumentan la latencia y el uso de tokens.",

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -349,6 +349,12 @@ const frMessages = {
     },
     modelTab: {
       description: "Contrôle l'effort de raisonnement utilisé par Claude Code à chaque tour. Laissez vide pour utiliser la valeur par défaut de Claude.",
+      modelLabel: "Modèle",
+      modelUnset: "(non défini — suivre la valeur par défaut de Claude Code)",
+      modelHelperText:
+        "Sans réglage, MulmoClaude suit ~/.claude/settings.json, un fichier que les autres clients Claude Code (VS Code / Cursor) écrivent aussi lorsque vous changez de modèle — leurs changements modifient donc aussi MulmoClaude. Choisissez un modèle ici pour fixer MulmoClaude indépendamment.",
+      modelConfigured: "Modèle : {model}",
+      modelNotConfigured: "Suit la valeur par défaut de Claude Code",
       effortLabel: "Effort de raisonnement",
       effortUnset: "(non défini — utiliser la valeur par défaut de Claude)",
       helperText: "Les niveaux plus élevés autorisent plus de temps de réflexion mais augmentent la latence et la consommation de tokens.",

--- a/src/lang/ja.ts
+++ b/src/lang/ja.ts
@@ -350,6 +350,12 @@ const jaMessages = {
     },
     modelTab: {
       description: "Claude Code が各ターンで使う推論 effort を設定します。未設定の場合は Claude のデフォルトに従います。",
+      modelLabel: "モデル",
+      modelUnset: "(未設定 — Claude Code のデフォルトに従う)",
+      modelHelperText:
+        "未設定のときは ~/.claude/settings.json に従います。このファイルは他の Claude Code クライアント（VS Code / Cursor）がモデル切り替え時に書き換えるため、そちらでモデルを変えると MulmoClaude も一緒に変わります。ここでモデルを選ぶと、MulmoClaude だけを固定できます。",
+      modelConfigured: "モデル: {model}",
+      modelNotConfigured: "Claude Code のデフォルトに従っています",
       effortLabel: "推論 effort",
       effortUnset: "(未設定 — Claude のデフォルトを使用)",
       helperText: "高いレベルほど思考時間が長くなりますが、レイテンシとトークン消費も増えます。",

--- a/src/lang/ko.ts
+++ b/src/lang/ko.ts
@@ -350,6 +350,12 @@ const koMessages = {
     },
     modelTab: {
       description: "Claude Code가 각 턴에 사용하는 추론 effort를 제어합니다. 설정하지 않으면 Claude의 기본값이 사용됩니다.",
+      modelLabel: "모델",
+      modelUnset: "(미설정 — Claude Code 기본값을 따름)",
+      modelHelperText:
+        "미설정이면 MulmoClaude는 ~/.claude/settings.json을 따릅니다. 이 파일은 다른 Claude Code 클라이언트(VS Code / Cursor)도 모델을 전환할 때 기록하므로, 그쪽에서 모델을 바꾸면 MulmoClaude도 함께 바뀝니다. 여기서 모델을 선택하면 MulmoClaude만 독립적으로 고정할 수 있습니다.",
+      modelConfigured: "모델: {model}",
+      modelNotConfigured: "Claude Code 기본값을 따르는 중",
       effortLabel: "추론 effort",
       effortUnset: "(미설정 — Claude 기본값 사용)",
       helperText: "레벨이 높을수록 사고 시간이 늘어나지만 지연 시간과 토큰 사용량도 증가합니다.",

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -348,6 +348,12 @@ const ptBRMessages = {
     },
     modelTab: {
       description: "Controla o esforço de raciocínio que o Claude Code usa em cada turno. Deixe sem configurar para usar o padrão do Claude.",
+      modelLabel: "Modelo",
+      modelUnset: "(sem configurar — seguir o padrão do Claude Code)",
+      modelHelperText:
+        "Sem configurar, o MulmoClaude segue o ~/.claude/settings.json, arquivo que outros clientes do Claude Code (VS Code / Cursor) também escrevem ao trocar de modelo — então as trocas deles mudam o MulmoClaude junto. Escolha um modelo aqui para fixar o MulmoClaude de forma independente.",
+      modelConfigured: "Modelo: {model}",
+      modelNotConfigured: "Seguindo o padrão do Claude Code",
       effortLabel: "Esforço de raciocínio",
       effortUnset: "(sem configurar — usar padrão do Claude)",
       helperText: "Níveis mais altos permitem mais tempo de pensamento mas aumentam latência e uso de tokens.",

--- a/src/lang/zh.ts
+++ b/src/lang/zh.ts
@@ -340,6 +340,12 @@ const zhMessages = {
     },
     modelTab: {
       description: "控制 Claude Code 每个回合使用的推理强度。留空则使用 Claude 的默认值。",
+      modelLabel: "模型",
+      modelUnset: "(未设置 — 遵循 Claude Code 的默认值)",
+      modelHelperText:
+        "未设置时，MulmoClaude 会遵循 ~/.claude/settings.json。其他 Claude Code 客户端（VS Code / Cursor）在切换模型时也会写入该文件，因此在那边切换也会改变 MulmoClaude。在此选择模型即可单独固定 MulmoClaude。",
+      modelConfigured: "模型:{model}",
+      modelNotConfigured: "正在遵循 Claude Code 的默认值",
       effortLabel: "推理强度",
       effortUnset: "(未设置 — 使用 Claude 的默认值)",
       helperText: "更高的等级会带来更多思考时间,但也会增加延迟和 token 消耗。",

--- a/test/agent/test_agent_config.ts
+++ b/test/agent/test_agent_config.ts
@@ -267,6 +267,30 @@ describe("buildCliArgs", () => {
 
     assert.ok(!args.includes("--effort"));
   });
+
+  it("includes --model when chatModel is set", async () => {
+    const args = buildCliArgs({
+      systemPromptPath: "/tmp/sp.md",
+      activePlugins: [],
+      chatModel: "opus",
+    });
+
+    const modelIdx = args.indexOf("--model");
+    assert.ok(modelIdx >= 0, "--model flag must exist");
+    assert.equal(args[modelIdx + 1], "opus");
+  });
+
+  // Omission is load-bearing, not cosmetic: without the flag the CLI
+  // resolves the model from the user's own ~/.claude/settings.json, which
+  // is the documented default for an unset setting.
+  it("omits --model when chatModel is unset", async () => {
+    const args = buildCliArgs({
+      systemPromptPath: "/tmp/sp.md",
+      activePlugins: [],
+    });
+
+    assert.ok(!args.includes("--model"));
+  });
 });
 
 describe("resolveMcpConfigPaths", () => {

--- a/test/agent/test_cliArgsForInput.ts
+++ b/test/agent/test_cliArgsForInput.ts
@@ -50,6 +50,7 @@ describe("cliArgsForInput", () => {
         mcpConfigPath: "/cfg.json",
         extraAllowedTools: ["Bash"],
         effortLevel: "high",
+        chatModel: "opus",
       }),
       PROMPT_PATH,
     );
@@ -57,6 +58,7 @@ describe("cliArgsForInput", () => {
     assert.equal(params.mcpConfigPath, "/cfg.json");
     assert.deepEqual(params.extraAllowedTools, ["Bash"]);
     assert.equal(params.effortLevel, "high");
+    assert.equal(params.chatModel, "opus");
   });
 
   it("leaves optional fields undefined when the input omits them", () => {
@@ -64,6 +66,7 @@ describe("cliArgsForInput", () => {
     assert.equal(params.claudeSessionId, undefined);
     assert.equal(params.mcpConfigPath, undefined);
     assert.equal(params.effortLevel, undefined);
+    assert.equal(params.chatModel, undefined);
   });
 
   it("does not carry over non-CLI fields (message, workspacePath, port)", () => {

--- a/test/routes/test_configRoute.ts
+++ b/test/routes/test_configRoute.ts
@@ -306,6 +306,35 @@ describe("PUT /config/settings", () => {
     putSettingsHandler({ body: { journal: "opus" } } as Request, res);
     assert.equal(state.status, 400);
   });
+
+  it("sets chatModel from a patch and roundtrips it", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"] });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { chatModel: "opus" } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.equal(persisted.chatModel, "opus");
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+  });
+
+  // Key-absent, not merely "not the old value": the regression shape is
+  // the previous value leaking through `{...existing, ...patch}` once the
+  // patch is normalised to drop the null.
+  it("clears chatModel when the patch sends null", () => {
+    configMod.saveSettings({ extraAllowedTools: ["mcp__keep"], chatModel: "opus" });
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { chatModel: null } } as Request, res);
+    assert.equal(state.status, 200);
+    const persisted = configMod.loadSettings();
+    assert.equal(persisted.chatModel, undefined);
+    assert.deepEqual(persisted.extraAllowedTools, ["mcp__keep"]);
+  });
+
+  it("rejects unknown chatModel values with 400", () => {
+    const { state, res } = mockRes();
+    putSettingsHandler({ body: { chatModel: "claude-opus-4-8" } } as Request, res);
+    assert.equal(state.status, 400);
+  });
 });
 
 describe("PUT /config (atomic)", () => {

--- a/test/server/test_config.ts
+++ b/test/server/test_config.ts
@@ -120,6 +120,25 @@ describe("isAppSettingsPatch", () => {
     assert.equal(mod.isAppSettingsPatch({ journal: "" }), false);
     assert.equal(mod.isAppSettingsPatch({ journal: 42 }), false);
   });
+
+  // `chatModel` pins the model the main agent spawns with. Unset is the
+  // documented default (follow ~/.claude/settings.json), so it uses the
+  // same null clear-sentinel as effortLevel / chatIndex / journal.
+  it("accepts every known chat model and the null clear-sentinel", () => {
+    for (const model of mod.CHAT_MODELS) {
+      assert.ok(mod.isAppSettingsPatch({ chatModel: model }), `expected ${model} to be accepted`);
+    }
+    assert.ok(mod.isAppSettingsPatch({ chatModel: null }));
+  });
+
+  it("rejects unknown chatModel values on the patch path", () => {
+    // A pinned model id is deliberately rejected: only family aliases are
+    // accepted, so the stored choice keeps tracking the newest model.
+    assert.equal(mod.isAppSettingsPatch({ chatModel: "claude-opus-4-8" }), false);
+    assert.equal(mod.isAppSettingsPatch({ chatModel: "default" }), false);
+    assert.equal(mod.isAppSettingsPatch({ chatModel: "" }), false);
+    assert.equal(mod.isAppSettingsPatch({ chatModel: 42 }), false);
+  });
 });
 
 describe("normaliseAppSettingsPatch", () => {
@@ -152,6 +171,15 @@ describe("normaliseAppSettingsPatch", () => {
   it("preserves a present journal", () => {
     assert.deepEqual(mod.normaliseAppSettingsPatch({ journal: "haiku" }), { journal: "haiku" });
     assert.deepEqual(mod.normaliseAppSettingsPatch({ journal: "sonnet" }), { journal: "sonnet" });
+  });
+
+  it("strips null chatModel", () => {
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ chatModel: null }), {});
+  });
+
+  it("preserves a present chatModel", () => {
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ chatModel: "opus" }), { chatModel: "opus" });
+    assert.deepEqual(mod.normaliseAppSettingsPatch({ chatModel: "haiku" }), { chatModel: "haiku" });
   });
 });
 
@@ -496,6 +524,20 @@ describe("saveSettings", () => {
     const raw = readFileSync(mod.settingsPath(), "utf-8");
     const parsed = JSON.parse(raw);
     assert.equal("chatIndex" in parsed, false);
+  });
+
+  it("persists chatModel and roundtrips it through loadSettings", () => {
+    mod.saveSettings({ extraAllowedTools: [], chatModel: "opus" });
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [], chatModel: "opus" });
+    mod.saveSettings({ extraAllowedTools: [], chatModel: "sonnet" });
+    assert.deepEqual(mod.loadSettings(), { extraAllowedTools: [], chatModel: "sonnet" });
+  });
+
+  it("omits chatModel when unset so settings.json stays default-clean", () => {
+    mod.saveSettings({ extraAllowedTools: [] });
+    const raw = readFileSync(mod.settingsPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    assert.equal("chatModel" in parsed, false);
   });
 
   it("persists journal and roundtrips it through loadSettings", () => {


### PR DESCRIPTION
## なぜ

MulmoClaude は `--model` を渡していないため、モデルは常に `~/.claude/settings.json` の `model` から解決される。このファイルは VS Code / Cursor の Claude Code が `/model` の選択を保存する先でもある（CLI 内部で `userSettings` に書き込む）。

結果として、**別クライアントでモデルを切り替えると MulmoClaude のモデルまで黙って変わる**。UI には何も出ないので気づけず、意図しない価格帯のモデルで動き続けうる。実際にこれを踏んで調べたのがこの PR の発端。

## 変更

Settings → Model に `chatModel`（`opus` / `sonnet` / `haiku`）を追加し、設定されていれば `claude --model <alias>` を渡して MulmoClaude だけを固定する。

- **未設定＝これまで通り**（フラグ省略＝共有ファイルに追従）。既定の挙動は変えていない。プランによっては到達できないファミリーがあるため、既定を特定モデルに固定はしない
- 受け付けるのはファミリーエイリアスのみ。ピン留めした model id（`claude-opus-4-8` 等）は弾く。保存した選択が新しい世代へ自動追随するようにするため
- 経路は `effortLevel` と完全に同じ4ホップ（settings → AgentInput → cliArgsForInput → buildCliArgs）
- クリアは既存の null センチネル方式に合わせ、`settings.json` に既定値を残さない

## ついでの整理

`hasValidOptionalAppSettings` は設定が増えるたびに分岐が増える形で、今回で複雑度の上限（15）を超えた。テーブル駆動（`OPTIONAL_APP_SETTINGS_GUARDS`）に変更し、次の追加が1行で済むようにした。キー型が `keyof AppSettings` なので、リネームは未検証化ではなくビルドエラーになる。

## 検証

`yarn lint` / `yarn typecheck` / `yarn test` / `yarn build` すべて通過。

追加テスト：バリデータ（エイリアス受理・model id 拒否・null センチネル）、`normaliseAppSettingsPatch`、保存/読み込みの往復と未設定時のキー非出力、ルートの set / clear / 400、`--model` の付与と省略、`cliArgsForInput` の受け渡し。

既存の e2e-live `settings.spec.ts` は `settings-model-effort-select` と `settings-model-status` を対象にしており、追加した select は別 testid（`settings-chat-model-select`）なので影響なし。

## レビュー時の注意

`packages/core/assets/helps/bug-report-faq.md` に「想定と違うモデルで動く」の項目を追加している。この PR 自体では `@mulmoclaude/core` のバージョンは上げていないので、次の core リリースに載せてほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a configurable chat model setting that can pin MulmoClaude to a specific Claude family alias while keeping the previous shared-settings behaviour as the default, and propagate this setting through backend agent inputs to CLI arguments.

New Features:
- Introduce a chatModel option in the Settings model tab, allowing users to choose between opus, sonnet, and haiku for MulmoClaude.
- Expose the chatModel setting in the server-side AppSettings and wire it through the agent pipeline so it becomes an optional --model flag for claude CLI invocations.

Enhancements:
- Refactor optional AppSettings validation to a table-driven guard list, making future optional settings additions simpler and less complex.
- Add status messaging and helper text across supported locales to clarify how the chat model setting interacts with the Claude Code default and shared ~/.claude/settings.json.

Tests:
- Extend server, route, and agent tests to cover chatModel validation, null clear-sentinel handling, persistence/roundtrip behaviour, and inclusion/omission of the --model CLI flag.
- Add FAQ documentation and ensure existing e2e settings tests remain unaffected by the new chat model selector.
- Verify cliArgsForInput correctly passes the new chatModel setting through to buildCliArgs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings option to select Claude chat models: Opus, Sonnet, or Haiku.
  * Unset selections use the model configured in Claude settings; selected models apply independently to new turns.
  * Added support for clearing and saving model preferences.
* **Documentation**
  * Added FAQ guidance explaining model selection and turn behavior.
* **Localization**
  * Added translated model-setting labels and guidance across supported languages.
* **Bug Fixes**
  * Improved settings validation and persistence for model selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->