### PR TITLE
fix(mastodon): 画像だけの DM をプロンプト付きで届ける (#2952)

### DIFF
--- a/packages/bridges/mastodon/README.md
+++ b/packages/bridges/mastodon/README.md
@@ -8,7 +8,8 @@ Mastodon bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). Sub
 
 Images attached to a DM are downloaded and forwarded, so you can post a screenshot and ask about it. A DM with **only** images and no caption is forwarded too, with `Describe / analyze this file.` as the body.
 
-- 8 MB per image; any that fail to download are noted in the body MulmoClaude receives.
+- 8 MB per image. Images that fail to download are noted in the body MulmoClaude receives.
+- If every image in a caption-less DM fails to download, the bridge replies with an error instead of relaying.
 - Only Mastodon's `image` media type is forwarded — `video`, `gifv` and `audio` are left alone.
 - A DM whose entire body is the bot's handle counts as "no caption" — the handle is not sent as the prompt.
 

--- a/packages/bridges/mastodon/README.md
+++ b/packages/bridges/mastodon/README.md
@@ -4,6 +4,14 @@
 
 Mastodon bridge for [MulmoClaude](https://github.com/receptron/mulmoclaude). Subscribes to your bot account's streaming notifications and forwards DMs (and optionally public mentions) to MulmoClaude. Outbound-only WebSocket — **no public URL / tunnel / relay needed**.
 
+## Images
+
+Images attached to a DM are downloaded and forwarded, so you can post a screenshot and ask about it. A DM with **only** images and no caption is forwarded too, with `Describe / analyze this file.` as the body.
+
+- 8 MB per image; any that fail to download are noted in the body MulmoClaude receives.
+- Only Mastodon's `image` media type is forwarded — `video`, `gifv` and `audio` are left alone.
+- A DM whose entire body is the bot's handle counts as "no caption" — the handle is not sent as the prompt.
+
 ## Setup
 
 ### 1. Create a bot account + access token

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -25,7 +25,7 @@ import WebSocket from "ws";
 import { createBridgeClient, chunkText, formatAckReply, frameText } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 import { parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
-import { hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText, type ImageMedia } from "./media.js";
+import { fitBudget, hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText, type ImageMedia } from "./media.js";
 import { resolvePublicUrl } from "./urlGuard.js";
 
 const TRANSPORT_ID = "mastodon";
@@ -177,7 +177,10 @@ async function collectImageAttachments(media: ImageMedia[]): Promise<MulmoAttach
     const att = await fetchImageAttachment(item.url);
     if (att) out.push(att);
   }
-  return out;
+  // Four images at the 8 MB cap are 42 MB of base64 — past both the
+  // server's attachment budget and the socket frame. Trim here so the
+  // caller can count what was left out.
+  return fitBudget(out);
 }
 
 // ── Notification handling ───────────────────────────────────────

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -25,6 +25,7 @@ import WebSocket from "ws";
 import { createBridgeClient, chunkText, formatAckReply, frameText } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 import { parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
+import { hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText, type ImageMedia } from "./media.js";
 import { resolvePublicUrl } from "./urlGuard.js";
 
 const TRANSPORT_ID = "mastodon";
@@ -170,11 +171,9 @@ async function fetchImageAttachment(rawUrl: string): Promise<MulmoAttachment | n
   }
 }
 
