### PR TITLE
fix(discord): 添付ファイルを MulmoClaude に渡す (#2939)

### DIFF
--- a/packages/bridges/discord/README.md
+++ b/packages/bridges/discord/README.md
@@ -4,6 +4,14 @@
 
 Discord bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). The bot responds to messages in channels it has access to.
 
+## Attachments
+
+Files posted with a message are downloaded from Discord's CDN and forwarded to MulmoClaude, so you can paste a screenshot and ask about it. A post with **only** files and no text is forwarded too, with `Describe / analyze this file.` as the body.
+
+- Up to 10 files per message, 8 MB each — anything larger is skipped and noted in the message MulmoClaude receives.
+- Images and PDFs reach Claude directly; text, DOCX, XLSX and PPTX are converted server-side. Other types are skipped with a log line.
+- Attachments arrive over the **Message Content Intent**, the same privileged intent the bot already needs to read text.
+
 ## Setup
 
 ### 1. Create a Discord Application

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -16,8 +16,8 @@
     "build": "tsc",
     "prepack": "yarn build",
     "typecheck": "tsc --noEmit",
-    "test": "echo no tests yet",
-    "lint": "eslint src"
+    "test": "tsx --test test/test_*.ts",
+    "lint": "eslint src test"
   },
   "license": "MIT",
   "author": "Receptron Team",
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
+    "tsx": "^4.23.5",
     "typescript": "^6.0.3"
   },
   "homepage": "https://github.com/receptron/mulmoclaude/tree/main/packages/bridges/discord#readme",

--- a/packages/bridges/discord/src/attachments.ts
+++ b/packages/bridges/discord/src/attachments.ts
@@ -175,12 +175,28 @@ function withinBudget(files: DiscordAttachmentLike[]): { considered: DiscordAtta
   return { considered, skipped };
 }
 
+/** Re-check the budget against the bytes actually in hand. `withinBudget`
+ *  spends it on Discord's declared sizes; this is what makes the guarantee
+ *  hold if a declared size ever under-reports, since the server would
+ *  otherwise truncate the overflow without telling anyone. */
+function fitBudget(attachments: Attachment[]): Attachment[] {
+  const kept: Attachment[] = [];
+  let remaining = MAX_TOTAL_BASE64_CHARS;
+  attachments.forEach((attachment) => {
+    const cost = attachment.data?.length ?? 0;
+    if (cost > remaining) return;
+    remaining -= cost;
+    kept.push(attachment);
+  });
+  return kept;
+}
+
 export async function collectAttachments(files: DiscordAttachmentLike[], deps: DownloadDeps): Promise<CollectedAttachments> {
   const log = deps.log ?? defaultLog;
   const { considered, skipped } = withinBudget(files);
   skipped.forEach((file) => log.warn(`[discord] attachment skipped: ${logLabel(file.name)} — over what one message may carry`));
   const results = await Promise.all(considered.map((file) => downloadAttachment(file, deps)));
-  const attachments = results.filter((entry): entry is Attachment => entry !== null);
+  const attachments = fitBudget(results.filter((entry): entry is Attachment => entry !== null));
   return { attachments, dropped: files.length - attachments.length };
 }
 

--- a/packages/bridges/discord/src/attachments.ts
+++ b/packages/bridges/discord/src/attachments.ts
@@ -39,6 +39,9 @@ export const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 /** chat-service's `parseAttachments` drops everything past the tenth
  *  entry, so downloading more than that is wasted bandwidth. */
 export const MAX_ATTACHMENT_COUNT = 10;
+/** …and it drops whatever pushes the message past this much base64,
+ *  silently. Mirrored here so the bridge can say what it left out. */
+export const MAX_TOTAL_BASE64_CHARS = 20 * 1024 * 1024;
 const FETCH_TIMEOUT_MS = 30_000;
 const FALLBACK_MIME = "application/octet-stream";
 /** chat-service rejects an empty `text`, so an attachment-only message
@@ -106,10 +109,15 @@ async function drainCapped(reader: ReadableStreamDefaultReader<Uint8Array>, maxB
 /** Read at most `maxBytes`, aborting mid-stream rather than after the
  *  fact — `arrayBuffer()` would have already materialised the body. */
 async function readCappedBody(res: Response, maxBytes: number): Promise<Buffer | null> {
-  const declared = Number(res.headers.get("content-length") ?? "");
-  if (Number.isFinite(declared) && declared > maxBytes) return null;
   const { body } = res;
   if (body === null) return null;
+  const declared = Number(res.headers.get("content-length") ?? "");
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    // Returning without draining would leave the connection open until
+    // the socket times out, one leak per oversized attachment.
+    await body.cancel();
+    return null;
+  }
   return drainCapped(body.getReader(), maxBytes);
 }
 
@@ -138,8 +146,39 @@ export async function downloadAttachment(file: DiscordAttachmentLike, deps: Down
   }
 }
 
