### PR TITLE
feat: mulmoscript-plugin を @mulmocast/beat-editor へ移行 + plugin 単体デモ (#2945)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Changed
+
+#### The MulmoScript deck editor now runs on `@mulmocast/beat-editor` (#2945)
+
+`@mulmocast/deck-web` is deprecated as a rename, but the component the plugin used —
+`MulmoScriptDeckEditor` — was removed along with the iframe editor, so this is a swap rather
+than a rename. `BeatListEditor` takes and emits a beat array, and the script goes through
+`beatsOf` / `withBeats` on the way in and out; writing `{ ...script, beats }` by hand would drop
+`presentationStyle` and `slideParams` silently.
+
+The `layout="compact"` prop is gone: the editor lays itself out from its own width, so inside
+the plugin card the editing pane moves below the beat list instead of beside it.
+
+This also fixes a stylesheet gap that predates the migration. Nothing imported the editor's
+`style.css`, and Tailwind only scans the package it is building, so the deck editor had been
+rendering without `w-96`, `min-h-0`, `overflow-auto` or `border-r`. It is imported from the
+plugin now, which keeps it correct on any host rather than one that remembers to add an
+`@source`.
+
+`@mulmoclaude/mulmoscript-plugin` goes to **4.0.0** — the peer dependency change is breaking.
+
 ### Fixed
 
 #### Wiki pages named in Japanese could not be opened, and every link to one was reported broken (#2940)
@@ -353,7 +374,7 @@ translation behind it.
 
 ### Changed
 
-#### `@mulmoclaude/mulmoscript-plugin@3.1.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+#### `@mulmoclaude/mulmoscript-plugin@4.0.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
 
 Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
 hosts had moved to deck-web 2.0.0, so every install printed
@@ -385,7 +406,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@3.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@marp-team/marp-core": "^4.4.0",
     "@mulmobridge/client": "^1.0.2",
     "@mulmocast/deck": "^2.0.0",
-    "@mulmocast/beat-editor": "^1.1.0",
+    "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/types": "^2.11.0",
     "@mulmochat-plugin/quiz": "^2.0.0",
     "@mulmochat-plugin/ui-image": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@marp-team/marp-core": "^4.4.0",
     "@mulmobridge/client": "^1.0.2",
     "@mulmocast/deck": "^2.0.0",
-    "@mulmocast/deck-web": "^2.0.0",
+    "@mulmocast/beat-editor": "^1.1.0",
     "@mulmocast/types": "^2.11.0",
     "@mulmochat-plugin/quiz": "^2.0.0",
     "@mulmochat-plugin/ui-image": "^0.4.1",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^3.1.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.0.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/demo/App.vue
+++ b/packages/plugins/mulmoscript-plugin/demo/App.vue
@@ -17,7 +17,12 @@ import { createRuntimeStub } from "./runtimeStub";
 import { sampleDeck } from "./sampleDeck";
 import RuntimeProvider from "./RuntimeProvider.vue";
 import ShadowFrame from "./ShadowFrame.vue";
-import pluginCss from "../src/style.css?inline";
+// The BUILT stylesheet, which is what the host injects into the shadow root — not the
+// source one. `src/style.css` is `@import "tailwindcss"` and carries no utilities until
+// Vite compiles it, so injecting that put the editor in a shadow root with no rules at all:
+// the container query never applied, the pane took 498px of 589px, and the slide preview
+// was clipped to 91px. Run `yarn build` before `yarn dev` when the styles change.
+import pluginCss from "../dist/style.css?inline";
 
 // The transport hands the WHOLE envelope back as `data` (`transport.ts` returns
 // `{ ok: true, data: result }`), so each kind's payload sits beside `ok` rather than under a

--- a/packages/plugins/mulmoscript-plugin/demo/App.vue
+++ b/packages/plugins/mulmoscript-plugin/demo/App.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+/**
+ * Standalone harness for the presentMulmoScript View.
+ *
+ * Two toggles, because the two things that are hard to judge from the code are both about
+ * where the component ends up rather than what it renders:
+ *
+ *  - **width** — the editor lays itself out from its own width now (no `layout` prop), and the
+ *    plugin card in MulmoTerminal is narrow. 600px is that card; "wide" is the desktop case.
+ *  - **shadow** — the plugin really mounts inside a Shadow DOM with only its own bundled CSS.
+ *    A stylesheet appended to `document.head` at runtime does not cross that boundary.
+ */
+import { computed, ref } from "vue";
+import type { ToolResultComplete } from "gui-chat-protocol/vue";
+import View from "../src/vue/View.vue";
+import { createRuntimeStub } from "./runtimeStub";
+import { sampleDeck } from "./sampleDeck";
+import RuntimeProvider from "./RuntimeProvider.vue";
+import ShadowFrame from "./ShadowFrame.vue";
+import pluginCss from "../src/style.css?inline";
+
+// The transport hands the WHOLE envelope back as `data` (`transport.ts` returns
+// `{ ok: true, data: result }`), so each kind's payload sits beside `ok` rather than under a
+// `data` key. Measured: nesting it threw `pending.data.pending is not iterable` on mount.
+const DISPATCH_RESULTS: Record<string, object> = {
+  pendingGenerations: { pending: [] },
+};
+
+const { runtime, calls } = createRuntimeStub((args) => {
+  const kind = (args as { kind?: string }).kind ?? "";
+  return { ok: true, ...(DISPATCH_RESULTS[kind] ?? {}) };
+});
+
+const NARROW_PX = 600;
+const narrow = ref(true);
+const inShadow = ref(true);
+
+const result = ref({
+  uuid: "demo-mulmoscript",
+  status: "complete",
+  data: { filePath: "/demo/deck.json", script: sampleDeck },
+} as unknown as ToolResultComplete<never>);
+
+const frameStyle = computed(() => (narrow.value ? { width: `${NARROW_PX}px` } : { width: "100%" }));
+const dispatched = computed(() => calls.map((c) => c.kind));
+</script>
+
+<template>
+  <div class="min-h-screen bg-gray-100 p-6 space-y-4">
+    <header class="space-y-2">
+      <h1 class="text-xl font-bold text-gray-900">presentMulmoScript — deck editor</h1>
+      <div class="flex gap-4 text-sm text-gray-700">
+        <label class="flex items-center gap-2">
+          <input v-model="narrow" type="checkbox" />
+          narrow ({{ NARROW_PX }}px — the plugin card)
+        </label>
+        <label class="flex items-center gap-2">
+          <input v-model="inShadow" type="checkbox" />
+          inside a Shadow DOM (how the host mounts it)
+        </label>
+      </div>
+      <p class="text-xs text-gray-500">dispatched: {{ dispatched.length ? dispatched.join(", ") : "(nothing yet)" }}</p>
+    </header>
+
+    <div :style="frameStyle" class="h-[720px] rounded-lg border border-gray-300 bg-white overflow-hidden">
+      <ShadowFrame v-if="inShadow" :key="`shadow-${narrow}`" :css="pluginCss" :runtime="runtime" :component="View" :component-props="{ selectedResult: result }" />
+      <RuntimeProvider v-else :runtime="runtime">
+        <View :selected-result="result" />
+      </RuntimeProvider>
+    </div>
+  </div>
+</template>

--- a/packages/plugins/mulmoscript-plugin/demo/App.vue
+++ b/packages/plugins/mulmoscript-plugin/demo/App.vue
@@ -21,7 +21,10 @@ import ShadowFrame from "./ShadowFrame.vue";
 // source one. `src/style.css` is `@import "tailwindcss"` and carries no utilities until
 // Vite compiles it, so injecting that put the editor in a shadow root with no rules at all:
 // the container query never applied, the pane took 498px of 589px, and the slide preview
-// was clipped to 91px. Run `yarn build` before `yarn dev` when the styles change.
+// was clipped to 91px.
+//
+// `dist/` is gitignored, so `predev` builds it first — without that a fresh clone answers
+// 500 for this import, measured.
 import pluginCss from "../dist/style.css?inline";
 
 // The transport hands the WHOLE envelope back as `data` (`transport.ts` returns

--- a/packages/plugins/mulmoscript-plugin/demo/RuntimeProvider.vue
+++ b/packages/plugins/mulmoscript-plugin/demo/RuntimeProvider.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+/**
+ * Installs the runtime for the light-DOM case.
+ *
+ * `provide` reaches descendants, not the component that calls it, so the runtime has to come
+ * from a PARENT of the View — calling `provide` beside it in App.vue throws
+ * "useRuntime() called outside of <PluginScopedRoot>". The Shadow DOM case installs it on its
+ * own app instead (see ShadowFrame), which is how a host does it per plugin.
+ */
+import { provide } from "vue";
+import { PLUGIN_RUNTIME_KEY, type BrowserPluginRuntime } from "gui-chat-protocol/vue";
+
+const props = defineProps<{ runtime: BrowserPluginRuntime }>();
+provide(PLUGIN_RUNTIME_KEY, props.runtime);
+</script>
+
+<template>
+  <slot />
+</template>

--- a/packages/plugins/mulmoscript-plugin/demo/ShadowFrame.vue
+++ b/packages/plugins/mulmoscript-plugin/demo/ShadowFrame.vue
@@ -15,6 +15,24 @@
 import { createApp, onBeforeUnmount, onMounted, ref, type App, type Component } from "vue";
 import { PLUGIN_RUNTIME_KEY, type BrowserPluginRuntime } from "gui-chat-protocol/vue";
 
+/** Copied from the host's PluginFrame so the demo shows what a user actually sees. */
+const ICON_ALIAS_CSS = `
+.material-icons,
+.material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
+}`;
+
 const props = defineProps<{ css: string; runtime: BrowserPluginRuntime; component: Component; componentProps: Record<string, unknown> }>();
 
 const host = ref<HTMLDivElement | null>(null);
@@ -24,6 +42,13 @@ onMounted(() => {
   const element = host.value;
   if (!element) return;
   const shadow = element.attachShadow({ mode: "open" });
+  // The host aliases the icon classes inside every plugin's shadow root
+  // (`PluginFrame.vue` → MATERIAL_ICONS_SHADOW_CSS); without it `content_copy` renders as
+  // the literal word. The @font-face itself is registered on the document by main.ts —
+  // a shadow root cannot register one.
+  const iconStyle = document.createElement("style");
+  iconStyle.textContent = ICON_ALIAS_CSS;
+  shadow.appendChild(iconStyle);
   const style = document.createElement("style");
   style.textContent = props.css;
   shadow.appendChild(style);

--- a/packages/plugins/mulmoscript-plugin/demo/ShadowFrame.vue
+++ b/packages/plugins/mulmoscript-plugin/demo/ShadowFrame.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+/**
+ * The plugin's real mounting condition: a Shadow DOM, with only the plugin's own CSS inside.
+ *
+ * MulmoTerminal mounts every plugin this way (`PluginFrame.vue` → `attachShadow({ mode: "open" })`)
+ * and injects the plugin's compiled stylesheet into the shadow root. A stylesheet the component
+ * appends to `document.head` at runtime does NOT cross that boundary — which is exactly the
+ * question this demo exists to answer, so the toggle has to reproduce it faithfully.
+ *
+ * A shadow root is a separate tree, so the content is mounted as its own Vue app rather than
+ * teleported: `provide`/`inject` walks the component chain, and re-rendering a slot into a
+ * detached container breaks that chain. The runtime is therefore installed on the app created
+ * here, exactly as a host installs it per plugin.
+ */
+import { createApp, onBeforeUnmount, onMounted, ref, type App, type Component } from "vue";
+import { PLUGIN_RUNTIME_KEY, type BrowserPluginRuntime } from "gui-chat-protocol/vue";
+
+const props = defineProps<{ css: string; runtime: BrowserPluginRuntime; component: Component; componentProps: Record<string, unknown> }>();
+
+const host = ref<HTMLDivElement | null>(null);
+let mounted: App | null = null;
+
+onMounted(() => {
+  const element = host.value;
+  if (!element) return;
+  const shadow = element.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = props.css;
+  shadow.appendChild(style);
+  const mount = document.createElement("div");
+  // The host gives the isolated frame a light surface; match it so colours read the same.
+  mount.style.cssText = "background:#ffffff;color:#111827;height:100%;overflow:hidden";
+  shadow.appendChild(mount);
+  mounted = createApp(props.component, props.componentProps);
+  mounted.provide(PLUGIN_RUNTIME_KEY, props.runtime);
+  mounted.mount(mount);
+});
+
+onBeforeUnmount(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+</script>
+
+<template>
+  <div ref="host" class="h-full"></div>
+</template>

--- a/packages/plugins/mulmoscript-plugin/demo/main.ts
+++ b/packages/plugins/mulmoscript-plugin/demo/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+import "../src/style.css";
+
+createApp(App).mount("#app");

--- a/packages/plugins/mulmoscript-plugin/demo/main.ts
+++ b/packages/plugins/mulmoscript-plugin/demo/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from "vue";
 import App from "./App.vue";
+import "material-symbols/outlined.css";
 import "../src/style.css";
 
 createApp(App).mount("#app");

--- a/packages/plugins/mulmoscript-plugin/demo/runtimeStub.ts
+++ b/packages/plugins/mulmoscript-plugin/demo/runtimeStub.ts
@@ -1,0 +1,47 @@
+// A `BrowserPluginRuntime` that answers without a host.
+//
+// The demo exists to look at the View, not to exercise the server: `dispatch` records the
+// call and reports success, so a save round-trip completes and the View stays on the edit
+// the user just made. Anything that would need a real backend answers with an empty result
+// rather than throwing, because a thrown dispatch is folded into an error banner and hides
+// the UI the demo is there to show.
+//
+// Written to be liftable: nothing here knows about mulmoscript, so this becomes the shared
+// harness when the other plugins get a demo (#2945).
+
+import { ref } from "vue";
+import type { BrowserPluginRuntime } from "gui-chat-protocol/vue";
+
+export type DispatchRecord = { kind: string; args: object };
+
+export interface RuntimeStub {
+  runtime: BrowserPluginRuntime;
+  /** Every dispatch the View made, newest last — shown in the demo so the wiring is visible. */
+  calls: DispatchRecord[];
+}
+
+const kindOf = (args: object): string => {
+  const kind = (args as { kind?: unknown }).kind;
+  return typeof kind === "string" ? kind : "(no kind)";
+};
+
+export const createRuntimeStub = (respond: (args: object) => unknown = () => ({ ok: true })): RuntimeStub => {
+  const calls: DispatchRecord[] = [];
+  const runtime = {
+    pubsub: { subscribe: () => () => {} },
+    locale: ref("en"),
+    log: {
+      debug: (msg: string) => console.debug("[demo]", msg),
+      info: (msg: string) => console.info("[demo]", msg),
+      warn: (msg: string) => console.warn("[demo]", msg),
+      error: (msg: string) => console.error("[demo]", msg),
+    },
+    openUrl: (url: string) => window.open(url, "_blank", "noopener,noreferrer"),
+    dispatch: (args: object, parse?: (raw: unknown) => unknown) => {
+      calls.push({ kind: kindOf(args), args });
+      const raw = respond(args);
+      return Promise.resolve(parse ? parse(raw) : raw);
+    },
+  } as unknown as BrowserPluginRuntime;
+  return { runtime, calls };
+};

--- a/packages/plugins/mulmoscript-plugin/demo/sampleDeck.ts
+++ b/packages/plugins/mulmoscript-plugin/demo/sampleDeck.ts
@@ -1,0 +1,49 @@
+// An all-slide MulmoScript, which is the condition that makes the View mount the deck editor
+// (`isAllSlideDeck`). Layouts are chosen for what the demo has to show: `grid` and `columns`
+// carry reorderable list items, `bigQuote` was the layout whose marker used to swallow its own
+// quotation marks, and `title` is the plain case.
+
+export const sampleDeck = {
+  title: "Beat editor demo",
+  lang: "en",
+  presentationStyle: { slideParams: { theme: { name: "default" } } },
+  beats: [
+    {
+      text: "Opening",
+      image: { type: "slide", slide: { layout: "title", title: "Beat editor demo", subtitle: "mounted the way the plugin mounts it" } },
+    },
+    {
+      text: "Three things",
+      image: {
+        type: "slide",
+        slide: {
+          layout: "grid",
+          title: "What to look at",
+          items: [
+            { title: "Layout", description: "does the pane sit beside the list, or under it" },
+            { title: "Slide styling", description: "do the slides themselves have their theme" },
+            { title: "Reorder", description: "drag one of these cards onto another" },
+          ],
+        },
+      },
+    },
+    {
+      text: "Two columns",
+      image: {
+        type: "slide",
+        slide: {
+          layout: "columns",
+          title: "Columns",
+          columns: [
+            { title: "Left", content: [{ type: "bullets", items: ["first", "second"] }] },
+            { title: "Right", content: [{ type: "bullets", items: ["third", "fourth"] }] },
+          ],
+        },
+      },
+    },
+    {
+      text: "Closing",
+      image: { type: "slide", slide: { layout: "bigQuote", quote: "Design is not just what it looks like", author: "Steve Jobs" } },
+    },
+  ],
+};

--- a/packages/plugins/mulmoscript-plugin/index.html
+++ b/packages/plugins/mulmoscript-plugin/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>presentMulmoScript — plugin demo</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/demo/main.ts"></script>
+  </body>
+</html>

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -34,6 +34,7 @@
     "access": "public"
   },
   "scripts": {
+    "predev": "vite build",
     "dev": "vite",
     "build": "vite build && vue-tsc -p tsconfig.build.json --emitDeclarationOnly",
     "prepack": "vite build && vue-tsc -p tsconfig.build.json --emitDeclarationOnly",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmocast/beat-editor": "^1.1.0",
+    "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
     "@mulmoclaude/core": "^4.1.0",
     "graphai": "^2.0.18",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",
@@ -34,6 +34,7 @@
     "access": "public"
   },
   "scripts": {
+    "dev": "vite",
     "build": "vite build && vue-tsc -p tsconfig.build.json --emitDeclarationOnly",
     "prepack": "vite build && vue-tsc -p tsconfig.build.json --emitDeclarationOnly",
     "typecheck": "vue-tsc --noEmit",
@@ -44,7 +45,7 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmocast/deck-web": "^2.0.0",
+    "@mulmocast/beat-editor": "^1.1.0",
     "@mulmocast/types": "^2.9.0",
     "@mulmoclaude/core": "^4.1.0",
     "graphai": "^2.0.18",

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -78,12 +78,18 @@
       @render-character="renderCharacter"
     />
 
-    <!-- Deck editor (#1575): every beat is a slide → mount the
-         interactive deck editor from @mulmocast/deck-web. The Vue
-         component is lazy-loaded via defineAsyncComponent, so users
-         whose scripts aren't decks never pay the bundle cost. -->
+    <!-- Deck editor (#1575, #2945): every beat is a slide → mount the interactive
+         editor from @mulmocast/beat-editor. Lazy-loaded via defineAsyncComponent, so
+         users whose scripts aren't decks never pay the bundle cost.
+
+         It takes and emits a beat ARRAY, so the script goes through beatsOf / withBeats
+         on the way in and out. Writing `{ ...script, beats }` by hand instead drops
+         presentationStyle and slideParams, and nothing tells you it happened.
+
+         No `layout` prop: the editor lays itself out from its own width, so the pane
+         moves below the list on a narrow host (this card) rather than beside it. -->
     <div v-if="isDeck" class="flex-1 overflow-hidden" data-testid="mulmo-script-deck-editor">
-      <MulmoScriptDeckEditor :script="deckScriptInput" layout="compact" @update:script="onDeckUpdate" />
+      <BeatListEditor :beats="deckBeats" @update:beats="onDeckBeatsUpdate" />
     </div>
 
     <!-- Beat list (fallback when the script has any non-slide beat) -->
@@ -359,6 +365,7 @@ import {
   clearReactiveRecords,
   type Beat,
 } from "./helpers";
+import { beatsOf, withBeats, type EditableBeat } from "@mulmocast/beat-editor";
 import { errorMessage } from "@mulmoclaude/common";
 import { readFileAsDataUrl, useClipboardCopy } from "./support";
 import { useMulmoScriptTransport } from "./transport";
@@ -373,11 +380,11 @@ import CharacterStrip from "./components/CharacterStrip.vue";
 import MulmoScriptToolbar from "./components/MulmoScriptToolbar.vue";
 import { useT } from "../lang/index";
 
-// Lazy-loaded so the deck editor's Vue / tailwind / SlidePreview chunk
-// stays out of the initial bundle for users whose scripts aren't decks
+// Lazy-loaded so the editor's Vue / tailwind chunk stays out of the initial
+// bundle for users whose scripts aren't decks
 // (movies, html_tailwind animations, mixed beats). `defineAsyncComponent`
 // triggers the dynamic import only when `isDeck` first flips true.
-const MulmoScriptDeckEditor = defineAsyncComponent(() => import("@mulmocast/deck-web").then((mod) => mod.MulmoScriptDeckEditor));
+const BeatListEditor = defineAsyncComponent(() => import("@mulmocast/beat-editor").then((mod) => mod.BeatListEditor));
 
 const api = useMulmoScriptTransport();
 const adapter = useHostAdapter();
@@ -693,10 +700,20 @@ function commitScript(next: MulmoScript): void {
 }
 
 // #1575 — when every beat is a `slide`, swap the per-beat list UI for the
-// interactive deck editor (@mulmocast/deck-web). Mixed scripts (any non-slide
+// interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
 const { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave } = useDeckEditor({ api, filePath, effectiveScript, commitScript });
+
+// The editor takes and emits a beat array; the composable, the transport and the
+// toolResult all speak whole scripts. `beatsOf` / `withBeats` are the conversion, and
+// `withBeats` is what keeps presentationStyle / slideParams from being dropped on the
+// way back — `{ ...script, beats }` loses them silently.
+const deckBeats = computed<EditableBeat[]>(() => beatsOf(deckScriptInput.value));
+
+function onDeckBeatsUpdate(beats: EditableBeat[]): void {
+  onDeckUpdate(withBeats(deckScriptInput.value, beats));
+}
 
 onBeforeUnmount(() => {
   flushPendingDeckSave();

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -1,5 +1,5 @@
 // #1575 — when every beat is a `slide`, the View swaps the per-beat list for
-// the interactive deck editor (@mulmocast/deck-web). Each editor emit fires
+// the interactive deck editor (@mulmocast/beat-editor). Each editor emit fires
 // `update:script`; this debounces them into one updateScript round-trip per
 // quiet stretch (300ms — short enough to feel live, long enough that typing in
 // the Inspector doesn't carpet-bomb the server).

--- a/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
@@ -94,8 +94,8 @@ export function isBeatImageReference(beat: { image?: { type?: string; [key: stri
 }
 
 /** Pure check: is every beat in the script a `slide`-typed beat?
- *  When true, the View mounts `@mulmocast/deck-web`'s
- *  `MulmoScriptDeckEditor` instead of the per-beat list UI (#1575).
+ *  When true, the View mounts `@mulmocast/beat-editor`'s
+ *  `BeatListEditor` instead of the per-beat list UI (#1575).
  *  Empty / missing `beats[]` returns false — there's nothing to edit
  *  as a deck, fall through to the existing UI which renders an empty
  *  state. Mixed scripts (any non-`slide` beat) also return false; that

--- a/packages/plugins/mulmoscript-plugin/src/vue/index.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/index.ts
@@ -1,4 +1,10 @@
 import "../style.css";
+// The editor's own utilities. Tailwind only scans THIS package's source, and a host's
+// Tailwind build only scans what its `@source` names — so nothing here generates the
+// classes `BeatListEditor`'s markup uses. Measured before the migration: the deck editor
+// was rendering without `w-96`, `min-h-0`, `overflow-auto` or `border-r`, and no host
+// imported the stylesheet either.
+import "@mulmocast/beat-editor/style.css";
 
 import type { ToolPlugin } from "gui-chat-protocol/vue";
 import type { MulmoScriptData, SaveMulmoScriptArgs } from "../core/types";

--- a/packages/plugins/mulmoscript-plugin/src/vue/viewTypes.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/viewTypes.ts
@@ -1,10 +1,10 @@
 // Loose UI-facing script shapes shared between the View orchestrator and its
 // composables. `MulmoScript` is intentionally a structural superset (every
 // field optional + index signature) so the empty-beat fallbacks and the
-// deck-web boundary re-typing stay cast-light. Kept out of View.vue so the
+// beat-editor boundary re-typing stay cast-light. Kept out of View.vue so the
 // extracted composables can import the same shapes without importing the SFC.
 
-import type { SlideLayout, SlideTheme } from "@mulmocast/deck-web";
+import type { SlideLayout, SlideTheme } from "@mulmocast/beat-editor";
 import type { Beat } from "./helpers";
 
 export interface ImageEntry {
@@ -35,10 +35,10 @@ export interface MulmoScript {
   [key: string]: unknown;
 }
 
-// `@mulmocast/deck-web` types its `script` prop as a *structural* superset of
-// MulmoScript (every key optional + index signature) using `SlideLayout` /
-// `SlideTheme` from `@mulmocast/deck`. Our strict `MulmoScript` doesn't unify
-// with that shape by name, so the deck editor boundary re-types through these.
+// `BeatListEditor` takes a beat ARRAY, and its beats are a structural superset of
+// ours (every key optional + index signature) built on `SlideLayout` / `SlideTheme`.
+// Our strict `MulmoScript` doesn't unify with that shape by name, so the editor
+// boundary re-types through these.
 export interface DeckBeatShape {
   image?: {
     type?: string;

--- a/packages/plugins/mulmoscript-plugin/vite.config.ts
+++ b/packages/plugins/mulmoscript-plugin/vite.config.ts
@@ -28,7 +28,7 @@ export default createVuePluginConfig({
     "gui-chat-protocol",
     "gui-chat-protocol/vue",
     "@mulmocast/types",
-    "@mulmocast/deck-web",
+    "@mulmocast/beat-editor",
     "mulmocast",
     "graphai",
     "fs",

--- a/plans/feat-2945-migrate-to-beat-editor.md
+++ b/plans/feat-2945-migrate-to-beat-editor.md
@@ -1,0 +1,87 @@
+# feat: mulmoscript-plugin を @mulmocast/beat-editor へ移行 (#2945)
+
+## なぜ
+
+`@mulmocast/deck-web` は `@mulmocast/beat-editor` へのリネームとして npm 上で deprecated だが、
+**同じコンポーネントは残っていない**。plugin が使っている `MulmoScriptDeckEditor` は
+iframe エディタごと削除されている。素直なリネームでは移行できない。
+
+移行に必要なホスト統合面の機能は beat-editor 1.1.0 で揃った。
+
+## 変更点（5ファイル + スタイル1行）
+
+| ファイル | 変更 |
+|---|---|
+| `package.json` | peer を `@mulmocast/beat-editor: ^1.1.0` へ。version 3.1.0 → **4.0.0**（peer の変更は破壊的） |
+| `vite.config.ts` | `external` の指定を差し替え |
+| `src/vue/viewTypes.ts` | `SlideLayout` / `SlideTheme` の import 元（beat-editor が同名で re-export） |
+| `src/vue/View.vue` | 動的 import を `BeatListEditor` へ。テンプレートを beats 受け渡しへ |
+| `src/vue/index.ts` | `@mulmocast/beat-editor/style.css` を import（下記） |
+
+`src/vue/composables/useDeckEditor.ts`（69行、300ms デバウンス）は **script 単位のまま変更不要**。
+変換は View.vue 側で `beatsOf` / `withBeats` を挟むだけ。
+
+## API 対応
+
+| deck-web | beat-editor |
+|---|---|
+| `:script="deckScriptInput"` | `:beats="beatsOf(deckScriptInput)"` |
+| `@update:script="onDeckUpdate"` | `@update:beats` → `withBeats(script, beats)` して `onDeckUpdate` |
+| `layout="compact"` | prop 廃止。コンテナクエリで自動、幅は `--beat-editor-pane-width` |
+
+`withBeats` を使うのは、`{ ...script, beats }` を手書きすると `presentationStyle` /
+`slideParams` を落とす事故が起きるため。
+
+## スタイルシート — 移行で直る既存バグ
+
+移行前の実測で、**現状のデッキエディタは必要な CSS が当たっていない**ことが分かった。
+`w-56` / `w-96` / `min-h-0` / `overflow-auto` / `border-r` / `bg-gray-100` / `px-8` は
+plugin の `dist/style.css` に定義が無く、`@mulmocast/deck-web/style.css` を
+import している箇所もどこにも無い。
+
+原因は Tailwind v4 が**そのパッケージ自身のソースしかスキャンしない**こと。
+ホスト（mulmoterminal）の `plugin-tailwind.css` も `@mulmochat-plugin/*` の dist しか
+`@source` していない。同じ失敗がそのファイルのコメントに既に記録されている。
+
+→ **plugin が `@mulmocast/beat-editor/style.css` を import する**。plugin は複数のホストに
+載りうるので、ホストごとに `@source` を足す運用は同じ見落としを生む。
+
+## 検証
+
+1. `yarn build` / `lint` / `typecheck` / `test`
+2. **ビルド成果物に beat-editor のクラスが入っていること**を実測で確認
+   （移行前に欠けていた `w-96` などが `dist/style.css` に出るか）
+3. 実機: mulmoterminal に載せて、全 beat が slide のスクリプトでデッキ編集が動くか
+
+## 順序
+
+plugin 4.0.0 を先に出す。mulmoterminal はそのあと plugin を上げ、
+自分の `@mulmocast/deck-web` 依存を `@mulmocast/beat-editor` に差し替える（別 PR）。
+逆順にすると plugin のデッキ編集が壊れる。
+
+## デモハーネス（このPRで追加）
+
+`yarn dev` で plugin 単体を Vite で起動できるようにした（`index.html` + `demo/`）。
+GUIChatPlugins 側の各 plugin と同じ形。**このモノレポの plugin では初**。
+
+移行の2つの疑問（コンテナクエリでの幅対応 / Shadow DOM へのスタイル到達）は
+コードを読んでも答えが出ず、ホストを丸ごと起動するのは重い。デモはその中間。
+
+- `demo/runtimeStub.ts` — `BrowserPluginRuntime` のスタブ。mulmoscript を知らないので、
+  他 plugin へデモを広げるときの共通ハーネスになる
+- `demo/ShadowFrame.vue` — ホストと同じ Shadow DOM 条件。`provide`/`inject` は
+  コンポーネント階層で解決されるため、slot を別ツリーへ描き直すと連鎖が切れる。
+  よって shadow 側は**独立した Vue アプリ**として mount し、そこに runtime を install する
+  （ホストが plugin ごとに行うのと同じ）
+- 幅と Shadow DOM の2トグル
+
+### デモで実測できたこと
+
+| | Shadow DOM 内 | 通常 DOM |
+|---|---|---|
+| スライドの背景 / テーマ変数 | `#F8FAFC` ✓ | `#F8FAFC` ✓ |
+| item の `cursor` | **`auto`**（効かない） | `grab` ✓ |
+
+**スライド本体のスタイルは Shadow DOM でも効く** — beat-editor はテーマ変数をスライド要素に
+インラインで出すため。届かないのは `ensureDocumentStyles` が `document.head` に注入する
+**編集アフォーダンス**（grab カーソル / hover の outline / 編集中の outline）だけ。

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,13 +2098,6 @@
   resolved "https://registry.yarnpkg.com/@mulmochat-plugin/ui-image/-/ui-image-0.4.1.tgz#8fd3b1c4ffe21e6bc22761ff48eac03306e0d345"
   integrity sha512-I3AqTIuQPsSMNxDON9UTxT2KO57HV6uUVotCIFskV0UqBMQrQ3FUu8J+qXRWDdjPyYaHoC8AJsi91TbNrOMwng==
 
-"@mulmoclaude/mulmoscript-plugin@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/mulmoscript-plugin/-/mulmoscript-plugin-3.1.0.tgz#5bb177a486a5d8b8f4fe94818fd89a4bd6d9f463"
-  integrity sha512-NQWU9qYh7AVdKMbEeGiVhrjQAEh/J9WMmmvmVlfg4FN4E6nyPIb87GCXsyoFBhoyzrjbceCDqk/RQ1DpcRHpbQ==
-  dependencies:
-    "@mulmoclaude/common" "^1.2.0"
-
 "@napi-rs/wasm-runtime@^1.1.4", "@napi-rs/wasm-runtime@^1.1.6", "@napi-rs/wasm-runtime@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz#c70706532e5827c0932ca6bf43ee2c512f29c639"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,10 +2066,10 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/deck-web@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@mulmocast/deck-web/-/deck-web-2.0.0.tgz#d5de0a69d15bbafcf0f4ac5cb268e6725a6c4cb8"
-  integrity sha512-d7eLR2IK5r75oS/naZddVENwQjR2B7rzlIYdGWfU0617W4RVxd7f2g2pL1X2NIWnNn36T7CwdgXncOPBI4rC0g==
+"@mulmocast/beat-editor@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmocast/beat-editor/-/beat-editor-1.1.0.tgz#7a2a894848bd7ab553866d690ce58a261b756a03"
+  integrity sha512-xHFhURQfXb9Os0q/bXaeW2sNVJni8mnaVwdRUBnLCiCiDrurRNA0Ud1fkfhF75j3xdL60m64VO8iiBRXyGEFSA==
   dependencies:
     dompurify "^3.4.14"
 
@@ -2097,6 +2097,13 @@
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@mulmochat-plugin/ui-image/-/ui-image-0.4.1.tgz#8fd3b1c4ffe21e6bc22761ff48eac03306e0d345"
   integrity sha512-I3AqTIuQPsSMNxDON9UTxT2KO57HV6uUVotCIFskV0UqBMQrQ3FUu8J+qXRWDdjPyYaHoC8AJsi91TbNrOMwng==
+
+"@mulmoclaude/mulmoscript-plugin@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/mulmoscript-plugin/-/mulmoscript-plugin-3.1.0.tgz#5bb177a486a5d8b8f4fe94818fd89a4bd6d9f463"
+  integrity sha512-NQWU9qYh7AVdKMbEeGiVhrjQAEh/J9WMmmvmVlfg4FN4E6nyPIb87GCXsyoFBhoyzrjbceCDqk/RQ1DpcRHpbQ==
+  dependencies:
+    "@mulmoclaude/common" "^1.2.0"
 
 "@napi-rs/wasm-runtime@^1.1.4", "@napi-rs/wasm-runtime@^1.1.6", "@napi-rs/wasm-runtime@^1.2.0":
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,10 +2066,10 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/beat-editor@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@mulmocast/beat-editor/-/beat-editor-1.1.0.tgz#7a2a894848bd7ab553866d690ce58a261b756a03"
-  integrity sha512-xHFhURQfXb9Os0q/bXaeW2sNVJni8mnaVwdRUBnLCiCiDrurRNA0Ud1fkfhF75j3xdL60m64VO8iiBRXyGEFSA==
+"@mulmocast/beat-editor@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@mulmocast/beat-editor/-/beat-editor-1.1.1.tgz#c849d796c6a6a7f8fef71aca95051947795fa2bb"
+  integrity sha512-soHUueTQIAUrVztgPVilvnUrClewAYeHExdL4ikeUzUiE5+wyO6qnKJ7DuLgj6u986aFCD/YxaunJ0gIK/2usw==
   dependencies:
     dompurify "^3.4.14"
 


### PR DESCRIPTION
## Summary

`@mulmocast/deck-web` は `@mulmocast/beat-editor` へのリネームとして deprecated だが、plugin が
使っていた `MulmoScriptDeckEditor` は iframe エディタごと削除されているため、**リネームではなく
作り替え**になる。beat-editor 1.1.0 で必要な部品が揃ったので移行する。

あわせて **plugin 単体を `yarn dev` で起動できるデモ**を追加した（このモノレポでは初）。

## 変更（5ファイル + スタイル1行）

| ファイル | 変更 |
|---|---|
| `package.json` | peer を `@mulmocast/beat-editor: ^1.1.0` へ。**3.1.0 → 4.0.0**（peer の変更は破壊的） |
| ルート `package.json` | `deck-web` → `beat-editor`（peer を満たすホスト依存） |
| `vite.config.ts` | `external` の差し替え |
| `src/vue/viewTypes.ts` | `SlideLayout` / `SlideTheme` の import 元 |
| `src/vue/View.vue` | 動的 import を `BeatListEditor` へ。`beatsOf` / `withBeats` で beats ⇄ script を変換 |
| `src/vue/index.ts` | `@mulmocast/beat-editor/style.css` を import |

`src/vue/composables/useDeckEditor.ts`（69行、300ms デバウンス）は **無変更**。

## Items to Confirm / Review

- **`withBeats` を使っている理由**: `{ ...script, beats }` と手書きすると
  `presentationStyle` / `slideParams` が黙って落ちる。
- **`layout="compact"` は廃止**。beat-editor はコンテナクエリで自分の幅から判断する。
  600px（plugin カード相当）で編集ペインが下半分に回ることを実機で確認済み（下記）。
- **スタイルシートの import は移行前から壊れていた既存バグの修正**。誰も
  `deck-web/style.css` を読み込んでおらず、Tailwind は自分のパッケージしかスキャンしないため、
  `w-96` / `min-h-0` / `overflow-auto` / `border-r` に規則が無かった。
  ホストの `plugin-tailwind.css` に**同じ失敗が別 plugin について既に記録されている**。
  plugin は複数ホストに載りうるので、ホストごとに `@source` を足す運用ではなく
  plugin 側で自己完結させた。

## デモ（`yarn dev`）

移行の2つの疑問はコードを読んでも決着せず、ホストを丸ごと起動するのは重い。その中間として追加。

- `demo/runtimeStub.ts` — `BrowserPluginRuntime` のスタブ。mulmoscript を知らないので
  他 plugin へ広げるときの共通ハーネスになる
- `demo/ShadowFrame.vue` — ホストと同じ Shadow DOM 条件（ビルド済み CSS + アイコンのエイリアス）
- 幅 / Shadow DOM の2トグル

作る過程で実測しないと分からなかったこと:

1. `provide` は呼んだコンポーネント自身には効かない → 親が要る
2. **Shadow root は別ツリーなので `provide`/`inject` の連鎖が切れる** → shadow 側は
   独立した Vue アプリとして mount（ホストが plugin ごとに行うのと同じ）
3. transport はエンベロープ全体を `data` として返す

### デモが実際に暴いたもの

最初、デモは `src/style.css`（`@import "tailwindcss"` の1行）を注入しており、Shadow root に
規則が1つも無かった。その結果:

| | 修正前 | 修正後 |
|---|---|---|
| リスト側 | 91px（スライドが 300px→91px に切られる） | **295px** |
| 編集ペイン | 498px（`max-height: none`） | 295px（**`max-height: 50%`**） |
| `container-type` | `normal` | **`inline-size`** |

ホストが注入するのはビルド済み `dist/style.css`（57KB）なので、そちらを使うよう修正した。
**移行そのものは正しく、コンテナクエリは 600px で意図どおり動く**ことが確認できた。

## 検証

`typecheck` / `lint` / `test`（**124 pass / 0 fail**）/ `build` すべて green。
`npm pack --dry-run` で **demo / index.html が publish 対象に入らない**ことを確認（`files: ["dist"]`）。

実ブラウザ（Chromium）でスライドがテーマ付きで描画され、uncaught console error 無し。

## 既知の残課題（別対応）

Shadow DOM 内では `cursor: grab` などの**編集アフォーダンス**が効かない。beat-editor が
`document.head` に実行時注入するため。**移行前（deck-web）から同じ**で、この PR が
持ち込んだものではない。beat-editor 側の変更が要るので #2947 に分離した。
機能自体は動き、スライドも崩れない。

## User Prompt

> - mulmoterminalで、@mulmocast/beat-editorに移行できる？deck-webを。@mulmoclaude/mulmoscript-plugin の移行もおこないたい
> - では、pluginから慎重に進めよう
> - ~/ss/llm/GUIChatPlugins/以下のpluginってそれ単体でviteが起動して簡単なテストできるんだけど、ここもできるかな？
> - 画面、これで想定あっている？CSSあたってる？
> - 順番に全部なおして

Closes #2945

## Summary by Sourcery

Migrate the MulmoScript plugin to beat-editor and add a standalone demo for validating its responsive and Shadow DOM behavior.

New Features:
- Add a standalone Vite demo that exercises the plugin in light DOM and Shadow DOM at narrow and wide sizes.

Bug Fixes:
- Ensure the beat editor's bundled styles are included so its layout and scrolling utilities render correctly across hosts.

Enhancements:
- Migrate the MulmoScript deck editing UI from the removed deck-web editor to beat-editor while preserving the full script during beat updates.
- Use beat-editor's width-aware responsive layout instead of the deprecated compact layout option.

Build:
- Replace the deck-web host dependency and peer dependency with beat-editor and update the plugin's externalization configuration.
- Bump the plugin major version to 4.0.0 for the breaking peer dependency migration.

Documentation:
- Document the beat-editor migration, responsive behavior, stylesheet correction, and breaking release in the changelog and migration plan.

Tests:
- Validate the migration with type checking, linting, tests, builds, package dry-run, and browser verification.

Chores:
- Update workspace references and lockfile entries for the new editor dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrated the MulmoScript editor to the newer Beat Editor experience.
  * Added a standalone demo supporting full-width, narrow, and Shadow DOM layouts.
  * Added sample presentation content for beat-based editing.

* **Improvements**
  * Preserved presentation metadata while editing beats.
  * Included the editor’s styles for improved visual consistency.
  * Updated the plugin package and editor integration to the latest supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->