-async function collectImageAttachments(media: unknown): Promise<MulmoAttachment[]> {
-  if (!Array.isArray(media)) return [];
+async function collectImageAttachments(media: ImageMedia[]): Promise<MulmoAttachment[]> {
   const out: MulmoAttachment[] = [];
   for (const item of media) {
-    if (!isRecord(item) || item.type !== "image" || typeof item.url !== "string") continue;
     const att = await fetchImageAttachment(item.url);
     if (att) out.push(att);
   }
@@ -203,18 +202,32 @@ async function handleNotification(raw: string): Promise<void> {
     return;
   }
 
-  // Collect attachments first so image-only DMs (no caption) still flow through.
-  const attachments = await collectImageAttachments(parsed.media);
-  if (!parsed.text && attachments.length === 0) return;
-
-  console.log(`[mastodon] message from=${parsed.senderAcct} len=${parsed.text.length} attachments=${attachments.length}`);
+  // Images are looked at before the empty-body check so an image-only
+  // DM (no caption) still flows through.
+  const media = imageMediaEntries(parsed.media);
+  if (!hasRelayableContent(parsed.text, media.length)) return;
 
   try {
-    const ack = await mulmo.send(parsed.senderAcct, parsed.text, attachments.length > 0 ? attachments : undefined);
-    await postStatus(parsed.senderAcct, formatAckReply(ack), parsed.statusId, parsed.visibility);
+    await relayStatus(parsed, media);
   } catch (err) {
     console.error(`[mastodon] message handling failed: ${err}`);
   }
+}
+
+async function relayStatus(parsed: ParsedStatus, media: ImageMedia[]): Promise<void> {
+  const attachments = await collectImageAttachments(media);
+  const dropped = media.length - attachments.length;
+  console.log(`[mastodon] message from=${parsed.senderAcct} len=${parsed.text.length} attachments=${attachments.length} dropped=${dropped}`);
+
+  // Nothing survived on an image-only DM: say so, rather than relaying a
+  // prompt about an image the agent never receives.
+  if (isLostImagesOnly(parsed.text, attachments.length)) {
+    await postStatus(parsed.senderAcct, "Sorry, I could not download that image. Please try again.", parsed.statusId, parsed.visibility);
+    return;
+  }
+
+  const ack = await mulmo.send(parsed.senderAcct, resolveMessageText(parsed.text, dropped), attachments.length > 0 ? attachments : undefined);
+  await postStatus(parsed.senderAcct, formatAckReply(ack), parsed.statusId, parsed.visibility);
 }
 
 // ── WebSocket stream ────────────────────────────────────────────

--- a/packages/bridges/mastodon/src/media.ts
+++ b/packages/bridges/mastodon/src/media.ts
@@ -15,6 +15,11 @@ export interface ImageMedia {
  *  bridges — an instruction, so the agent treats the image as the
  *  subject rather than looking for a caption. */
 const ATTACHMENT_ONLY_PROMPT = "Describe / analyze this file.";
+/** chat-service's `parseAttachments` drops whatever pushes a message past
+ *  this much base64, silently, and the socket frame is capped just above
+ *  it. Mirrored here so the bridge can say what it left out instead of
+ *  letting the message be truncated or the connection closed. */
+export const MAX_TOTAL_BASE64_CHARS = 20 * 1024 * 1024;
 
 /** The image entries of a status' `media_attachments`, in order. */
 export function imageMediaEntries(media: unknown): ImageMedia[] {
@@ -43,4 +48,19 @@ export function resolveMessageText(text: string, dropped: number): string {
   if (dropped <= 0) return body;
   const plural = dropped === 1 ? "file" : "files";
   return `${body}\n\n(note: ${dropped} attached ${plural} could not be downloaded)`;
+}
+
+/** The images that fit in one message, in order. Mastodon does not state
+ *  a media entry's size up front, so the budget can only be spent once
+ *  the bytes are in hand. An image that does not fit is skipped rather
+ *  than ending the loop: a smaller one after it may still fit. */
+export function fitBudget<T extends { data: string }>(attachments: T[]): T[] {
+  const kept: T[] = [];
+  let remaining = MAX_TOTAL_BASE64_CHARS;
+  attachments.forEach((attachment) => {
+    if (attachment.data.length > remaining) return;
+    remaining -= attachment.data.length;
+    kept.push(attachment);
+  });
+  return kept;
 }

--- a/packages/bridges/mastodon/src/media.ts
+++ b/packages/bridges/mastodon/src/media.ts
@@ -1,0 +1,46 @@
+// Pure rules for the media on an incoming status (#2952). Kept out of
+// `index.ts` because that module reads env and calls `process.exit` at
+// import time, so it cannot be pulled into a test.
+
+import { isRecord } from "@mulmoclaude/common";
+
+/** A media entry the bridge forwards. Mastodon also carries `video`,
+ *  `gifv`, `audio` and `unknown` types; those are left alone. */
+export interface ImageMedia {
+  url: string;
+}
+
+/** chat-service rejects an empty `text`, so an attachment-only status
+ *  needs a body. Same wording as the Telegram, LINE and Discord
+ *  bridges — an instruction, so the agent treats the image as the
+ *  subject rather than looking for a caption. */
+const ATTACHMENT_ONLY_PROMPT = "Describe / analyze this file.";
+
+/** The image entries of a status' `media_attachments`, in order. */
+export function imageMediaEntries(media: unknown): ImageMedia[] {
+  if (!Array.isArray(media)) return [];
+  return media.flatMap((item) => (isRecord(item) && item.type === "image" && typeof item.url === "string" ? [{ url: item.url }] : []));
+}
+
+/** False when there is nothing to relay at all — no caption, and no
+ *  images to stand in for one. */
+export function hasRelayableContent(text: string, mediaCount: number): boolean {
+  return text.trim().length > 0 || mediaCount > 0;
+}
+
+/** True when a status that DID carry images ends up with none of them
+ *  and no caption to fall back on. Only meaningful once
+ *  `hasRelayableContent` has already passed. */
+export function isLostImagesOnly(text: string, attachmentCount: number): boolean {
+  return text.trim().length === 0 && attachmentCount === 0;
+}
+
+/** The body sent to MulmoClaude: a placeholder when the sender posted
+ *  only images, plus a note when some of them were lost. */
+export function resolveMessageText(text: string, dropped: number): string {
+  const trimmed = text.trim();
+  const body = trimmed.length > 0 ? trimmed : ATTACHMENT_ONLY_PROMPT;
+  if (dropped <= 0) return body;
+  const plural = dropped === 1 ? "file" : "files";
+  return `${body}\n\n(note: ${dropped} attached ${plural} could not be downloaded)`;
+}

--- a/packages/bridges/mastodon/src/parse.ts
+++ b/packages/bridges/mastodon/src/parse.ts
@@ -63,8 +63,11 @@ export function htmlToText(html: string): string {
 // fails in O(n) per match. eslint-plugin-security's safe-regex
 // heuristic flags any `(...)?` containing `+` generically, even
 // when the surrounding pattern can't drive exponential backtracking.
+// The trailing `(?:\s+|$)` also strips a mention that ENDS the body:
+// an image-only DM is nothing but the handle, and leaving `@bot` behind
+// made it the prompt the agent received (#2952).
 // eslint-disable-next-line security/detect-unsafe-regex -- single-mention pattern, no nested-quantifier overlap; the iterative caller bounds total work to O(N) in the input length
-const SINGLE_MENTION_RE = /^@[A-Za-z0-9_.]+(?:@[A-Za-z0-9_.-]+)?\s+/;
+const SINGLE_MENTION_RE = /^@[A-Za-z0-9_.]+(?:@[A-Za-z0-9_.-]+)?(?:\s+|$)/;
 
 export function stripLeadingMentions(text: string): string {
   // Iterative strip — peel off one leading "@acct" / "@acct@instance"

--- a/packages/bridges/mastodon/test/test_media.ts
+++ b/packages/bridges/mastodon/test/test_media.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText } from "../src/media.ts";
+
+describe("imageMediaEntries", () => {
+  it("keeps the image entries in order", () => {
+    const media = [
+      { type: "image", url: "https://a.example/1.png" },
+      { type: "image", url: "https://a.example/2.png" },
+    ];
+    assert.deepEqual(imageMediaEntries(media), [{ url: "https://a.example/1.png" }, { url: "https://a.example/2.png" }]);
+  });
+
+  it("skips the media types the bridge does not forward", () => {
+    const media = [
+      { type: "video", url: "https://a.example/clip.mp4" },
+      { type: "image", url: "https://a.example/1.png" },
+      { type: "gifv", url: "https://a.example/loop.mp4" },
+      { type: "audio", url: "https://a.example/a.ogg" },
+      { type: "unknown", url: "https://a.example/x" },
+    ];
+    assert.deepEqual(imageMediaEntries(media), [{ url: "https://a.example/1.png" }]);
+  });
+
+  it("skips entries with no usable url", () => {
+    const media = [{ type: "image" }, { type: "image", url: 42 }, { type: "image", url: null }, "not an object", null];
+    assert.deepEqual(imageMediaEntries(media), []);
+  });
+
+  it("returns an empty list when the status carries no media field", () => {
+    assert.deepEqual(imageMediaEntries(undefined), []);
+    assert.deepEqual(imageMediaEntries(null), []);
+    assert.deepEqual(imageMediaEntries({}), []);
+    assert.deepEqual(imageMediaEntries([]), []);
+  });
+});
+
+describe("resolveMessageText", () => {
+  it("keeps the sender's caption when nothing was lost", () => {
+    assert.equal(resolveMessageText("  what is this?  ", 0), "what is this?");
+  });
+
+  it("substitutes a prompt for an image-only DM — chat-service rejects an empty text", () => {
+    assert.equal(resolveMessageText("", 0), "Describe / analyze this file.");
+    // `stripLeadingMentions` trims, but a caption of pure whitespace
+    // would still reach here.
+    assert.equal(resolveMessageText("   ", 0), "Describe / analyze this file.");
+  });
+
+  it("notes the images that could not be downloaded", () => {
+    assert.equal(resolveMessageText("look", 1), "look\n\n(note: 1 attached file could not be downloaded)");
+    assert.equal(resolveMessageText("look", 2), "look\n\n(note: 2 attached files could not be downloaded)");
+    assert.equal(resolveMessageText("", 1), "Describe / analyze this file.\n\n(note: 1 attached file could not be downloaded)");
+  });
+
+  it("ignores a negative drop count", () => {
+    assert.equal(resolveMessageText("look", -1), "look");
+  });
+});
+
+describe("hasRelayableContent", () => {
+  it("relays a caption with no images", () => {
+    assert.equal(hasRelayableContent("hello", 0), true);
+  });
+
+  it("relays images with no caption — the bug in #2952", () => {
+    assert.equal(hasRelayableContent("", 1), true);
+    assert.equal(hasRelayableContent("   ", 2), true);
+  });
+
+  it("ignores a bare mention carrying neither", () => {
+    assert.equal(hasRelayableContent("", 0), false);
+    assert.equal(hasRelayableContent("  ", 0), false);
+  });
+});
+
+describe("isLostImagesOnly", () => {
+  it("is true when no image survived and there is no caption", () => {
+    assert.equal(isLostImagesOnly("", 0), true);
+  });
+
+  it("is false while a caption can carry the turn", () => {
+    assert.equal(isLostImagesOnly("look at this", 0), false);
+  });
+
+  it("is false once at least one image is in hand", () => {
+    assert.equal(isLostImagesOnly("", 1), false);
+  });
+});

--- a/packages/bridges/mastodon/test/test_media.ts
+++ b/packages/bridges/mastodon/test/test_media.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText } from "../src/media.ts";
+import { fitBudget, hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText, MAX_TOTAL_BASE64_CHARS } from "../src/media.ts";
 
 describe("imageMediaEntries", () => {
   it("keeps the image entries in order", () => {
@@ -85,5 +85,35 @@ describe("isLostImagesOnly", () => {
 
   it("is false once at least one image is in hand", () => {
     assert.equal(isLostImagesOnly("", 1), false);
+  });
+});
+
+describe("fitBudget", () => {
+  const entry = (chars: number) => ({ data: "x".repeat(chars) });
+
+  it("keeps everything that fits", () => {
+    const kept = fitBudget([entry(10), entry(20)]);
+    assert.equal(kept.length, 2);
+  });
+
+  it("stops at the budget the server enforces", () => {
+    // Four images at the bridge's 8 MB cap: ~10.7 MB of base64 each.
+    const perImage = Math.ceil((8 * 1024 * 1024) / 3) * 4;
+    const kept = fitBudget([entry(perImage), entry(perImage), entry(perImage), entry(perImage)]);
+    const total = kept.reduce((sum, item) => sum + item.data.length, 0);
+    assert.equal(kept.length, 1, "only one 10.7 MB image fits in the 20 MB budget alongside… nothing else that big");
+    assert.equal(total <= MAX_TOTAL_BASE64_CHARS, true);
+  });
+
+  it("skips one oversized image but keeps a small one after it", () => {
+    const kept = fitBudget([entry(MAX_TOTAL_BASE64_CHARS - 5), entry(100), entry(3)]);
+    assert.deepEqual(
+      kept.map((item) => item.data.length),
+      [MAX_TOTAL_BASE64_CHARS - 5, 3],
+    );
+  });
+
+  it("returns an empty list for no images", () => {
+    assert.deepEqual(fitBudget([]), []);
   });
 });

--- a/packages/bridges/mastodon/test/test_parse.ts
+++ b/packages/bridges/mastodon/test/test_parse.ts
@@ -75,6 +75,69 @@ describe("stripLeadingMentions", () => {
     const adversarial = "@a@a@a@a@a";
     assert.equal(stripLeadingMentions(adversarial), adversarial);
   });
+
+  // #2952 — a mention that ENDS the body used to survive, so an
+  // image-only DM reached the agent with "@bot" as its prompt.
+  it("strips a mention that ends the body", () => {
+    assert.equal(stripLeadingMentions("@bot"), "");
+    assert.equal(stripLeadingMentions("@bot@example.social"), "");
+    assert.equal(stripLeadingMentions("@a @b"), "");
+    assert.equal(stripLeadingMentions("@bot  "), "");
+  });
+
+  it("leaves a mention that does not start the body — the pattern is anchored", () => {
+    // Unreachable through the bridge (`htmlToText` trims first), but
+    // pinned so the anchoring is a decision rather than an accident.
+    assert.equal(stripLeadingMentions("  @bot  "), "@bot");
+  });
+
+  it("still keeps a body that merely follows a mention", () => {
+    assert.equal(stripLeadingMentions("@bot hello"), "hello");
+    assert.equal(stripLeadingMentions("hello @bot"), "hello @bot");
+    assert.equal(stripLeadingMentions("@bot see @x"), "see @x");
+  });
+
+  // The generator harvested from the differential run that pinned this
+  // change (54k inputs, old implementation vs new). The harness itself
+  // could not survive — half of it was the pre-change implementation —
+  // so what stays is the generator plus the two properties it proved.
+  const VALID_HANDLES = ["@bot", "@a", "@bot@example.social", "@a_b.c", "@x@y-z.social"];
+  const SEPARATORS = [" ", "  ", "\n", "\t"];
+
+  it("reduces a body made only of mentions to nothing", () => {
+    let checked = 0;
+    VALID_HANDLES.forEach((first) => {
+      SEPARATORS.forEach((separator) => {
+        VALID_HANDLES.forEach((second) => {
+          ["", " ", "  "].forEach((trailing) => {
+            assert.equal(stripLeadingMentions(`${first}${separator}${second}${trailing}`), "");
+            assert.equal(stripLeadingMentions(`${first}${trailing}`), "");
+            checked += 2;
+          });
+        });
+      });
+    });
+    assert.ok(checked > 100, `expected a broad sweep, ran ${checked}`);
+  });
+
+  it("keeps the body that follows the mentions, whatever the separator", () => {
+    const tails = ["hello", "what is this?", "see @x", "\u65e5\u672c\u8a9e"];
+    let checked = 0;
+    VALID_HANDLES.forEach((first) => {
+      SEPARATORS.forEach((separator) => {
+        VALID_HANDLES.forEach((second) => {
+          tails.forEach((tail) => {
+            const stripped = stripLeadingMentions(`${first}${separator}${second}${separator}${tail}`);
+            assert.equal(stripped, tail, `lost or kept too much: ${JSON.stringify(stripped)}`);
+            // A second pass must change nothing.
+            assert.equal(stripLeadingMentions(stripped), stripped);
+            checked += 1;
+          });
+        });
+      });
+    });
+    assert.ok(checked > 100, `expected a broad sweep, ran ${checked}`);
+  });
 });
 
 describe("parseMentionStatus", () => {

--- a/plans/fix-2952-mastodon-attachment-only-dm.md
+++ b/plans/fix-2952-mastodon-attachment-only-dm.md
@@ -9,7 +9,7 @@
 「画像だけの DM は `parsed.text` が空になり、サーバに拒否される」と書いたが、
 実物のパーサに実際の `content` 形状を通したところ **`text = "@bot"`** だった。
 
-```
+```text
 image-only DM (mention alone)      htmlToText="@bot"                → text="@bot"
 image-only DM (trailing space/br)  htmlToText="@bot"                → text="@bot"
 mention + caption                  htmlToText="@bot what is this?"  → text="what is this?"

--- a/plans/fix-2952-mastodon-attachment-only-dm.md
+++ b/plans/fix-2952-mastodon-attachment-only-dm.md
@@ -1,0 +1,58 @@
+# Mastodon の画像だけ DM (#2952)
+
+**Status**: implementing
+**Tracks**: #2952
+**Last updated**: 2026-08-25
+
+## 起票時の前提は誤りだった（実測で訂正済み）
+
+「画像だけの DM は `parsed.text` が空になり、サーバに拒否される」と書いたが、
+実物のパーサに実際の `content` 形状を通したところ **`text = "@bot"`** だった。
+
+```
+image-only DM (mention alone)      htmlToText="@bot"                → text="@bot"
+image-only DM (trailing space/br)  htmlToText="@bot"                → text="@bot"
+mention + caption                  htmlToText="@bot what is this?"  → text="what is this?"
+reply with media, no body at all   htmlToText=""                    → text=""
+```
+
+原因は `stripLeadingMentions` の `SINGLE_MENTION_RE` が **末尾の空白 `\s+` を要求**していること。
+メンションで本文が終わると剥がれない。
+
+## 実際の欠陥（2つ、連動している）
+
+1. 画像だけの DM は届いてはいるが、本文が `"@bot"` という無意味な文字列になる
+2. 本文が完全に空のメディア返信は `text is required` で拒否され、画像が失われる
+
+1 だけを直す（末尾メンションを剥がす）と、`"@bot"` が `""` になって
+**今は届いている画像だけ DM が落ちるようになる**。2 のプレースホルダとセットでしか直せない。
+
+## 実装
+
+1. `parse.ts` — `SINGLE_MENTION_RE` の末尾を `(?:\s+|$)` に。差分検証で
+   「旧が末尾メンションを残していた入力でのみ挙動が変わる」ことを確認（54,061 入力、
+   差異 5,870 件、想定外 0 件）。ジェネレータと性質は恒久テストに移した
+2. 新規 `src/media.ts`（純粋・テスト可能。`index.ts` は起動時に env を読んで
+   `process.exit` するので import できない）
+   - `imageMediaEntries` — image 型の media だけを取り出す
+   - `hasRelayableContent` / `isLostImagesOnly` — 送信可否のガード
+   - `resolveMessageText` — 空本文のプレースホルダ、落とした添付の注記
+3. `index.ts` — `relayStatus` に分離。全滅時は失敗を返信、一部失敗は本文に注記、
+   ログに `dropped=` を追加
+
+## 挙動の変化（PR で明記する）
+
+| ケース                       | 変更前                      | 変更後                                   |
+| ---------------------------- | --------------------------- | ---------------------------------------- |
+| `@bot` + 画像                | 本文 `"@bot"` で届く        | `"Describe / analyze this file."` + 画像 |
+| 本文なしメディア返信         | `text is required` で消える | 届く                                     |
+| 画像 DL 全滅・本文なし       | 本文なしで送って拒否        | 失敗を返信                               |
+| 素の `@bot` だけ（画像なし） | `"@bot"` として届く         | **無視** ← 要判断                        |
+
+## スコープ外
+
+- `fetchImageAttachment` が `content-type` をパラメータごと `mimeType` に入れている
+  （`image/jpeg; charset=binary` のような値が Claude API にそのまま渡る）。
+  Discord 側では除去したが、Mastodon 既存挙動の変更になるので別途
+- `"Describe / analyze this file."` が telegram / line / discord / mastodon の4箇所に複製。
+  `@mulmobridge/client` への集約は publish 順の都合で別 PR


### PR DESCRIPTION
## Summary

Mastodon ブリッジで、画像だけの DM がまともに扱えていなかった問題を直す。
**起票時の私の見立ては誤っていて、実測して書き直した**（[訂正コメント](https://github.com/receptron/mulmoclaude/issues/2952#issuecomment-5404251939)）。実際の欠陥は2つで、**連動しているため一緒にしか直せない**。

### 欠陥1: 本文が `"@bot"` になる

`stripLeadingMentions` の `SINGLE_MENTION_RE` が**末尾の空白 `\s+` を要求**しているため、
メンションで本文が終わる（＝画像だけの）DM ではメンションが剥がれず、`"@bot"` が
そのままエージェントへのプロンプトになっていた。実測:

```
image-only DM (mention alone)      htmlToText="@bot"                → text="@bot"
image-only DM (trailing space/br)  htmlToText="@bot"                → text="@bot"
mention + caption                  htmlToText="@bot what is this?"  → text="what is this?"
reply with media, no body at all   htmlToText=""                    → text=""
```

### 欠陥2: 本文が完全に空だと画像が消える

本文なしのメディア返信は `text=""` のまま `mulmo.send()` に渡り、chat-service の
`parseMessagePayload` が `text is required` で拒否する（実測: `{"ok":false,"error":"text is required","status":400}`）。

### なぜ一緒に直すのか

欠陥1だけ直すと `"@bot"` が `""` になり、**今は届いている画像だけ DM が欠陥2で落ちる**。
プレースホルダ本文（Telegram / LINE / Discord と同じ `Describe / analyze this file.`）とセットでないと直せない。

## 変更

- **`parse.ts`** — `SINGLE_MENTION_RE` の末尾を `(?:\s+|$)` に
- **新規 `src/media.ts`**（純粋関数。`index.ts` は起動時に env を読んで `process.exit` するのでテストから import できない）
  - `imageMediaEntries` — `image` 型の media だけを取り出す
  - `hasRelayableContent` / `isLostImagesOnly` — 送信可否のガード
  - `resolveMessageText` — 空本文のプレースホルダ、落とした添付の注記
- **`index.ts`** — `relayStatus` に分離。DL 全滅かつ本文なしは失敗を返信、一部失敗は本文に注記、ログに `dropped=` を追加
- テスト 25 件追加（パッケージ全体で 55 件・全緑）

## 挙動の変化

| ケース | 変更前 | 変更後 |
|---|---|---|
| `@bot` + 画像 | 本文 `"@bot"` で届く | `"Describe / analyze this file."` + 画像 |
| `@bot こういう画像です` + 画像 | そのまま届く | **変更なし** |
| 本文なしメディア返信 | `text is required` で消える | 届く |
| 画像 DL が全滅・本文なし | 本文なしで送って拒否される | 失敗を返信 |
| 素の `@bot` だけ（画像なし） | `"@bot"` として届く | **無視される** ← 要判断 |

## Items to Confirm / Review

1. **最終行の挙動変更** — 素の `@bot` だけの DM（画像も本文も無い）は無視されるようになる。「呼びかけただけで反応してほしい」使い方があるなら別扱いが要る。**推奨は無視**（誤起動を防げる）だが運用の好み。
2. **`(?:\s+|$)` の差分検証** — 旧実装をそのままコピーして 54,061 入力で突き合わせた: 差異 5,870 件、**すべてが「旧が末尾に残していたメンションを新が剥がした」形**、想定外 0 件。ハーネス自体は片側が旧実装なので残せないため、ジェネレータと性質を `test_parse.ts` の恒久テストに移した。ReDoS 面では `\s+` と `$` は互いに素で、入れ子量化子の重なりは増えていない。
3. **`image` 型のみ転送** — `video` / `gifv` / `audio` は従来どおり無視。Discord (#2951) は全種類をサーバ判断に任せる形にしたので、揃えるかは別途。
4. **既存の別件（このPRでは触っていない）** — `fetchImageAttachment` は `content-type` をパラメータごと `mimeType` に入れる。`image/jpeg; charset=binary` のような値が Claude API にそのまま渡り得る。Discord 側では除去したが、こちらは既存挙動の変更になるため見送った。

## 検証

- パッケージ単体で `typecheck` / `build` / `test`(55件) / `eslint` / `prettier --check` 実行済み・全緑
- **実物のパーサ + 実物の chat-service ソケット + 実物の `@mulmobridge/client` + 実物の `buildUserMessageLine`** を繋いだ使い捨てハーネスで通し確認（コミットしていない）:

```
[A] image-only DM  parsed.text=""  images=1
[A] relayed as "Describe / analyze this file." → {"ok":true,"reply":"got it"}
[A] agent turn → {"type":"user","message":{"role":"user","content":[{"type":"image",…
[B] main today relays "@bot" → {"ok":true,...} (accepted, but the prompt is a handle)
[C] main today, bodyless media reply → {"ok":false,"error":"text is required","status":400}
[D] captioned DM → "what is this?" (unchanged)
[E] all-images-failed, no caption → error reply, no relay
[F] bare @bot ping with no media → ignored (was relayed as "@bot")
```

**実 Mastodon インスタンスでの確認は未実施**（アカウント／トークンが要るため）。
実際に画像を貼って確認していただきたいです。

## User Prompt

> これなおせる？？
> https://github.com/receptron/mulmoclaude/issues/2939
>
> （Mastodon にも同種のバグがあると報告したのに対し）はい。
>
> 両方直して。動作確認は出来ないから、issue でユーザに最終的に確認してもらおう

Closes #2952

Related: #2939, #2951（Discord 側の同種修正）

work in mulmoclaude5

## Summary by Sourcery

Fix Mastodon image-only DMs so their images reach MulmoClaude with a meaningful prompt and appropriate failure handling.

New Features:
- Forward image-only Mastodon DMs with an attachment-analysis prompt and report attachments that could not be downloaded.
- Handle failed image-only deliveries with an error reply instead of silently dropping them.

Bug Fixes:
- Remove trailing bot mentions from Mastodon message text so handles are not sent as prompts.
- Prevent empty Mastodon media messages from being rejected by the chat service.

Enhancements:
- Limit Mastodon forwarding to supported image media and ignore empty messages without relayable content.

Documentation:
- Document Mastodon image DM behavior, download limits, failure handling, and supported media types.

Tests:
- Add coverage for trailing mention parsing, image media selection, relay guards, prompt resolution, attachment loss, and attachment size budgeting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mastodon image attachments in direct messages are forwarded for analysis, including image-only messages.
  * Multiple images are supported, with an 8 MB limit per image.
  * Partial image-download failures are noted in the message sent for processing.

* **Bug Fixes**
  * Image-only messages no longer retain the bot mention as the prompt.
  * Unsupported media is not forwarded incorrectly.
  * Caption-less messages whose images all fail to download now receive an error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->