### PR TITLE
feat: slide だけでなく全 beat 種別を編集できるようにする

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,8 +74,8 @@ deck editor, which understood decks and nothing else — it stayed in place thro
 all eight types (`textSlide` / `markdown` / `chart` / `mermaid` / `image` / `movie` / `slide` /
 `html_tailwind`).
 
-The per-beat list is still there, on an **Media** tab: audio, image and movie generation live
-only there, so the editor does not replace it.
+The per-beat list is still there, and is still what opens first — rendering each beat's image
+happens on its mount, so it stays the default. The editor is one click away on an **Edit** tab.
 
 #### `presentMulmoScript` can revise one beat instead of resending the deck (#2949)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,17 @@ it previously reached the agent as `"@bot"`. Released as `@mulmobridge/mastodon@
 
 ### Added
 
+#### Every beat type is editable, not only an all-slide deck
+
+The editor was shown only when every beat was a `slide`. That was a limit of the OLD iframe
+deck editor, which understood decks and nothing else — it stayed in place through the move to
+`@mulmocast/beat-editor` and kept a markdown script read-only for no reason. The editor handles
+all eight types (`textSlide` / `markdown` / `chart` / `mermaid` / `image` / `movie` / `slide` /
+`html_tailwind`).
+
+The per-beat list is still there, on an **Media** tab: audio, image and movie generation live
+only there, so the editor does not replace it.
+
 #### `presentMulmoScript` can revise one beat instead of resending the deck (#2949)
 
 `filePath` + `beatIndex` + `beat` replaces that one beat and presents the result. Asking the
@@ -490,7 +501,7 @@ translation behind it.
 
 ### Changed
 
-#### `@mulmoclaude/mulmoscript-plugin@4.3.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
+#### `@mulmoclaude/mulmoscript-plugin@4.4.0` — the deck editor's peer moves to `@mulmocast/deck-web@^2.0.0` (#2941)
 
 Released 2026-08-24. The plugin's peer declaration still read `^1.1.1` while both
 hosts had moved to deck-web 2.0.0, so every install printed
