### PR TITLE
fix(wiki): index.md の `- [[非ASCII名]]` を生の stem で索引する (#2944)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 
+#### The lint called a Japanese wiki page both missing and orphaned at the same time (#2944)
+
+`index.md` supports three shapes, and one of them — `- [[page name]]` — derives
+the entry's slug by slugifying the text between the brackets. For a page file
+named in Japanese that produced `-4`, while the file itself is indexed under its
+real stem. The two never met, so the same page was reported as an index entry
+whose file is missing AND as a file the index never mentions. Following either
+diagnostic makes it worse.
+
+Entries whose only identifier is human-written text now keep a safe non-ASCII
+name verbatim, the same rule the "create this page" hint uses. ASCII entries are
+untouched: `- [[Sakura Internet]]` still indexes `sakura-internet`, and a name no
+file could carry still falls back to the old slug rather than becoming an empty
+entry.
+
+One consequence worth knowing about: `findTagDrift` looks its pages up by
+`entry.slug`, so for these pages it has been silently skipping the check
+entirely. It now runs, and a wiki with genuine frontmatter/index tag differences
+on non-ASCII pages will start reporting them.
+
 #### Wiki pages named in Japanese could not be opened, and every link to one was reported broken (#2940)
 
 A wiki page's slug IS its filename stem, so a page saved as

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,12 @@ untouched: `- [[Sakura Internet]]` still indexes `sakura-internet`, and a name n
 file could carry still falls back to the old slug rather than becoming an empty
 entry.
 
+An index entry written with no page name at all — `- [[|display text]]` — used to
+borrow the display half as its slug, so a typo could quietly name a real page and
+disappear from the report. It is now reported as a malformed entry instead, with
+a message that says what is wrong rather than the old "references `` but the file
+does not exist".
+
 One consequence worth knowing about: `findTagDrift` looks its pages up by
 `entry.slug`, so for these pages it has been silently skipping the check
 entirely. It now runs, and a wiki with genuine frontmatter/index tag differences

--- a/packages/core/src/wiki/index-parse.ts
+++ b/packages/core/src/wiki/index-parse.ts
@@ -176,7 +176,11 @@ function parseBulletWikiLinkRow(trimmed: string): WikiPageEntry | null {
   // produces a wrong slug — Codex review on PR #1312.
   const { target, display } = parseWikiLink(match[1] ?? "");
   const title = (display || target).trim();
-  const slug = entrySlugFor(target || title);
+  // No title fallback: an explicitly empty target (`- [[|display]]`) is
+  // malformed, and borrowing the display half would let it name a real
+  // page — silently accepting the typo instead of reporting it. An
+  // empty slug reaches `findMissingFiles`, which says so (#2944).
+  const slug = entrySlugFor(target);
   const raw = match[2]?.trim() ?? "";
   const { description, tags } = extractHashTags(raw);
   return { title, slug, description, tags };

--- a/packages/core/src/wiki/index-parse.ts
+++ b/packages/core/src/wiki/index-parse.ts
@@ -8,7 +8,7 @@
 // touches `node:path`; nothing here touches disk).
 
 import { parseWikiLink } from "./link.js";
-import { wikiSlugify } from "./slug.js";
+import { wikiPageStem, wikiSlugify } from "./slug.js";
 
 export interface WikiPageEntry {
   title: string;
@@ -140,6 +140,16 @@ export function extractSlugFromBulletHref(rawHref: string): string {
   return lastSegment.replace(/\.md$/i, "");
 }
 
+/** Slug for an entry whose only identifier is human-written text.
+ *  A page file may be named in Japanese, and its slug IS that filename
+ *  stem — slugifying would index `-4` and leave the real file reported
+ *  as both missing and orphaned (#2944). `wikiPageStem` keeps the
+ *  hyphenated convention for ASCII and returns null for a name no file
+ *  could carry, where the old slug is still the best guess. */
+function entrySlugFor(name: string): string {
+  return wikiPageStem(name) ?? wikiSlugify(name);
+}
+
 function parseBulletLinkRow(trimmed: string): WikiPageEntry | null {
   const match = BULLET_LINK_PATTERN.exec(trimmed);
   if (!match) return null;
@@ -148,10 +158,10 @@ function parseBulletLinkRow(trimmed: string): WikiPageEntry | null {
   const raw = match[3]?.trim() ?? "";
   const { description, tags } = extractHashTags(raw);
   // Prefer the slug embedded in the href so non-ASCII titles keep
-  // a navigable slug. Fall back to slugifying the title only when
-  // the href has no recognisable slug (rare — usually means the
-  // author put an external URL here).
-  const slug = extractSlugFromBulletHref(href) || wikiSlugify(title);
+  // a navigable slug. Fall back to the title only when the href has
+  // no recognisable slug (rare — usually means the author put an
+  // external URL here).
+  const slug = extractSlugFromBulletHref(href) || entrySlugFor(title);
   return { title, slug, description, tags };
 }
 
@@ -166,7 +176,7 @@ function parseBulletWikiLinkRow(trimmed: string): WikiPageEntry | null {
   // produces a wrong slug — Codex review on PR #1312.
   const { target, display } = parseWikiLink(match[1] ?? "");
   const title = (display || target).trim();
-  const slug = target ? wikiSlugify(target) : wikiSlugify(title);
+  const slug = entrySlugFor(target || title);
   const raw = match[2]?.trim() ?? "";
   const { description, tags } = extractHashTags(raw);
   return { title, slug, description, tags };

--- a/packages/core/src/wiki/lint.ts
+++ b/packages/core/src/wiki/lint.ts
@@ -28,7 +28,9 @@ export function findOrphanPages(fileSlugs: ReadonlySet<string>, indexedSlugs: Re
 export function findMissingFiles(pageEntries: readonly WikiPageEntry[], fileSlugs: ReadonlySet<string>): string[] {
   const issues: string[] = [];
   for (const entry of pageEntries) {
-    if (!fileSlugs.has(entry.slug)) {
+    if (entry.slug.length === 0) {
+      issues.push(`- **Malformed entry**: index.md lists \`${entry.title}\` with no page name`);
+    } else if (!fileSlugs.has(entry.slug)) {
       issues.push(`- **Missing file**: index.md references \`${entry.slug}\` but the file does not exist`);
     }
   }

--- a/packages/core/src/wiki/lint.ts
+++ b/packages/core/src/wiki/lint.ts
@@ -47,10 +47,12 @@ export function findMissingFiles(pageEntries: readonly WikiPageEntry[], fileSlug
  *  "broken link" warnings. */
 function brokenLinkIssue(fileName: string, body: string, fileSlugs: ReadonlySet<string>, slugByTitle: ReadonlyMap<string, string>): string | null {
   const { target } = parseWikiLink(body);
-  // Empty target is its own diagnostic — `[[|display]]` or `[[]]` has
-  // nothing to resolve and would otherwise be flagged identically to a
-  // real broken link. Keep the original raw bracket body in the report
-  // so the user can grep their pages for the malformed link.
+  // Empty target is its own diagnostic — `[[|display]]` has nothing to
+  // resolve and would otherwise be flagged identically to a real broken
+  // link. Keep the original raw bracket body in the report so the user
+  // can grep their pages for the malformed link. (`[[]]` never reaches
+  // here: a zero-length body matches neither `WIKI_LINK_PATTERN` nor the
+  // renderer's scanner, so it stays literal text everywhere.)
   if (target.trim().length === 0) return `- **Broken link** in \`${fileName}\`: [[${body}]] → empty target`;
   if (resolveLinkTarget(target, fileSlugs, slugByTitle) !== null) return null;
   const stem = wikiPageStem(target);

--- a/packages/core/test/wiki/test_engine.ts
+++ b/packages/core/test/wiki/test_engine.ts
@@ -94,3 +94,26 @@ describe("frontmatterTagIndex", () => {
     assert.deepEqual(index.get("plain"), []);
   });
 });
+
+// The second supported index shape: `- [[page name]]`. Its slug comes
+// from the parser rather than an href, which is where #2944 lived.
+describe("collectLintIssues — `- [[…]]` index form", () => {
+  let wikiLinkWorkspace: string;
+
+  before(async () => {
+    wikiLinkWorkspace = await mkdtemp(path.join(tmpdir(), "wiki-bullet-"));
+    const pages = path.join(wikiLinkWorkspace, "data", "wiki", "pages");
+    await mkdir(pages, { recursive: true });
+    await writeFile(path.join(pages, `${CJK_STEM}.md`), `# ${CJK_TITLE}\n`);
+    await writeFile(path.join(wikiLinkWorkspace, "data", "wiki", "index.md"), `# Wiki\n\n- [[${CJK_STEM}]] — 概要\n`);
+  });
+
+  after(async () => {
+    await rm(wikiLinkWorkspace, { recursive: true, force: true });
+  });
+
+  it("reports neither a missing file nor an orphan for a non-ASCII page", async () => {
+    __resetPageIndexCache();
+    assert.deepEqual(await collectLintIssues(wikiLinkWorkspace), []);
+  });
+});

--- a/packages/core/test/wiki/test_engine.ts
+++ b/packages/core/test/wiki/test_engine.ts
@@ -117,3 +117,30 @@ describe("collectLintIssues — `- [[…]]` index form", () => {
     assert.deepEqual(await collectLintIssues(wikiLinkWorkspace), []);
   });
 });
+
+// A malformed `- [[|display]]` entry must stay visible even when the
+// display half names a real page — the case Codex raised on #2946.
+describe("collectLintIssues — empty index target", () => {
+  let aliasWorkspace: string;
+
+  before(async () => {
+    aliasWorkspace = await mkdtemp(path.join(tmpdir(), "wiki-alias-"));
+    const pages = path.join(aliasWorkspace, "data", "wiki", "pages");
+    await mkdir(pages, { recursive: true });
+    await writeFile(path.join(pages, "日本語.md"), "# 日本語\n");
+    await writeFile(path.join(aliasWorkspace, "data", "wiki", "index.md"), "# Wiki\n\n- [[|日本語]] — note\n");
+  });
+
+  after(async () => {
+    await rm(aliasWorkspace, { recursive: true, force: true });
+  });
+
+  it("reports the malformed entry even though the display half names a real page", async () => {
+    __resetPageIndexCache();
+    const issues = await collectLintIssues(aliasWorkspace);
+    assert.equal(issues.filter((issue) => issue.includes("Malformed entry")).length, 1);
+    // The page file is not claimed by any valid entry, so it is also an
+    // orphan — both halves of the truth, neither silently swallowed.
+    assert.equal(issues.filter((issue) => issue.includes("Orphan page")).length, 1);
+  });
+});

--- a/packages/core/test/wiki/test_indexParse.ts
+++ b/packages/core/test/wiki/test_indexParse.ts
@@ -130,6 +130,36 @@ describe("parseIndexEntries — bullet formats", () => {
     assert.equal(entry.description, "first");
   });
 
+  it("keeps a non-ASCII `- [[…]]` target as the slug (#2944)", () => {
+    // The page file is named in Japanese, so the target IS the slug.
+    // Slugifying reduced it to `-4`, and the page was then reported as
+    // BOTH a missing index reference and an orphan file.
+    const entries = parseIndexEntries("- [[不耕起栽培-カバークロップ4年計画]] — 概要");
+    assert.equal(entries.length, 1);
+    const [entry] = entries;
+    assert.ok(entry);
+    assert.equal(entry.slug, "不耕起栽培-カバークロップ4年計画");
+    assert.equal(entry.title, "不耕起栽培-カバークロップ4年計画");
+  });
+
+  it("keeps slugifying an ASCII `- [[…]]` target", () => {
+    const entries = parseIndexEntries("- [[Sakura Internet]] — note");
+    assert.equal(entries[0]?.slug, "sakura-internet");
+  });
+
+  it("falls back to a non-ASCII TITLE when the href names no page", () => {
+    // An external URL yields no href slug; the title is all there is.
+    const entries = parseIndexEntries("- [不耕起栽培](https://example.com) — note");
+    assert.equal(entries[0]?.slug, "不耕起栽培");
+  });
+
+  it("still slugifies a name that could not be a filename", () => {
+    // `wikiPageStem` returns null here, so the old slug remains the
+    // best guess rather than an empty entry.
+    const entries = parseIndexEntries("- [[../secret]] — note");
+    assert.equal(entries[0]?.slug, "secret");
+  });
+
   it("prefers slug from href when title is non-ASCII", () => {
     // wikiSlugify strips non-ASCII to "", so without the href fall-
     // back the slug would be lost. The bullet parser keeps the slug

--- a/packages/core/test/wiki/test_indexParse.ts
+++ b/packages/core/test/wiki/test_indexParse.ts
@@ -150,6 +150,12 @@ describe("parseIndexEntries — bullet formats", () => {
     assert.equal(parseIndexEntries("- [[|日本語]] — note")[0]?.title, "日本語", "the display half still titles the entry");
   });
 
+  it("skips `- [[]]` — a zero-length body is not a bullet wiki link", () => {
+    // index.md is freeform markdown: an unrecognised row is skipped,
+    // the same as a heading or a prose paragraph.
+    assert.deepEqual(parseIndexEntries("- [[]] — note"), []);
+  });
+
   it("keeps slugifying an ASCII `- [[…]]` target", () => {
     const entries = parseIndexEntries("- [[Sakura Internet]] — note");
     assert.equal(entries[0]?.slug, "sakura-internet");

--- a/packages/core/test/wiki/test_indexParse.ts
+++ b/packages/core/test/wiki/test_indexParse.ts
@@ -142,6 +142,14 @@ describe("parseIndexEntries — bullet formats", () => {
     assert.equal(entry.title, "不耕起栽培-カバークロップ4年計画");
   });
 
+  it("leaves an empty `- [[|display]]` target unresolved, whatever the script", () => {
+    // Borrowing the display half would let a malformed entry name a
+    // real page and vanish from the lint (Codex review on #2946).
+    assert.equal(parseIndexEntries("- [[|日本語]] — note")[0]?.slug, "");
+    assert.equal(parseIndexEntries("- [[|Sakura Internet]] — note")[0]?.slug, "");
+    assert.equal(parseIndexEntries("- [[|日本語]] — note")[0]?.title, "日本語", "the display half still titles the entry");
+  });
+
   it("keeps slugifying an ASCII `- [[…]]` target", () => {
     const entries = parseIndexEntries("- [[Sakura Internet]] — note");
     assert.equal(entries[0]?.slug, "sakura-internet");

--- a/packages/core/test/wiki/test_lint.ts
+++ b/packages/core/test/wiki/test_lint.ts
@@ -76,6 +76,13 @@ describe("findBrokenLinksInPage — [[slug|alias]] regression", () => {
     assert.equal(findBrokenLinksInPage("a.md", content, fileSlugs, slugByTitle).length, 1);
   });
 
+  it("leaves `[[]]` alone — a zero-length body is not a wiki link at all", () => {
+    // Pins the boundary Codex read the other way twice: `[[]]` matches
+    // neither WIKI_LINK_PATTERN nor the renderer's scanner, so it is
+    // literal text, not an empty-target link.
+    assert.deepEqual(findBrokenLinksInPage("a.md", "see [[]] here", new Set(["x"])), []);
+  });
+
   it("says a target that cannot be a filename is unusable, not merely missing", () => {
     // `../secrets` is rejected by the write guard, so `../secrets.md
     // not found` would invite creating a file that cannot exist.

--- a/packages/core/test/wiki/test_lint.ts
+++ b/packages/core/test/wiki/test_lint.ts
@@ -117,6 +117,19 @@ describe("findOrphanPages / findMissingFiles", () => {
   });
 });
 
+describe("findMissingFiles — malformed entries", () => {
+  it("names an entry with no page name as malformed, not as a missing file", () => {
+    // `- [[|日本語]]` parses to an empty slug; "references `` but the
+    // file does not exist" is unactionable (Codex review on #2946).
+    const entries: WikiPageEntry[] = [{ slug: "", title: "日本語", description: "", tags: [] }];
+    const issues = findMissingFiles(entries, new Set(["sakura-internet"]));
+    assert.equal(issues.length, 1);
+    const [issue] = issues;
+    assert.ok(issue);
+    assert.match(issue, /Malformed entry.*日本語.*no page name/);
+  });
+});
+
 describe("findTagDrift", () => {
   it("flags slugs whose index tags disagree with frontmatter tags", () => {
     const entries: WikiPageEntry[] = [

--- a/plans/fix-2944-wiki-index-cjk-bullet.md
+++ b/plans/fix-2944-wiki-index-cjk-bullet.md
@@ -1,0 +1,65 @@
+# #2944 — `- [[非ASCII名]]` 形式の index.md が Missing file / Orphan page を誤検出する
+
+## 症状
+
+`index.md` を `- [[ページ名]]` 形式で書いている場合、非 ASCII 名のページが
+**Missing file と Orphan page の両方**で同時に誤検出される。
+
+実測（`parseIndexEntries` + lint を直接実行）:
+
+```ts
+parseIndexEntries("- [[不耕起栽培-カバークロップ4年計画]] — 概要")
+// → [{ slug: "-4", title: "不耕起栽培-カバークロップ4年計画" }]
+
+findMissingFiles(entries, new Set(["不耕起栽培-カバークロップ4年計画"]))
+// → ["- **Missing file**: index.md references `-4` but the file does not exist"]
+findOrphanPages(new Set(["不耕起栽培-カバークロップ4年計画"]), new Set(["-4"]))
+// → ["- **Orphan page**: `不耕起栽培-カバークロップ4年計画.md` exists but is missing from index.md"]
+```
+
+#2940（PR #2943）で解決側 3 箇所は直したが、そこはいずれも「既知スラグ集合に
+突き合わせる」ので `matchWikiSlug` で足りた。**パース時点には既知スラグ集合が無い**ため
+別ルールが要り、独立に revert できることからスコープ外にしていた。本 PR がその残り。
+
+## 原因
+
+`packages/core/src/wiki/index-parse.ts`:
+
+- `parseBulletWikiLinkRow`（`- [[…]]` 形式）: `wikiSlugify(target)` で slug を作る
+- `parseBulletLinkRow`（`- [Title](href)` 形式）: href から stem を取れないとき
+  `wikiSlugify(title)` に落ちる
+
+`wikiSlugify` は非 ASCII を全削除するので、ファイル名 stem（＝ page index のキー）と
+永久に一致しない。
+
+## 変更
+
+slug 導出を `wikiPageStem(name) ?? wikiSlugify(name)` にする。
+`wikiPageStem` は #2943 で入れた「作るべきファイル名」の規則:
+
+- 非 ASCII を含み、かつファイル名として安全 → **生のまま**
+- ASCII → 従来どおり slugify（`- [[Sakura Internet]]` → `sakura-internet`）
+- ファイル名にできない名前 → null なので `wikiSlugify` に落として従来挙動を保つ
+
+適用は 2 箇所（`parseBulletWikiLinkRow` / `parseBulletLinkRow` の title フォールバック）。
+テーブル形式は slug 列をそのまま使うので対象外。
+
+## 副作用として直るもの
+
+`findTagDrift` は `frontmatterTagsBySlug.get(entry.slug.toLowerCase())` を引く。
+これまで非 ASCII ページの entry.slug は `-4` だったので**タグ差分の検査自体が
+黙って飛ばされていた**。今回から実際に検査されるので、既存 wiki で新たに
+（正しい）Tag drift が出ることがある。
+
+グラフのノードタイトル（`titleBySlug`）も正しい entry を引くようになる。
+
+## 検証
+
+- 修正前の実測を上に記録済み（誤検出の再現）
+- ユニットテスト:
+  - `test_indexParse.ts`: `- [[非ASCII名]]` が生 stem、ASCII は slugify のまま、
+    ファイル名にできない名前は従来どおり
+  - `test_lint.ts` / engine の fs フィクスチャ: `- [[非ASCII名]]` 形式の index で
+    Missing file / Orphan page が出ないこと
+- **修正を revert するとこれらが赤になることを確認する**
+- `yarn format` → `yarn lint` → `yarn typecheck` → `yarn build` → `yarn test`


### PR DESCRIPTION
## Summary

`index.md` を `- [[ページ名]]` 形式で書いている場合、日本語（非 ASCII）名のページが
**Missing file と Orphan page の両方で同時に**誤検出される問題を直す。Fixes #2944

#2940 / PR #2943 で解決側（`resolvePagePath` / `findBrokenLinksInPage` /
`resolveLinkTarget`）は直したが、そこはいずれも「既知スラグ集合に突き合わせる」ので
`matchWikiSlug` で足りた。**パース時点には既知スラグ集合が無い**ため別ルールが要り、
独立に revert できることからスコープ外にしていた。本 PR がその残り。

### 実測（修正前）

```ts
parseIndexEntries("- [[不耕起栽培-カバークロップ4年計画]] — 概要")
// → [{ slug: "-4", title: "不耕起栽培-カバークロップ4年計画" }]

findMissingFiles(entries, new Set(["不耕起栽培-カバークロップ4年計画"]))
// → ["- **Missing file**: index.md references `-4` but the file does not exist"]
findOrphanPages(new Set(["不耕起栽培-カバークロップ4年計画"]), new Set(["-4"]))
// → ["- **Orphan page**: `不耕起栽培-カバークロップ4年計画.md` exists but is missing from index.md"]
```

ファイルは存在し index.md にも載っているのに、**「参照先が無い」と「index に無い」が同時に**出る。
片方の指摘に従うともう片方が悪化する。

### 変更

人間が書いたテキストしか手がかりが無い entry の slug 導出を
`wikiPageStem(name) ?? wikiSlugify(name)` にする（#2943 で入れた
「作るべきファイル名」の規則をそのまま使う）:

| 入力 | before | after |
|---|---|---|
| `- [[不耕起栽培-カバークロップ4年計画]]` | `-4` | `不耕起栽培-カバークロップ4年計画` |
| `- [[Sakura Internet]]` | `sakura-internet` | `sakura-internet`（不変） |
| `- [不耕起栽培](https://example.com)` | `-` | `不耕起栽培` |
| `- [[../secret]]` | `secret` | `secret`（不変・空 entry にしない） |

テーブル形式は slug 列をそのまま使うので対象外。href から stem を取れる
`- [Title](pages/….md)` 形式も従来どおり（#2940 の報告者はこの形式）。

## Items to Confirm / Review

1. **`findTagDrift` がこれまで黙って飛ばされていた**。`entry.slug` で
   frontmatter タグ索引を引くため、非 ASCII ページの entry.slug が `-4` だった間は
   一致せず検査自体が走っていなかった。本 PR 以降は実際に走るので、
   **既存 wiki で新たに（正しい）Tag drift 指摘が出ることがある**。
   これは意図した挙動という理解でよいか確認してほしい。
2. **ファイル名にできない名前は従来の slug に落とす**判断（`- [[../secret]]` → `secret`）。
   空 entry にすると `Missing file: index.md references \`\`` という無意味な指摘が出るため
   こうしている。
3. `@mulmoclaude/core` は npm 公開パッケージなので、npm 経由ユーザーに届けるには
   別途 publish が必要（#2943 と合わせて 1 回で足りる）。

## 検証

- 修正前の誤検出を実測で再現 → 修正後は Missing file / Orphan page とも 0 件
- ユニットテスト:
  - `test_indexParse.ts`: 非 ASCII target が生 stem / ASCII は slugify のまま /
    外部 URL でタイトルだけの場合 / ファイル名にできない名前は従来どおり
  - `test_engine.ts`: `- [[非ASCII名]]` 形式の index.md を持つ実 fs フィクスチャで
    `collectLintIssues` が 0 件
- **修正（1 行）を revert すると新規テスト 3 本が赤になることを確認**。
  ASCII / 不正名のテストは revert しても緑のままで、挙動を変えていないことを示す
- `yarn format` → `yarn lint`（0 errors）→ `yarn typecheck` → `yarn build` → `yarn test`

## User Prompt

> 一旦マージしてつぎBでよい？

（#2943 をマージしたうえで、そこでスコープ外にした B = 本 PR を続けて実施する、の意）

work in mulmoclaude2

## Summary by Sourcery

Correct wiki index parsing so page entries resolve to the same stems as their files and malformed targets remain visible to linting.

Bug Fixes:
- Prevent non-ASCII wiki pages listed as `- [[page name]]` from being reported simultaneously as missing files and orphan pages.
- Report empty wiki-link targets in index entries as malformed entries instead of treating their display text as a page name.

Enhancements:
- Preserve safe non-ASCII page names as index stems while retaining existing ASCII slugification and invalid-name fallback behavior.

Documentation:
- Document the corrected non-ASCII index behavior, malformed entry diagnostics, and the resulting tag-drift checks.

Tests:
- Add parser and lint coverage for non-ASCII targets, malformed empty targets, ASCII compatibility, external links, invalid names, and literal `[[]]` handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed wiki indexes incorrectly converting Japanese and other safe non-ASCII page names into invalid slugs.
  - Prevented false “Missing file” and “Orphan page” diagnostics for non-ASCII wiki pages.
  - Preserved existing ASCII slug behavior and fallback handling for invalid page names.
  - Improved page resolution for tag drift and related wiki checks.
  - Reported empty wiki-link targets as malformed entries instead of using display text as the page name.
  - Clarified that empty wiki links such as `[[]]` are treated as literal text.

- **Tests**
  - Added coverage for non-ASCII links, empty targets, ASCII slugs, invalid names, and malformed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->