### PR TITLE
chore(release): @mulmoclaude/mulmoscript-plugin@3.1.0 — deck-web peer を ^2.0.0 へ

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -324,9 +324,41 @@ ONLY through a `mulmoclaude` publish. Until that happens, an npm-installed
 sandboxed agent gets the `itemsFile` argument without the container-path
 translation behind it.
 
+### Changed
+
+#### `@mulmoclaude/mulmoscript-plugin@3.1.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+
+Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
+hosts had moved to deck-web 2.0.0, so every install printed
+`incorrect peer dependency` and npm 7+ consumers would have hit `ERESOLVE`.
+
+The declaration was stale rather than wrong: the plugin uses exactly two things
+from deck-web — `MulmoScriptDeckEditor` (one dynamic import in `View.vue`, mounted
+when every beat is a `slide`) and the `SlideLayout` / `SlideTheme` types — and
+`MulmoScriptDeckEditor.vue.d.ts` is byte-identical between 1.1.1 and 2.0.0. The
+2.0.0 major adds the `BeatListEditor` family and deprecates the iframe editor; it
+does not change the contract this plugin consumes.
+
+That also settles the stylesheet question 2.0.0 raises. Its new
+`@mulmocast/deck-web/style.css` carries the Tailwind utilities `beatToHtml` and
+`generateSlideFragment` emit — neither of which is in the shipped bundle. The path
+this plugin takes, `MulmoScriptDeckEditor` -> `SlidePreview`, renders through
+`<iframe srcdoc>` with a complete document from `generateSlideHTML()`, so it
+depends on no host stylesheet and none was added.
+
+No behaviour change and no source change — only the declared floor moves, which is
+what stops a host from assembling a deck-web 1.x combination the code is not
+tested against. Hosts satisfy the peer themselves; the launcher's dep range follows
+the workspace-lockstep ratchet, and its OWN version stays put.
+
+The deck editor's rendering has no automated coverage in this repo — nothing
+references the `mulmo-script-deck-editor` testid and `mulmo-script-edit.spec.ts`
+does not exercise a slide deck — so this rests on the contract being identical,
+not on a run.
+
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^3.0.0",
+    "@mulmoclaude/mulmoscript-plugin": "^3.1.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

PR #2941 で `@mulmoclaude/mulmoscript-plugin` の peerDependencies を `@mulmocast/deck-web: ^1.1.1` → `^2.0.0` に引き上げた分を npm に届けるための **3.1.0 リリース準備**。ソース変更はなく、動く範囲も変わらない。宣言された floor だけが動く。

| ファイル | 変更 |
|---|---|
| `packages/plugins/mulmoscript-plugin/package.json` | `version` 3.0.0 → 3.1.0 |
| `packages/mulmoclaude/package.json` | dep range `@mulmoclaude/mulmoscript-plugin` `^3.0.0` → `^3.1.0`（launcher 自身の `version` は据え置き） |
| `docs/CHANGELOG.md` | `[Unreleased]` に `### Changed` エントリ、`Ships` 行を `@3.1.0` へ |

**`npm publish` と GitHub release はこの PR には含まれません。** マージ後に author 側で実施します（下記「マージ後の手順」）。

## Items to Confirm / Review

- **launcher の range スイープは minor でも必要でした。** 当初「`^3.0.0` がそのまま 3.1.0 を拾うのでスイープ不要」と判断していましたが、`auditLauncherSync` の `workspace-lockstep` invariant が「launcher range の下限 == workspace のバージョン」を要求するため誤りでした。`yarn test` が検出:
  ```
  [workspace-lockstep] @mulmoclaude/mulmoscript-plugin: workspace source 3.1.0 is
  ahead of launcher range "^3.0.0" (lower bound 3.0.0) — bump the launcher range to match
  ```
  `docs/package-releases.md` の「never bump the launcher's `version` in a `chore(release)` commit」に従い、動かしたのは **range だけ**です。
- **minor で妥当かどうか。** peer の下限引き上げは semver 上コンシューマにとって破壊的で、npm 7+ の利用者は 4.0.0 相当の扱いを期待するかもしれません。yarn v1 は警告止まりであること、既知のホストが2つとも同時に移行することから minor を選んでいます。major にするなら launcher と mulmoterminal の range スイープが追加で必要です。
- **デッキエディタの実描画は依然として未確認**で、この repo に自動カバレッジもありません（`mulmo-script-deck-editor` testid を参照するテストは 0 件、`e2e-live/tests/mulmo-script-edit.spec.ts` も slide deck を通らない）。契約が 1.1.1 と 2.0.0 で同一であることに依拠しています。CHANGELOG にもその旨を明記しました。
- **`docs/CHANGELOG.md` の `Ships` 行**は `check:changelog-ships` が要求するため更新しています。意味は「この launcher が引き込むバージョン一覧」であって「今週 publish したもの」ではない、という script のコメントに従いました。

## User Prompt

- （PR #2941 マージ後）plugin を publish したい
- publish は PR でやってほしい。`npm publish` は認証があるので自分でやる

## 検証

bump 後の tree で、CI と同じゲートを実行:

| ゲート | 結果 |
|---|---|
| `yarn install` | exit 0 |
| `yarn typecheck` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn build:packages` / `yarn build` | exit 0 / exit 0 |
| `yarn test` | exit 0 |
| `yarn check:launcher-sync` | OK |
| `yarn check:changelog-ships` | OK — `[Unreleased]` lists all 13 `@mulmoclaude/*` dependencies |

pre-publish チェックも clean: `file:` 依存なし、`console.log` / `console.debug` / `debugger` 0 件、TODO / FIXME 0 件。

`yarn build` は commit 済みバンドルを書き換えませんでした（差分は上記3ファイルのみ）。`yarn.lock` も変化なし（workspace 内部の range のため）。

## マージ後の手順（author 側）

`docs/package-releases.md` に従い、**tag は publish の前**に:

```bash
git checkout main && git pull origin main
git tag "@mulmoclaude/mulmoscript-plugin@3.1.0"
git push origin "@mulmoclaude/mulmoscript-plugin@3.1.0"

cd packages/plugins/mulmoscript-plugin
npm publish --access public --registry https://registry.npmjs.org/

gh release create "@mulmoclaude/mulmoscript-plugin@3.1.0" --latest=false --generate-notes \
  --title "@mulmoclaude/mulmoscript-plugin@3.1.0"
```

`--latest=false` は実測で決めています（`gh release list --limit 1000` で `^v[0-9]` にマッチする app release が **45 件**あるため、パッケージリリースが Latest を奪わないようにする）。`@mulmoclaude/mulmoscript-plugin@3.0.0` タグ以降にこのパッケージのディレクトリを触ったコミットは PR #2941 の 1 件のみなので、リリースノートの対象もそれ 1 本です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDtaTRSaoFgtT8Ytvw4XnB

## Summary by Sourcery

Release @mulmoclaude/mulmoscript-plugin 3.1.0 with an updated @mulmocast/deck-web peer dependency floor and synchronized launcher metadata.

Enhancements:
- Raise the mulmoscript plugin release to 3.1.0 and align the mulmoclaude launcher dependency range with the workspace version.
- Update the changelog to document the deck-web peer dependency floor change and reflect the new package release.

Documentation:
- Document the deck-web 2.0.0 peer dependency compatibility and the absence of source or behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the MulmoScript plugin release to version 3.1.0.
  * Updated its compatible deck package version to the 2.0 release line.

* **Documentation**
  * Added an Unreleased changelog entry describing the version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->