### PR TITLE
ci(pr_triage): 外部からの PR は規模によらず受け付けない（mulmoterminal に揃える） (#2966)

### DIFF
--- a/.github/workflows/pr_triage.yaml
+++ b/.github/workflows/pr_triage.yaml
@@ -1,59 +1,33 @@
-# Auto-triage incoming pull requests against the "open an issue and
-# agree on a plan first" contribution policy (docs/developer.md →
-# Contributing). PRs from listed maintainers / bots fall through with
-# no action. PRs from anyone else are allowed only when the diff is
-# small (additions + deletions ≤ LINE_LIMIT). Anything larger gets a
-# templated comment pointing at the policy and is closed.
+# Enforce the "open an issue and agree on a plan first" contribution policy
+# (docs/developer.md → Contributing). PRs from the maintainer / bot allowlist fall
+# through with no action. PRs from anyone else get a templated comment pointing at
+# the policy and are closed — there is no small-diff exemption.
 #
 # Why `pull_request_target` over `pull_request`:
-#   - Forked PRs running `pull_request` don't get write-scoped
-#     GITHUB_TOKEN, so we couldn't comment + close them.
-#   - `pull_request_target` runs from the base repo's workflow on the
-#     base branch, and we never check out the PR's code, so the usual
-#     `pull_request_target` security concerns (running attacker code
-#     with elevated permissions) don't apply here.
+#   - Forked PRs running `pull_request` don't get a write-scoped GITHUB_TOKEN, so
+#     we couldn't comment + close them.
+#   - `pull_request_target` runs the base branch's copy of this workflow and we
+#     never check out the PR's code, so the usual `pull_request_target` concern
+#     (running attacker code with elevated permissions) doesn't apply.
 #
 # Maintainer list — keep in sync with the Contributing section of
-# docs/developer.md. Adding a maintainer is a one-line edit in both
-# places.
+# docs/developer.md. Adding a maintainer is a one-line edit in both places.
 
 name: PR triage (non-maintainer guard)
 
 on:
   # zizmor: ignore[dangerous-triggers]
-  # `pull_request_target` is needed so forked PRs get a write-scoped
-  # GITHUB_TOKEN (we must comment + close them). The two usual abuse
-  # paths for this trigger don't apply here:
-  #   1. We never `actions/checkout` the PR's code, so no attacker
-  #      script ever runs with elevated permissions.
-  #   2. PR-controlled fields (author login, additions count) reach
-  #      the shell only through `env:` bindings and are referenced as
-  #      `${VAR}` (quoted) inside bash. There is no `${{ github.event.
-  #      pull_request.* }}` template substitution into the shell body,
-  #      so zizmor's template-injection vector is closed.
+  # PR-controlled fields (author login, PR number) reach the shell only through
+  # `env:` bindings and are referenced as quoted `${VAR}` inside bash. No
+  # `${{ github.event.pull_request.* }}` substitution happens inside a script
+  # body, so the template-injection vector is closed.
   pull_request_target:
-    # `edited` catches base-branch retargets: a contributor could open
-    # the PR against a non-main branch (bypassing `branches: [main]`)
-    # then edit it to point at main. That arrives as `edited`, not
-    # `opened` / `reopened`, so triage would otherwise never fire on
-    # the retargeted PR. CodeRabbit + Codex review on PR #1708.
-    #
-    # `synchronize` removed (#1869 follow-up): a `synchronize` event
-    # arrives a few seconds after we call `gh pr close` on a large
-    # PR, and the post-close `edited` event from CodeRabbit's title /
-    # body edits arrives a beat later. Both re-ran this workflow and
-    # each posted another copy of the closing comment (PR #1869
-    # received three identical close comments inside 90 s). The
-    # `if: state == 'open'` guard below catches the residual `edited`
-    # case; dropping `synchronize` removes the primary duplicate
-    # source. Net behaviour: a contributor who opens a small PR and
-    # later pushes a large commit is no longer auto-closed, but the
-    # PR is still in the human review queue (and the doc-link in the
-    # opening comment still points at the policy) — that's an
-    # acceptable trade for not spamming three copies of the same
-    # close comment every time.
+    # No `branches:` filter on purpose: a PR opened against `dev_tool` or any
+    # other long-lived branch is just as unreviewable as one against `main`.
+    # `edited` still matters because a base-branch retarget arrives as `edited`,
+    # and re-running on it is harmless — the guards in the script below make a
+    # second run a no-op rather than a second comment.
     types: [opened, reopened, edited]
-    branches: [main]
 
 permissions:
   contents: read
@@ -62,23 +36,15 @@ permissions:
 
 concurrency:
   group: pr-triage-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   triage:
-    # Skip everything once the PR is closed. Without this, a residual
-    # `edited` event (e.g. CodeRabbit re-summarising the title/body
-    # after we already closed) re-runs the whole script — `gh pr close`
-    # on a closed PR is a no-op, but the `gh pr comment` above it is
-    # NOT idempotent and posts another copy of the closing template.
-    # This guard is the second half of the #1869 fix (the first half
-    # is dropping `synchronize` from `types` above).
-    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     env:
-      # Newline-separated allowlist. Match is exact (full GitHub login
-      # including the `[bot]` suffix for App accounts).
+      # Newline-separated allowlist. Match is exact (full GitHub login, including
+      # the `[bot]` suffix for App accounts).
       MAINTAINERS: |
         isamu
         snakajima
@@ -87,14 +53,11 @@ jobs:
         dependabot[bot]
         coderabbitai[bot]
         sourcery-ai[bot]
-      # Combined cap on additions + deletions for non-maintainer PRs.
-      # The docs/developer.md "When you can skip the plan" section
-      # quotes the same number — bump both together if it changes.
-      LINE_LIMIT: 10
-      # Link target for the closing comment. Kept here so the URL
-      # interpolation happens at workflow-load time (not inside the
-      # bash heredoc) and stays grep-able alongside the policy.
-      DOC_LINK: https://github.com/${{ github.repository }}/blob/main/docs/developer.md#contributing--please-open-an-issue-with-a-plan-first
+      # Marker embedded in the comment body so a re-run recognises its own
+      # previous comment and stays silent. `gh pr comment` is not idempotent, so
+      # without it an author who reopens the PR collects a second copy of the
+      # same template.
+      TRIAGE_MARKER: "<!-- mulmoclaude-pr-triage -->"
     steps:
       - name: Decide and act
         env:
@@ -102,42 +65,84 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          ADDITIONS: ${{ github.event.pull_request.additions }}
-          DELETIONS: ${{ github.event.pull_request.deletions }}
+          SENDER: ${{ github.event.sender.login }}
+          DOC_LINK: https://github.com/${{ github.repository }}/blob/main/docs/developer.md#contributing--please-open-an-issue-with-a-plan-first
         run: |
           set -euo pipefail
-          echo "PR=#${PR_NUMBER} author=${PR_AUTHOR} +${ADDITIONS} -${DELETIONS}"
+          echo "PR=#${PR_NUMBER} author=${PR_AUTHOR}"
 
-          # Exact-line match against the allowlist. `grep -Fxq` treats
-          # the pattern as a fixed string and requires whole-line
-          # equality, so the `[bot]` suffix isn't interpreted as a
-          # regex character class.
-          if echo "${MAINTAINERS}" | grep -Fxq "${PR_AUTHOR}"; then
+          # `grep -Fxq` requires whole-line equality against a fixed string, so
+          # the `[bot]` suffix isn't read as a regex character class and a login
+          # that merely contains a maintainer's name doesn't match.
+          is_allowlisted() {
+            echo "${MAINTAINERS}" | grep -Fxq "$1"
+          }
+
+          if is_allowlisted "${PR_AUTHOR}"; then
             echo "maintainer / allowlisted bot — pass through"
             exit 0
           fi
 
-          TOTAL=$((ADDITIONS + DELETIONS))
-          if [ "${TOTAL}" -le "${LINE_LIMIT}" ]; then
-            echo "small PR (${TOTAL} lines ≤ ${LINE_LIMIT}) — allowed"
+          # Any event a maintainer triggered is a deliberate human action on this
+          # PR — the automation must not fight it. `opened` always has
+          # sender == author, so the main path is untouched; what this protects is
+          # a maintainer retitling an outside PR they've chosen to keep (including
+          # the ones that predate this workflow), and CodeRabbit rewriting the
+          # title right after we closed.
+          if is_allowlisted "${SENDER}"; then
+            echo "event triggered by ${SENDER} (maintainer) — standing down"
             exit 0
           fi
 
-          # Large unsolicited PR — comment then close. Comment first
-          # so the closing event arrives with the explanation already
-          # attached (email notifications batch them together).
-          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "$(cat <<EOF
-          ## This PR is being closed automatically — please open an issue first
+          # Live state, not the event payload: a `synchronize`/`edited` event
+          # generated moments before we closed still carries state=open.
+          STATE=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json state --jq .state)
+          if [ "${STATE}" != "OPEN" ]; then
+            echo "already ${STATE} — nothing to do"
+            exit 0
+          fi
 