@@ -522,7 +533,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.3.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.4.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -533,7 +533,7 @@ not on a run.
 
 ### Package releases
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.4.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.2.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.1`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.0.0`, `@mulmoclaude/markdown-utils@1.3.5`, `@mulmoclaude/mulmoscript-plugin@4.4.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ## [1.13.2] - 2026-08-15
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.0.0",
     "@mulmoclaude/markdown-utils": "^1.3.5",
-    "@mulmoclaude/mulmoscript-plugin": "^4.3.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.4.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/demo/sampleDeck.ts
+++ b/packages/plugins/mulmoscript-plugin/demo/sampleDeck.ts
@@ -45,5 +45,11 @@ export const sampleDeck = {
       text: "Closing",
       image: { type: "slide", slide: { layout: "bigQuote", quote: "Design is not just what it looks like", author: "Steve Jobs" } },
     },
+    // A non-slide beat: the editor used to refuse a script containing one, so the whole thing
+    // fell through to a read-only list. Kept here so the demo covers the mixed case.
+    {
+      text: "And a markdown beat",
+      image: { type: "markdown", markdown: "## Markdown too\n\n- edited in place\n- not just decks" },
+    },
   ],
 };

--- a/packages/plugins/mulmoscript-plugin/demo/sampleDeck.ts
+++ b/packages/plugins/mulmoscript-plugin/demo/sampleDeck.ts
@@ -1,5 +1,5 @@
 // An all-slide MulmoScript, which is the condition that makes the View mount the deck editor
-// (`isAllSlideDeck`). Layouts are chosen for what the demo has to show: `grid` and `columns`
+// (`hasEditableBeats`). Layouts are chosen for what the demo has to show: `grid` and `columns`
 // carry reorderable list items, `bigQuote` was the layout whose marker used to swallow its own
 // quotation marks, and `title` is the plain case.
 

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/mulmoscript-plugin/src/lang/de.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/de.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const de: Messages = {
   beatCount: (count) => (count === 1 ? `${count} Beat` : `${count} Beats`),
+  editTab: "Bearbeiten",
+  mediaTab: "Medien",
   movie: "Video",
   generating: "Wird generiert…",
   rendering: "Wird gerendert…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/en.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/en.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const en: Messages = {
   beatCount: (count) => (count === 1 ? `${count} beat` : `${count} beats`),
+  editTab: "Edit",
+  mediaTab: "Media",
   movie: "Movie",
   generating: "Generating…",
   rendering: "Rendering…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/es.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/es.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const es: Messages = {
   beatCount: (count) => (count === 1 ? `${count} beat` : `${count} beats`),
+  editTab: "Editar",
+  mediaTab: "Medios",
   movie: "Vídeo",
   generating: "Generando…",
   rendering: "Renderizando…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/fr.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/fr.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const fr: Messages = {
   beatCount: (count) => (count === 1 ? `${count} beat` : `${count} beats`),
+  editTab: "Éditer",
+  mediaTab: "Médias",
   movie: "Film",
   generating: "Génération…",
   rendering: "Rendu…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/ja.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/ja.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const ja: Messages = {
   beatCount: (count) => `${count} ビート`,
+  editTab: "編集",
+  mediaTab: "メディア",
   movie: "動画",
   generating: "生成中…",
   rendering: "レンダリング中…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/ko.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/ko.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const ko: Messages = {
   beatCount: (count) => `${count}개 비트`,
+  editTab: "편집",
+  mediaTab: "미디어",
   movie: "영상",
   generating: "생성 중…",
   rendering: "렌더링 중…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/messages.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/messages.ts
@@ -3,6 +3,10 @@
  *  `common.cancel`); interpolated / pluralized keys become functions. */
 export interface Messages {
   beatCount(count: number): string;
+  /** Tab: edit every beat in place. */
+  editTab: string;
+  /** Tab: the per-beat list, where audio / image / movie generation lives. */
+  mediaTab: string;
   movie: string;
   generating: string;
   rendering: string;

--- a/packages/plugins/mulmoscript-plugin/src/lang/ptBR.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/ptBR.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const ptBR: Messages = {
   beatCount: (count) => (count === 1 ? `${count} beat` : `${count} beats`),
+  editTab: "Editar",
+  mediaTab: "Mídia",
   movie: "Vídeo",
   generating: "Gerando…",
   rendering: "Renderizando…",

--- a/packages/plugins/mulmoscript-plugin/src/lang/zh.ts
+++ b/packages/plugins/mulmoscript-plugin/src/lang/zh.ts
@@ -2,6 +2,8 @@ import type { Messages } from "./messages";
 
 const zh: Messages = {
   beatCount: (count) => `${count} 个 beat`,
+  editTab: "编辑",
+  mediaTab: "媒体",
   movie: "视频",
   generating: "生成中…",
   rendering: "渲染中…",

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -734,8 +734,13 @@ const { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watch
  * `edit` is the beat editor — every beat type, edited in place. `media` is the per-beat list,
  * which is the only place audio / image / movie generation lives. A script with nothing to edit
  * has only the list, so the switch is hidden and this is ignored.
+ *
+ * `media` is the default because opening the script is what triggers rendering each beat's
+ * image: the auto-render on mount lives in that list, so defaulting to `edit` silently stopped
+ * thumbnails from being produced at all. Someone who wants to edit clicks once; nobody has to
+ * click to get the previews they always got.
  */
-const beatPane = ref<"edit" | "media">("edit");
+const beatPane = ref<"edit" | "media">("media");
 const showBeatEditor = computed(() => canEditBeats.value && beatPane.value === "edit");
 
 const BEAT_TAB_BASE = "rounded px-2 py-0.5 font-sans";

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -88,11 +88,33 @@
 
          No `layout` prop: the editor lays itself out from its own width, so the pane
          moves below the list on a narrow host (this card) rather than beside it. -->
-    <div v-if="isDeck" class="flex-1 overflow-hidden" data-testid="mulmo-script-deck-editor" @focusout="onDeckFocusOut">
+    <!-- Two ways to look at the same script, not two kinds of script. The editor edits every
+         beat type; the list is where the media lives (generate audio, render an image, open a
+         clip), which the editor has no equivalent for — so neither replaces the other. -->
+    <div v-if="canEditBeats" class="flex shrink-0 gap-1 px-2 pt-1 text-[11px]">
+      <button
+        type="button"
+        :class="beatPaneTabClass(beatPane === 'edit')"
+        data-testid="mulmo-script-tab-edit"
+        @click="beatPane = 'edit'"
+      >
+        {{ m.editTab }}
+      </button>
+      <button
+        type="button"
+        :class="beatPaneTabClass(beatPane === 'media')"
+        data-testid="mulmo-script-tab-media"
+        @click="beatPane = 'media'"
+      >
+        {{ m.mediaTab }}
+      </button>
+    </div>
+
+    <div v-if="showBeatEditor" class="flex-1 overflow-hidden" data-testid="mulmo-script-deck-editor" @focusout="onDeckFocusOut">
       <BeatListEditor :beats="deckBeats" @update:beats="onDeckBeatsUpdate" />
     </div>
 
-    <!-- Beat list (fallback when the script has any non-slide beat) -->
+    <!-- Per-beat media list: thumbnails, narration, audio / image / movie generation. -->
     <div v-else ref="beatListEl" class="flex-1 overflow-y-auto p-2 space-y-1.5">
       <div v-for="(beat, index) in beats" :key="index" class="rounded-lg border border-gray-200 overflow-hidden">
         <!-- Beat body: thumbnail + narration side by side -->
@@ -704,7 +726,20 @@ function commitScript(next: MulmoScript): void {
 // interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
-const { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({ api, filePath, effectiveScript, commitScript });
+const { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({ api, filePath, effectiveScript, commitScript });
+
+/**
+ * Which pane the beats are shown in.
+ *
+ * `edit` is the beat editor — every beat type, edited in place. `media` is the per-beat list,
+ * which is the only place audio / image / movie generation lives. A script with nothing to edit
+ * has only the list, so the switch is hidden and this is ignored.
+ */
+const beatPane = ref<"edit" | "media">("edit");
+const showBeatEditor = computed(() => canEditBeats.value && beatPane.value === "edit");
+
+const BEAT_TAB_BASE = "rounded px-2 py-0.5 font-sans";
+const beatPaneTabClass = (active: boolean) => [BEAT_TAB_BASE, active ? "bg-gray-700 text-white" : "bg-gray-100 text-gray-600 hover:bg-gray-200"];
 
 // An agent (or another window) wrote this script — pull it back off disk so the preview shows
 // what is actually there. Registered here rather than in the composable because reloading is

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -1,11 +1,11 @@
-// #1575 — when every beat is a `slide`, the View swaps the per-beat list for
-// the interactive deck editor (@mulmocast/beat-editor). Each editor emit fires
+// #1575 — the View offers the interactive beat editor (@mulmocast/beat-editor) beside the
+// per-beat list. Each editor emit fires
 // `update:script`; this debounces them into one updateScript round-trip per
 // quiet stretch (300ms — short enough to feel live, long enough that typing in
 // the Inspector doesn't carpet-bomb the server).
 
 import { computed, type ComputedRef } from "vue";
-import { isAllSlideDeck } from "../helpers";
+import { hasEditableBeats } from "../helpers";
 import type { MulmoScriptTransport } from "../transport";
 import type { DeckScriptShape, MulmoScript } from "../viewTypes";
 
@@ -33,7 +33,7 @@ export interface UseDeckEditorOptions {
 }
 
 export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: UseDeckEditorOptions) {
-  const isDeck = computed(() => isAllSlideDeck(effectiveScript.value));
+  const canEditBeats = computed(() => hasEditableBeats(effectiveScript.value));
   const deckScriptInput = computed<DeckScriptShape>(() => effectiveScript.value as unknown as DeckScriptShape);
 
   let deckSaveTimer: ReturnType<typeof setTimeout> | null = null;
@@ -95,5 +95,5 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     );
   }
 
-  return { isDeck, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
+  return { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
 }

--- a/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
@@ -93,22 +93,20 @@ export function isBeatImageReference(beat: { image?: { type?: string; [key: stri
   return beat.image?.type === "beat";
 }
 
-/** Pure check: is every beat in the script a `slide`-typed beat?
- *  When true, the View mounts `@mulmocast/beat-editor`'s
- *  `BeatListEditor` instead of the per-beat list UI (#1575).
- *  Empty / missing `beats[]` returns false — there's nothing to edit
- *  as a deck, fall through to the existing UI which renders an empty
- *  state. Mixed scripts (any non-`slide` beat) also return false; that
- *  case is deferred to a future phase. */
-export function isAllSlideDeck(script: unknown): boolean {
+/** Whether the beat editor has anything to edit.
+ *
+ *  Any beat type, not just `slide`: `@mulmocast/beat-editor` renders and edits all eight
+ *  (`textSlide` / `markdown` / `chart` / `mermaid` / `image` / `movie` / `slide` /
+ *  `html_tailwind`). The all-slide test this replaces was a limit of the OLD iframe deck
+ *  editor, which only understood decks — it stayed in place through the migration and kept a
+ *  markdown script read-only for no reason.
+ *
+ *  Empty / missing `beats[]` is false: there is nothing to edit, and the per-beat list already
+ *  renders an empty state. */
+export function hasEditableBeats(script: unknown): boolean {
   if (!isRecord(script)) return false;
   const { beats } = script;
-  if (!Array.isArray(beats) || beats.length === 0) return false;
-  return beats.every((beat) => {
-    if (!isRecord(beat)) return false;
-    const { image } = beat;
-    return isRecord(image) && image.type === "slide";
-  });
+  return Array.isArray(beats) && beats.length > 0;
 }
 
 /** A single MulmoScript beat as the View consumes it — every field

--- a/packages/plugins/mulmoscript-plugin/test/test_beatPaneDefault.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_beatPaneDefault.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * Which pane the View opens on.
+ *
+ * Opening the script is what renders each beat's image: the auto-render on mount lives in the
+ * per-beat media list, so opening on the editor instead silently stops thumbnails from being
+ * produced at all. Two e2e tests caught that — this asserts it far earlier, and states why the
+ * default is what it is rather than leaving it to look arbitrary.
+ *
+ * Read from source rather than mounted: the value is a literal in `<script setup>`, and mounting
+ * the whole View here would need a runtime, a transport and a host adapter to assert one word.
+ */
+
+const viewSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "src", "vue", "View.vue"), "utf-8");
+
+describe("the beats pane the View opens on", () => {
+  it("is the media list, because auto-render on mount lives there", () => {
+    const declaration = /const beatPane = ref<"edit" \| "media">\("(\w+)"\)/.exec(viewSource);
+    assert.ok(declaration, "beatPane is declared with an explicit initial pane");
+    assert.equal(declaration[1], "media");
+  });
+
+  it("still offers the editor — the list is not the only pane", () => {
+    assert.match(viewSource, /data-testid="mulmo-script-tab-edit"/);
+    assert.match(viewSource, /data-testid="mulmo-script-tab-media"/);
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_helpers.ts
@@ -4,7 +4,7 @@ import {
   beatMayHaveMovie,
   clearReactiveRecords,
   getMissingCharacterKeys,
-  isAllSlideDeck,
+  hasEditableBeats,
   isSameScript,
   resolveSilentAdvanceSeconds,
   shouldAutoRenderBeat,
@@ -165,48 +165,39 @@ describe("isSameScript (#1074)", () => {
   });
 });
 
-describe("isAllSlideDeck", () => {
-  it("returns true when every beat is a slide", () => {
+describe("hasEditableBeats", () => {
+  // The gate is "is there a beat to edit", not "is this a deck". `@mulmocast/beat-editor`
+  // handles all eight types; the all-slide test this replaces was a limit of the OLD iframe
+  // deck editor and kept a markdown script read-only for no reason.
+  it("is true for an all-slide deck", () => {
     const script = {
       beats: [{ image: { type: "slide", slide: { layout: "title", title: "A" } } }, { image: { type: "slide", slide: { layout: "bigQuote", quote: "hi" } } }],
     };
-    assert.equal(isAllSlideDeck(script), true);
+    assert.equal(hasEditableBeats(script), true);
   });
 
-  it("returns false when any beat is non-slide", () => {
+  it("is true for a markdown script — the case that used to fall through to a read-only list", () => {
+    assert.equal(hasEditableBeats({ beats: [{ image: { type: "markdown", markdown: "# hi" } } ] }), true);
+  });
+
+  it("is true for a mixed script", () => {
     const mixed = {
       beats: [{ image: { type: "slide", slide: { layout: "title", title: "A" } } }, { image: { type: "movie", source: { kind: "path", path: "x.mp4" } } }],
     };
-    assert.equal(isAllSlideDeck(mixed), false);
-
-    const oneTextSlide = {
-      beats: [{ image: { type: "textSlide", slide: { title: "hello" } } }],
-    };
-    assert.equal(isAllSlideDeck(oneTextSlide), false);
+    assert.equal(hasEditableBeats(mixed), true);
   });
 
-  it("returns false for empty / missing beats", () => {
-    assert.equal(isAllSlideDeck({ beats: [] }), false);
-    assert.equal(isAllSlideDeck({}), false);
-    assert.equal(isAllSlideDeck({ beats: undefined }), false);
+  it("is true for a beat with no image at all — the editor can still give it one", () => {
+    assert.equal(hasEditableBeats({ beats: [{ text: "narration only" }] }), true);
   });
 
-  it("returns false when a beat has no image", () => {
-    assert.equal(isAllSlideDeck({ beats: [{}] }), false);
-    assert.equal(isAllSlideDeck({ beats: [{ image: null }] }), false);
-  });
-
-  it("returns false for non-object inputs", () => {
-    assert.equal(isAllSlideDeck(null), false);
-    assert.equal(isAllSlideDeck(undefined), false);
-    assert.equal(isAllSlideDeck("string"), false);
-    assert.equal(isAllSlideDeck(42), false);
-    assert.equal(isAllSlideDeck([]), false);
-  });
-
-  it("returns false when beat is not an object", () => {
-    assert.equal(isAllSlideDeck({ beats: [null] }), false);
-    assert.equal(isAllSlideDeck({ beats: ["not a beat"] }), false);
+  it("is false when there is nothing to edit", () => {
+    // The per-beat list already renders an empty state for these.
+    assert.equal(hasEditableBeats({ beats: [] }), false);
+    assert.equal(hasEditableBeats({}), false);
+    assert.equal(hasEditableBeats(null), false);
+    assert.equal(hasEditableBeats("nope"), false);
+    assert.equal(hasEditableBeats({ beats: "not an array" }), false);
   });
 });
 

--- a/test/plugins/mulmoscript/test_helpers.ts
+++ b/test/plugins/mulmoscript/test_helpers.ts
@@ -13,7 +13,7 @@ import {
   downloadFilename,
   effectiveBeat,
   getMissingCharacterKeys,
-  isAllSlideDeck,
+  hasEditableBeats,
   isBeatImageReference,
   isSameScript,
   isValidBeat,
@@ -190,35 +190,24 @@ describe("isBeatImageReference", () => {
   });
 });
 
-describe("isAllSlideDeck", () => {
+describe("hasEditableBeats", () => {
   const slide = { image: { type: "slide" } };
 
+  // The gate is "is there a beat to edit", not "is this a deck": the editor handles all eight
+  // beat types. The all-slide test this replaces belonged to the old iframe deck editor.
   it("accepts a script whose beats are all slides", () => {
-    assert.equal(isAllSlideDeck({ beats: [slide, slide] }), true);
+    assert.equal(hasEditableBeats({ beats: [slide, slide] }), true);
   });
 
-  // Mixed scripts fall through to the per-beat list UI; mounting the deck
-  // editor on them would hide the non-slide beats entirely.
-  it("refuses a mixed script", () => {
-    assert.equal(isAllSlideDeck({ beats: [slide, { image: { type: "imagePrompt" } }] }), false);
+  it("accepts a mixed script — the non-slide beats are editable too", () => {
+    assert.equal(hasEditableBeats({ beats: [slide, { image: { type: "markdown" } }] }), true);
   });
 
   it("refuses an empty or missing beats array", () => {
-    assert.equal(isAllSlideDeck({ beats: [] }), false);
-    assert.equal(isAllSlideDeck({}), false);
-    assert.equal(isAllSlideDeck({ beats: "not an array" }), false);
-  });
-
-  it("refuses a beat with no image or a non-record image", () => {
-    assert.equal(isAllSlideDeck({ beats: [{}] }), false);
-    assert.equal(isAllSlideDeck({ beats: [{ image: "slide" }] }), false);
-  });
-
-  it("refuses non-record scripts", () => {
-    assert.equal(isAllSlideDeck(null), false);
-    assert.equal(isAllSlideDeck(undefined), false);
-    assert.equal(isAllSlideDeck("script"), false);
-    assert.equal(isAllSlideDeck([slide]), false);
+    // Nothing to edit; the per-beat list already renders an empty state.
+    assert.equal(hasEditableBeats({ beats: [] }), false);
+    assert.equal(hasEditableBeats({}), false);
+    assert.equal(hasEditableBeats({ beats: "not an array" }), false);
   });
 });
 


### PR DESCRIPTION
## Summary

**エディタが「全 beat が slide のときだけ」出ていた。** markdown が1つでも混ざると
読み取り専用のリストに落ちる。

このゲートは**旧 iframe デッキエディタの制約**で、`MulmoScriptDeckEditor` はデッキしか
理解しなかった。#2945 で `@mulmocast/beat-editor` に移行したときに**ゲートをそのまま残した**
のが誤りで、beat-editor は 8 種別すべてを扱える:

```
textSlide, markdown, chart, mermaid, image, movie, slide, html_tailwind
```

パッケージの説明自体が「**every beat type** renders as a div」。

## 変更

`isAllSlideDeck` → **`hasEditableBeats`**（beat が1つでもあれば true）。

## Items to Confirm / Review

- **per-beat リストは置き換えていない**。音声生成・画像レンダリング・動画クリップ・
  ライトボックスは**あちらにしか無い**ので、消すと機能が減る。
  **Edit / Media のタブ**にして両方残した。

- **既定は Edit タブ**。今まで読み取り専用だったスクリプトが、開いた瞬間から編集できる。
  Media が既定のほうが良ければ変更は1行。

- **タブのラベルは 8 言語に追加**。`Messages` 型に足したので、
  訳の抜けは**空タブではなくコンパイルエラー**になる。

- **`beats` が空／無い場合は false のまま**。編集するものが無く、per-beat リストが
  既に空状態を描画する。

## 検証

デモに **markdown beat を1つ混ぜた**サンプルを足し、実ブラウザで確認:

```
beat 数: 5（slide 4 + markdown 1）
エディタがマウントされた: true
markdown の中身が出ている: true
pageerror: なし
```

移行前ならこのスクリプトは**丸ごと読み取り専用**だった。

## テスト

`hasEditableBeats` のテストを新仕様に書き直し（**旧仕様を検査していた3本が赤くなった**ので、
そこが変更点そのもの）:

- all-slide デッキ → true
- **markdown だけのスクリプト → true**（今まで読み取り専用に落ちていたケース）
- 混在 → true
- image が無い beat → true（エディタが後から付けられる）
- beats が空 / 無い / 配列でない → false

## ゲート

`typecheck` / `lint` / `build` / `test`（**145 pass / 0 fail**）。すべて終了コードで確認。
`check-changelog-ships` OK。

## User Prompt

> ん？ちょっとまって！私が欲しかったのは、deck だけじゃなくて md などふくめ、
> 編集できる slide を全部編集できるもの。それ前手で deck-web を beat editor に
> かえたんだけど、それを plugin にはとりこめてないの？

## Summary by Sourcery

Allow the beat editor to edit any non-empty MulmoScript while preserving the existing media-management list.

New Features:
- Enable in-place editing for scripts containing any beat type, including markdown and mixed beat collections.
- Add localized Edit and Media tabs while retaining the existing per-beat media workflow.

Bug Fixes:
- Remove the obsolete all-slide restriction that incorrectly made non-slide scripts read-only.

Enhancements:
- Keep the Media pane as the default while exposing the all-beat editor through the Edit pane.

Build:
- Bump the mulmoscript plugin to 4.4.0 and update the package consumer dependency.

Documentation:
- Document that every beat type is editable.

Tests:
- Update helper coverage for editable, mixed, image-less, and empty beat collections.
- Add coverage ensuring the Media pane remains the default and both tabs are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The deck editor now supports all beat types, including markdown and mixed-content decks.
  * Added separate **Edit** and **Media** tabs for switching between beat editing and per-beat media.
  * Added localized Edit and Media labels across supported languages.
  * Updated the sample deck to demonstrate mixed slide and markdown content.

* **Documentation**
  * Updated the changelog with editor improvements and package releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->