+/** Length of the base64 a payload of `byteLength` bytes encodes to —
+ *  4 characters per 3-byte group, rounded up. That string length, not
+ *  the raw size, is what the server's per-message budget counts. */
+export function base64Length(byteLength: number): number {
+  return Math.ceil(byteLength / 3) * 4;
+}
+
+/** Spend the server's per-message budget before anything is downloaded —
+ *  Discord states each file's size up front. Without this the bridge
+ *  would ship attachments that `parseAttachments` silently truncates,
+ *  so the user is never told a file went missing. A file that does not
+ *  fit is skipped rather than ending the loop: a smaller one after it
+ *  may still fit. */
+function withinBudget(files: DiscordAttachmentLike[]): { considered: DiscordAttachmentLike[]; skipped: DiscordAttachmentLike[] } {
+  const considered: DiscordAttachmentLike[] = [];
+  const skipped: DiscordAttachmentLike[] = [];
+  let remaining = MAX_TOTAL_BASE64_CHARS;
+  files.forEach((file) => {
+    const cost = base64Length(file.size);
+    if (considered.length >= MAX_ATTACHMENT_COUNT || cost > remaining) {
+      skipped.push(file);
+      return;
+    }
+    remaining -= cost;
+    considered.push(file);
+  });
+  return { considered, skipped };
+}
+
 export async function collectAttachments(files: DiscordAttachmentLike[], deps: DownloadDeps): Promise<CollectedAttachments> {
-  const considered = files.slice(0, MAX_ATTACHMENT_COUNT);
+  const log = deps.log ?? defaultLog;
+  const { considered, skipped } = withinBudget(files);
+  skipped.forEach((file) => log.warn(`[discord] attachment skipped: ${logLabel(file.name)} — over what one message may carry`));
   const results = await Promise.all(considered.map((file) => downloadAttachment(file, deps)));
   const attachments = results.filter((entry): entry is Attachment => entry !== null);
   return { attachments, dropped: files.length - attachments.length };

--- a/packages/bridges/discord/src/attachments.ts
+++ b/packages/bridges/discord/src/attachments.ts
@@ -1,0 +1,156 @@
+// Attachment handling for the Discord bridge (#2939). Kept out of
+// `index.ts` so the download rules can be exercised with a stubbed
+// fetch — no gateway, no CDN, no env reads.
+
+import { mimeFromExtension } from "@mulmobridge/client";
+import type { Attachment } from "@mulmobridge/protocol";
+
+/** The fields of discord.js' `Attachment` this bridge reads. */
+export interface DiscordAttachmentLike {
+  url: string;
+  name: string;
+  size: number;
+  contentType: string | null;
+}
+
+export interface CollectedAttachments {
+  attachments: Attachment[];
+  /** Attachments on the message that could not be forwarded — over the
+   *  cap, past the count limit, or the download failed. */
+  dropped: number;
+}
+
+export type FetchFn = (url: string, init: RequestInit) => Promise<Response>;
+
+export interface DownloadDeps {
+  fetchFn: FetchFn;
+  log?: { warn: (message: string) => void };
+}
+
+// Discord serves message attachments from its own CDN. A URL pointing
+// anywhere else means the payload was tampered with, so it is refused
+// rather than turned into a server-side request forgery primitive.
+const ALLOWED_HOST_SUFFIXES = [".discordapp.com", ".discordapp.net", ".discord.com"];
+
+/** Per-file byte cap. chat-service's own gate is 20 MB of base64
+ *  across the whole message (~15 MB raw), so one file stays well
+ *  under it. Discord's free-tier upload limit is 10 MB. */
+export const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+/** chat-service's `parseAttachments` drops everything past the tenth
+ *  entry, so downloading more than that is wasted bandwidth. */
+export const MAX_ATTACHMENT_COUNT = 10;
+const FETCH_TIMEOUT_MS = 30_000;
+const FALLBACK_MIME = "application/octet-stream";
+/** chat-service rejects an empty `text`, so an attachment-only message
+ *  needs a body. Same wording as the Telegram and LINE bridges — an
+ *  instruction, so the agent treats the file as the subject. */
+const ATTACHMENT_ONLY_PROMPT = "Describe / analyze this file.";
+const LOG_LABEL_MAX_CHARS = 100;
+const UNPRINTABLE_RE = /[^\p{L}\p{N}\p{P}\p{S}\p{Zs}]/gu;
+
+const defaultLog = { warn: (message: string) => console.warn(message) };
+
+export function isDiscordCdnUrl(raw: string): boolean {
+  const url = parseUrl(raw);
+  if (url === null || url.protocol !== "https:") return false;
+  const hostname = url.hostname.toLowerCase();
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
+
+function parseUrl(raw: string): URL | null {
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Discord's `contentType` carries parameters (`text/plain; charset=utf-8`)
+ *  and is null for types it cannot sniff, so fall back to the filename. */
+export function resolveMimeType(file: DiscordAttachmentLike): string {
+  const declared = (file.contentType ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+  if (declared.length > 0) return declared;
+  const dot = file.name.lastIndexOf(".");
+  if (dot < 0 || dot === file.name.length - 1) return FALLBACK_MIME;
+  return mimeFromExtension(file.name.slice(dot + 1), FALLBACK_MIME);
+}
+
+/** Why this file cannot be fetched at all, or null when it may be. */
+function refuseReason(file: DiscordAttachmentLike): string | null {
+  if (!isDiscordCdnUrl(file.url)) return "not served from a Discord CDN host";
+  if (file.size > MAX_ATTACHMENT_BYTES) return `${file.size} bytes is over the ${MAX_ATTACHMENT_BYTES} byte cap`;
+  return null;
+}
+
+/** A filename reaches the log verbatim; control characters in it would
+ *  forge log lines, so keep only printable categories. */
+function logLabel(name: string): string {
+  return name.replace(UNPRINTABLE_RE, " ").slice(0, LOG_LABEL_MAX_CHARS);
+}
+
+async function drainCapped(reader: ReadableStreamDefaultReader<Uint8Array>, maxBytes: number): Promise<Buffer | null> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return Buffer.concat(chunks);
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+}
+
+/** Read at most `maxBytes`, aborting mid-stream rather than after the
+ *  fact — `arrayBuffer()` would have already materialised the body. */
+async function readCappedBody(res: Response, maxBytes: number): Promise<Buffer | null> {
+  const declared = Number(res.headers.get("content-length") ?? "");
+  if (Number.isFinite(declared) && declared > maxBytes) return null;
+  const { body } = res;
+  if (body === null) return null;
+  return drainCapped(body.getReader(), maxBytes);
+}
+
+export async function downloadAttachment(file: DiscordAttachmentLike, deps: DownloadDeps): Promise<Attachment | null> {
+  const log = deps.log ?? defaultLog;
+  const refused = refuseReason(file);
+  if (refused !== null) {
+    log.warn(`[discord] attachment skipped: ${logLabel(file.name)} — ${refused}`);
+    return null;
+  }
+  try {
+    const res = await deps.fetchFn(file.url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS), redirect: "error" });
+    if (!res.ok) {
+      log.warn(`[discord] attachment fetch failed: ${logLabel(file.name)} — HTTP ${res.status}`);
+      return null;
+    }
+    const bytes = await readCappedBody(res, MAX_ATTACHMENT_BYTES);
+    if (bytes === null) {
+      log.warn(`[discord] attachment skipped: ${logLabel(file.name)} — body over the ${MAX_ATTACHMENT_BYTES} byte cap`);
+      return null;
+    }
+    return { mimeType: resolveMimeType(file), data: bytes.toString("base64"), filename: file.name };
+  } catch (err) {
+    log.warn(`[discord] attachment download failed: ${logLabel(file.name)} — ${err}`);
+    return null;
+  }
+}
+
+export async function collectAttachments(files: DiscordAttachmentLike[], deps: DownloadDeps): Promise<CollectedAttachments> {
+  const considered = files.slice(0, MAX_ATTACHMENT_COUNT);
+  const results = await Promise.all(considered.map((file) => downloadAttachment(file, deps)));
+  const attachments = results.filter((entry): entry is Attachment => entry !== null);
+  return { attachments, dropped: files.length - attachments.length };
+}
+
+/** The body sent to MulmoClaude: a placeholder when the user posted
+ *  only files, plus a note when some of them were lost. */
+export function resolveMessageText(text: string, dropped: number): string {
+  const trimmed = text.trim();
+  const body = trimmed.length > 0 ? trimmed : ATTACHMENT_ONLY_PROMPT;
+  if (dropped <= 0) return body;
+  const plural = dropped === 1 ? "file" : "files";
+  return `${body}\n\n(note: ${dropped} attached ${plural} could not be downloaded)`;
+}

--- a/packages/bridges/discord/src/index.ts
+++ b/packages/bridges/discord/src/index.ts
@@ -13,6 +13,7 @@ import "dotenv/config";
 import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
 import { createBridgeClient } from "@mulmobridge/client";
 import { parseCsvSet } from "@mulmoclaude/common";
+import { collectAttachments, resolveMessageText, type DiscordAttachmentLike } from "./attachments.js";
 
 const TRANSPORT_ID = "discord";
 const MAX_DISCORD_LENGTH = 2000;
@@ -59,22 +60,39 @@ discord.on("messageCreate", (msg: Message) => {
 async function onMessageCreate(msg: Message): Promise<void> {
   if (msg.author.bot) return;
   const { channelId } = msg;
-  const text = msg.content.trim();
-  if (!text) return;
+  // Checked before the attachment downloads so a denied channel never
+  // makes the bridge fetch anything.
   if (!allowAll && !allowedChannels.has(channelId)) return;
 
-  console.log(`[discord] message channel=${channelId} user=${msg.author.tag} len=${text.length}`);
+  const text = msg.content.trim();
+  const files = [...msg.attachments.values()];
+  if (text.length === 0 && files.length === 0) return;
+
+  console.log(`[discord] message channel=${channelId} user=${msg.author.tag} len=${text.length} attachments=${files.length}`);
 
   try {
-    const ack = await mulmo.send(channelId, text);
-    if (ack.ok) {
-      await sendChunked(msg, ack.reply ?? "");
-    } else {
-      const status = ack.status ? ` (${ack.status})` : "";
-      await msg.reply(`Error${status}: ${ack.error ?? "unknown"}`);
-    }
+    await relayMessage(msg, text, files);
   } catch (err) {
     console.error(`[discord] message handling failed: ${err}`);
+  }
+}
+
+async function relayMessage(msg: Message, text: string, files: DiscordAttachmentLike[]): Promise<void> {
+  const { attachments, dropped } = await collectAttachments(files, { fetchFn: fetch, log: console });
+
+  // Nothing survived on a file-only post: say so instead of relaying a
+  // prompt about a file the agent never receives.
+  if (text.length === 0 && attachments.length === 0) {
+    await msg.reply("Sorry, I could not download that attachment. Please try again.");
+    return;
+  }
+
+  const ack = await mulmo.send(msg.channelId, resolveMessageText(text, dropped), attachments.length > 0 ? attachments : undefined);
+  if (ack.ok) {
+    await sendChunked(msg, ack.reply ?? "");
+  } else {
+    const status = ack.status ? ` (${ack.status})` : "";
+    await msg.reply(`Error${status}: ${ack.error ?? "unknown"}`);
   }
 }
 

--- a/packages/bridges/discord/test/test_attachments.ts
+++ b/packages/bridges/discord/test/test_attachments.ts
@@ -187,6 +187,19 @@ describe("collectAttachments", () => {
     assert.equal(fetchFn.calls.length, 1, "the files that cannot be sent are never downloaded");
   });
 
+  it("still holds the budget when Discord under-reports a file's size", async () => {
+    // `withinBudget` trusts the declared size; this pins that the bytes
+    // actually downloaded are re-checked, so the server never has to
+    // truncate silently.
+    const oversized = new Uint8Array(3 * 1024 * 1024); // ~4 MB of base64 each
+    const fetchFn = stubFetch(oversized);
+    const files = Array.from({ length: 6 }, (_, i) => file({ name: `f${i}.png`, size: 1 })); // all claim 1 byte
+    const got = await collectAttachments(files, { fetchFn, log: silentLog });
+    const total = got.attachments.reduce((sum, entry) => sum + (entry.data?.length ?? 0), 0);
+    assert.equal(total <= MAX_TOTAL_BASE64_CHARS, true, `forwarded ${total} chars, over the ${MAX_TOTAL_BASE64_CHARS} budget`);
+    assert.equal(got.attachments.length + got.dropped, files.length, "every file is either forwarded or counted as dropped");
+  });
+
   it("keeps a small file that still fits after a big one was skipped", async () => {
     const fetchFn = stubFetch(new Uint8Array([1]));
     const files = [

--- a/packages/bridges/discord/test/test_attachments.ts
+++ b/packages/bridges/discord/test/test_attachments.ts
@@ -6,8 +6,10 @@ import {
   isDiscordCdnUrl,
   resolveMessageText,
   resolveMimeType,
+  base64Length,
   MAX_ATTACHMENT_BYTES,
   MAX_ATTACHMENT_COUNT,
+  MAX_TOTAL_BASE64_CHARS,
   type DiscordAttachmentLike,
   type FetchFn,
 } from "../src/attachments.ts";
@@ -115,6 +117,21 @@ describe("downloadAttachment", () => {
     assert.equal(got, null);
   });
 
+  it("releases the connection when the declared length is over the cap", async () => {
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const fetchFn: FetchFn = async () => new Response(body, { headers: { "content-length": String(MAX_ATTACHMENT_BYTES + 1) } });
+    assert.equal(await downloadAttachment(file({ size: 10 }), { fetchFn, log: silentLog }), null);
+    assert.equal(cancelled, true, "an undrained body leaks the connection until it times out");
+  });
+
   it("returns null on a non-2xx response", async () => {
     const fetchFn = stubFetch(new Uint8Array([1]), { status: 404 });
     assert.equal(await downloadAttachment(file(), { fetchFn, log: silentLog }), null);
@@ -155,6 +172,39 @@ describe("collectAttachments", () => {
   it("returns an empty result for a message with no files", async () => {
     const fetchFn = stubFetch(new Uint8Array([1]));
     assert.deepEqual(await collectAttachments([], { fetchFn, log: silentLog }), { attachments: [], dropped: 0 });
+  });
+
+  // chat-service's parseAttachments stops at 20 MB of base64 and says
+  // nothing, so files past that would vanish without the user hearing.
+  it("stops at the base64 budget the server enforces, and counts the rest", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]));
+    const big = MAX_ATTACHMENT_BYTES; // 8 MB → ~10.7 MB of base64
+    const files = [file({ name: "a.png", size: big }), file({ name: "b.png", size: big }), file({ name: "c.png", size: big })];
+    const got = await collectAttachments(files, { fetchFn, log: silentLog });
+    assert.equal(base64Length(big) * 2 > MAX_TOTAL_BASE64_CHARS, true, "two of these must not fit — otherwise this test proves nothing");
+    assert.equal(got.attachments.length, 1);
+    assert.equal(got.dropped, 2);
+    assert.equal(fetchFn.calls.length, 1, "the files that cannot be sent are never downloaded");
+  });
+
+  it("keeps a small file that still fits after a big one was skipped", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]));
+    const files = [
+      file({ name: "big.png", size: MAX_ATTACHMENT_BYTES }),
+      file({ name: "huge.png", size: MAX_ATTACHMENT_BYTES }),
+      file({ name: "tiny.png", size: 10 }),
+    ];
+    const got = await collectAttachments(files, { fetchFn, log: silentLog });
+    assert.equal(got.attachments.length, 2, "big + tiny fit; huge does not");
+    assert.equal(got.dropped, 1);
+  });
+});
+
+describe("base64Length", () => {
+  it("matches what Buffer.toString('base64') actually produces", () => {
+    [0, 1, 2, 3, 4, 5, 6, 100, 1023, 4096].forEach((size) => {
+      assert.equal(base64Length(size), Buffer.alloc(size).toString("base64").length, `size ${size}`);
+    });
   });
 });
 