-          Thanks for sending this! Our contribution policy is to **agree on a plan in a GitHub issue before opening a pull request**, except for very small fixes. This PR is **${TOTAL} lines of diff** (additions + deletions) and you're not on the maintainer allowlist, so it's being closed automatically.
+          # Collect first, match second. `gh ... | grep -qF` would look equivalent,
+          # but `grep -q` exits on the first match and `gh` then dies of SIGPIPE
+          # (141); `pipefail` propagates that, the `if` reads it as "no marker",
+          # and the guard posts the duplicate comment it exists to prevent. It
+          # only misfires once the comment list is big enough to still be
+          # streaming — i.e. never in a small test, always on a busy PR.
+          COMMENTS=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '.[].body')
+          if grep -qF "${TRIAGE_MARKER}" <<< "${COMMENTS}"; then
+            # Already triaged but open again: the author reopened it (a
+            # maintainer reopening already returned above). Re-close, silently —
+            # the explanation is still sitting in the thread.
+            echo "already triaged — closing again without commenting twice"
+            gh pr close "${PR_NUMBER}" --repo "${REPO}"
+            exit 0
+          fi
 
-          ### What to do next
+          # Quoted heredoc: nothing in the body is expanded by the shell, so
+          # backticks and `$` in the template are inert. The one variable we do
+          # need is substituted afterwards with bash parameter expansion.
+          BODY=$(cat <<'EOF'
+          <!-- mulmoclaude-pr-triage -->
+          ## この pull request は自動的にクローズされました / Closed automatically
 
-          1. **Open an issue** describing the problem and your proposed plan. Keep the **first three lines a compact summary** so a maintainer can decide whether to engage at a glance. Save the longer rationale for the rest of the body.
-          2. **Wait for the plan to be agreed in the issue thread.** We may suggest scope adjustments, point out helpers you can reuse, or surface in-flight work that overlaps.
-          3. Once agreed, a maintainer drafts the pull request.
+          送っていただいてありがとうございます。ただ、MulmoClaude では **開発チーム外からの pull request は、規模によらずお受けしていません**。代わりに、次の流れでお願いしています。
 
-          Direct pull requests are welcome for typos, copy fixes, doc tweaks, dependency bumps, and single-file bug fixes under **${LINE_LIMIT} lines of diff**. The full rationale lives in [docs/developer.md → Contributing](${DOC_LINK}).
+          1. **issue を立てて、問題と実装プランを説明してください。** メンテナが一目で判断できるよう、**最初の 3 行を要約**にしてください。詳しい背景はその後ろに。
+          2. **issue のスレッドでプランを合意します。** スコープの調整、再利用できる既存のヘルパー、進行中の作業との重複などをこちらから提示します。
+          3. **合意できたら、メンテナが実装して pull request を出します。** 実装へのコメントは歓迎です。
+
+          バグ報告・機能要望の **issue はいつでも歓迎**です。制限しているのは pull request だけです。理由と詳しい手順は [docs/developer.md → Contributing](__DOC_LINK__) にあります。
+
+          ---
+
+          Thanks for sending this! MulmoClaude **does not accept pull requests from outside the development team**, regardless of size. What we ask for instead:
+
+          1. **Open an issue** describing the problem and your proposed plan. Keep the **first three lines a compact summary** so a maintainer can decide whether to engage at a glance.
+          2. **Agree on the plan in the issue thread.** We may adjust scope, point at helpers you can reuse, or surface in-flight work that overlaps.
+          3. **A maintainer then writes the pull request.** You're welcome to follow along and comment on the implementation.
+
+          **Issues — bug reports and feature requests — are always welcome**; only pull requests are restricted. The full rationale is in [docs/developer.md → Contributing](__DOC_LINK__).
           EOF
-          )"
+          )
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "${BODY//__DOC_LINK__/${DOC_LINK}}"
           gh pr close "${PR_NUMBER}" --repo "${REPO}"

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -6,7 +6,7 @@ Reference for contributors hacking on MulmoClaude. End-user instructions live in
 
 ## Contributing — please open an issue with a plan first
 
