### PR TITLE
fix(deps): resync yarn.lock with the existing undici resolutions pin

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10186,10 +10186,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@7.28.0, undici@7.29.0, undici@^6.27.0, undici@^7.25.0, undici@^7.29.0:
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
-  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
+undici@7.28.0, undici@^6.27.0, undici@^7.25.0, undici@^7.29.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unenv@2.0.0-rc.24:
   version "2.0.0-rc.24"


### PR DESCRIPTION
`resolutions.undici` in package.json has pinned undici to 7.28.0 since 2026-07-01 (746eefa338). Dependabot PR #2803 bumped undici to 7.29.0 in packages/bridges/slack/package.json and regenerated yarn.lock, but did not update the resolutions pin — leaving the committed yarn.lock inconsistent with package.json (a real `yarn install` re-resolves undici back to 7.28.0 to honor the pin, as observed locally).

This reverts yarn.lock's undici entry back to 7.28.0 so it matches what package.json actually specifies. The resolutions pin itself is left as-is; bumping it to track 7.29.0 is a separate decision.

## Summary by Sourcery

Bug Fixes:
- Align yarn.lock's undici resolution with the existing package.json pin at version 7.28.0.