--- a/packages/bridges/discord/test/test_attachments.ts
+++ b/packages/bridges/discord/test/test_attachments.ts
@@ -1,0 +1,176 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  collectAttachments,
+  downloadAttachment,
+  isDiscordCdnUrl,
+  resolveMessageText,
+  resolveMimeType,
+  MAX_ATTACHMENT_BYTES,
+  MAX_ATTACHMENT_COUNT,
+  type DiscordAttachmentLike,
+  type FetchFn,
+} from "../src/attachments.ts";
+
+const silentLog = { warn: () => {} };
+
+const CDN = "https://cdn.discordapp.com/attachments/1/2/shot.png";
+
+function file(overrides: Partial<DiscordAttachmentLike> = {}): DiscordAttachmentLike {
+  return { url: CDN, name: "shot.png", size: 4, contentType: "image/png", ...overrides };
+}
+
+interface StubResponseInit {
+  status?: number;
+  headers?: Record<string, string>;
+}
+
+/** A fetch that answers every URL with the same body. */
+function stubFetch(body: Uint8Array<ArrayBuffer>, init: StubResponseInit = {}): FetchFn & { calls: string[] } {
+  const calls: string[] = [];
+  const fetchFn = async (url: string) => {
+    calls.push(url);
+    return new Response(body, init);
+  };
+  return Object.assign(fetchFn, { calls });
+}
+
+describe("isDiscordCdnUrl", () => {
+  it("accepts the CDN hosts Discord serves attachments from", () => {
+    assert.equal(isDiscordCdnUrl(CDN), true);
+    assert.equal(isDiscordCdnUrl("https://media.discordapp.net/attachments/1/2/a.png"), true);
+    assert.equal(isDiscordCdnUrl("https://images-ext-1.discordapp.net/x.png"), true);
+  });
+
+  it("refuses anything that is not a Discord host", () => {
+    assert.equal(isDiscordCdnUrl("https://evil.example.com/a.png"), false);
+    // A lookalike that merely ends with the brand, without the dot.
+    assert.equal(isDiscordCdnUrl("https://notdiscordapp.com/a.png"), false);
+    // The suffix as a prefix of an attacker-controlled domain.
+    assert.equal(isDiscordCdnUrl("https://cdn.discordapp.com.evil.example/a.png"), false);
+  });
+
+  it("refuses non-https schemes and internal targets", () => {
+    assert.equal(isDiscordCdnUrl("http://cdn.discordapp.com/a.png"), false);
+    assert.equal(isDiscordCdnUrl("file:///etc/passwd"), false);
+    assert.equal(isDiscordCdnUrl("https://127.0.0.1/a.png"), false);
+    assert.equal(isDiscordCdnUrl("http://169.254.169.254/latest/meta-data/"), false);
+  });
+
+  it("refuses a malformed URL instead of throwing", () => {
+    assert.equal(isDiscordCdnUrl(""), false);
+    assert.equal(isDiscordCdnUrl("not a url"), false);
+  });
+});
+
+describe("resolveMimeType", () => {
+  it("uses the type Discord declares, without its parameters", () => {
+    assert.equal(resolveMimeType(file({ contentType: "text/plain; charset=utf-8" })), "text/plain");
+    assert.equal(resolveMimeType(file({ contentType: "IMAGE/PNG" })), "image/png");
+  });
+
+  it("falls back to the filename extension when Discord declares nothing", () => {
+    assert.equal(resolveMimeType(file({ contentType: null, name: "spec.pdf" })), "application/pdf");
+    assert.equal(resolveMimeType(file({ contentType: "", name: "photo.JPG" })), "image/jpeg");
+  });
+
+  it("falls back to octet-stream for an unknown or missing extension", () => {
+    assert.equal(resolveMimeType(file({ contentType: null, name: "archive.zzz" })), "application/octet-stream");
+    assert.equal(resolveMimeType(file({ contentType: null, name: "README" })), "application/octet-stream");
+    assert.equal(resolveMimeType(file({ contentType: null, name: "trailing." })), "application/octet-stream");
+  });
+});
+
+describe("downloadAttachment", () => {
+  it("returns the bytes as base64 with the filename kept", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1, 2, 3]));
+    const got = await downloadAttachment(file({ size: 3 }), { fetchFn, log: silentLog });
+    assert.deepEqual(got, { mimeType: "image/png", data: Buffer.from([1, 2, 3]).toString("base64"), filename: "shot.png" });
+    assert.deepEqual(fetchFn.calls, [CDN]);
+  });
+
+  it("never fetches a URL outside the Discord CDN", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]));
+    const got = await downloadAttachment(file({ url: "https://evil.example.com/a.png" }), { fetchFn, log: silentLog });
+    assert.equal(got, null);
+    assert.deepEqual(fetchFn.calls, []);
+  });
+
+  it("skips a file Discord declares as over the cap without fetching it", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]));
+    const got = await downloadAttachment(file({ size: MAX_ATTACHMENT_BYTES + 1 }), { fetchFn, log: silentLog });
+    assert.equal(got, null);
+    assert.deepEqual(fetchFn.calls, []);
+  });
+
+  it("drops a body that exceeds the cap even when the declared size lied", async () => {
+    const fetchFn = stubFetch(new Uint8Array(MAX_ATTACHMENT_BYTES + 1));
+    const got = await downloadAttachment(file({ size: 10 }), { fetchFn, log: silentLog });
+    assert.equal(got, null);
+  });
+
+  it("drops a body whose content-length header exceeds the cap", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]), { headers: { "content-length": String(MAX_ATTACHMENT_BYTES + 1) } });
+    const got = await downloadAttachment(file({ size: 10 }), { fetchFn, log: silentLog });
+    assert.equal(got, null);
+  });
+
+  it("returns null on a non-2xx response", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]), { status: 404 });
+    assert.equal(await downloadAttachment(file(), { fetchFn, log: silentLog }), null);
+  });
+
+  it("returns null when the fetch throws", async () => {
+    const fetchFn: FetchFn = async () => {
+      throw new Error("network down");
+    };
+    assert.equal(await downloadAttachment(file(), { fetchFn, log: silentLog }), null);
+  });
+});
+
+describe("collectAttachments", () => {
+  it("keeps every downloadable file and reports none dropped", async () => {
+    const fetchFn = stubFetch(new Uint8Array([7]));
+    const got = await collectAttachments([file(), file({ name: "b.png" })], { fetchFn, log: silentLog });
+    assert.equal(got.attachments.length, 2);
+    assert.equal(got.dropped, 0);
+  });
+
+  it("counts a failed download as dropped and keeps the rest", async () => {
+    const fetchFn: FetchFn = async (url) => (url.endsWith("bad.png") ? new Response(null, { status: 500 }) : new Response(new Uint8Array([1])));
+    const got = await collectAttachments([file(), file({ name: "bad.png", url: `${CDN}/bad.png` })], { fetchFn, log: silentLog });
+    assert.equal(got.attachments.length, 1);
+    assert.equal(got.dropped, 1);
+  });
+
+  it("stops at the count the server would accept and reports the excess", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]));
+    const files = Array.from({ length: MAX_ATTACHMENT_COUNT + 3 }, (_, i) => file({ name: `f${i}.png` }));
+    const got = await collectAttachments(files, { fetchFn, log: silentLog });
+    assert.equal(got.attachments.length, MAX_ATTACHMENT_COUNT);
+    assert.equal(got.dropped, 3);
+    assert.equal(fetchFn.calls.length, MAX_ATTACHMENT_COUNT);
+  });
+
+  it("returns an empty result for a message with no files", async () => {
+    const fetchFn = stubFetch(new Uint8Array([1]));
+    assert.deepEqual(await collectAttachments([], { fetchFn, log: silentLog }), { attachments: [], dropped: 0 });
+  });
+});
+
+describe("resolveMessageText", () => {
+  it("keeps the user's text when nothing was lost", () => {
+    assert.equal(resolveMessageText("  what is this?  ", 0), "what is this?");
+  });
+
+  it("substitutes a prompt for a file-only post — chat-service rejects an empty text", () => {
+    assert.equal(resolveMessageText("", 0), "Describe / analyze this file.");
+    assert.equal(resolveMessageText("   ", 0), "Describe / analyze this file.");
+  });
+
+  it("notes the files that could not be downloaded", () => {
+    assert.equal(resolveMessageText("look", 1), "look\n\n(note: 1 attached file could not be downloaded)");
+    assert.equal(resolveMessageText("look", 2), "look\n\n(note: 2 attached files could not be downloaded)");
+    assert.equal(resolveMessageText("", 1), "Describe / analyze this file.\n\n(note: 1 attached file could not be downloaded)");
+  });
+});