-Thanks for wanting to contribute! Please read this section before sending a pull request — **we cannot accept large or AI-generated pull requests from outside contributors**, and unsolicited ones will be closed without a detailed review. The flow we ask for instead is:
+Thanks for wanting to contribute! Please read this section before sending a pull request — **we do not accept pull requests from outside the development team, regardless of size**, and unsolicited ones are commented on and closed automatically. **Issues are a different story — bug reports and feature requests are always welcome, and an issue is the way to get a change in.** The flow we ask for instead is:
 
 1. **Open a GitHub issue describing the problem and a proposed plan.** A few paragraphs are enough: what's wrong (or what's missing), the approach you have in mind, the files you expect to touch, and any open questions. The files under [`plans/`](../plans/) are good references for the level of detail we want.
 2. **Discuss the plan in the issue thread.** We may suggest scope adjustments, point out existing helpers or in-flight refactors that overlap, or surface constraints that are hard to see from the outside, such as security boundaries or deprecation paths. This is usually a short back-and-forth.
@@ -27,26 +27,28 @@ AI coding assistants make it easy to generate large, polished-looking diffs in m
 
 This is not about screening out AI-assisted work — the maintainer who drafts the pull request will often be using an agent too. The point is that **the plan is what we agree on, and the resulting code is owned by whoever lands it**. Locking that ownership boundary at the plan keeps responsibility clear and review focused on the parts that need human judgement.
 
