### PR TITLE
chore: mulmoscript-plugin の整形と、README 翻訳ゲートの誤検出・Windows 実行不能の修正

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/core/definition.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/definition.ts
@@ -113,13 +113,11 @@ IMPORTANT: "imagePrompt" and "moviePrompt" are plain string fields on the beat, 
       },
       beatIndex: {
         type: "number",
-        description:
-          "0-based index of the beat to replace. Requires `filePath` and `beat`. Omit to re-display the script unchanged.",
+        description: "0-based index of the beat to replace. Requires `filePath` and `beat`. Omit to re-display the script unchanged.",
       },
       beat: {
         type: "object",
-        description:
-          "The replacement beat, complete (it overwrites the old one — it is not merged). Requires `filePath` and `beatIndex`.",
+        description: "The replacement beat, complete (it overwrites the old one — it is not merged). Requires `filePath` and `beatIndex`.",
         additionalProperties: true,
       },
       autoGenerateMovie: {

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -92,20 +92,10 @@
          beat type; the list is where the media lives (generate audio, render an image, open a
          clip), which the editor has no equivalent for — so neither replaces the other. -->
     <div v-if="canEditBeats" class="flex shrink-0 gap-1 px-2 pt-1 text-[11px]">
-      <button
-        type="button"
-        :class="beatPaneTabClass(beatPane === 'edit')"
-        data-testid="mulmo-script-tab-edit"
-        @click="beatPane = 'edit'"
-      >
+      <button type="button" :class="beatPaneTabClass(beatPane === 'edit')" data-testid="mulmo-script-tab-edit" @click="beatPane = 'edit'">
         {{ m.editTab }}
       </button>
-      <button
-        type="button"
-        :class="beatPaneTabClass(beatPane === 'media')"
-        data-testid="mulmo-script-tab-media"
-        @click="beatPane = 'media'"
-      >
+      <button type="button" :class="beatPaneTabClass(beatPane === 'media')" data-testid="mulmo-script-tab-media" @click="beatPane = 'media'">
         {{ m.mediaTab }}
       </button>
     </div>
@@ -726,7 +716,12 @@ function commitScript(next: MulmoScript): void {
 // interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
-const { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({ api, filePath, effectiveScript, commitScript });
+const { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
+  api,
+  filePath,
+  effectiveScript,
+  commitScript,
+});
 
 /**
  * Which pane the beats are shown in.

--- a/packages/plugins/mulmoscript-plugin/test/test_helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_helpers.ts
@@ -177,7 +177,7 @@ describe("hasEditableBeats", () => {
   });
 
   it("is true for a markdown script — the case that used to fall through to a read-only list", () => {
-    assert.equal(hasEditableBeats({ beats: [{ image: { type: "markdown", markdown: "# hi" } } ] }), true);
+    assert.equal(hasEditableBeats({ beats: [{ image: { type: "markdown", markdown: "# hi" } }] }), true);
   });
 
   it("is true for a mixed script", () => {

--- a/scripts/packages/check-readme-translations.d.mts
+++ b/scripts/packages/check-readme-translations.d.mts
@@ -21,3 +21,20 @@ export const TRANSLATION_RE: RegExp;
  *  an object keyed by package name (npm 12). Null when the value is neither —
  *  which the caller must treat as "cannot verify", never as "no files". */
 export function packEntry(parsed: unknown): PackEntry | null;
+
+/** One package's audit result. `error` set = the tarball could never be read,
+ *  which is a gate failure in its own right, not a pass. */
+export interface AuditResult {
+  name: string;
+  onDiskTranslations: string[];
+  missing: string[];
+  skipped?: string;
+  error?: string;
+}
+
+/** The roster line for one result: `OK`, `skipped (…)`, `MISSING: …`, `ERROR: …`. */
+export function statusLine(result: AuditResult): string;
+
+/** The two distinct reasons the gate fails: translations absent from a tarball
+ *  that WAS read, and packages whose tarball could not be read at all. */
+export function classify(results: AuditResult[]): { missing: AuditResult[]; unverified: AuditResult[] };

--- a/scripts/packages/check-readme-translations.d.mts
+++ b/scripts/packages/check-readme-translations.d.mts
@@ -1,0 +1,23 @@
+// Type declarations for check-readme-translations.mjs. Sidecar so the script
+// stays plain JS (runnable with `node` on a fresh clone) while tests get a typed
+// import surface — same arrangement as scripts/packages/audit-releases.d.mts.
+
+/** One file inside a packed tarball, as `npm pack --json` describes it. */
+export interface PackedFile {
+  path: string;
+}
+
+/** One packed package out of `npm pack --json`. */
+export interface PackEntry {
+  name?: string;
+  files: PackedFile[];
+}
+
+/** Matches a README translation (`README.ja.md`, `README.pt-BR.md`). The
+ *  canonical `README.md` is deliberately NOT a match — it ships by default. */
+export const TRANSLATION_RE: RegExp;
+
+/** The single packed package, whichever shape npm used: an array (npm <= 11) or
+ *  an object keyed by package name (npm 12). Null when the value is neither —
+ *  which the caller must treat as "cannot verify", never as "no files". */
+export function packEntry(parsed: unknown): PackEntry | null;

--- a/scripts/packages/check-readme-translations.mjs
+++ b/scripts/packages/check-readme-translations.mjs
@@ -56,7 +56,13 @@ async function findPackageJsons(root) {
 // was red on a tarball that had shipped the file all along.
 export function packEntry(parsed) {
   const candidate = Array.isArray(parsed) ? parsed[0] : isRecord(parsed) ? Object.values(parsed)[0] : null;
-  return isRecord(candidate) && Array.isArray(candidate.files) ? candidate : null;
+  if (!isRecord(candidate) || !Array.isArray(candidate.files)) return null;
+  // Every entry must carry a string `path`. A `files` array of shapes we cannot
+  // read maps to `[undefined, …]`, which compares unequal to every translation
+  // name — so the gate would fail the package for "the tarball omits this file"
+  // when the truth is "npm's output was unreadable", sending the maintainer to
+  // edit a `files` array that was never the problem.
+  return candidate.files.every((file) => isRecord(file) && typeof file.path === "string") ? candidate : null;
 }
 
 function isRecord(value) {

--- a/scripts/packages/check-readme-translations.mjs
+++ b/scripts/packages/check-readme-translations.mjs
@@ -27,7 +27,7 @@ const PACKAGES_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)),
 // Match README translations with a BCP-47-ish suffix (ja, ja-JP,
 // pt-BR, etc.). README.md itself is excluded — that's the canonical
 // one and ships by default.
-const TRANSLATION_RE = /^README\.[a-z]{2}(-[A-Z]{2})?\.md$/;
+export const TRANSLATION_RE = /^README\.[a-z]{2}(-[A-Z]{2})?\.md$/;
 
 async function findPackageJsons(root) {
   const out = [];
@@ -48,6 +48,21 @@ async function findPackageJsons(root) {
 // of file entries the tarball would contain. The output prints to
 // stderr when `--dry-run` is used — parse stdout, which carries the
 // JSON.
+// The one packed package out of `npm pack --json`, whatever shape npm used.
+// npm <= 11 answered an ARRAY with one entry per packed package; npm 12 answers
+// an OBJECT keyed by package name. Reading `parsed[0]` on the object yields
+// `undefined`, so the previous version of this check saw an empty file list for
+// every package and reported each of their translations as missing — the gate
+// was red on a tarball that had shipped the file all along.
+export function packEntry(parsed) {
+  const candidate = Array.isArray(parsed) ? parsed[0] : isRecord(parsed) ? Object.values(parsed)[0] : null;
+  return isRecord(candidate) && Array.isArray(candidate.files) ? candidate : null;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null;
+}
+
 async function packedFiles(cwd) {
   return new Promise((resolve, reject) => {
     // `--ignore-scripts` keeps `prepack` hooks (which often run
@@ -69,11 +84,15 @@ async function packedFiles(cwd) {
       }
       try {
         const parsed = JSON.parse(Buffer.concat(stdout).toString("utf8"));
-        // `npm pack --json` returns an array with one entry per
-        // package (we always pack exactly one). `.files` is the
-        // array of included-file descriptors.
-        const files = parsed[0]?.files ?? [];
-        resolve(files.map((entry) => entry.path));
+        const entry = packEntry(parsed);
+        // Not "no files" — an unrecognised shape. Answering `[]` here would
+        // report every translation as missing, which is exactly what npm 12's
+        // change to this output did to the previous version of this check.
+        if (!entry) {
+          reject(new Error(`npm pack --json returned an unrecognised shape in ${cwd}; cannot verify the tarball`));
+          return;
+        }
+        resolve((entry.files ?? []).map((file) => file.path));
       } catch (err) {
         reject(err);
       }
@@ -97,33 +116,40 @@ async function auditPackage(packageJsonPath) {
   return { name: pkg.name ?? path.basename(dir), onDiskTranslations, missing };
 }
 
-const packageJsons = await findPackageJsons(PACKAGES_ROOT);
-const results = [];
-for (const pkgJson of packageJsons) {
-  try {
-    const result = await auditPackage(pkgJson);
-    if (result.onDiskTranslations.length > 0) results.push({ ...result, packageJsonPath: pkgJson });
-  } catch (err) {
-    console.error(`[check:readmes] error auditing ${pkgJson}: ${err instanceof Error ? err.message : String(err)}`);
+async function main() {
+  const packageJsons = await findPackageJsons(PACKAGES_ROOT);
+  const results = [];
+  for (const pkgJson of packageJsons) {
+    try {
+      const result = await auditPackage(pkgJson);
+      if (result.onDiskTranslations.length > 0) results.push({ ...result, packageJsonPath: pkgJson });
+    } catch (err) {
+      console.error(`[check:readmes] error auditing ${pkgJson}: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
+
+  if (results.length === 0) {
+    console.log(`[check:readmes] no packages have README translations on disk. Nothing to check.`);
+    return 0;
+  }
+
+  const problems = results.filter((r) => r.missing.length > 0);
+  console.log(`[check:readmes] scanned ${results.length} packages with README translations:`);
+  for (const r of results) {
+    const status = r.skipped ? `skipped (${r.skipped})` : r.missing.length === 0 ? "OK" : `MISSING: ${r.missing.join(", ")}`;
+    console.log(`  ${r.name} — ${r.onDiskTranslations.join(", ")} — ${status}`);
+  }
+
+  if (problems.length > 0) {
+    console.error(`\n[check:readmes] FAIL — ${problems.length} package(s) ship README translations on disk that are excluded from the tarball.`);
+    console.error(`Check .npmignore and the 'files' array in the package.json of each flagged package.`);
+    return 1;
+  }
+
+  return 0;
 }
 
-if (results.length === 0) {
-  console.log(`[check:readmes] no packages have README translations on disk. Nothing to check.`);
-  process.exit(0);
+// Only run the CLI when invoked directly, so tests can import the helpers.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.exitCode = await main();
 }
-
-const problems = results.filter((r) => r.missing.length > 0);
-console.log(`[check:readmes] scanned ${results.length} packages with README translations:`);
-for (const r of results) {
-  const status = r.skipped ? `skipped (${r.skipped})` : r.missing.length === 0 ? "OK" : `MISSING: ${r.missing.join(", ")}`;
-  console.log(`  ${r.name} — ${r.onDiskTranslations.join(", ")} — ${status}`);
-}
-
-if (problems.length > 0) {
-  console.error(`\n[check:readmes] FAIL — ${problems.length} package(s) ship README translations on disk that are excluded from the tarball.`);
-  console.error(`Check .npmignore and the 'files' array in the package.json of each flagged package.`);
-  process.exit(1);
-}
-
-process.exit(0);

--- a/scripts/packages/check-readme-translations.mjs
+++ b/scripts/packages/check-readme-translations.mjs
@@ -63,41 +63,34 @@ function isRecord(value) {
   return typeof value === "object" && value !== null;
 }
 
-async function packedFiles(cwd) {
+/** The file paths inside `stdout`'s pack result. Throws rather than answering
+ *  `[]` when the shape is unreadable — the caller must be able to tell "this
+ *  tarball ships nothing" from "we never managed to read this tarball". */
+function parsePackedPaths(stdout, cwd) {
+  const entry = packEntry(JSON.parse(stdout));
+  if (!entry) throw new Error(`npm pack --json returned an unrecognised shape in ${cwd}; cannot verify the tarball`);
+  return (entry.files ?? []).map((file) => file.path);
+}
+
+/** `npm pack --dry-run --json` in `cwd`, as `{ code, stdout, stderr }`.
+ *  `--ignore-scripts` keeps `prepack` hooks (which often run `yarn build` and
+ *  pollute stdout with yarn's banner) from corrupting the JSON. */
+async function runPack(cwd) {
   return new Promise((resolve, reject) => {
-    // `--ignore-scripts` keeps `prepack` hooks (which often run
-    // `yarn build` and pollute stdout with yarn's banner) from
-    // corrupting the JSON output we're about to parse.
-    const child = spawn("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawn("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], { cwd, stdio: ["ignore", "pipe", "pipe"] });
     const stdout = [];
     const stderr = [];
     child.stdout.on("data", (chunk) => stdout.push(chunk));
     child.stderr.on("data", (chunk) => stderr.push(chunk));
     child.once("error", reject);
-    child.once("close", (code) => {
-      if (code !== 0) {
-        reject(new Error(`npm pack failed in ${cwd} (exit ${code})\n${Buffer.concat(stderr).toString("utf8")}`));
-        return;
-      }
-      try {
-        const parsed = JSON.parse(Buffer.concat(stdout).toString("utf8"));
-        const entry = packEntry(parsed);
-        // Not "no files" — an unrecognised shape. Answering `[]` here would
-        // report every translation as missing, which is exactly what npm 12's
-        // change to this output did to the previous version of this check.
-        if (!entry) {
-          reject(new Error(`npm pack --json returned an unrecognised shape in ${cwd}; cannot verify the tarball`));
-          return;
-        }
-        resolve((entry.files ?? []).map((file) => file.path));
-      } catch (err) {
-        reject(err);
-      }
-    });
+    child.once("close", (code) => resolve({ code, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8") }));
   });
+}
+
+async function packedFiles(cwd) {
+  const { code, stdout, stderr } = await runPack(cwd);
+  if (code !== 0) throw new Error(`npm pack failed in ${cwd} (exit ${code})\n${stderr}`);
+  return parsePackedPaths(stdout, cwd);
 }
 
 async function auditPackage(packageJsonPath) {
@@ -116,37 +109,72 @@ async function auditPackage(packageJsonPath) {
   return { name: pkg.name ?? path.basename(dir), onDiskTranslations, missing };
 }
 
-async function main() {
-  const packageJsons = await findPackageJsons(PACKAGES_ROOT);
+/** Audit every package, keeping only those that have translations on disk.
+ *  A package that could not be VERIFIED is kept too, carrying `error` — the
+ *  gate has to fail on it, not drop it from the roster. */
+async function auditAll(packageJsons) {
   const results = [];
-  for (const pkgJson of packageJsons) {
+  for (const packageJsonPath of packageJsons) {
     try {
-      const result = await auditPackage(pkgJson);
-      if (result.onDiskTranslations.length > 0) results.push({ ...result, packageJsonPath: pkgJson });
+      const result = await auditPackage(packageJsonPath);
+      if (result.onDiskTranslations.length > 0) results.push({ ...result, packageJsonPath });
     } catch (err) {
-      console.error(`[check:readmes] error auditing ${pkgJson}: ${err instanceof Error ? err.message : String(err)}`);
+      const dir = path.dirname(packageJsonPath);
+      const onDisk = (await readdir(dir).catch(() => [])).filter((name) => TRANSLATION_RE.test(name));
+      results.push({
+        name: path.basename(dir),
+        onDiskTranslations: onDisk,
+        missing: [],
+        error: err instanceof Error ? err.message : String(err),
+        packageJsonPath,
+      });
     }
   }
+  return results;
+}
 
+/** One roster line per package: what it has on disk and how it ended up. */
+export function statusLine(result) {
+  if (result.error) return `ERROR: ${result.error}`;
+  if (result.skipped) return `skipped (${result.skipped})`;
+  return result.missing.length === 0 ? "OK" : `MISSING: ${result.missing.join(", ")}`;
+}
+
+/** Split a roster into the two reasons the gate can fail. `unverified` is
+ *  deliberately separate from `missing`: "the tarball does not ship this file"
+ *  and "we could not read the tarball at all" need different fixes, and
+ *  collapsing the second into a pass is how a shape change silences the gate. */
+export function classify(results) {
+  return {
+    missing: results.filter((result) => !result.error && result.missing.length > 0),
+    unverified: results.filter((result) => result.error),
+  };
+}
+
+function report(results) {
+  const { missing, unverified } = classify(results);
+  console.log(`[check:readmes] scanned ${results.length} packages with README translations:`);
+  results.forEach((result) => console.log(`  ${result.name} — ${result.onDiskTranslations.join(", ")} — ${statusLine(result)}`));
+  if (missing.length === 0 && unverified.length === 0) return 0;
+
+  if (missing.length > 0) {
+    console.error(`\n[check:readmes] FAIL — ${missing.length} package(s) ship README translations on disk that are excluded from the tarball.`);
+    console.error(`Check .npmignore and the 'files' array in the package.json of each flagged package.`);
+  }
+  if (unverified.length > 0) {
+    console.error(`\n[check:readmes] FAIL — ${unverified.length} package(s) could not be verified at all.`);
+    console.error(`This is not "the translations are fine" — the tarball was never read. Check the npm pack output above.`);
+  }
+  return 1;
+}
+
+async function main() {
+  const results = await auditAll(await findPackageJsons(PACKAGES_ROOT));
   if (results.length === 0) {
     console.log(`[check:readmes] no packages have README translations on disk. Nothing to check.`);
     return 0;
   }
-
-  const problems = results.filter((r) => r.missing.length > 0);
-  console.log(`[check:readmes] scanned ${results.length} packages with README translations:`);
-  for (const r of results) {
-    const status = r.skipped ? `skipped (${r.skipped})` : r.missing.length === 0 ? "OK" : `MISSING: ${r.missing.join(", ")}`;
-    console.log(`  ${r.name} — ${r.onDiskTranslations.join(", ")} — ${status}`);
-  }
-
-  if (problems.length > 0) {
-    console.error(`\n[check:readmes] FAIL — ${problems.length} package(s) ship README translations on disk that are excluded from the tarball.`);
-    console.error(`Check .npmignore and the 'files' array in the package.json of each flagged package.`);
-    return 1;
-  }
-
-  return 0;
+  return report(results);
 }
 
 // Only run the CLI when invoked directly, so tests can import the helpers.

--- a/scripts/packages/check-readme-translations.mjs
+++ b/scripts/packages/check-readme-translations.mjs
@@ -81,9 +81,14 @@ function parsePackedPaths(stdout, cwd) {
 /** `npm pack --dry-run --json` in `cwd`, as `{ code, stdout, stderr }`.
  *  `--ignore-scripts` keeps `prepack` hooks (which often run `yarn build` and
  *  pollute stdout with yarn's banner) from corrupting the JSON. */
+// Windows ships npm as `npm.cmd`, and `spawn` without a shell does not apply
+// PATHEXT — so a bare "npm" is ENOENT there. Naming the file is precise and
+// keeps the arguments off a command line entirely, unlike `shell: true`.
+const NPM_BIN = process.platform === "win32" ? "npm.cmd" : "npm";
+
 async function runPack(cwd) {
   return new Promise((resolve, reject) => {
-    const child = spawn("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(NPM_BIN, ["pack", "--dry-run", "--json", "--ignore-scripts"], { cwd, stdio: ["ignore", "pipe", "pipe"] });
     const stdout = [];
     const stderr = [];
     child.stdout.on("data", (chunk) => stdout.push(chunk));

--- a/scripts/packages/check-readme-translations.mjs
+++ b/scripts/packages/check-readme-translations.mjs
@@ -81,14 +81,21 @@ function parsePackedPaths(stdout, cwd) {
 /** `npm pack --dry-run --json` in `cwd`, as `{ code, stdout, stderr }`.
  *  `--ignore-scripts` keeps `prepack` hooks (which often run `yarn build` and
  *  pollute stdout with yarn's banner) from corrupting the JSON. */
-// Windows ships npm as `npm.cmd`, and `spawn` without a shell does not apply
-// PATHEXT — so a bare "npm" is ENOENT there. Naming the file is precise and
-// keeps the arguments off a command line entirely, unlike `shell: true`.
-const NPM_BIN = process.platform === "win32" ? "npm.cmd" : "npm";
+// Windows ships npm as `npm.cmd`, and two separate things stop a bare
+// `spawn("npm")` from reaching it: `spawn` without a shell does not apply
+// PATHEXT (ENOENT), and since the CVE-2024-27980 fix Node refuses to execute a
+// `.cmd` at all unless a shell is asked for (EINVAL). So Windows needs both the
+// explicit name and `shell: true`. The usual objection to `shell: true` —
+// interpolating an untrusted value into a command line — does not apply: every
+// argument here is a literal constant, and `cwd` is passed as an option rather
+// than as part of the command. POSIX keeps the shell-free path unchanged.
+const IS_WINDOWS = process.platform === "win32";
+const NPM_BIN = IS_WINDOWS ? "npm.cmd" : "npm";
+const PACK_ARGS = ["pack", "--dry-run", "--json", "--ignore-scripts"];
 
 async function runPack(cwd) {
   return new Promise((resolve, reject) => {
-    const child = spawn(NPM_BIN, ["pack", "--dry-run", "--json", "--ignore-scripts"], { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(NPM_BIN, PACK_ARGS, { cwd, stdio: ["ignore", "pipe", "pipe"], shell: IS_WINDOWS });
     const stdout = [];
     const stderr = [];
     child.stdout.on("data", (chunk) => stdout.push(chunk));

--- a/test/scripts/packages/test_readmeTranslations.ts
+++ b/test/scripts/packages/test_readmeTranslations.ts
@@ -122,18 +122,21 @@ function writeFakeNpm(bin: string, packJson: string): void {
   writeFileSync(path.join(bin, "npm.cmd"), `@echo off\r\necho ${packJson}\r\n`);
 }
 
-/** Run the real checker with that stub on PATH, and return the process exit
- *  code — which is all CI ever looks at. */
-function exitCodeWithFakeNpm(packJson: string): number {
+/** Run the real checker with that stub on PATH. Returns the exit code AND the
+ *  output: the code alone cannot tell "the checker read our fixture and found a
+ *  problem" from "the checker never ran the fixture at all" — both exit 1. That
+ *  is exactly how the Windows fixture looked healthy while `spawn("npm")` was
+ *  failing with ENOENT on every case. */
+function runWithFakeNpm(packJson: string): { code: number; output: string } {
   const bin = mkdtempSync(path.join(tmpdir(), "fake-npm-"));
   try {
     writeFakeNpm(bin, packJson);
     const env = { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}` };
-    execFileSync(process.execPath, [SCRIPT], { env, stdio: "pipe" });
-    return 0;
+    const output = execFileSync(process.execPath, [SCRIPT], { env, encoding: "utf8", stdio: "pipe" });
+    return { code: 0, output };
   } catch (err) {
-    const { status } = err as { status?: number };
-    return typeof status === "number" ? status : -1;
+    const { status, stdout, stderr } = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: typeof status === "number" ? status : -1, output: `${stdout ?? ""}${stderr ?? ""}` };
   } finally {
     rmSync(bin, { recursive: true, force: true });
   }
@@ -141,18 +144,23 @@ function exitCodeWithFakeNpm(packJson: string): number {
 
 const shipped = (...paths: string[]) => JSON.stringify({ "@mulmobridge/slack": { files: paths.map((filePath) => ({ path: filePath })) } });
 
-const CLI_CASES: { label: string; packJson: string; exitCode: number }[] = [
-  { label: "npm's output cannot be read", packJson: "{}", exitCode: 1 },
-  { label: "the tarball genuinely omits a translation", packJson: shipped("README.md"), exitCode: 1 },
-  { label: "the tarball ships the translation", packJson: shipped("README.md", "README.ja.md"), exitCode: 0 },
+const CLI_CASES: { label: string; packJson: string; exitCode: number; says: RegExp }[] = [
+  { label: "npm's output cannot be read", packJson: "{}", exitCode: 1, says: /unrecognised shape/ },
+  { label: "the tarball genuinely omits a translation", packJson: shipped("README.md"), exitCode: 1, says: /MISSING: README\.ja\.md/ },
+  { label: "the tarball ships the translation", packJson: shipped("README.md", "README.ja.md"), exitCode: 0, says: /README\.ja\.md — OK/ },
   // Distinct from the first row: npm answered a shape, but its file entries are
   // unreadable. It must still fail — as unverified, not as a missing file.
-  { label: "the file entries cannot be read", packJson: '{"@mulmobridge/slack":{"files":[{},{}]}}', exitCode: 1 },
+  { label: "the file entries cannot be read", packJson: '{"@mulmobridge/slack":{"files":[{},{}]}}', exitCode: 1, says: /unrecognised shape/ },
 ];
 
 describe("the CLI itself (end to end)", () => {
-  CLI_CASES.forEach(({ label, packJson, exitCode }) => {
-    it(`exits ${exitCode} when ${label}`, () => assert.equal(exitCodeWithFakeNpm(packJson), exitCode));
+  CLI_CASES.forEach(({ label, packJson, exitCode, says }) => {
+    it(`exits ${exitCode} when ${label}`, () => {
+      const { code, output } = runWithFakeNpm(packJson);
+      // The message first: it is what proves the fixture was actually read.
+      assert.match(output, says, `the checker did not report ${label}`);
+      assert.equal(code, exitCode);
+    });
   });
 });
 

--- a/test/scripts/packages/test_readmeTranslations.ts
+++ b/test/scripts/packages/test_readmeTranslations.ts
@@ -30,20 +30,16 @@ const UNREADABLE_SHAPES: [string, unknown][] = [
 
 const result = (over: Partial<AuditResult>): AuditResult => ({ name: "@scope/pkg", onDiskTranslations: ["README.ja.md"], missing: [], ...over });
 
+const READABLE_SHAPES: [string, unknown][] = [
+  ["the array shape (npm <= 11)", [{ name: "@scope/pkg", files }]],
+  ["the object-keyed-by-name shape (npm 12)", { "@scope/pkg": { name: "@scope/pkg", files } }],
+];
+
 describe("packEntry — whichever shape npm used", () => {
-  it("reads the array shape (npm <= 11)", () => {
-    assert.deepEqual(packEntry([{ name: "@scope/pkg", files }])?.files, files);
-  });
-
-  it("reads the object-keyed-by-name shape (npm 12)", () => {
-    assert.deepEqual(packEntry({ "@scope/pkg": { name: "@scope/pkg", files } })?.files, files);
-  });
-
-  // The bug, stated as a test: the object shape used to yield no files at all.
-  it("does not lose the file list on the object shape", () => {
-    const entry = packEntry({ "@mulmobridge/slack": { files } });
-    assert.ok(entry, "an object-shaped result must still resolve to an entry");
-    assert.ok(entry.files.map((file) => file.path).includes("README.ja.md"), "a translation present in the tarball must not read as missing");
+  READABLE_SHAPES.forEach(([label, input]) => {
+    // The bug, stated as a test: the object shape used to yield no files at all,
+    // so a translation the tarball ships read as missing.
+    it(`keeps the file list on ${label}`, () => assert.deepEqual(packEntry(input)?.files, files));
   });
 
   // An unrecognised shape must be distinguishable from "packed nothing" — the
@@ -105,35 +101,36 @@ describe("statusLine", () => {
 // unit tests above pin `classify`, but the defect was that nothing CALLED it on
 // the error path. This runs the real CLI with a fake `npm` on PATH and asserts
 // the process exit code, which is all CI ever looks at.
-describe("the CLI itself (end to end)", () => {
-  const SCRIPT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "../../../scripts/packages/check-readme-translations.mjs");
+const SCRIPT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "../../../scripts/packages/check-readme-translations.mjs");
 
-  /** Run the checker with a stub `npm` that prints `stdout`, and return its exit code. */
-  function runWithFakeNpm(stdout: string): number {
-    const bin = mkdtempSync(path.join(tmpdir(), "fake-npm-"));
-    try {
-      const fake = path.join(bin, "npm");
-      writeFileSync(fake, `#!/bin/bash\ncat <<'JSON'\n${stdout}\nJSON\n`);
-      chmodSync(fake, 0o755);
-      execFileSync(process.execPath, [SCRIPT], { env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` }, stdio: "pipe" });
-      return 0;
-    } catch (err) {
-      const { status } = err as { status?: number };
-      return typeof status === "number" ? status : -1;
-    } finally {
-      rmSync(bin, { recursive: true, force: true });
-    }
+/** Run the real checker with a stub `npm` that prints `packJson`, and return the
+ *  process exit code — which is all CI ever looks at. */
+function exitCodeWithFakeNpm(packJson: string): number {
+  const bin = mkdtempSync(path.join(tmpdir(), "fake-npm-"));
+  try {
+    const fake = path.join(bin, "npm");
+    writeFileSync(fake, `#!/bin/bash\ncat <<'JSON'\n${packJson}\nJSON\n`);
+    chmodSync(fake, 0o755);
+    execFileSync(process.execPath, [SCRIPT], { env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` }, stdio: "pipe" });
+    return 0;
+  } catch (err) {
+    const { status } = err as { status?: number };
+    return typeof status === "number" ? status : -1;
+  } finally {
+    rmSync(bin, { recursive: true, force: true });
   }
+}
 
-  it("exits non-zero when npm's output cannot be read", () => {
-    assert.equal(runWithFakeNpm("{}"), 1, "an unreadable pack output must fail the gate, not pass it");
-  });
+const shipped = (...paths: string[]) => JSON.stringify({ "@mulmobridge/slack": { files: paths.map((filePath) => ({ path: filePath })) } });
 
-  it("exits non-zero when the tarball genuinely omits a translation", () => {
-    assert.equal(runWithFakeNpm('{"@mulmobridge/slack":{"files":[{"path":"README.md"}]}}'), 1);
-  });
+const CLI_CASES: { label: string; packJson: string; exitCode: number }[] = [
+  { label: "npm's output cannot be read", packJson: "{}", exitCode: 1 },
+  { label: "the tarball genuinely omits a translation", packJson: shipped("README.md"), exitCode: 1 },
+  { label: "the tarball ships the translation", packJson: shipped("README.md", "README.ja.md"), exitCode: 0 },
+];
 
-  it("exits zero when the tarball ships the translation", () => {
-    assert.equal(runWithFakeNpm('{"@mulmobridge/slack":{"files":[{"path":"README.md"},{"path":"README.ja.md"}]}}'), 0);
+describe("the CLI itself (end to end)", () => {
+  CLI_CASES.forEach(({ label, packJson, exitCode }) => {
+    it(`exits ${exitCode} when ${label}`, () => assert.equal(exitCodeWithFakeNpm(packJson), exitCode));
   });
 });

--- a/test/scripts/packages/test_readmeTranslations.ts
+++ b/test/scripts/packages/test_readmeTranslations.ts
@@ -8,9 +8,27 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { packEntry, TRANSLATION_RE, type PackedFile } from "../../../scripts/packages/check-readme-translations.mjs";
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classify, packEntry, statusLine, TRANSLATION_RE, type AuditResult, type PackedFile } from "../../../scripts/packages/check-readme-translations.mjs";
 
 const files: PackedFile[] = [{ path: "README.md" }, { path: "README.ja.md" }, { path: "dist/index.js" }];
+
+const UNREADABLE_SHAPES: [string, unknown][] = [
+  ["null", null],
+  ["undefined", undefined],
+  ["a number", 42],
+  ["a string", "text"],
+  ["an empty array", []],
+  ["an empty object", {}],
+  ["an array entry with no files", [{ name: "no-files" }]],
+  ["an object entry with no files", { pkg: { name: "no-files" } }],
+];
+
+const result = (over: Partial<AuditResult>): AuditResult => ({ name: "@scope/pkg", onDiskTranslations: ["README.ja.md"], missing: [], ...over });
 
 describe("packEntry — whichever shape npm used", () => {
   it("reads the array shape (npm <= 11)", () => {
@@ -30,10 +48,8 @@ describe("packEntry — whichever shape npm used", () => {
 
   // An unrecognised shape must be distinguishable from "packed nothing" — the
   // caller rejects on null rather than reporting every translation missing.
-  it("answers null for a shape it cannot read", () => {
-    [null, undefined, 42, "text", [], {}, [{ name: "no-files" }], { pkg: { name: "no-files" } }].forEach((input) => {
-      assert.equal(packEntry(input), null, `${JSON.stringify(input)} must not be read as a pack entry`);
-    });
+  UNREADABLE_SHAPES.forEach(([label, input]) => {
+    it(`answers null for ${label}`, () => assert.equal(packEntry(input), null));
   });
 });
 
@@ -46,5 +62,78 @@ describe("TRANSLATION_RE", () => {
     ["README.md", "README.txt", "READMEja.md", "README..md", "CHANGELOG.ja.md", "README.JA.md", "README.pt-br.md"].forEach((name) =>
       assert.ok(!TRANSLATION_RE.test(name), name),
     );
+  });
+});
+
+// Codex on #2971: the "unrecognised shape" rejection was caught per package and
+// only logged, so the gate still exited 0 — and with the sole translated
+// package dropped from the roster it even printed "no packages … Nothing to
+// check". Reproduced with a fake `npm` emitting `{}`. "Could not read the
+// tarball" is a failure of its own, never a pass.
+describe("classify — the two ways the gate fails", () => {
+  it("separates a missing translation from an unreadable tarball", () => {
+    const missing = result({ missing: ["README.ja.md"] });
+    const unverified = result({ error: "npm pack --json returned an unrecognised shape" });
+    const { missing: gotMissing, unverified: gotUnverified } = classify([result({}), missing, unverified]);
+    assert.deepEqual(gotMissing, [missing]);
+    assert.deepEqual(gotUnverified, [unverified]);
+  });
+
+  it("never counts an unverified package as clean", () => {
+    const { missing, unverified } = classify([result({ error: "boom" })]);
+    assert.equal(missing.length, 0, "an unread tarball is not a missing-file finding");
+    assert.equal(unverified.length, 1, "…but it must still fail the gate");
+  });
+
+  it("passes only when every package was read and shipped its translations", () => {
+    const { missing, unverified } = classify([result({}), result({ skipped: "private" })]);
+    assert.deepEqual([missing.length, unverified.length], [0, 0]);
+  });
+});
+
+describe("statusLine", () => {
+  it("names the outcome, with the error winning over a silent OK", () => {
+    assert.equal(statusLine(result({})), "OK");
+    assert.equal(statusLine(result({ skipped: "private" })), "skipped (private)");
+    assert.equal(statusLine(result({ missing: ["README.ja.md"] })), "MISSING: README.ja.md");
+    assert.equal(statusLine(result({ error: "boom" })), "ERROR: boom");
+    assert.equal(statusLine(result({ error: "boom", missing: [] })), "ERROR: boom", "an unread tarball must not read as OK");
+  });
+});
+
+// Codex asked for the end-to-end assertion, and it is the one that matters: the
+// unit tests above pin `classify`, but the defect was that nothing CALLED it on
+// the error path. This runs the real CLI with a fake `npm` on PATH and asserts
+// the process exit code, which is all CI ever looks at.
+describe("the CLI itself (end to end)", () => {
+  const SCRIPT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "../../../scripts/packages/check-readme-translations.mjs");
+
+  /** Run the checker with a stub `npm` that prints `stdout`, and return its exit code. */
+  function runWithFakeNpm(stdout: string): number {
+    const bin = mkdtempSync(path.join(tmpdir(), "fake-npm-"));
+    try {
+      const fake = path.join(bin, "npm");
+      writeFileSync(fake, `#!/bin/bash\ncat <<'JSON'\n${stdout}\nJSON\n`);
+      chmodSync(fake, 0o755);
+      execFileSync(process.execPath, [SCRIPT], { env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` }, stdio: "pipe" });
+      return 0;
+    } catch (err) {
+      const { status } = err as { status?: number };
+      return typeof status === "number" ? status : -1;
+    } finally {
+      rmSync(bin, { recursive: true, force: true });
+    }
+  }
+
+  it("exits non-zero when npm's output cannot be read", () => {
+    assert.equal(runWithFakeNpm("{}"), 1, "an unreadable pack output must fail the gate, not pass it");
+  });
+
+  it("exits non-zero when the tarball genuinely omits a translation", () => {
+    assert.equal(runWithFakeNpm('{"@mulmobridge/slack":{"files":[{"path":"README.md"}]}}'), 1);
+  });
+
+  it("exits zero when the tarball ships the translation", () => {
+    assert.equal(runWithFakeNpm('{"@mulmobridge/slack":{"files":[{"path":"README.md"},{"path":"README.ja.md"}]}}'), 0);
   });
 });

--- a/test/scripts/packages/test_readmeTranslations.ts
+++ b/test/scripts/packages/test_readmeTranslations.ts
@@ -1,0 +1,50 @@
+// `npm pack --json` changed shape between npm 11 and npm 12: an ARRAY of packed
+// packages became an OBJECT keyed by package name. The check read `parsed[0]`,
+// which is `undefined` on the object — so it saw an empty file list for every
+// package and reported each translation as missing. `@mulmobridge/slack` had
+// been failing this gate on a tarball that shipped `README.ja.md` all along
+// (verified against `npm pack --dry-run`, which listed the file). A gate that is
+// permanently red is a gate everyone learns to ignore, so the shapes are pinned.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { packEntry, TRANSLATION_RE, type PackedFile } from "../../../scripts/packages/check-readme-translations.mjs";
+
+const files: PackedFile[] = [{ path: "README.md" }, { path: "README.ja.md" }, { path: "dist/index.js" }];
+
+describe("packEntry — whichever shape npm used", () => {
+  it("reads the array shape (npm <= 11)", () => {
+    assert.deepEqual(packEntry([{ name: "@scope/pkg", files }])?.files, files);
+  });
+
+  it("reads the object-keyed-by-name shape (npm 12)", () => {
+    assert.deepEqual(packEntry({ "@scope/pkg": { name: "@scope/pkg", files } })?.files, files);
+  });
+
+  // The bug, stated as a test: the object shape used to yield no files at all.
+  it("does not lose the file list on the object shape", () => {
+    const entry = packEntry({ "@mulmobridge/slack": { files } });
+    assert.ok(entry, "an object-shaped result must still resolve to an entry");
+    assert.ok(entry.files.map((file) => file.path).includes("README.ja.md"), "a translation present in the tarball must not read as missing");
+  });
+
+  // An unrecognised shape must be distinguishable from "packed nothing" — the
+  // caller rejects on null rather than reporting every translation missing.
+  it("answers null for a shape it cannot read", () => {
+    [null, undefined, 42, "text", [], {}, [{ name: "no-files" }], { pkg: { name: "no-files" } }].forEach((input) => {
+      assert.equal(packEntry(input), null, `${JSON.stringify(input)} must not be read as a pack entry`);
+    });
+  });
+});
+
+describe("TRANSLATION_RE", () => {
+  it("matches a language suffix, with or without a region", () => {
+    ["README.ja.md", "README.fr.md", "README.pt-BR.md", "README.zh-CN.md"].forEach((name) => assert.ok(TRANSLATION_RE.test(name), name));
+  });
+
+  it("does not match the canonical README or unrelated files", () => {
+    ["README.md", "README.txt", "READMEja.md", "README..md", "CHANGELOG.ja.md", "README.JA.md", "README.pt-br.md"].forEach((name) =>
+      assert.ok(!TRANSLATION_RE.test(name), name),
+    );
+  });
+});

--- a/test/scripts/packages/test_readmeTranslations.ts
+++ b/test/scripts/packages/test_readmeTranslations.ts
@@ -26,6 +26,12 @@ const UNREADABLE_SHAPES: [string, unknown][] = [
   ["an empty object", {}],
   ["an array entry with no files", [{ name: "no-files" }]],
   ["an object entry with no files", { pkg: { name: "no-files" } }],
+  // CodeRabbit on #2971: a `files` array whose entries have no string `path`
+  // mapped to `[undefined, …]`, which matches no translation name — so the gate
+  // failed the package for "the tarball omits this file" when the truth was
+  // "npm's output was unreadable", pointing the maintainer at the wrong fix.
+  ["a files array of unreadable entries", { pkg: { files: [{}, {}] } }],
+  ["a files entry whose path is not a string", { pkg: { files: [{ path: 42 }] } }],
 ];
 
 const result = (over: Partial<AuditResult>): AuditResult => ({ name: "@scope/pkg", onDiskTranslations: ["README.ja.md"], missing: [], ...over });
@@ -103,15 +109,27 @@ describe("statusLine", () => {
 // the process exit code, which is all CI ever looks at.
 const SCRIPT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "../../../scripts/packages/check-readme-translations.mjs");
 
-/** Run the real checker with a stub `npm` that prints `packJson`, and return the
- *  process exit code — which is all CI ever looks at. */
+/** Write a stub `npm` into `bin` that prints `packJson` and exits 0. Both forms
+ *  are written unconditionally: a shell script for POSIX, and a `.cmd` because
+ *  Windows resolves `spawn("npm")` through PATHEXT and cannot execute the
+ *  former. The Windows CI job runs this file — `test:coverage` globs two levels
+ *  under `test/` — so a POSIX-only fixture is a red job there. */
+function writeFakeNpm(bin: string, packJson: string): void {
+  writeFileSync(path.join(bin, "npm"), `#!/bin/sh\ncat <<'JSON'\n${packJson}\nJSON\n`);
+  chmodSync(path.join(bin, "npm"), 0o755);
+  // No batch metacharacters in these fixtures (`{`, `"`, `[`, `:` are literal),
+  // so a bare `echo` reproduces the JSON exactly.
+  writeFileSync(path.join(bin, "npm.cmd"), `@echo off\r\necho ${packJson}\r\n`);
+}
+
+/** Run the real checker with that stub on PATH, and return the process exit
+ *  code — which is all CI ever looks at. */
 function exitCodeWithFakeNpm(packJson: string): number {
   const bin = mkdtempSync(path.join(tmpdir(), "fake-npm-"));
   try {
-    const fake = path.join(bin, "npm");
-    writeFileSync(fake, `#!/bin/bash\ncat <<'JSON'\n${packJson}\nJSON\n`);
-    chmodSync(fake, 0o755);
-    execFileSync(process.execPath, [SCRIPT], { env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ""}` }, stdio: "pipe" });
+    writeFakeNpm(bin, packJson);
+    const env = { ...process.env, PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}` };
+    execFileSync(process.execPath, [SCRIPT], { env, stdio: "pipe" });
     return 0;
   } catch (err) {
     const { status } = err as { status?: number };
@@ -127,10 +145,27 @@ const CLI_CASES: { label: string; packJson: string; exitCode: number }[] = [
   { label: "npm's output cannot be read", packJson: "{}", exitCode: 1 },
   { label: "the tarball genuinely omits a translation", packJson: shipped("README.md"), exitCode: 1 },
   { label: "the tarball ships the translation", packJson: shipped("README.md", "README.ja.md"), exitCode: 0 },
+  // Distinct from the first row: npm answered a shape, but its file entries are
+  // unreadable. It must still fail — as unverified, not as a missing file.
+  { label: "the file entries cannot be read", packJson: '{"@mulmobridge/slack":{"files":[{},{}]}}', exitCode: 1 },
 ];
 
 describe("the CLI itself (end to end)", () => {
   CLI_CASES.forEach(({ label, packJson, exitCode }) => {
     it(`exits ${exitCode} when ${label}`, () => assert.equal(exitCodeWithFakeNpm(packJson), exitCode));
+  });
+});
+
+// The `.cmd` fixture reproduces its JSON with a bare `echo`, which is only exact
+// while the payload has no batch metacharacter. This cannot be observed from a
+// POSIX machine — a payload containing one would produce a Windows-only failure
+// with no local signal — so the constraint is asserted instead of trusted.
+describe("the Windows fixture's payloads stay echo-safe", () => {
+  const BATCH_METACHARACTERS = /[%^&|<>()]/;
+
+  CLI_CASES.forEach(({ label, packJson }) => {
+    it(`"${label}" survives a batch echo verbatim`, () => {
+      assert.ok(!BATCH_METACHARACTERS.test(packJson), `${packJson} needs escaping before a .cmd echo can reproduce it`);
+    });
   });
 });


### PR DESCRIPTION
## Summary

リリース作業のたびに邪魔になっていた 2 つの雑務を片付けます。**独立した 2 コミット**なので、片方だけ revert できます。

### 1. `yarn format` を mulmoscript-plugin にかける（`a80769f2e`）

3 ファイルが prettier 未整形のまま main に入っており、`yarn build` / `yarn lint` を回すたびに作業ツリーが汚れていました。直近 3 回のリリース作業で、毎回「無関係な変更」として `git checkout --` する必要がありました。

- `src/core/definition.ts` — 折り返された文字列を 1 行に
- `src/vue/View.vue` — 属性の折り返し 2 箇所と、引数オブジェクトの展開
- `test/test_helpers.ts` — 配列リテラル内の余分な空白

整形のみで意味的変更はありません。混入元は #2949 / #2962 と `23adc1ee9` です。

### 2. `check-readme-translations` の 3 つの実バグ（`b4371f2f8` 以降）

**`@mulmobridge/slack` がこのゲートで FAIL していましたが、tarball には `README.ja.md` が入っていました。** バグはパッケージ側ではなくチェッカー側です。

`npm pack --json` の出力形が変わっていました:

```jsonc
// npm <= 11
[ { "name": "@mulmobridge/slack", "files": [ … ] } ]

// npm 12（このリポジトリの現行）
{ "@mulmobridge/slack": { "name": "…", "files": [ … ] } }
```

チェッカーは `parsed[0]?.files ?? []` と配列前提で読んでいたため、オブジェクトでは `undefined` になり、**ファイル一覧が空 → 全ての翻訳が「tarball に無い」**と判定されていました。

- 両方の形を読む `packEntry()` を追加
- **読めない形は `[]` ではなく reject** します。空を返すと「pack できなかった」と「形が違う」が区別できず、まさに今回の誤検出が起きるためです
- 純粋関数を export し、CLI 部は直接実行時のみ走るようガード（兄弟の `check-changelog-ships.mjs` と同じ形）
- 型は `.d.mts` サイドカーで提供（`audit-releases.d.mts` / `check-changelog-ships.d.mts` と同じ house style）

**レビュー中に、当初想定していなかった 2 つの実バグが追加で見つかりました。** どちらも main に既存で、この PR が持ち込んだものではありません。

| バグ | 発見経路 | 影響 |
|---|---|---|
| 検証不能を `catch` が握りつぶし、ゲートが exit 0 で通る | Codex P1 | **ゲートが黙って通る**。fake `npm` で再現し、翻訳を持つ唯一のパッケージが roster から落ちて「翻訳を持つパッケージは無い」とまで表示されることを確認 |
| `spawn("npm")` が Windows で npm を起動できない | Windows 手動実行 | **チェッカーが Windows で一度も動いていなかった**。原因は 2 つ重なっており、PATHEXT が適用されず `npm.cmd` が ENOENT になる件と、CVE-2024-27980 の修正以降 Node が `shell` 無しに `.cmd` を実行しない（EINVAL）件 |

このため PR のタイトルも「Windows 実行不能の修正」を含む形に更新しています。

## Items to Confirm / Review

1. **`@mulmobridge/slack` の packaging 自体は変更していません。** 元から正しく、`files: ["dist", "README.md", "README.ja.md"]` で `.npmignore` もありません。直すべきはチェッカーだけでした。
2. **整形コミットを別 PR に分けるべきかどうか。** 「1 feature 1 PR」の観点では 2 つは無関係ですが、どちらも「リリース作業を邪魔していた雑務」という括りで、コミットは分けてあるので revert 単位は保たれています。分けたほうがよければ言ってください。
3. **`security/detect-unsafe-regex` の warning が `TRANSLATION_RE` に付いています。** 既存の warning で、正規表現自体は変更していません（`export` を付けただけ）。

## 検証

- **ゲートが赤かったのは誤検出だと、外部の ground truth で確認しました。** `npm pack --dry-run` の実出力に `12.5kB README.ja.md` が含まれています。チェッカーの主張ではなく tarball の中身を見ています。
- **回帰テストを追加し、旧実装で落ちることを確認済み**（`packEntry` を配列専用に戻すと 3 ケースが fail）。オブジェクト形・配列形・読めない形（`null` / `42` / `[]` / `{}` / `files` 欠落）を網羅しています。
- 整形が意味的変更を含まないことは、差分を目視で確認（属性の折り返しと引数展開のみ）。
- `mulmoscript-plugin` 単体テスト: **147 pass / 0 fail**
- pre-commit フックが `build:packages → format --check → lint → typecheck → build → test` を全て実行して通過しています。**この過程で、私が最初に書いたテストの型エラー 2 件をこのフックが検出しました**（`.d.mts` が無く暗黙の `any`）。ゲートが機能した形です。

## User Prompt

- mulmoscript-plugin の prettier 再整形のコミット、git stash@{0} の破棄、@mulmobridge/slack の README 同梱漏れ修正 やって

3 件目の「README 同梱漏れ」は、調べたところ同梱漏れではなくチェッカーの誤検出だったため、チェッカー側を修正しています。`git stash@{0}` の破棄は本 PR とは別に実施します。

work in mulmoclaude3

## Summary by Sourcery

Keep release workflows clean by formatting mulmoscript-plugin and making README translation verification reliable across npm versions.

Bug Fixes:
- Fix the README translation gate to support both npm pack output formats and fail explicitly when tarball contents cannot be verified.
- Add regression coverage for npm output parsing, audit classification, CLI exit behavior, and platform-specific execution.

Enhancements:
- Reformat the mulmoscript-plugin sources with Prettier without changing behavior.
- Expose reusable README translation checker helpers while keeping CLI execution restricted to direct invocation.
- Add type declarations for the README translation checker scripts.

Tests:
- Add comprehensive tests covering readable and unreadable npm pack shapes, translation detection, failure classification, and end-to-end gate results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved README translation checks to support multiple npm package metadata formats.
  - Added clearer reporting for missing translations and unreadable or unsupported package metadata.
  - Improved handling of package verification failures and command-line results across platforms.

- **Tests**
  - Added coverage for invalid package output, translation classification, status reporting, cross-platform execution, and command-line success or failure results.

- **Style**
  - Reformatted editor controls, descriptions, and test assertions without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