--- a/plans/fix-2939-discord-attachments.md
+++ b/plans/fix-2939-discord-attachments.md
@@ -1,0 +1,54 @@
+# Discord ブリッジが添付を渡していない (#2939)
+
+**Status**: implementing
+**Tracks**: #2939
+**Last updated**: 2026-08-25
+
+## 問題
+
+`packages/bridges/discord/src/index.ts` の `onMessageCreate` は `msg.attachments`
+を一度も読んでいない。加えて `if (!text) return;` があるため、画像だけの投稿は
+本文が空の時点で捨てられる。結果として Discord に画像を貼っても何も起きない。
+
+`@mulmobridge/client` の `send(externalChatId, text, attachments)` も
+`@mulmobridge/protocol` の `Attachment` も #382 で用意済みで、Telegram / LINE /
+Mastodon は既にこの経路に繋がっている。Discord だけが繋がっていない。
+
+## 制約（実装前に確認した事実）
+
+- `packages/chat-service/src/socket.ts` の `parseMessagePayload` は **空 text を拒否**
+  する (`text is required`)。添付のみのメッセージにはプレースホルダ本文が要る。
+  LINE / Telegram は `"Describe / analyze this file."` を使っている → 揃える。
+- 同ファイルのサーバ側上限: `MAX_ATTACHMENT_COUNT = 10`、
+  `MAX_ATTACHMENT_TOTAL_BYTES = 20MB`（base64 長）。ブリッジ側はこれ以下に収める。
+- `server/agent/config.ts` の `buildUserMessageLine` は image / PDF をネイティブ
+  ブロック、text / docx / xlsx / pptx を変換、それ以外は warn してスキップする。
+  つまり **ブリッジ側で MIME を絞る必要はない**（Telegram の document 経路と同じ）。
+- discord.js の `Attachment` は `url` / `name` / `size` / `contentType` を持つ。
+  添付は MESSAGE_CONTENT 特権インテント配下 — ブリッジは既に要求済み。
+
+## 方針
+
+1. 新規 `packages/bridges/discord/src/attachments.ts`（純粋関数 + fetch を DI）
+   - `isDiscordCdnUrl(url)` — https かつ discord 系ホストのみ許可（SSRF ガード）
+   - `resolveMimeType(att)` — `contentType` のパラメータ除去 → 拡張子推定
+     (`mimeFromExtension` を再利用) → `application/octet-stream`
+   - `readCappedBody(res, maxBytes)` — 宣言サイズ + ストリーム両方で打ち切り
+   - `downloadAttachment` / `collectAttachments` — 件数上限・サイズ上限・
+     失敗件数を返す
+   - `resolveMessageText(text, dropped)` — 空本文のプレースホルダ、落とした添付の注記
+2. `index.ts` を繋ぎ替える
+   - allowlist チェックを **fetch より前** に（拒否チャンネルで通信しない）
+   - `text` が空でも添付があれば送る
+   - 添付のみ + 全滅した場合はユーザーに失敗を返す（Telegram と同じ扱い）
+3. `packages/bridges/discord/test/test_attachments.ts` を追加、package.json に
+   `test` script（tsx）と eslint.config.mjs を mastodon / telegram に揃えて追加
+
+## スコープ外（別 issue にする）
+
+- **Mastodon も添付のみの DM で壊れている**: `handleNotification` は
+  `parsed.text` が空でも `mulmo.send(acct, "")` を呼ぶので、サーバの
+  `text is required` で弾かれる。同じプレースホルダ処理が要る。
+- `readCappedBody` 相当が mastodon と discord で重複する。共通化するなら
+  `@mulmobridge/client` に置くのが筋だが、client → discord の順で publish が
+  必要になり本 fix の出荷が遅れるため、フォローアップに回す。