-### When you can skip the plan
+### There is no small-diff exemption
 
-A direct pull request is welcome for:
+Every change from outside the development team starts as an issue — typos, copy fixes,
+documentation tweaks and dependency bumps included. A one-line fix still needs a maintainer to
+judge whether it is the right fix, and routing it through an issue costs you less than writing a
+pull request that will be closed.
 
-- Typos, copy fixes, documentation tweaks
-- Dependency version bumps
-- Single-file bug fixes with an obvious root cause and a matching test, **10 lines of diff or fewer (additions + deletions, inclusive)**
-- Anything a maintainer or a continuous integration bot explicitly asks for in a review comment
+The one exception is a change **a maintainer or a continuous integration bot explicitly asked
+for in a review comment on your existing pull request** — that request is the agreement, so
+there is nothing left to negotiate in an issue.
 
-Anything larger than that should start as an issue. If you are not sure, opening an issue first is always cheaper than writing a pull request that will not be accepted. Thanks for understanding.
+If you are not sure, opening an issue first is always cheaper. Thanks for understanding.
 
 ### Automated triage on pull requests
 
 The `.github/workflows/pr_triage.yaml` workflow runs on every PR and enforces the rule above mechanically:
 
-- PRs from maintainers and allowlisted bots fall through. The current allowlist is `isamu`, `snakajima`, `ystknsh`, `yuki0627`, `dependabot[bot]`, `coderabbitai[bot]`, `sourcery-ai[bot]`. To add a maintainer, edit the `MAINTAINERS` list in the workflow and the same list here.
-- PRs from anyone else are accepted automatically when the diff is ≤ 10 lines (additions + deletions).
-- Larger non-maintainer PRs receive a templated comment that links back to this section and asks for an issue first — **the issue body's first three lines should be a compact summary of the problem and the proposed plan** so a maintainer can decide whether to engage at a glance — and the PR is closed.
-
-The line cap and the documentation are intentionally kept in lock-step. If the cap moves, update both the workflow's `LINE_LIMIT` and the bullet above in the same commit.
+- PRs from maintainers and allowlisted bots pass through untouched. The current allowlist is `isamu`, `snakajima`, `ystknsh`, `yuki0627`, `dependabot[bot]`, `coderabbitai[bot]`, `sourcery-ai[bot]`. To add a maintainer, edit the `MAINTAINERS` list in the workflow and the same list here, in the same commit.
+- **Every other PR gets a templated comment linking back to this section and is closed. There is no small-diff exemption.** The comment asks for an issue instead — **its first three lines should be a compact summary of the problem and the proposed plan** so a maintainer can decide whether to engage at a glance.
+- The guard runs on PRs against **any** branch, not just `main`: a PR opened against a long-lived branch is exactly as unreviewable as one against `main`.
+- An event a maintainer triggered stands the automation down, so retitling an outside PR you have decided to keep does not re-close it.
+- Re-closing a reopened PR is silent — the workflow recognises its own earlier comment and does not post a second copy.
 
 ---
 

