### PR TITLE
chore(release): @mulmoclaude/core@4.3.0 — putItems の strict-tier lint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,10 +10,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
-#### `putItems` reports the value shapes it does not refuse (mulmoterminal#1763)
+#### `@mulmoclaude/core@4.3.0` — `putItems` reports the value shapes it does not refuse (mulmoterminal#1763)
 
-`manageCollection` `putItems` gains a **`lint`** block beside `written` and
-`rejected`: the strict-tier findings on the rows it just wrote.
+Released 2026-08-17. `manageCollection` `putItems` gains a **`lint`** block beside
+`written` and `rejected`: the strict-tier findings on the rows it just wrote.
+
+Only `core`'s version and the launcher's DEP RANGE move. The plugins keep their
+declared ranges — a `^4.x` caret floats across minors, so they resolve 4.3.0 on
+their own, and ratcheting them here would force a publish cascade for a change
+none of them calls (the same reasoning as 4.1.1). The launcher's OWN version
+stays 1.13.2, which `/publish-mulmoclaude` owns.
 
 Record validation has had two tiers since the ontology work. The **enforced**
 tier is the write gate — required fields, enum values, `primaryKey` = record id,
@@ -167,7 +173,7 @@ translation behind it.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.2.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.2.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.2.0",
+    "@mulmoclaude/core": "^4.3.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",


### PR DESCRIPTION
#2925（mulmoterminal#1763 の C1/C2）がマージされたので、その publish 用のバージョンです。npm の latest は 4.2.0 のままで、tree も 4.2.0 だったため publish できませんでした。

**なぜ publish が必要か**: 変更は `dist/` だけでなく `assets/helps/collection-skills.md` と `error-recovery.md` にも入っています。この 2 つは `files: ["dist", "assets"]` で npm に出るもので、`schemaDocs` と「ツールが失敗したとき」に agent が読む文書です。publish しない限り、`datetime` は壁時計であるという記述も lint の説明も agent には届きません。

**動かしたもの**
- `packages/core/package.json` の version → 4.3.0
- ランチャーの dep range → `^4.3.0`（workspace-lockstep を保つため）
- `[Unreleased]` の `Ships` 行の core → 4.3.0、および該当エントリの見出しにバージョンを明記

**動かしていないもの**
- プラグインの宣言レンジ（`^4.1.0` / `^4.2.0`）— `^4.x` の caret は minor を跨いで浮くので自力で 4.3.0 を解決します。どのプラグインも呼んでいない変更のために publish カスケードを起こさない、という 4.1.1 と同じ判断です。
- ランチャー自身の `version`（1.13.2 のまま）— `/publish-mulmoclaude` が動かすフィールドなので、`chore(release)` では触りません。

`check:changelog-ships` と `check:launcher-sync` はローカルで green を確認済みです。

## Summary by Sourcery

Release @mulmoclaude/core 4.3.0 and align launcher dependency and changelog metadata for the putItems strict-tier lint change.

Enhancements:
- Clarify changelog entry for the putItems strict-tier lint feature with release date and packaging rationale.
- Update package release listing to reflect @mulmoclaude/core@4.3.0 within the existing bundle.

Build:
- Bump @mulmoclaude/core package version from 4.2.0 to 4.3.0.
- Update the MulmoClaude launcher dependency range to require @mulmoclaude/core@^4.3.0 while leaving plugin ranges unchanged.