### PR DESCRIPTION
> [!IMPORTANT]
> **先に PR #2957（#2956）をマージしてください。** ソケットのフレーム上限が Socket.IO 既定の
> 1MB のままだと、このPRが宣言する 8MB の添付上限は機能しません（約 730KB を超えると接続が切れます）。
> codex-review の指摘を実測で確認し、基盤側の修正として分離しました。

## Summary

Discord ブリッジは `msg.attachments` を一度も読んでおらず、さらに `if (!text) return;` が画像だけの投稿を本文チェックで捨てていた。#382 で用意された `send(externalChatId, text, attachments)` の経路に Discord だけが繋がっていなかった状態を繋ぐ。

- **新規 `packages/bridges/discord/src/attachments.ts`**（fetch を DI して単体テスト可能に）
  - `isDiscordCdnUrl` — https かつ Discord CDN ホストのみ許可。ゲートウェイ応答が細工された場合に SSRF の踏み台にしない
  - `resolveMimeType` — `contentType` のパラメータ除去 → 拡張子推定（`mimeFromExtension` を再利用）→ `application/octet-stream`
  - ダウンロードは **content-length とストリーム両方**で打ち切り（`arrayBuffer()` だと読み切ってから判定になる）
  - 1ファイル 8MB / 1メッセージ 10件（chat-service の `MAX_ATTACHMENT_COUNT=10` / `MAX_ATTACHMENT_TOTAL_BYTES=20MB` に合わせた）
  - 落とした添付は件数を数えて本文に注記
