### PR TITLE
docs(sandbox): fix broken relative link to help doc

### DIFF
--- a/docs/sandbox-credentials.md
+++ b/docs/sandbox-credentials.md
@@ -137,5 +137,5 @@ Extending the list is a code change, not a user config. This is deliberate — t
 ## Related
 
 - Issue [#259](https://github.com/receptron/mulmoclaude/issues/259) — the design discussion that led to this doc.
-- [server/workspace/helps/sandbox.md](../server/workspace/helps/sandbox.md) — general sandbox behaviour (what runs where, how to disable it).
+- [packages/core/assets/helps/sandbox.md](../packages/core/assets/helps/sandbox.md) — general sandbox behaviour (what runs where, how to disable it).
 - [docs/developer.md](./developer.md) — full list of env vars honoured by the server.


### PR DESCRIPTION
## What
Fix a stale relative link in `docs/sandbox-credentials.md` pointing to
`server/workspace/helps/sandbox.md`.

## Why
The target file no longer exists at that path. It moved in two prior
refactors:

1. `server/workspace/helps/sandbox.md` → `packages/services/workspace-setup/assets/helps/sandbox.md` (95af22cde, "extract workspace bootstrap into @mulmoclaude/workspace-setup")
2. `packages/services/workspace-setup/assets/helps/sandbox.md` → `packages/core/assets/helps/sandbox.md` (434f80b3b, "consolidate shared server services into @mulmoclaude/core")

The link in `docs/sandbox-credentials.md` was never updated across either
move, so it 404s from GitHub.

## Change
Updated the link to point at the file's current location:
`packages/core/assets/helps/sandbox.md`.

## Summary by Sourcery

Fix the stale sandbox help link in the sandbox credentials documentation.

Bug Fixes:
- Fix the broken related-documentation link in the sandbox credentials guide.

Documentation:
- Update the sandbox credentials documentation to reference the sandbox help document at its current location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the related documentation link to point to the sandbox help page’s new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->