### PR TITLE
feat: スクリプトの書き込みを通知して、LLM の編集が開いている画面に出るようにする (#2949)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Added
+
+#### An agent's edit to a MulmoScript now appears in an open canvas (#2949)
+
+The preview only updated when the person in front of it typed. An agent writing the same
+script left the canvas showing the old file until it was reopened — the plugin's pubsub
+channel carries image / audio / movie generation, and nothing carried the script itself.
+
+`updateScript` / `updateBeat` now broadcast after the write lands, and an open View reloads
+from disk. Every write carries an `origin`, and a View ignores the echo of its own: without
+that, a save would come back and rebuild the element the caret is in on every keystroke.
+
+This is the first half of "a human and an agent taking turns on the same script". Flushing the
+editor's pending keystrokes when a request is sent to the agent, and locking the editor while
+the agent works, are still to come.
+
 ### Changed
 
 #### The MulmoScript deck editor now runs on `@mulmocast/beat-editor` (#2945)
@@ -374,7 +390,7 @@ translation behind it.
 
 ### Changed
 
-#### `@mulmoclaude/mulmoscript-plugin@4.0.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+#### `@mulmoclaude/mulmoscript-plugin@4.1.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
 
 Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
 hosts had moved to deck-web 2.0.0, so every install printed
@@ -406,7 +422,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^4.0.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.1.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -31,6 +31,32 @@ export interface MulmoScriptGenerationEvent {
  *  (full channel: `plugin:<scope>:generation`). */
 export const GENERATION_EVENT = "generation";
 
+/** Plugin pubsub event name for "this script changed on disk"
+ *  (full channel: `plugin:<scope>:scriptChanged`). */
+export const SCRIPT_CHANGED_EVENT = "scriptChanged";
+
+/**
+ * A script was written — by the agent, or by another View.
+ *
+ * `origin` is who wrote it. A View passes its own id on every write and ignores the echo of
+ * its own: without that, a keystroke would round-trip through the server and reload the very
+ * element the caret is in. An agent write carries no origin, so every View reloads.
+ */
+export interface MulmoScriptChangedEvent {
+  filePath: string;
+  origin?: string;
+}
+
+/**
+ * Whether a View watching `watching` should reload because of `event`.
+ *
+ * A pure rule rather than a condition inside the subscriber, because the case that matters is
+ * the one that is invisible when it is wrong: a View acting on the echo of its own write
+ * rebuilds the element the caret is in, on every keystroke.
+ */
+export const shouldReloadForScriptChange = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string): boolean =>
+  watching !== "" && event.filePath === watching && event.origin !== ownOrigin;
+
 interface BeatRef {
   filePath: string;
   beatIndex: number;
@@ -50,8 +76,8 @@ interface SessionTag {
 
 export type MulmoScriptDispatchArgs =
   | ({ kind: "save" } & { filePath?: string; script?: unknown; filename?: string })
-  | { kind: "updateBeat"; filePath: string; beatIndex: number; beat: unknown }
-  | { kind: "updateScript"; filePath: string; script: unknown }
+  | { kind: "updateBeat"; filePath: string; beatIndex: number; beat: unknown; origin?: string }
+  | { kind: "updateScript"; filePath: string; script: unknown; origin?: string }
   | ({ kind: "beatImage" } & BeatRef)
   | ({ kind: "beatAudio" } & BeatRef)
   | ({ kind: "beatMovie" } & BeatRef)

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -107,7 +107,11 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     const guard = ops.guardStoryWirePath(args.filePath);
     if (guard) return fromOpFailure(guard);
     const outcome = kind === "updateBeat" ? await executeUpdateBeat(executeContext, args) : await executeUpdateScript(executeContext, args);
-    return outcome.ok ? { ok: true } : fromPackageFailure(outcome);
+    if (!outcome.ok) return fromPackageFailure(outcome);
+    // After the write landed, never before: a View that reloads on a failed write would
+    // discard the user's edit and show the old file back.
+    ops.publishScriptChanged(str(args.filePath) ?? "", str(args.origin));
+    return { ok: true };
   }
 
   const STATUS_OPS = { movieStatus: ops.movieStatusOp, pdfStatus: ops.pdfStatusOp } as const;

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -348,6 +348,17 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     backend.onGenerationEvent?.(chatSessionId, event);
   }
 
+  /**
+   * Tell every open View that this script was written.
+   *
+   * `origin` is the writer. A View passes its own id so it can ignore the echo of its own
+   * save — reloading there would rebuild the element the caret is in, mid-keystroke. A write
+   * from the agent carries no origin, so everyone reloads.
+   */
+  function publishScriptChanged(filePath: string, origin?: string): void {
+    backend.onScriptChanged?.({ filePath: canonicalWirePath(filePath), ...(origin === undefined ? {} : { origin }) });
+  }
+
   /** Snapshot of generations currently in flight for one script — the
    *  View's mount-time catch-up, filtered to its wire `filePath`. */
   function pendingGenerations(filePath: string): MulmoScriptGenerationEvent[] {
@@ -846,6 +857,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     ffmpegGuard,
     runStoryOp,
     publishGeneration,
+    publishScriptChanged,
     pendingGenerations,
     beatImageOp,
     beatAudioOp,

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -5,7 +5,7 @@
 
 import type { MinimalLogger } from "@mulmoclaude/common";
 import type { FileOps } from "gui-chat-protocol";
-import type { MulmoScriptGenerationEvent } from "../core/contract";
+import type { MulmoScriptChangedEvent, MulmoScriptGenerationEvent } from "../core/contract";
 
 export interface OpFailure {
   ok: false;
@@ -70,5 +70,10 @@ export interface MulmoScriptServerBackend {
    * session. The package keeps the in-flight snapshot itself.
    */
   onGenerationEvent?: (chatSessionId: string | undefined, event: MulmoScriptGenerationEvent) => void;
+  /**
+   * A script was written. Every open View reloads from disk, which is what makes an agent's
+   * edit appear without the user reopening the canvas.
+   */
+  onScriptChanged?: (event: MulmoScriptChangedEvent) => void;
   log?: MulmoScriptServerLog;
 }

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -703,7 +703,14 @@ function commitScript(next: MulmoScript): void {
 // interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
-const { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave } = useDeckEditor({ api, filePath, effectiveScript, commitScript });
+const { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({ api, filePath, effectiveScript, commitScript });
+
+// An agent (or another window) wrote this script — pull it back off disk so the preview shows
+// what is actually there. Registered here rather than in the composable because reloading is
+// the View's job; the composable only knows that someone else wrote.
+const unsubscribeForeignWrites = watchForeignWrites(() => {
+  void refreshScriptFromDisk();
+});
 
 // The editor takes and emits a beat array; the composable, the transport and the
 // toolResult all speak whole scripts. `beatsOf` / `withBeats` are the conversion, and
@@ -721,6 +728,7 @@ onBeforeUnmount(() => {
   // otherwise (document-scoped, not GC'd with it).
   resetBeatMovies();
   unsubscribeGenerationEvents();
+  unsubscribeForeignWrites();
 });
 const loadedSource = ref("");
 const sourceChanged = computed(() => editableSource.value !== loadedSource.value);

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -11,6 +11,18 @@ import type { DeckScriptShape, MulmoScript } from "../viewTypes";
 
 const DECK_SAVE_DEBOUNCE_MS = 300;
 
+/**
+ * Who this editor is, on the wire.
+ *
+ * Every write carries it so the server's "this script changed" broadcast can be told apart
+ * from someone else's. Without it a save would echo back and reload the editor mid-keystroke,
+ * rebuilding the element the caret sits in.
+ *
+ * Per module instance rather than per component: one View is mounted at a time, and a value
+ * that survives a remount keeps a save in flight from being mistaken for a foreign write.
+ */
+const EDITOR_ORIGIN = `deck-editor-${Math.random().toString(36).slice(2)}`;
+
 export interface UseDeckEditorOptions {
   api: MulmoScriptTransport;
   filePath: ComputedRef<string>;
@@ -40,7 +52,7 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     const next = pendingDeckScript;
     pendingDeckScript = null;
     if (!next || !filePath.value) return;
-    const response = await api.call("updateScript", { filePath: filePath.value, script: next });
+    const response = await api.call("updateScript", { filePath: filePath.value, script: next, origin: EDITOR_ORIGIN });
     if (!response.ok) {
       // Surface via console; the deck editor still holds the latest edit in
       // its props until the next refresh, so the view doesn't snap back on a
@@ -65,5 +77,23 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     }
   }
 
-  return { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave };
+  /**
+   * Reload when someone else writes this script — the agent, or another window.
+   *
+   * A pending local edit is flushed first rather than dropped: the user's keystrokes are the
+   * thing they would notice losing, and the write that triggered this has already landed, so
+   * flushing cannot clobber it out of order.
+   */
+  function watchForeignWrites(reload: () => void): () => void {
+    return api.onScriptChanged(
+      () => filePath.value,
+      EDITOR_ORIGIN,
+      () => {
+        flushPendingDeckSave();
+        reload();
+      },
+    );
+  }
+
+  return { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
 }

--- a/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
@@ -10,8 +10,8 @@
 // failure shape.
 
 import { useRuntime } from "gui-chat-protocol/vue";
-import type { MulmoScriptDispatchArgs, MulmoScriptDispatchResult, MulmoScriptGenerationEvent } from "../core/contract";
-import { GENERATION_EVENT } from "../core/contract";
+import type { MulmoScriptChangedEvent, MulmoScriptDispatchArgs, MulmoScriptDispatchResult, MulmoScriptGenerationEvent } from "../core/contract";
+import { GENERATION_EVENT, SCRIPT_CHANGED_EVENT, shouldReloadForScriptChange } from "../core/contract";
 import { errorMessage } from "@mulmoclaude/common";
 import { isRecord } from "./support";
 
@@ -20,6 +20,13 @@ export type TransportResult<T> = { ok: true; data: T } | { ok: false; error: str
 type ArgsFor<K extends MulmoScriptDispatchArgs["kind"]> = Omit<Extract<MulmoScriptDispatchArgs, { kind: K }>, "kind">;
 
 const GENERATION_EVENT_KINDS: ReadonlySet<string> = new Set(["beatImage", "beatAudio", "characterImage", "movie", "pdf"]);
+
+function parseScriptChangedEvent(payload: unknown): MulmoScriptChangedEvent | null {
+  if (!isRecord(payload)) return null;
+  const { filePath, origin } = payload;
+  if (typeof filePath !== "string") return null;
+  return { filePath, ...(typeof origin === "string" ? { origin } : {}) };
+}
 
 function parseGenerationEvent(payload: unknown): MulmoScriptGenerationEvent | null {
   if (!isRecord(payload)) return null;
@@ -40,6 +47,9 @@ export interface MulmoScriptTransport {
   /** Subscribe to the host's generation channel, pre-filtered to one
    *  script's wire path. Returns the unsubscribe function. */
   onGenerationEvent(filePath: () => string, handler: (event: MulmoScriptGenerationEvent) => void): () => void;
+  /** Subscribe to writes of one script, skipping the echo of this View's own
+   *  (`ownOrigin`). Returns the unsubscribe function. */
+  onScriptChanged(filePath: () => string, ownOrigin: string, handler: () => void): () => void;
 }
 
 export function useMulmoScriptTransport(): MulmoScriptTransport {
@@ -69,5 +79,21 @@ export function useMulmoScriptTransport(): MulmoScriptTransport {
     });
   }
 
-  return { call, onGenerationEvent };
+  /**
+   * A write to this script landed — reload from disk.
+   *
+   * `ownOrigin` is this View's id. Its own writes echo back on the same channel, and acting
+   * on them would rebuild the element the caret is in on every keystroke, so they are dropped
+   * here. A write from the agent carries no origin and always reaches the handler.
+   */
+  function onScriptChanged(filePath: () => string, ownOrigin: string, handler: () => void): () => void {
+    return runtime.pubsub.subscribe(SCRIPT_CHANGED_EVENT, (payload: unknown) => {
+      const event = parseScriptChangedEvent(payload);
+      if (!event) return;
+      if (!shouldReloadForScriptChange(event, filePath(), ownOrigin)) return;
+      handler();
+    });
+  }
+
+  return { call, onGenerationEvent, onScriptChanged };
 }

--- a/packages/plugins/mulmoscript-plugin/test/test_scriptChanged.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_scriptChanged.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { SCRIPT_CHANGED_EVENT, shouldReloadForScriptChange } from "../src/core/contract";
+
+/**
+ * "Someone else wrote this script" — the signal that lets an agent's edit appear without the
+ * user reopening the canvas.
+ *
+ * The rule that carries the weight is the ECHO: a View's own save comes back on the same
+ * channel, and acting on it would rebuild the element the caret is in on every keystroke. So a
+ * View tags each write with its own origin and drops what comes back carrying it.
+ */
+
+const MINE = "deck-editor-aaa";
+const PATH = "stories/deck.json";
+
+describe("script-changed filtering", () => {
+  it("reloads for a write with no origin — that is the agent", () => {
+    assert.equal(shouldReloadForScriptChange({ filePath: PATH }, PATH, MINE), true);
+  });
+
+  it("ignores the echo of this editor's own write", () => {
+    // Without this the caret's own element is rebuilt mid-keystroke.
+    assert.equal(shouldReloadForScriptChange({ filePath: PATH, origin: MINE }, PATH, MINE), false);
+  });
+
+  it("reloads for another window editing the same file", () => {
+    assert.equal(shouldReloadForScriptChange({ filePath: PATH, origin: "deck-editor-bbb" }, PATH, MINE), true);
+  });
+
+  it("ignores a write to a different script", () => {
+    assert.equal(shouldReloadForScriptChange({ filePath: "stories/other.json" }, PATH, MINE), false);
+  });
+
+  it("ignores everything while no script is open", () => {
+    assert.equal(shouldReloadForScriptChange({ filePath: PATH }, "", MINE), false);
+  });
+
+  it("names the channel, which the host and the View have to agree on", () => {
+    assert.equal(SCRIPT_CHANGED_EVENT, "scriptChanged");
+  });
+});


### PR DESCRIPTION
## Summary

**LLM が MulmoScript を書き換えても、開いているキャンバスは古いまま**だった。plugin の pubsub は
画像 / 音声 / 動画の生成を運んでいるだけで、**スクリプト本体の変更を運ぶ経路が無かった**ため。

`updateScript` / `updateBeat` が書き込み成功後に `scriptChanged` を publish し、
View が購読して `refreshScriptFromDisk()` する。

これは「人間と LLM が交互に同じスクリプトを直す」の**前半**。

## Items to Confirm / Review

- **エコー抑止がこの変更の肝**。すべての書き込みに `origin` を付け、View は自分の書き込みが
  返ってきたら無視する。これが無いと**保存が返ってきてカーソルのある要素を再構築**し、
  打鍵のたびに編集が壊れる。

  判定は subscriber の中の条件ではなく `contract.ts` の**純関数** `shouldReloadForScriptChange`
  に切り出した。壊れても画面を見ないと分からない種類のルールなので、テストから直接触れる形にしたい。

- **publish は書き込みの「後」**。失敗した書き込みで通知すると、View が保持している編集内容を
  捨てて古いファイルを表示してしまう。

- **`onScriptChanged` は backend の optional**。実装しないホストは今までどおり動く。
  **MulmoTerminal 側の配線は別 PR**（`server/backends/mulmoscript.ts` の
  `onGenerationEvent` の隣に足す）で、この版が npm に出てから。

- **`origin` はモジュール単位で1つ**（`deck-editor-<random>`）。View は同時に1つしか
  マウントされず、再マウントをまたいで値が生きるほうが、飛行中の保存を他人の書き込みと
  取り違えずに済む。

## テスト

`test/test_scriptChanged.ts`（6本）。**述語を本体から import** しているので、
出荷コードが変われば赤くなる。

> 最初はテスト内にロジックのコピーを書いてしまい、直した。コピーだと出荷コードが
> 変わってもテストは緑のままで、意味が無い。

### break-check

| 変異 | 結果 |
|------|------|
| エコー抑止（`event.origin !== ownOrigin`）を外す | **1件 赤** |
| 戻す | 6/6 green |

## ゲート

`typecheck` / `lint` / `build` / `test`（**130 pass / 0 fail**、+6本）。
`check-changelog-ships` OK。

## 次

| | 内容 |
|---|---|
| ✅ 1 | 変更の通知（この PR） |
| 1' | MulmoTerminal 側の配線（別 PR、この版の publish 後） |
| 2 | LLM へ送信するタイミングで `flushPendingDeckSave()` |
| 3 | LLM 作業中はエディタをロック |
| 4 | 細粒度の編集ツールを LLM に見せる |

## User Prompt

> - 私のこの目的は mulmoterminal で mulmoscript をリアルタイムで preview して、人間が修正しつつ llm でも修正させたい
> - 3って、llm に依頼するタイミングで web のデータ保存して、それをもとに更新する、、みたいにできるとよいのかな
> - できるものはすすめて。提案方法で
> - plugin 側の PR を出して、publish

Refs #2949

## Summary by Sourcery

Synchronize open MulmoScript canvases with successful external edits while preserving local editing continuity.

New Features:
- Broadcast script changes after successful writes so open canvases can reflect agent or other-window edits without being reopened.

Bug Fixes:
- Prevent views from reloading in response to their own save notifications, preserving active editor state and caret position.

Enhancements:
- Add optional backend support for script-change notifications and centralize filtering of relevant foreign writes.
- Upgrade the MulmoScript plugin to 4.1.0 and consume that version from MulmoClaude.

Documentation:
- Document the new script-change synchronization behavior and remaining follow-up work in the changelog.

Tests:
- Add coverage for agent writes, own-write echoes, other-window edits, unrelated files, closed views, and the notification channel name.