- **`index.ts`**
  - 本文が空でも添付があれば送る。chat-service の `parseMessagePayload` は空 text を `text is required` で拒否するので、Telegram / LINE と同じ `Describe / analyze this file.` をプレースホルダにする
  - allowlist チェックをダウンロードより **前** に移動（拒否チャンネルのために通信しない）
  - 添付のみで全滅した場合はユーザーに失敗を返す（Telegram と同じ扱い）
- **MIME で絞っていない**: `server/agent/config.ts` の `buildUserMessageLine` が image / PDF はネイティブブロック、text / docx / xlsx / pptx は変換、それ以外は warn してスキップする。ブリッジ側で絞ると対応形式が二重管理になる（Telegram の document 経路と同じ判断）
- テスト 21 件と `test` script（tsx、mastodon / telegram と同じ形）を追加

## Items to Confirm / Review

1. **`redirect: "error"`** — mastodon ブリッジに合わせた。`cdn.discordapp.com` は 200 を直接返すはずだが、Discord がリダイレクトを挟む構成に変わると添付が落ちる（ログには残る）。ここは実運用で確認したい。
2. **CDN ホスト許可リスト** — `.discordapp.com` / `.discordapp.net` / `.discord.com` のサフィックス一致。Discord が別ドメインの CDN に移すと無言で落ちるトレードオフ（ログには出る）。
3. **8MB / 10件の上限** — Discord の無料枠アップロード上限は 10MB、boost 済みサーバはもっと大きい。8MB 超の画像を弾くのが妥当か。
4. **`fetchFn: fetch` に `AbortSignal.timeout(30s)`** — 8MB を 30 秒で引けない回線だと落ちる。
5. **duplication**: `readCappedBody` 相当が mastodon ブリッジにもある。共通化するなら `@mulmobridge/client` が筋だが、client → discord の順で publish が必要になり本 fix の出荷が遅れるため今回は見送った。フォローアップにしたい。

