### PR TITLE
test(dev-proxy): xfwd を落とすと落ちるテストにする (#2928 レビュー追随)

### DIFF
--- a/plans/fix-2928-htmlfile-dev-proxy.md
+++ b/plans/fix-2928-htmlfile-dev-proxy.md
@@ -10,7 +10,7 @@ iframe が空白になる。sandboxed iframe（opaque origin）が Vite の注�
 
 backend を起動せず Vite だけを上げて経路差を確認（`npx vite --port 45999 --strictPort`）:
 
-```
+```text
 /artifacts/html/x.html   -> 502   （proxy されている = backend 不在なので 502）
 /api/config              -> 502
 /htmlfile/abs/tmp/x.html -> 200   <!DOCTYPE html> …  ← SPA catch-all の index.html

--- a/test/config/test_viteDevProxy.ts
+++ b/test/config/test_viteDevProxy.ts
@@ -22,13 +22,34 @@ const iframeSources: readonly (readonly [string, string | null])[] = [
   ["a page presentHtml wrote", htmlArtifactPreviewUrl("artifacts/html/2026/08/report.html")],
   ["an absolute path presentHtml was pointed at", htmlFileUrl("/Users/someone/proj/demo.html")],
   ["a workspace-relative path presentHtml was pointed at", htmlFileUrl("docs/report.html")],
+  ["a Windows absolute path presentHtml was pointed at", htmlFileUrl("C:\\proj\\demo.html")],
 ];
+
+/** The two mounts whose handler emits the preview CSP from `browserVisibleOrigin(req)`
+ *  (server/index.ts). `changeOrigin` hides the browser's Host from Express, so without
+ *  `xfwd` the CSP names the backend and Safari blocks every subresource the page pulls
+ *  (#991) — a failure no URL-coverage check can see. */
+const CSP_ORIGIN_MOUNTS = ["/artifacts/html", "/htmlfile"] as const;
+
+const proxyOptionsFor = (prefix: string): { changeOrigin?: boolean; xfwd?: boolean } | null => {
+  const entry = viteConfig.server?.proxy?.[prefix];
+  return typeof entry === "object" ? entry : null;
+};
 
 describe("vite dev proxy", () => {
   iframeSources.forEach(([label, url]) => {
     it(`forwards the iframe src for ${label} to the backend`, () => {
       assert.notEqual(url, null, `the html plugin built no URL for ${label} — the fixture path no longer qualifies`);
       assert.equal(isCoveredBy(proxyPrefixes, url ?? ""), true, `${url} is not proxied — Vite's SPA catch-all would answer it with index.html`);
+    });
+  });
+
+  CSP_ORIGIN_MOUNTS.forEach((prefix) => {
+    it(`forwards the browser-visible origin on ${prefix}`, () => {
+      const options = proxyOptionsFor(prefix);
+      assert.notEqual(options, null, `${prefix} has no proxy entry to carry the forwarded origin`);
+      assert.equal(options?.changeOrigin, true, `${prefix} no longer rewrites Host — the xfwd reasoning below assumes it does`);
+      assert.equal(options?.xfwd, true, `${prefix} drops X-Forwarded-*, so its CSP would name the backend origin instead of the browser's`);
     });
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,9 @@ const requestFromLoopback = new AsyncLocalStorage<boolean>()
 // connect middleware never sees a WebSocket handshake (those arrive on the
 // http server's `upgrade` event, not the request pipeline), so the prefix
 // alone would not stop it.
+//
+// Exported for that test alone — this module is the dev server's config and
+// loads node builtins, so client code under `src/` can never import it.
 export const PROXIED_BACKEND_PREFIXES = ['/api', '/artifacts', '/htmlfile', '/ws'] as const
 
 function startsWithProxiedPrefix(url: string | undefined): boolean {


### PR DESCRIPTION
## Summary

#2929 のマージ後に届いた bot レビュー 3 件への追随。挙動の変更は無く、テストとコメントだけ。

- **CodeRabbit（実質的な指摘）**: #2929 のテストは「URL が proxy 表に当たるか」と
  「proxy 表が LAN ガードに覆われているか」は見ていたが、**`/htmlfile` が `changeOrigin` /
  `xfwd` を保っているかは見ていなかった**。`xfwd` が消えてもテストは緑のままで、
  Safari だけが CSP で subresource を全部落とす — つまり #2929 が直したのと同じ形の
  silent failure が、隣にもう一つ残っていた。CSP を `browserVisibleOrigin(req)` から
  組む 2 つの mount（`/artifacts/html` と `/htmlfile`）について両オプションを assert する。
- **Sourcery**: 絶対パスの fixture が POSIX 前提 → Windows 形 `C:\proj\demo.html` を追加し、
  `/htmlfile/abs/C%3A/…` も proxy 表に当たることを明示。
- **Sourcery**: `PROXIED_BACKEND_PREFIXES` の export がクライアントに漏れる懸念 →
  export の理由と、この module が node builtin を読むのでクライアントからは import できない
  ことをコメントに書いた（コードの変更は無し）。
- **CodeRabbit**: plan の fenced block に language tag（MD040）。

## Items to Confirm / Review

- `CSP_ORIGIN_MOUNTS` を `["/artifacts/html", "/htmlfile"]` とリテラルで持っている。
  `server/index.ts` で `browserVisibleOrigin(req)` を呼ぶ mount がこの 2 つであることに
  依存しているので、3 つ目が増えたときにここへ足す必要がある（足し忘れは
  「新しい mount の xfwd が守られない」という形で出る）。定数を server 側と共有する形に
  すべきかは判断を仰ぎたい。
- Sourcery の 2 件目は**コメントだけの対応**で、機構的な防止（lint ルール等）は入れていない。

## 検証

- 新 assert が実際に効くこと: `vite.config.ts` の `/htmlfile` から `xfwd: true` だけを外すと
  `forwards the browser-visible origin on /htmlfile` が
  「drops X-Forwarded-*, so its CSP would name the backend origin instead of the browser's」
  で fail することを確認（戻すと 7/7 pass）。
- `yarn format` → `yarn lint`（0 errors / 41 warnings、いずれも既存）→ `yarn typecheck`（exit 0）
  → `yarn build`（exit 0）→ `yarn test`（exit 0、fail 0）。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2928 fix

> あ、2929マージした

（#2929 のマージ後に届いた bot レビューを取りこぼさないための追随 PR）

Refs #2928, #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

## Summary by Sourcery

Strengthen development-proxy regression tests so origin forwarding and cross-platform HTML file paths cannot silently regress.

Enhancements:
- Add regression coverage ensuring the HTML preview proxy preserves the browser-visible origin headers required for CSP generation, including Windows absolute paths.
- Document why the backend proxy prefix export is intentionally limited to development-server configuration.

Documentation:
- Add a language tag to the fenced code block in the fix plan.

Tests:
- Expand dev-proxy tests to verify both `changeOrigin` and `xfwd` on CSP-sensitive mounts and to cover Windows absolute-path fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iframe and HTML file proxy handling for Windows absolute paths.
  * Preserved browser-visible origins for proxied artifact and HTML file requests.
  * Improved reliability when accessing proxied content across supported environments.

* **Tests**
  * Added coverage validating proxy behavior across supported path formats and origin settings.

* **Documentation**
  * Clarified configuration behavior and annotated a reproduction command for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->