--- a/plans/ci-2966-pr-triage-no-outside-prs.md
+++ b/plans/ci-2966-pr-triage-no-outside-prs.md
@@ -1,0 +1,71 @@
+# ci(pr_triage): 外部 PR は規模によらず受け付けない方針へ揃える (#2966)
+
+## 背景
+
+`.github/workflows/pr_triage.yaml` は「開発チーム外からの PR は plan-first ポリシーに沿わせる」
+ためのガードだが、**10 行以下の外部 PR を素通りさせる例外**（`LINE_LIMIT: 10`）を持っている。
+実際の方針は「外部からの PR は規模によらず受け付けない」なので、実装が方針を反映していない。
+
+mulmoterminal の同名ワークフローが既にその方針を実装しており、さらに運用で踏んだ穴を
+いくつか塞いでいる。そちらへ揃える。
+
+## 差分（mulmoclaude 現状 → mulmoterminal 準拠）
+
+| 項目 | 現状 | 変更後 | 理由 |
+|---|---|---|---|
+| 小規模例外 | 10 行以下は通す | **例外なし** | 方針そのもの |
+| `branches:` | `[main]` のみ | フィルタなし | `main` 以外の長命ブランチ宛の PR も同じくレビュー不能 |
+| `sender` 判定 | 無し | 許可リストで stand down | メンテナが意図的に残した外部 PR をリタイトルすると `edited` で再発火し、自動化が人間の判断と衝突する |
+| 冪等化 | `synchronize` を外す + payload の `state` | コメント本文の marker を検出 | reopen 時に二重コメントしない。`gh pr comment` は冪等でない |
+| state 判定 | イベント payload | `gh pr view` でライブ取得 | クローズ直前に生成された `edited` は state=open を載せたまま届く |
+| 文面 | 英語のみ | 日英併記 | 日本語話者の contributor が主 |
+| `cancel-in-progress` | `true` | `false` | 連続イベントで前段の実行がキャンセルされるとクローズを取りこぼす |
+
+## 移植時に落としてはいけない実装細部
+
+mulmoterminal 側のコメントに、実際に踏んだ罠として記録されているもの:
+
+- **`grep -qF` をパイプの受け手にしない。** `gh api --paginate ... | grep -qF` は `grep` が
+  最初のマッチで抜け、`gh` が SIGPIPE(141) で死に、`pipefail` がそれを伝播する。`if` は
+  「marker 無し」と読んで、防ごうとしていた二重コメントをまさに投稿する。**コメント一覧を
+  先に変数へ集めてから** `grep -qF <<< "$COMMENTS"` で判定する。小さなテスト PR では
+  再現せず、コメントが増えた本番 PR でだけ壊れる種類のバグ。
+- **クォート付きヒアドキュメント（`<<'EOF'`）で本文を組み立てる。** 本文にバッククォートや
+  `$` が入るため。変数の埋め込みは後段の bash パラメータ展開（`${BODY//__DOC_LINK__/...}`）で行う。
+- **`grep -Fxq` で許可リストを判定する。** 固定文字列かつ行全体一致なので、`[bot]` の角括弧が
+  正規表現の文字クラスとして解釈されず、メンテナ名を部分的に含むだけの login も誤マッチしない。
+- **`pull_request_target` を使う理由と、それが安全である根拠のコメントを残す。** PR のコードを
+  checkout しない・PR 由来の値は `env:` 経由でのみシェルへ渡す、の 2 点。zizmor の
+  `dangerous-triggers` 抑制コメントも維持する。
+
+## mulmoclaude 固有で残すもの
+
+- 許可リストに **`yuki0627`** を含める（mulmoterminal 側には居ない）
+- リンク先は `docs/developer.md#contributing--please-open-an-issue-with-a-plan-first`
+  （mulmoclaude は `CONTRIBUTING.md` を持たず、Contributing は developer.md の一節）
+
+## ドキュメント同時更新（必須）
+
+`docs/developer.md` の Contributing セクションは現在:
+
+- 「### When you can skip the plan」に **「10 行以下の単一ファイルのバグ修正」** を直接 PR 可として列挙
+- 「### Automated triage on pull requests」に **「10 行以下なら自動で受理」** と明記
+- 「The line cap and the documentation are intentionally kept in lock-step」と自ら宣言
+
+ワークフローだけ変えると文書と実装が矛盾するため、**同じ PR で両方直す**。
+
+## 検証
+
+ワークフローは CI 上でしか実行できないため、次で担保する:
+
+1. `yarn lint:workflows`（zizmor 相当があれば）／`workflow-lint.yaml` の CI ジョブ
+2. YAML パースと、シェル部分の `bash -n` 相当の構文チェック
+3. 埋め込みシェルスクリプトを取り出し、**許可リスト判定・marker 判定・state 判定の分岐を
+   ローカルで実際に走らせて**期待どおりに分岐することを確認する（メンテナ / 外部 / bot /
+   marker 済み / クローズ済みの各ケース）
+4. 実 PR での発火は本番でしか観測できないため、PR に「未検証の範囲」として明記する
+
+## スコープ外
+
+- `CONTRIBUTING.md` の新規作成（GitHub の PR 作成画面に提示される利点はあるが別判断）
+- 許可リストの人員変更