## 検証

ユニットテスト（21件）に加えて、**実物の chat-service ソケット + 実物の `@mulmobridge/client` + 実物の `buildUserMessageLine`** を繋いだ使い捨てハーネスで、画像のみ投稿が実際に届くところまで確認した（コミットはしていない）:

```
[1] main today, image-only post →  {"ok":false,"error":"text is required","status":400}
[2] with the fix → {"ok":true,"reply":"got it"}
[3] relay received: { text: 'Describe / analyze this file.',
                      mimeType: 'image/png', filename: 'screenshot.png', bytesMatch: true }
[4] user message line → {"type":"user","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw0KGg…
```

- `[1]` は「今の main が無言で失敗する理由」そのもの（空 text がサーバに拒否される）
- `[3]` は PNG のバイト列が base64 のまま wire を通り抜けたことの確認
- `[4]` はエージェントのターンが実際に vision ブロックになることの確認

実 Discord ボットでの動作確認（本物の CDN URL からのダウンロード、`redirect` 挙動、特権インテント経由で `attachments` が実際に載ってくること）は **未実施** — トークンが要るため。上の 1・2 はそこで確認したい。

ローカルゲートは discord パッケージ単体で `typecheck` / `build` / `test` / `eslint` を実行済み（マシンの load average が 15 超だったため、リポジトリ全体の build は CI に委ねる）。`yarn install --frozen-lockfile` が lockfile 無変更で通ることも確認済み（`tsx@^4.23.5` は既に lockfile にあるキーなので lockfile 変更なし）。

