### PR TITLE
feat: presentMulmoScript が 1 beat だけ差し替えられるようにする (#2949)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### `presentMulmoScript` can revise one beat instead of resending the deck (#2949)
+
+`filePath` + `beatIndex` + `beat` replaces that one beat and presents the result. Asking the
+agent to change a single slide used to mean re-sending the whole script: expensive on a long
+deck, and it overwrites anything edited in the canvas meanwhile.
+
+`beatIndex` and `beat` are required together — an index with no replacement is reported rather
+than ignored, since ignoring it would look like a successful edit that changed nothing.
+
 #### Leaving the deck editor writes the pending edit (#2949)
 
 Asking the agent to change a script means moving focus out of the editor first — and in
@@ -425,7 +434,7 @@ translation behind it.
 
 ### Changed
 
-#### `@mulmoclaude/mulmoscript-plugin@4.2.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+#### `@mulmoclaude/mulmoscript-plugin@4.3.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
 
 Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
 hosts had moved to deck-web 2.0.0, so every install printed
@@ -457,7 +466,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.2.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.3.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^4.2.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.3.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/core/definition.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/definition.ts
@@ -11,10 +11,11 @@ export const TOOL_DEFINITION: ToolDefinition = {
   name: TOOL_NAME,
   description: `Save and present a MulmoScript story or presentation as a visual storyboard in the canvas.
 
-Two modes — provide EXACTLY ONE of \`script\` or \`filePath\`:
+Provide EXACTLY ONE of \`script\` or \`filePath\`:
 
 1. **Create new** — pass \`script\` (full MulmoScript JSON). Server saves it to disk and presents it.
 2. **Re-display existing** — pass \`filePath\` (the \`filePath\` returned by a previous call, e.g. "stories/my-story-1700000000000.json"; it is resolved against the workspace's \`artifacts/\` directory, NOT the workspace root). Much cheaper than re-sending the full script. Use whenever the user wants to revisit a presentation that was already created in this workspace.
+3. **Edit one beat** — pass \`filePath\` PLUS \`beatIndex\` and \`beat\`. Replaces that one beat and presents the result. **Use this whenever the user asks to change part of an existing presentation** — re-sending the whole script instead wastes tokens and overwrites anything edited in the canvas meanwhile.
 
 Optional \`autoGenerateMovie: true\` kicks off movie generation in the background, so the final video is ready by the time the user opens the canvas. Movie generation is expensive (multiple image + audio API calls + video encoding) — only set this when the user has explicitly asked for the movie. Default \`false\`.
 
@@ -109,6 +110,17 @@ IMPORTANT: "imagePrompt" and "moviePrompt" are plain string fields on the beat, 
         type: "string",
         description:
           "Path of an EXISTING MulmoScript JSON file, as returned by a previous call (e.g. 'stories/my-story-1700000000000.json'). Resolved against the workspace's `artifacts/` directory, not the workspace root ('artifacts/stories/…' is also accepted). Use this to re-display a script previously saved in this workspace, instead of resending the full JSON. Do NOT pass alongside `script`.",
+      },
+      beatIndex: {
+        type: "number",
+        description:
+          "0-based index of the beat to replace. Requires `filePath` and `beat`. Omit to re-display the script unchanged.",
+      },
+      beat: {
+        type: "object",
+        description:
+          "The replacement beat, complete (it overwrites the old one — it is not merged). Requires `filePath` and `beatIndex`.",
+        additionalProperties: true,
       },
       autoGenerateMovie: {
         type: "boolean",

--- a/packages/plugins/mulmoscript-plugin/src/core/plugin.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/plugin.ts
@@ -90,7 +90,7 @@ export async function executeMulmoScriptSave(
   args: SaveMulmoScriptArgs,
   now: Date = new Date(),
 ): Promise<SaveMulmoScriptOutcome> {
-  const { script, filename, filePath } = args ?? {};
+  const { script, filename, filePath, beatIndex, beat } = args ?? {};
   const hasScript = script !== undefined && script !== null;
   const hasFilePath = typeof filePath === "string" && filePath !== "";
   if (hasScript === hasFilePath) {
@@ -98,9 +98,21 @@ export async function executeMulmoScriptSave(
       hasScript ? "Provide either `script` or `filePath`, not both." : "Provide either `script` (new presentation) or `filePath` (existing presentation).",
     );
   }
-  return hasFilePath
-    ? loadExistingScript(context, filePath as string)
-    : saveNewScript(context, script, typeof filename === "string" ? filename : undefined, now);
+  if (!hasFilePath) return saveNewScript(context, script, typeof filename === "string" ? filename : undefined, now);
+
+  // `filePath` + `beatIndex` + `beat` replaces one beat before displaying, so revising a single
+  // slide does not mean re-sending a whole deck. Both halves are required together: an index
+  // with no replacement, or a replacement with no index, is a caller mistake worth reporting
+  // rather than silently ignoring — it would look like a successful edit that changed nothing.
+  const wantsBeatEdit = beatIndex !== undefined || beat !== undefined;
+  if (wantsBeatEdit) {
+    if (beatIndex === undefined || beat === undefined) {
+      return badRequest("`beatIndex` and `beat` go together — pass both to replace one beat, or neither to re-display.");
+    }
+    const updated = await executeUpdateBeat(context, { filePath, beatIndex, beat });
+    if (!updated.ok) return updated;
+  }
+  return loadExistingScript(context, filePath);
 }
 
 /** Resolve + guard a wire path for the update endpoints. */

--- a/packages/plugins/mulmoscript-plugin/src/core/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/types.ts
@@ -10,6 +10,10 @@ export interface SaveMulmoScriptArgs {
   filename?: string | undefined;
   filePath?: string | undefined;
   autoGenerateMovie?: boolean | undefined;
+  /** With `filePath`: replace just this beat instead of re-sending the whole script. */
+  beatIndex?: number | undefined;
+  /** The replacement beat. Only meaningful with `filePath` + `beatIndex`. */
+  beat?: unknown;
 }
 
 /** Result payload that drives the View. `filePath` is the historical

--- a/packages/plugins/mulmoscript-plugin/test/test_plugin.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_plugin.ts
@@ -246,8 +246,8 @@ describe("executeMulmoScriptSave — replacing one beat", () => {
 
     assert.equal(out.ok, true, JSON.stringify(out));
     const after = beatsIn(store, filePath);
-    assert.equal(after[0].text, "Rewritten.");
     assert.equal(after.length, before.length, "replacing must not add or drop a beat");
+    assert.equal(after[0]?.text, "Rewritten.");
   });
 
   it("answers with the whole script, so the canvas can show the result", async () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_plugin.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_plugin.ts
@@ -222,3 +222,70 @@ describe("executeMulmoScript (ToolResult wrapper)", () => {
     assert.match(result.message ?? "", /Provide either/);
   });
 });
+
+describe("executeMulmoScriptSave — replacing one beat", () => {
+  /** A saved script, and the wire path a caller would have been handed for it. */
+  async function withSavedScript() {
+    const { context, store } = makeFakeContext();
+    const saved = await executeMulmoScriptSave(context, { script: VALID_SCRIPT }, NOW);
+    assert.equal(saved.ok, true);
+    return { context, store, filePath: (saved as { filePath: string }).filePath };
+  }
+
+  const beatsIn = (store: Map<string, string>, filePath: string) => {
+    const key = [...store.keys()].find((k) => k.endsWith(filePath.replace(/^stories\//, "stories/")));
+    return JSON.parse(store.get(key ?? "") ?? "{}").beats as { text?: string }[];
+  };
+
+  it("replaces the named beat and leaves the others alone", async () => {
+    const { context, store, filePath } = await withSavedScript();
+    const before = beatsIn(store, filePath);
+    assert.ok(before.length >= 1);
+
+    const out = await executeMulmoScriptSave(context, { filePath, beatIndex: 0, beat: { ...VALID_BEAT, text: "Rewritten." } }, NOW);
+
+    assert.equal(out.ok, true, JSON.stringify(out));
+    const after = beatsIn(store, filePath);
+    assert.equal(after[0].text, "Rewritten.");
+    assert.equal(after.length, before.length, "replacing must not add or drop a beat");
+  });
+
+  it("answers with the whole script, so the canvas can show the result", async () => {
+    const { context, filePath } = await withSavedScript();
+    const out = await executeMulmoScriptSave(context, { filePath, beatIndex: 0, beat: { ...VALID_BEAT, text: "Rewritten." } }, NOW);
+    assert.equal(out.ok, true);
+    // The View is driven by this payload; a bare `{ ok: true }` would leave it showing nothing.
+    assert.ok((out as { script?: unknown }).script, "the reply must carry the script");
+  });
+
+  it("refuses an index with no replacement, rather than silently displaying the old script", async () => {
+    // Reporting nothing here would read as a successful edit that changed nothing.
+    const { context, filePath } = await withSavedScript();
+    const out = await executeMulmoScriptSave(context, { filePath, beatIndex: 0 }, NOW);
+    assert.equal(out.ok, false);
+    assert.match((out as { error: string }).error, /go together/);
+  });
+
+  it("refuses a replacement with no index", async () => {
+    const { context, filePath } = await withSavedScript();
+    const out = await executeMulmoScriptSave(context, { filePath, beat: VALID_BEAT }, NOW);
+    assert.equal(out.ok, false);
+    assert.match((out as { error: string }).error, /go together/);
+  });
+
+  it("refuses an index past the end, and writes nothing", async () => {
+    const { context, store, filePath } = await withSavedScript();
+    const before = JSON.stringify(beatsIn(store, filePath));
+    const out = await executeMulmoScriptSave(context, { filePath, beatIndex: 99, beat: VALID_BEAT }, NOW);
+    assert.equal(out.ok, false);
+    assert.equal(JSON.stringify(beatsIn(store, filePath)), before, "a refused edit must not touch the file");
+  });
+
+  it("still re-displays unchanged when neither is given", async () => {
+    const { context, store, filePath } = await withSavedScript();
+    const before = JSON.stringify(beatsIn(store, filePath));
+    const out = await executeMulmoScriptSave(context, { filePath }, NOW);
+    assert.equal(out.ok, true);
+    assert.equal(JSON.stringify(beatsIn(store, filePath)), before);
+  });
+});


### PR DESCRIPTION
## Summary

**LLM に「3枚目のタイトルだけ直して」と頼むと、スクリプト全体を再送していた。**
長いデッキではトークンも時間も無駄で、その間に人間がキャンバスで編集していたら**上書きして消す**。

`filePath` + `beatIndex` + `beat` で、その 1 枚だけ差し替えて結果を表示する。

## なぜ別ツールではなくモード追加なのか

**ホストは 1 パッケージ = 1 ツールしか登録しない**（mulmoterminal の
`server/infra/plugins-registry.ts` が `toolName: definition.name` で単数登録）。
`editMulmoScriptBeat` のような別ツールを足すにはホスト側を配列対応に変える必要があり、
全 plugin に波及する。

既に `filePath` を持っているので、`beatIndex` + `beat` を足すのが素直だと判断した。
サーバ側の `executeUpdateBeat` も既にある。

## Items to Confirm / Review

- **description が長くなる懸念**。モードが3つ（新規 / 再表示 / 1枚差し替え）になり、
  「EXACTLY ONE of `script` or `filePath`」という既存の排他ルールに条件が乗る。
  差し替えモードの説明は短くし、**いつ使うべきか**を明記した:

  > Use this whenever the user asks to change part of an existing presentation —
  > re-sending the whole script instead wastes tokens and overwrites anything edited
  > in the canvas meanwhile.

- **`beatIndex` と `beat` は必ず両方**。片方だけなら **bad_request で報告**する。
  黙って再表示すると「編集が成功したが何も変わっていない」ように見えるため。

- **応答はスクリプト全体**。View はこのペイロードで描画するので、`{ ok: true }` だけだと
  キャンバスが空になる。

## テスト

`test/test_plugin.ts` に 6 本追加（27 pass）。

- 指定した beat だけが変わり、**本数が増減しない**
- 応答にスクリプトが載る
- 片方だけの指定を拒否する（両方向）
- 範囲外の index を拒否し、**ファイルを書き換えない**
- どちらも無ければ従来どおり再表示

### break-check

| 変異 | 結果 |
|------|------|
| 差し替えを実行しない | **2件 赤** |
| 片方だけでも通す | **2件 赤** |
| `executeUpdateBeat` の失敗を握りつぶす | **1件 赤** |
| 戻す | 27/27 green |

## ゲート

`typecheck` / `lint` / `build` / `test`（**146 pass / 0 fail**、+6本）。
`check-changelog-ships` OK。

## #2949 の到達点

| | 内容 | 状態 |
|---|---|---|
| ✅ 1 | LLM の変更 → 画面が自動更新 | 完了 |
| ✅ 2 | 依頼前に保留中の編集を書く | 完了 |
| ❌ 3 | LLM 作業中のロック | **作らない**（案A）— 1+2 で交互編集は成立するので、実際に困ってから |
| ✅ 4 | 細粒度の編集ツール（この PR） | 完了 |

## User Prompt

> - できるものはすすめて。提案方法で
> - 案は A で
> - A

Closes #2949

## Summary by Sourcery

Support targeted updates to individual presentation beats without resending or overwriting the entire deck.

New Features:
- Enable `presentMulmoScript` to replace a single beat in an existing presentation using its file path and beat index.

Bug Fixes:
- Reject incomplete beat replacement requests and preserve the existing script when the requested beat index is invalid.

Enhancements:
- Return the updated full script so the canvas can immediately render the revised presentation.

Build:
- Bump the MulmoScript plugin and package dependency versions to 4.3.0.

Documentation:
- Document single-beat presentation updates and their required parameters in the changelog and tool description.

Tests:
- Add coverage for beat replacement, validation, unchanged re-display, full-script responses, and out-of-range updates.