### PR DESCRIPTION
## Summary

`.github/workflows/pr_triage.yaml` を mulmoterminal の同名ワークフローに揃え、**開発チーム外からの pull request を規模によらずクローズする**ようにしました。

現状は `LINE_LIMIT: 10` により **10 行以下（additions + deletions）の外部 PR が素通り**しており、「外部からの PR は受け付けない」という方針と実装が食い違っていました。実際、この変更を書いている時点で開いていた外部 PR 2 件（#2964 が 8 行、#2965 が 2 行）はどちらもこの例外で通過しています。

あわせて mulmoterminal 側が運用で踏んだ穴も取り込んでいます。

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 小規模例外 | 10 行以下は通す | **例外なし** |
| `branches:` | `[main]` のみ | フィルタなし（長命ブランチ宛も対象） |
| `sender` 判定 | 無し | 許可リストで stand down |
| 二重コメント防止 | `synchronize` 除外 + payload の `state` | 本文の marker を検出 |
| state 判定 | イベント payload | `gh pr view` でライブ取得 |
| 文面 | 英語のみ | 日英併記 |
| `cancel-in-progress` | `true` | `false` |

`docs/developer.md` の Contributing も同じ PR で更新しています。ワークフロー側のコメントが「ドキュメントと lock-step で保つ」と明記しており、10 行の例外が文書側（"When you can skip the plan"、"Automated triage on pull requests"）にも書かれていたため、片方だけ変えると矛盾します。

## Items to Confirm / Review

1. **`branches:` フィルタの削除** — これにより `main` 以外のブランチ宛の外部 PR もクローズ対象になります。意図どおりか確認してください。長命ブランチへ外部からの PR を受けたいケースがあるなら戻す必要があります。
2. **文面の日英併記** — mulmoterminal の文面をベースに、リンク先だけ mulmoclaude の `docs/developer.md#contributing--…` に差し替えています。mulmoclaude は `CONTRIBUTING.md` を持たないためです。
3. **`CONTRIBUTING.md` を作るかどうかはスコープ外にしました。** mulmoterminal はリポジトリ直下に持っており、GitHub が PR 作成画面で「Contributing guidelines」として提示してくれるので、**PR が開かれる前に止められる**という実利があります。別途判断してください。
4. **「メンテナ / CI bot がレビューコメントで明示的に依頼した変更」は例外として文書に残しました。** その依頼自体が合意なので issue を挟む意味がないという整理です。ワークフローはこのケースを判定できない（人間が判断する）ため、文書上の例外です。
5. **許可リストは現状維持**（`isamu` / `snakajima` / `ystknsh` / `yuki0627` + 3 bot）。mulmoterminal には `yuki0627` が居ないため、そこだけ mulmoclaude 側を優先しています。