## 別件（このPRのスコープ外）

**Mastodon ブリッジにも同じ欠陥がある**: `handleNotification` は本文が空でも `mulmo.send(acct, "")` を呼ぶため、画像だけの DM はサーバの `text is required` で弾かれる（`packages/bridges/mastodon/src/index.ts:208-213`）。同じプレースホルダ処理が要る。別 issue に切り出したい。

## User Prompt

> これなおせる？？
> https://github.com/receptron/mulmoclaude/issues/2939

Closes #2939

work in mulmoclaude5

## Summary by Sourcery

Connect the Discord bridge to MulmoClaude's attachment relay so users can send files, including image-only messages, for analysis.

New Features:
- Forward Discord message attachments to MulmoClaude, including messages containing only files.
- Support secure, bounded attachment downloads with MIME detection and reporting for skipped files.

Bug Fixes:
- Prevent attachment-only Discord messages from being discarded or rejected because their text is empty.

Enhancements:
- Apply Discord CDN validation and attachment count and size limits before relaying files.
- Document Discord attachment support and the supported file handling behavior.

Documentation:
- Document attachment forwarding, limits, supported formats, and required Discord intent.

Tests:
- Add comprehensive unit coverage for attachment validation, downloading, size budgeting, MIME resolution, and attachment-only message text.
