### PR TITLE
fix: SCRIPT_CHANGED_EVENT を entry point から re-export する (4.1.1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -416,7 +416,7 @@ translation behind it.
 
 ### Changed
 
-#### `@mulmoclaude/mulmoscript-plugin@4.1.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+#### `@mulmoclaude/mulmoscript-plugin@4.1.1` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
 
 Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
 hosts had moved to deck-web 2.0.0, so every install printed
@@ -448,7 +448,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.3.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.1.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^4.1.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.1.1",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/server/index.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/index.ts
@@ -27,5 +27,5 @@ export {
 } from "./ops";
 export { createMulmoScriptDispatchHandler, type MulmoScriptDispatchHandler } from "./dispatch";
 export { withMulmoErrorCapture, enableGraphAIErrorCapture, composeMulmoErrorMessage, describeMulmoCause } from "./mulmoErrorCapture";
-export { GENERATION_EVENT, type MulmoScriptGenerationEvent } from "../core/contract";
+export { GENERATION_EVENT, SCRIPT_CHANGED_EVENT, type MulmoScriptChangedEvent, type MulmoScriptGenerationEvent } from "../core/contract";
 export { executeMulmoScriptSave, executeUpdateBeat, executeUpdateScript, type MulmoScriptFailure } from "../core/plugin";

--- a/packages/plugins/mulmoscript-plugin/src/vue/index.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/index.ts
@@ -20,7 +20,7 @@ export const plugin: ToolPlugin<MulmoScriptData, MulmoScriptData, SaveMulmoScrip
 
 export type { MulmoScriptData, MulmoScriptExecuteContext, SaveMulmoScriptArgs } from "../core/types";
 export type { MulmoScriptDispatchArgs, MulmoScriptDispatchResult, MulmoScriptGenerationEvent, DispatchEnvelope, DispatchFailure } from "../core/contract";
-export { GENERATION_EVENT } from "../core/contract";
+export { GENERATION_EVENT, SCRIPT_CHANGED_EVENT } from "../core/contract";
 export { TOOL_NAME, TOOL_DEFINITION } from "../core/definition";
 export { MULMOSCRIPT_HOST_ADAPTER_KEY, useHostAdapter, type MulmoScriptHostAdapter } from "./hostAdapter";
 export { useMulmoScriptTransport, type MulmoScriptTransport, type TransportResult } from "./transport";

--- a/packages/plugins/mulmoscript-plugin/test/test_publicExports.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_publicExports.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * What a host can actually import.
+ *
+ * 4.1.0 shipped `SCRIPT_CHANGED_EVENT` in the bundle but did not re-export it from
+ * `/server`, so the one host that needed it could not name the channel. The tarball check
+ * passed because the string WAS in the archive — presence in a file is not reachability
+ * through an entry point, and only the entry point is the contract.
+ */
+
+describe("entry points", () => {
+  it("exposes the pubsub channel names a host has to publish on", async () => {
+    const server = await import("../src/server/index");
+    assert.equal(server.GENERATION_EVENT, "generation");
+    assert.equal(server.SCRIPT_CHANGED_EVENT, "scriptChanged");
+  });
+
+  it("serves the browser entry the same constants, from the one place they are defined", async () => {
+    // `src/vue/index.ts` cannot be imported here — it pulls in `style.css`, which node has no
+    // loader for. What matters is that both entries re-export the SAME module, so assert the
+    // source of truth and let the re-export lists be checked by typecheck.
+    const contract = await import("../src/core/contract");
+    const server = await import("../src/server/index");
+    assert.equal(server.GENERATION_EVENT, contract.GENERATION_EVENT);
+    assert.equal(server.SCRIPT_CHANGED_EVENT, contract.SCRIPT_CHANGED_EVENT);
+  });
+
+  it("names the channels the host builds its pubsub topic from", async () => {
+    const contract = await import("../src/core/contract");
+    // `plugin:mulmoScript:<event>` — a rename here silently stops every View listening.
+    assert.equal(contract.GENERATION_EVENT, "generation");
+    assert.equal(contract.SCRIPT_CHANGED_EVENT, "scriptChanged");
+  });
+
+  it("keeps the server's ops factory and dispatch handler reachable", async () => {
+    const server = await import("../src/server/index");
+    assert.equal(typeof server.createMulmoScriptServerOps, "function");
+    assert.equal(typeof server.createMulmoScriptDispatchHandler, "function");
+  });
+});


### PR DESCRIPTION
## Summary

**4.1.0 はホストから使えなかった。** `SCRIPT_CHANGED_EVENT` をバンドルには入れたが
`/server` から **re-export し忘れていた**ので、pubsub のチャンネル名を組み立てる唯一のホストが
import できなかった。

MulmoTerminal 側の配線を書いた時点で typecheck が落ちて発覚した:

```
error TS2305: Module '"@mulmoclaude/mulmoscript-plugin/server"'
has no exported member 'SCRIPT_CHANGED_EVENT'.
```

`/server` と `/vue` の両方から出す（`GENERATION_EVENT` と対称）。

## タールボール検証がこれを見逃した理由

publish 前に「アーカイブを展開して grep する」検証は**通っていた** —
`scriptChanged` は確かに 5 ファイルに入っていたため。

**ファイルの中に文字列があることと、entry point から届くことは別**で、
契約なのは後者だけだった。

そこで `test/test_publicExports.ts` を追加し、**ホストが import するものを import する**形にした。

> `src/vue/index.ts` は `style.css` を読むため node から直接 import できない。
> 両 entry が同じモジュールを re-export している以上、単一の出所（`core/contract`）を
> 検証し、re-export の一覧は typecheck に任せる形にした。

### break-check

| 変異 | 結果 |
|------|------|
| `/server` の re-export から外す | **2件 赤** |
| 戻す | 4/4 green |

## ゲート

`typecheck` / `lint` / `build` / `test`（**134 pass / 0 fail**、+4本）。
`check-changelog-ships` OK。

## User Prompt

> できるものはすすめて。提案方法で

Refs #2949

## Summary by Sourcery

Publish version 4.1.1 with the missing `SCRIPT_CHANGED_EVENT` entry-point exports and regression coverage for host-facing imports.

Bug Fixes:
- Re-export `SCRIPT_CHANGED_EVENT` from the server and Vue entry points so hosts can import the script-changed pubsub channel name.

Documentation:
- Update the changelog and package references for the 4.1.1 release.

Tests:
- Add public entry-point tests covering exported pubsub constants and server APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public access to script-change event notifications across server and Vue integrations.
  * Exposed the script-change event type for server-side consumers.

* **Documentation**
  * Updated changelog and package version references for release 4.1.1.

* **Tests**
  * Added coverage verifying event exports and their expected topic names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->