### PR TITLE
feat: エディタからフォーカスが外れたら保留中の編集を書き込む (#2949)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### Leaving the deck editor writes the pending edit (#2949)
+
+Asking the agent to change a script means moving focus out of the editor first — and in
+MulmoTerminal the agent is a terminal, so there is no "message sent" event a plugin could hook.
+Flushing on the way out lands ahead of every request without the host announcing one.
+
+The debounce is short enough that it has usually fired already; this closes the case where it
+has not, which would otherwise have the agent read a file missing the last thing the user typed.
+
 #### An agent's edit to a MulmoScript now appears in an open canvas (#2949)
 
 The preview only updated when the person in front of it typed. An agent writing the same
@@ -416,7 +425,7 @@ translation behind it.
 
 ### Changed
 
-#### `@mulmoclaude/mulmoscript-plugin@4.1.1` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+#### `@mulmoclaude/mulmoscript-plugin@4.2.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
 
 Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
 hosts had moved to deck-web 2.0.0, so every install printed
@@ -448,7 +457,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.1.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.2.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^4.1.1",
+    "@mulmoclaude/mulmoscript-plugin": "^4.2.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -88,7 +88,7 @@
 
          No `layout` prop: the editor lays itself out from its own width, so the pane
          moves below the list on a narrow host (this card) rather than beside it. -->
-    <div v-if="isDeck" class="flex-1 overflow-hidden" data-testid="mulmo-script-deck-editor">
+    <div v-if="isDeck" class="flex-1 overflow-hidden" data-testid="mulmo-script-deck-editor" @focusout="onDeckFocusOut">
       <BeatListEditor :beats="deckBeats" @update:beats="onDeckBeatsUpdate" />
     </div>
 
@@ -363,6 +363,7 @@ import {
   scriptSourceText as toScriptSourceText,
   resolveSilentAdvanceSeconds,
   clearReactiveRecords,
+  focusLeftContainer,
   type Beat,
 } from "./helpers";
 import { beatsOf, withBeats, type EditableBeat } from "@mulmocast/beat-editor";
@@ -720,6 +721,20 @@ const deckBeats = computed<EditableBeat[]>(() => beatsOf(deckScriptInput.value))
 
 function onDeckBeatsUpdate(beats: EditableBeat[]): void {
   onDeckUpdate(withBeats(deckScriptInput.value, beats));
+}
+
+/**
+ * Leaving the editor writes whatever is still in the debounce.
+ *
+ * Asking the agent to change the script means moving focus out of here first, so this lands
+ * ahead of every request without the host having to announce one — MulmoTerminal's agent is a
+ * terminal, and there is no "sent" event to hook. The debounce is short enough that it has
+ * usually fired already; this closes the case where it has not, which would otherwise have the
+ * agent read a file missing the last thing the user typed.
+ */
+function onDeckFocusOut(event: FocusEvent): void {
+  const container = event.currentTarget instanceof Node ? event.currentTarget : null;
+  if (focusLeftContainer(container, event.relatedTarget)) flushPendingDeckSave();
 }
 
 onBeforeUnmount(() => {

--- a/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
@@ -205,3 +205,20 @@ export function clearReactiveRecords(...records: object[]): void {
     Object.keys(record).forEach((key) => Reflect.deleteProperty(record, key));
   });
 }
+
+/**
+ * Whether a `focusout` means focus actually LEFT `container`, rather than moving between two
+ * fields inside it.
+ *
+ * The distinction decides whether pending edits are written: treating every focusout as a
+ * departure would write on each hop between inputs, and treating none as one would let the user
+ * walk away with the last keystroke unsaved.
+ *
+ * `null` is focus going nowhere the document can name — clicking the page chrome, or the window
+ * losing focus. That counts as leaving: the editor is no longer where the typing goes.
+ */
+export function focusLeftContainer(container: Node | null, movedTo: EventTarget | null): boolean {
+  if (!container) return false;
+  if (!(movedTo instanceof Node)) return true;
+  return !container.contains(movedTo);
+}

--- a/packages/plugins/mulmoscript-plugin/test/test_focusLeft.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_focusLeft.ts
@@ -1,0 +1,58 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+
+import { focusLeftContainer } from "../src/vue/helpers";
+
+/**
+ * "Focus actually left the editor" — the moment pending edits have to be written.
+ *
+ * MulmoTerminal's agent is a terminal, so there is no "message sent" event to hook. What the
+ * user always does before asking it for anything is move focus out of the editor, which makes
+ * this the reliable point to flush: the agent then reads a file that includes the last
+ * keystroke.
+ *
+ * The distinction that matters is BETWEEN fields versus OUT of the editor. Writing on every hop
+ * between inputs would save on each tab press; writing on none would let the user walk away
+ * with the last keystroke unsaved.
+ */
+
+const dom = new JSDOM(`<!doctype html><body>
+  <div id="editor"><input id="a" /><input id="b" /><div id="deep"><input id="c" /></div></div>
+  <textarea id="outside"></textarea>
+</body>`);
+const { document } = dom.window;
+// `focusLeftContainer` narrows with `instanceof Node`, which resolves against the global — the
+// browser has one, node does not.
+Object.defineProperty(globalThis, "Node", { value: dom.window.Node, configurable: true });
+const editor = document.querySelector("#editor");
+const at = (id: string) => document.querySelector(`#${id}`);
+
+describe("focusLeftContainer", () => {
+  it("is not a departure when focus moves to a sibling field inside", () => {
+    assert.equal(focusLeftContainer(editor, at("b")), false);
+  });
+
+  it("is not a departure when focus moves deeper inside", () => {
+    assert.equal(focusLeftContainer(editor, at("c")), false);
+  });
+
+  it("is a departure when focus moves to something outside", () => {
+    assert.equal(focusLeftContainer(editor, at("outside")), true);
+  });
+
+  it("is a departure when focus goes nowhere the document can name", () => {
+    // Clicking page chrome, or the window losing focus: the editor is no longer where the
+    // typing goes, so the edit has to be written.
+    assert.equal(focusLeftContainer(editor, null), true);
+  });
+
+  it("does nothing when there is no container to leave", () => {
+    assert.equal(focusLeftContainer(null, at("outside")), false);
+  });
+
+  it("treats the container itself as inside", () => {
+    // A container that takes focus directly (tabindex) has not been left.
+    assert.equal(focusLeftContainer(editor, editor), false);
+  });
+});


### PR DESCRIPTION
## Summary

**LLM に依頼する前に、打ちかけの編集を確実にディスクへ書く。**

これが無いと、人間が打った直後（デバウンス 300ms 以内）に依頼した場合、
**LLM が「最後に打った文字が入っていないファイル」を読む**。

## 当初案からの方針変更

issue #2949 では「LLM へ送信するタイミングでホストが pubsub で知らせ、plugin が flush する」
という案だった。**調べたら成立しなかった**ので変えた。

MulmoTerminal の LLM は**ターミナル上の Claude Code** で、ユーザーは xterm に直接打ち込む。
チャット入力欄の送信イベントは存在せず、あるのはキー入力の byte 変換だけ
（`src/composables/terminalKeyHandlers.ts`）。

Enter を横取りする案は:
- ターミナルのキー処理という**無関係な場所**に plugin のための処理を差し込むことになる
- 「Enter = LLM への依頼」とは限らない（シェルコマンド、確認応答、改行）

### 採用した形: フォーカス離脱で flush

| | 当初案（送信フック） | フォーカス離脱 |
|---|---|---|
| ホストへの改変 | ターミナルのキー処理に介入 | **不要** |
| plugin だけで閉じる | いいえ | **はい** |
| 取りこぼし | Enter 以外の送信手段 | 無い（依頼には必ずフォーカス移動が要る） |
| 他ホストでも効く | いいえ | **はい** |

## Items to Confirm / Review

- **判定は純関数** `focusLeftContainer(container, movedTo)`。
  「フィールド間の移動」と「エディタからの離脱」を区別する。
  **どちらに間違えても静か**なので、テストから直接触れる形にした:
  - 毎回の移動で書く → タブを押すたびに保存が飛ぶ
  - 一度も書かない → 最後の打鍵が保存されずに立ち去られる

- **`relatedTarget` が `null` は「離脱」扱い**。ページのクロームをクリックした、
  ウィンドウがフォーカスを失った、など。いずれもエディタはもう入力先ではない。

- **デバウンスの実態**: 300ms なので、フォーカスを移してターミナルに打ち始めるまでに
  ほぼ必ず flush 済み。この変更の価値は「稀だが起きうる取りこぼしを 0 にする」こと。

## テスト

`test/test_focusLeft.ts`（6本）。

> 最初 `Node is not defined` で5本落ちた。`instanceof Node` はグローバルに解決するので、
> jsdom の `Node` を注入する必要があった。**変異させても結果が変わらなかった**ことで
> テスト側の故障だと分かった。

### break-check

| 変異 | 結果 |
|------|------|
| 常に離脱扱い（`return true`） | **3件 赤** |
| `relatedTarget` が null を離脱扱いしない | **1件 赤** |
| 戻す | 6/6 green |

## ゲート

`typecheck` / `lint` / `build` / `test`（**140 pass / 0 fail**、+6本）。
`check-changelog-ships` OK。

## 次（#2949 の残り）

| | 内容 |
|---|---|
| ✅ 1 | 変更の通知 + ホスト配線 |
| ✅ 2 | 依頼前に保留中の編集を書く（この PR） |
| 3 | LLM 作業中はエディタをロック |
| 4 | 細粒度の編集ツールを LLM に見せる |

**3 も「LLM が作業中である」をホストがどう知らせるかという同じ問題を抱えている**ので、
着手前に方式を確認したい。

## User Prompt

> - できるものはすすめて。提案方法で
> - （方針変更の提案に対して）ok

Refs #2949

## Summary by Sourcery

Write pending deck editor edits before focus leaves the editor so agent requests always use the latest script content.

New Features:
- Flush pending deck editor changes when focus leaves the editor so agents receive the latest user edits.

Bug Fixes:
- Prevent agents from reading script files that omit keystrokes still waiting in the editor debounce.

Enhancements:
- Distinguish focus movement within the editor from leaving it, including focus loss with no related target.

Documentation:
- Document the focus-leave behavior and its release in the changelog.

Tests:
- Add coverage for internal focus transitions, external focus changes, null focus targets, missing containers, and container focus.

Chores:
- Bump the MulmoScript plugin to 4.2.0 and update the package dependency reference.