## 検証

ワークフローは本番でしか発火しないため、**埋め込みシェルスクリプトを YAML から取り出し、`gh` をフェイクに差し替えて全分岐を実際に実行**しました（読んで確かめるのではなく走らせています）。

| ケース | 結果 |
|---|---|
| メンテナ（isamu） | 素通り・アクション無し |
| bot（dependabot[bot] / coderabbitai[bot]） | 素通り・アクション無し |
| **外部・1 行の PR** | **comment + close**（変更前は素通りしていたケース） |
| 外部・大きい PR | comment + close |
| 外部 PR をメンテナがリタイトル | stand down・アクション無し |
| 外部 PR が既にクローズ済み | 何もしない |
| 外部 PR が reopen（marker あり） | **close のみ**（二重コメントしない） |
| `isamu2` / `isam` / `dependabot`（[bot] 無し） | comment + close（部分一致で誤って素通りしない） |

さらに **SIGPIPE の罠**（mulmoterminal のコメントに記録されているもの）を実測で確認:

- `gh api --paginate ... \| grep -qF` は 2MB / 16 万行のコメント一覧で **exit 141（SIGPIPE）** になり、`pipefail` により「marker 無し」と誤判定 → 防ぎたかった二重コメントを投稿する
- 採用した「先に変数へ集めてから `grep -qF <<<`」は **exit 0** で正しく検出。同条件でスクリプト全体を走らせても `close` のみで二重コメント無し

静的解析は CI と同じツール・同じピン版で実行:

- `actionlint 1.7.12` — clean
- `zizmor 1.25.2` — `No findings to report`（1 ignored = 既存の `dangerous-triggers` 抑制、4 suppressed）

**ローカルで再現できないもの**: 実際の PR イベントによる発火そのもの（`pull_request_target` の payload、`GITHUB_TOKEN` のスコープ）。これは本番の次の外部 PR でしか確認できません。フェイク `gh` はコマンドの呼ばれ方を検証しますが、GitHub 側の権限は検証していません。

## User Prompt

- mulmoterminal だと PR を受け付けないような CI が回っているが、mulmoclaude では設定していないか。外部から PR は受け付けない予定である
- （方針を確認した上で）mulmoterminal に合わせてほしい
- 並行して、開いている PR にはコメントを付けてクローズし、issue を立てるように伝えてほしい

最後の依頼は本 PR とは別に実施済みです: #2964 と #2965 に日英併記のコメントを付けてクローズし、内容自体は有効だったため #2968 / #2967 として起票、PR 側にも issue 番号を返信しました。#2963 はメンテナ（isamu）の PR なので対象外としています。

Closes #2966

work in mulmoclaude3

## Summary by Sourcery

Enforce the policy that external contributors must open an issue and agree on a plan before submitting changes, regardless of pull request size.

Bug Fixes:
- Prevent external pull requests of any size from bypassing the automated contribution-policy guard.
- Avoid duplicate triage comments and missed closures when pull requests are reopened, edited, or rapidly generate multiple events.

Enhancements:
- Apply PR triage to pull requests targeting any branch and allow maintainer-triggered events to stand down the automation.
- Update the contribution policy to require external changes to begin with an issue and an agreed plan, while documenting the maintainer-requested exception.

Documentation:
- Synchronize the developer contribution guidelines with the updated automated PR triage policy and provide bilingual closure guidance.

Chores:
- Add a plan document describing the policy change and its validation considerations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidelines to require an issue before external pull requests, including small fixes, documentation updates, and dependency changes.
  - Clarified exceptions for maintainer- or automation-requested contributions.

- **Chores**
  - Improved automated pull request triage to consistently enforce contribution policies across branches and pull request updates.
  - Added clearer bilingual policy messaging and prevented repeated notifications for previously reviewed submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->