### PR TITLE
fix(chat-service): ソケットのフレーム上限を添付上限に合わせる (#2956)

### DIFF
--- a/packages/chat-service/src/socket.ts
+++ b/packages/chat-service/src/socket.ts
@@ -106,6 +106,16 @@ type BridgeOptions = Readonly<Record<string, string | number | boolean>>;
 
 type HandshakeResult = { ok: true; transportId: string; options: BridgeOptions } | { ok: false; error: string };
 
+// Hard limits to prevent oversized payloads from bridges (DoS /
+// accidental misconfiguration). Express's JSON body limit (50 MB)
+// is the outer gate; these are tighter, attachment-specific caps.
+const MAX_ATTACHMENT_COUNT = 10;
+const MAX_ATTACHMENT_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB base64
+/** Transport ceiling for one socket frame. Headroom over the attachment
+ *  budget for the rest of the payload (text, ids, options) so the
+ *  application-level cap is what a bridge actually hits. */
+const MAX_SOCKET_PAYLOAD_BYTES = MAX_ATTACHMENT_TOTAL_BYTES + 4 * 1024 * 1024;
+
 export function bridgeRoom(transportId: string): string {
   return `bridge:${transportId}`;
 }
@@ -118,6 +128,12 @@ export function attachChatSocket(server: http.Server, deps: ChatSocketDeps): Cha
     // Loopback-only deployment; skip long-polling negotiation for
     // the same reason `/ws/pubsub` does (#311).
     transports: ["websocket"],
+    // Socket.IO's default is 1 MB — below the attachment budget
+    // `parseAttachments` enforces, so a bridge shipping a 900 KB image
+    // had its connection closed before the ack instead of a reply.
+    // `parseAttachments` stays the real gate; this only has to be
+    // wide enough not to pre-empt it.
+    maxHttpBufferSize: MAX_SOCKET_PAYLOAD_BYTES,
   });
 
   io.use((socket, next) => {
@@ -307,12 +323,6 @@ function parseMessagePayload(payload: MessagePayload): ParsedMessage {
   const attachments = parseAttachments(payload.attachments);
   return { ok: true, externalChatId, text, attachments };
 }
-
-// Hard limits to prevent oversized payloads from bridges (DoS /
-// accidental misconfiguration). Express's JSON body limit (50 MB)
-// is the outer gate; these are tighter, attachment-specific caps.
-const MAX_ATTACHMENT_COUNT = 10;
-const MAX_ATTACHMENT_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB base64
 
 export function parseAttachments(raw: unknown): Attachment[] | undefined {
   if (!Array.isArray(raw) || raw.length === 0) return undefined;

--- a/packages/chat-service/test/test_socket.ts
+++ b/packages/chat-service/test/test_socket.ts
@@ -90,6 +90,17 @@ function emitMessage(client: ClientSocket, payload: unknown): Promise<{ ok: bool
   });
 }
 
+/** Like `emitMessage`, but resolves to null instead of hanging when the
+ *  ack never arrives — a frame that closes the socket must fail the test
+ *  in seconds, not stall the CI job. */
+function emitMessageWithTimeout(client: ClientSocket, payload: unknown, timeoutMs: number): Promise<{ ok: boolean; reply?: string } | null> {
+  return new Promise((resolve) => {
+    client.timeout(timeoutMs).emit(CHAT_SOCKET_EVENTS.message, payload, (err: Error | null, ack: { ok: boolean; reply?: string } | undefined) => {
+      resolve(err ? null : (ack ?? null));
+    });
+  });
+}
+
 describe("chat-service socket — no auth", () => {
   let harness: Harness;
 
@@ -116,6 +127,39 @@ describe("chat-service socket — no auth", () => {
     assert.equal(harness.relayCalls[0].transportId, "cli");
     assert.equal(harness.relayCalls[0].externalChatId, "terminal");
     assert.equal(harness.relayCalls[0].text, "hi");
+
+    client.disconnect();
+  });
+
+  it("relays an attachment past Socket.IO's default 1 MB frame", async () => {
+    // Without an explicit `maxHttpBufferSize`, Socket.IO closes the
+    // connection at 1 MB — below the 20 MB `parseAttachments` budget, so
+    // a bridge shipping a ~900 KB screenshot got a dropped socket instead
+    // of a reply. Measured before the fix: 700 KB relayed, 900 KB killed
+    // the connection.
+    const client = connectClient(harness.url, { transportId: "cli" });
+    await waitConnect(client);
+    let disconnected = false;
+    client.on("disconnect", () => {
+      disconnected = true;
+    });
+
+    const data = Buffer.alloc(2 * 1024 * 1024, 7).toString("base64"); // ~2.7 MB of base64
+    const ack = await emitMessageWithTimeout(
+      client,
+      {
+        externalChatId: "terminal",
+        text: "look",
+        attachments: [{ mimeType: "image/png", data }],
+      },
+      5000,
+    );
+
+    assert.notEqual(ack, null, "no ack — the frame closed the socket");
+    assert.equal(disconnected, false, "the frame must not close the socket");
+    assert.equal(ack?.ok, true);
+    assert.equal(harness.relayCalls.at(-1)?.attachments?.length, 1);
+    assert.equal(harness.relayCalls.at(-1)?.attachments?.[0]?.data.length, data.length);
 
     client.disconnect();
   });

--- a/plans/fix-2956-chat-socket-buffer.md
+++ b/plans/fix-2956-chat-socket-buffer.md
@@ -1,0 +1,44 @@
+# ソケットの 1MB 既定バッファ (#2956)
+
+**Status**: implementing
+**Tracks**: #2956
+**Last updated**: 2026-08-25
+
+## 問題
+
+`attachChatSocket` が `maxHttpBufferSize` を設定していないため Socket.IO 既定の
+1,000,000 バイトが効き、**生バイトで約 730KB を超える添付でソケットが切断**される。
+同じファイルの `parseAttachments` は base64 20MB を上限に持っており、**到達不能**だった。
+
+添付を扱う全ブリッジ（Discord / Telegram / LINE / Mastodon）に影響する。
+
+## 実測
+
+| 生サイズ | base64 | 修正前 | 修正後 |
+|---|---|---|---|
+| 100 KiB | 133 KiB | 届く | 届く |
+| 700 KiB | 933 KiB | 届く | 届く |
+| 900 KiB | 1200 KiB | **切断** | 届く |
+| 8 MiB | 10923 KiB | 切断 | 届く |
+| 14 MiB | 19115 KiB | 切断 | 届く |
+| 15 MiB | 20480 KiB | 切断 | 届く（添付上限ちょうど） |
+| 20 MiB | 27307 KiB | 切断 | 切断（トランスポート上限超え） |
+
+## 実装
+
+`MAX_SOCKET_PAYLOAD_BYTES = MAX_ATTACHMENT_TOTAL_BYTES + 4MB` を `maxHttpBufferSize` に。
+上限の宣言を `attachChatSocket` より上に移動しただけで、値は変えていない。
+
+`parseAttachments` の 20MB / 10件はそのまま実効ゲートとして残る。
+ソケットはハンドシェイクでトークン検証済み・loopback 前提。
+
+## テスト
+
+`test_socket.ts` に 2MiB（base64 約 2.7MB）の添付が relay に届くことを確認するテストを追加。
+**修正を外すと 29ms で落ちる**ことを確認済み（`emitMessageWithTimeout` で ack 待ちを
+5秒で打ち切る。素の `emitMessage` だとハングして CI のジョブ時間を食い潰す）。
+
+## 残る課題（スコープ外）
+
+アプリ上限（20MB）とトランスポート上限（24MB）のあいだのサイズは `parseAttachments` が
+`break` して無言で添付を落とす。ack は成功で返る。本来はエラーを返すべき。


### PR DESCRIPTION
## Summary

`attachChatSocket` が `maxHttpBufferSize` を設定していないため **Socket.IO 既定の 1MB** が効き、
**生バイトで約 730KB を超える添付でソケットが切断**されていた。同じファイルの `parseAttachments` は
**base64 20MB** を上限に持っており、その上限には**原理的に到達できなかった**（base64 は 4/3 に膨らむため）。

添付を扱う**全ブリッジに影響**する（Discord #2939 / Telegram / LINE / Mastodon）。
症状が「無反応 + タイムアウト」なので、ユーザーからは原因が分かりません。

発見経緯: PR #2951（Discord 添付）に codex-review が「その 8MB 上限はソケットを通れない」と
指摘したので、実測して裏を取りました。

## 実測（実物の `attachChatSocket` + 実物の `@mulmobridge/client`）

| 生サイズ | base64 | 修正前 | 修正後 |
|---|---|---|---|
| 100 KiB | 133 KiB | 届く | 届く |
| 700 KiB | 933 KiB | 届く | 届く |
| **900 KiB** | 1200 KiB | **切断** | 届く |
| 8 MiB | 10923 KiB | 切断 | 届く |
| 14 MiB | 19115 KiB | 切断 | 届く |
| 15 MiB | 20480 KiB | 切断 | 届く（添付上限ちょうど） |
| 20 MiB | 27307 KiB | 切断 | 切断（トランスポート上限超え） |

修正前の ack: `{"ok":false,"error":"timeout: socket has been disconnected"}`
修正後: 20MB 未満では `disconnects observed: 0`

## 変更

`MAX_SOCKET_PAYLOAD_BYTES = MAX_ATTACHMENT_TOTAL_BYTES + 4MB` を `maxHttpBufferSize` に渡すだけ。
上限定数の宣言位置を `attachChatSocket` の上に移動しましたが、**値は変えていません**。

## Items to Confirm / Review

1. **余裕を +4MB にした根拠** — 添付以外（text / ids / bridgeOptions）の分。もっと絞る／広げる余地あり。
2. **DoS 面** — このソケットはハンドシェイクでベアラトークンを検証済み、かつ loopback 前提
   （`transports: ["websocket"]` は #311 で loopback を理由に選択済み）。`parseAttachments` の
   20MB / 10件の上限はそのまま残るので、無制限にはなりません。ここは判断をいただきたいです。
3. **配布経路** — `@mulmobridge/chat-service` は npm 公開パッケージなので、npm 利用者に届けるには
   chat-service の publish（→ ホストのレンジ更新 → launcher）が要ります。
4. **残る課題（このPRの範囲外）** — アプリ上限（base64 20MB）とトランスポート上限（24MB）の
   **あいだ**のサイズは `parseAttachments` が `break` して**無言で添付を落とし**、ack は成功で返ります。
   本来はエラーを返すべきですが既存挙動なので触っていません。

## テスト

`test_socket.ts` に 2MiB（base64 約 2.7MB）の添付が relay に届くことを確認するテストを追加（108件・全緑）。

**修正を外すと 29ms で落ちる**ことを確認済みです:

```
✖ relays an attachment past Socket.IO's default 1 MB frame (29.17ms)
  AssertionError: no ack — the frame closed the socket
```

素の `emitMessage` だと切断時に**ハングして CI のジョブ時間を食い潰す**ため、
ack 待ちを 5 秒で打ち切る `emitMessageWithTimeout` を用意しています。

## User Prompt

> これなおせる？？ https://github.com/receptron/mulmoclaude/issues/2939
>
> 両方直して。動作確認は出来ないから、issue でユーザに最終的に確認してもらおう

（Discord の添付対応 #2951 のレビューから派生した、基盤側の欠陥です）

Closes #2956

Related: #2939, #2951, #2952, #2954

work in mulmoclaude5

## Summary by Sourcery

Align the chat socket payload limit with the attachment size budget so supported attachments can be delivered reliably.

Bug Fixes:
- Increase the Socket.IO payload limit so attachments within the existing application-level budget are no longer rejected by the default 1 MB frame limit.

Enhancements:
- Keep the existing attachment count and size caps as the effective limits while allowing headroom for message metadata.

Tests:
- Add coverage proving that a 2 MiB attachment is relayed without disconnecting the socket and that failed acknowledgements time out promptly.