### PR TITLE
fix: Windows で itemsFile が常に拒否される問題と、atomic rename の EPERM 諦め (#2972)

### DIFF
--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -62,7 +62,7 @@ import { runCollectionQuery } from "./queryRunner";
 import { enrichItems } from "./derive";
 import { validateCollectionRecords, validateRecordObject } from "./validate";
 import { buildWorkspaceOntology } from "./ontology";
-import { isContainedInRoot, resolveDataDir } from "./paths";
+import { isContainedInRoot, isUnderRealRoot, resolveDataDir } from "./paths";
 import { getWorkspaceRoot, stagingSkillDir } from "./host";
 import { writeFileAtomic } from "../../files/atomic.js";
 import { mirrorSkillWrite } from "../../skill-bridge/index.js";
@@ -536,11 +536,18 @@ async function verifyOpenedItemsFile(handle: FileHandle, hostPath: string, root:
     return `manageCollection: \`itemsFile\` '${shown}' is ${opened.size} bytes, over the limit of ${MAX_ITEMS_FILE_BYTES}. Nothing was read; split the rows across several files and call once per file.`;
   }
   let real: string;
+  let rootReal: string;
   let atPath: Stats;
   let link: Stats;
   try {
     link = await lstat(hostPath);
     real = await realpath(hostPath);
+    // The ROOT resolved by the same api as the file. Canonicalising the two
+    // sides differently is not a style question: on Windows `realpath` expands
+    // an 8.3 short name and `realpathSync` does not, so a root from
+    // `os.tmpdir()` compared against an async-resolved file inside it read as
+    // "outside the workspace" and refused every itemsFile (#2972).
+    rootReal = await realpath(root);
     atPath = await stat(real);
   } catch (err) {
     return openItemsFileRefusal(err, shown);
@@ -550,7 +557,7 @@ async function verifyOpenedItemsFile(handle: FileHandle, hostPath: string, root:
   // and a link resolving back INSIDE the workspace passes both the containment
   // and the inode check, so nothing else here would catch it.
   if (link.isSymbolicLink()) return symlinkRefusal(shown);
-  if (!isContainedInRoot(real, root)) return outsideWorkspaceRefusal(shown);
+  if (!isUnderRealRoot(real, rootReal)) return outsideWorkspaceRefusal(shown);
   if (atPath.ino !== opened.ino || atPath.dev !== opened.dev) {
     return `manageCollection: \`itemsFile\` '${shown}' changed while it was being opened. Nothing was read; write the file, then call putItems.`;
   }

--- a/packages/core/src/collection/server/manageTool.ts
+++ b/packages/core/src/collection/server/manageTool.ts
@@ -529,39 +529,61 @@ function openItemsFileRefusal(err: unknown, shown: string): string {
  *  descriptor's inode is the one reachable at a contained path. A hardlink
  *  would satisfy it, but the agent cannot create one across the mount boundary
  *  — only the workspace is mounted, and a hardlink cannot cross filesystems. */
-async function verifyOpenedItemsFile(handle: FileHandle, hostPath: string, root: string, shown: string): Promise<{ size: number } | string> {
-  const opened = await handle.stat();
-  if (!opened.isFile()) return `manageCollection: \`itemsFile\` '${shown}' is not a regular file. It must be a JSON file holding an array of record objects.`;
-  if (opened.size > MAX_ITEMS_FILE_BYTES) {
-    return `manageCollection: \`itemsFile\` '${shown}' is ${opened.size} bytes, over the limit of ${MAX_ITEMS_FILE_BYTES}. Nothing was read; split the rows across several files and call once per file.`;
-  }
-  let real: string;
-  let rootReal: string;
-  let atPath: Stats;
-  let link: Stats;
-  try {
-    link = await lstat(hostPath);
-    real = await realpath(hostPath);
-    // The ROOT resolved by the same api as the file. Canonicalising the two
-    // sides differently is not a style question: on Windows `realpath` expands
-    // an 8.3 short name and `realpathSync` does not, so a root from
-    // `os.tmpdir()` compared against an async-resolved file inside it read as
-    // "outside the workspace" and refused every itemsFile (#2972).
-    rootReal = await realpath(root);
-    atPath = await stat(real);
-  } catch (err) {
-    return openItemsFileRefusal(err, shown);
-  }
+/** What the filesystem says about the path the descriptor was opened from:
+ *  the link itself (is it a symlink?), the resolved target, the root resolved
+ *  BY THE SAME API, and the target's stat.
+ *
+ *  Resolving the two sides with different apis is not a style question: on
+ *  Windows `realpath` expands an 8.3 short name and `realpathSync` does not, so
+ *  a root from `os.tmpdir()` compared against an async-resolved file inside it
+ *  read as "outside the workspace" and refused every itemsFile (#2972). */
+async function resolveOpenedPaths(hostPath: string, root: string): Promise<{ link: Stats; real: string; rootReal: string; atPath: Stats }> {
+  const link = await lstat(hostPath);
+  const real = await realpath(hostPath);
+  const rootReal = await realpath(root);
+  return { link, real, rootReal, atPath: await stat(real) };
+}
+
+/** Judge the opened descriptor against the paths it claims to be. Returns the
+ *  refusal text, or null when the descriptor is the contained file it should
+ *  be. `opened` is the descriptor's own stat, so the identity check compares
+ *  what was OPENED with what is reachable at the path. */
+function openedFileProblem(paths: Awaited<ReturnType<typeof resolveOpenedPaths>>, opened: Stats, shown: string): string | null {
   // The platform-independent half of the symlink refusal: `O_NOFOLLOW` above
   // does not exist on Windows, where the open would follow the link instead —
   // and a link resolving back INSIDE the workspace passes both the containment
   // and the inode check, so nothing else here would catch it.
-  if (link.isSymbolicLink()) return symlinkRefusal(shown);
-  if (!isUnderRealRoot(real, rootReal)) return outsideWorkspaceRefusal(shown);
-  if (atPath.ino !== opened.ino || atPath.dev !== opened.dev) {
+  if (paths.link.isSymbolicLink()) return symlinkRefusal(shown);
+  if (!isUnderRealRoot(paths.real, paths.rootReal)) return outsideWorkspaceRefusal(shown);
+  if (paths.atPath.ino !== opened.ino || paths.atPath.dev !== opened.dev) {
     return `manageCollection: \`itemsFile\` '${shown}' changed while it was being opened. Nothing was read; write the file, then call putItems.`;
   }
-  return { size: opened.size };
+  return null;
+}
+
+/** The descriptor's own shape: a regular file, within the byte cap. Returns the
+ *  refusal text, or null. Checked before any path work — a fifo or an 8 MiB
+ *  blob is refused without paying for a realpath. */
+function openedShapeProblem(opened: Stats, shown: string): string | null {
+  if (!opened.isFile()) return `manageCollection: \`itemsFile\` '${shown}' is not a regular file. It must be a JSON file holding an array of record objects.`;
+  if (opened.size > MAX_ITEMS_FILE_BYTES) {
+    return `manageCollection: \`itemsFile\` '${shown}' is ${opened.size} bytes, over the limit of ${MAX_ITEMS_FILE_BYTES}. Nothing was read; split the rows across several files and call once per file.`;
+  }
+  return null;
+}
+
+async function verifyOpenedItemsFile(handle: FileHandle, hostPath: string, root: string, shown: string): Promise<{ size: number } | string> {
+  const opened = await handle.stat();
+  const shapeProblem = openedShapeProblem(opened, shown);
+  if (shapeProblem !== null) return shapeProblem;
+
+  let paths: Awaited<ReturnType<typeof resolveOpenedPaths>>;
+  try {
+    paths = await resolveOpenedPaths(hostPath, root);
+  } catch (err) {
+    return openItemsFileRefusal(err, shown);
+  }
+  return openedFileProblem(paths, opened, shown) ?? { size: opened.size };
 }
 
 /** Open the file ONCE, then prove that descriptor is the contained file.

--- a/packages/core/src/collection/server/paths.ts
+++ b/packages/core/src/collection/server/paths.ts
@@ -78,8 +78,21 @@ export function isContainedInRoot(absPath: string, rootPath: string): boolean {
   }
   const ancestorReal = realpathClosestAncestor(absPath);
   if (ancestorReal === null) return false;
-  if (ancestorReal === rootReal) return true;
-  return ancestorReal.startsWith(rootReal + path.sep);
+  return isUnderRealRoot(ancestorReal, rootReal);
+}
+
+/** The containment comparison itself, on two paths a caller has ALREADY
+ *  canonicalised. Exported because a caller holding a resolved path must not
+ *  re-derive it: `isContainedInRoot` canonicalises with `realpathSync`, and a
+ *  path resolved by a DIFFERENT api can be a different string for the same
+ *  file — on Windows `fs/promises.realpath` expands an 8.3 short name that
+ *  `realpathSync` leaves alone, so `C:\Users\runneradmin\…` was compared
+ *  against `C:\Users\RUNNER~1\…` and every file under the workspace looked
+ *  like it was outside it (#2972). Canonicalise both sides the same way, then
+ *  come here. */
+export function isUnderRealRoot(realPath: string, realRoot: string): boolean {
+  if (realPath === realRoot) return true;
+  return realPath.startsWith(realRoot + path.sep);
 }
 
 // NOTE: there is deliberately no `isContainedInWorkspace(absPath)` helper here.

--- a/packages/core/src/files/atomic.ts
+++ b/packages/core/src/files/atomic.ts
@@ -41,13 +41,29 @@ function tmpPathFor(filePath: string, uniqueTmp: boolean | undefined): string {
 // gated to Windows because POSIX EPERM means a real perm problem (read-only fs, sticky, cross-device) — retrying
 // just adds latency before the inevitable throw.
 const IS_WINDOWS = process.platform === "win32";
-const RENAME_RETRY_DELAYS_MS = [30, 100, 300] as const;
+// The ASYNC ladder is generous because waiting is nearly free there — the call
+// yields, and a write that would otherwise throw is worth a few seconds. The
+// previous ~430 ms budget was not enough on a loaded Windows CI runner: the
+// notifier's `active.json` write lost the rename and threw, and the listener
+// waiting on it timed out ten seconds later, so the operation failed while the
+// contention it was retrying through had long since cleared (#2972 follow-up).
+const RENAME_RETRY_DELAYS_MS = [30, 100, 300, 600, 1000, 2000] as const;
+// The SYNC ladder stays short on purpose. `sleepSync` parks the whole thread,
+// so a long budget here does not delay one write — it freezes the process. A
+// caller that cannot afford to yield cannot afford to wait either; failing
+// after ~430 ms and letting the caller decide beats a four-second stall.
+const RENAME_RETRY_DELAYS_SYNC_MS = [30, 100, 300] as const;
 
 function hasErrnoCode(err: unknown): err is { code: string } {
   return typeof err === "object" && err !== null && "code" in err && typeof err.code === "string";
 }
 
 // `isWindows` is a parameter (defaulting to the real platform) so the safety-critical decision is testable on any OS.
+/** The retry budgets, exported so a test can assert what they cost rather than
+ *  hard-coding a second copy of the numbers. */
+export const RENAME_RETRY_BUDGET_MS = RENAME_RETRY_DELAYS_MS.reduce((total, delay) => total + delay, 0);
+export const RENAME_RETRY_BUDGET_SYNC_MS = RENAME_RETRY_DELAYS_SYNC_MS.reduce((total, delay) => total + delay, 0);
+
 export function isTransientRenameError(err: unknown, isWindows: boolean = IS_WINDOWS): boolean {
   if (!isWindows || !hasErrnoCode(err)) return false;
   return err.code === "EPERM" || err.code === "EBUSY" || err.code === "EACCES";
@@ -80,7 +96,8 @@ export async function renameWithWindowsRetry(fromPath: string, toPath: string, d
   await deps.rename(fromPath, toPath);
 }
 
-// Atomics.wait parks the thread instead of busy-spinning. Only on the Windows-rename retry path, total ≤ ~430ms.
+// Atomics.wait parks the thread instead of busy-spinning. Only on the Windows-rename retry path, and only on the SYNC
+// ladder, whose budget is capped at ~430ms precisely because this blocks everything.
 const SYNC_SLEEP_BUF = new Int32Array(new SharedArrayBuffer(4));
 function sleepSync(millis: number): void {
   Atomics.wait(SYNC_SLEEP_BUF, 0, 0, millis);
@@ -100,7 +117,7 @@ const defaultRenameRetryDepsSync: RenameRetryDepsSync = {
 };
 
 export function renameSyncWithWindowsRetry(fromPath: string, toPath: string, deps: RenameRetryDepsSync = defaultRenameRetryDepsSync): void {
-  for (const delayMs of RENAME_RETRY_DELAYS_MS) {
+  for (const delayMs of RENAME_RETRY_DELAYS_SYNC_MS) {
     try {
       deps.rename(fromPath, toPath);
       return;

--- a/packages/core/test/files/test_atomic.ts
+++ b/packages/core/test/files/test_atomic.ts
@@ -3,7 +3,15 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
-import { writeFileAtomic, writeFileAtomicSync, isTransientRenameError, renameWithWindowsRetry } from "../../src/files/atomic.js";
+import {
+  writeFileAtomic,
+  writeFileAtomicSync,
+  isTransientRenameError,
+  renameWithWindowsRetry,
+  renameSyncWithWindowsRetry,
+  RENAME_RETRY_BUDGET_MS,
+  RENAME_RETRY_BUDGET_SYNC_MS,
+} from "../../src/files/atomic.js";
 import { writeJsonAtomic } from "../../src/files/json.js";
 import { isEnoent } from "../../src/files/safe.js";
 
@@ -136,6 +144,37 @@ describe("renameWithWindowsRetry (injected rename/sleep)", () => {
     };
     await renameWithWindowsRetry("from", "to", { rename, sleep: noSleep, isWindows: true });
     assert.equal(calls, 3);
+  });
+
+  // The budget is the point of the retry, not the retry itself: the notifier's
+  // `active.json` write lost a Windows rename, exhausted the old ~430 ms
+  // ladder, threw, and the listener waiting on it timed out ten seconds later.
+  // The async path yields while it waits, so the budget is worth spending.
+  it("waits seconds, not milliseconds, before giving up on Windows", async () => {
+    const slept: number[] = [];
+    const rename = async () => {
+      throw errWithCode("EPERM");
+    };
+    await assert.rejects(() => renameWithWindowsRetry("from", "to", { rename, sleep: async (millis) => void slept.push(millis), isWindows: true }), /EPERM/);
+    const total = slept.reduce((sum, millis) => sum + millis, 0);
+    assert.equal(total, RENAME_RETRY_BUDGET_MS);
+    assert.ok(total >= 3000, `an async rename must be retried for seconds, not ${total}ms`);
+  });
+
+  // The sync twin blocks the thread through `Atomics.wait`, so the same budget
+  // would freeze the process rather than delay one write. Different number,
+  // stated as a rule so nobody "unifies" the two ladders later.
+  it("keeps the SYNC budget short, because that one blocks the whole thread", () => {
+    const slept: number[] = [];
+    const rename = () => {
+      throw errWithCode("EPERM");
+    };
+    assert.throws(() => renameSyncWithWindowsRetry("from", "to", { rename, sleep: (millis) => void slept.push(millis), isWindows: true }), /EPERM/);
+    assert.equal(
+      slept.reduce((sum, millis) => sum + millis, 0),
+      RENAME_RETRY_BUDGET_SYNC_MS,
+    );
+    assert.ok(RENAME_RETRY_BUDGET_SYNC_MS < RENAME_RETRY_BUDGET_MS, "the blocking ladder must stay shorter than the yielding one");
   });
 
   it("does NOT retry a non-transient error — throws on the first attempt", async () => {

--- a/test/agent/test_manageCollection.ts
+++ b/test/agent/test_manageCollection.ts
@@ -9,7 +9,7 @@ import "../../server/workspace/collections/configure.js"; // configure @mulmocla
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { appendFileSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -486,6 +486,11 @@ describe("manageCollection — putItems from itemsFile", () => {
     writeFileSync(file, JSON.stringify(rows));
     return file;
   };
+  // #2972: these refused the file as "outside the workspace" on Windows, where
+  // `os.tmpdir()` yields the 8.3 short form. A bare `assert.match` reports only
+  // the refusal text, which names the path as PASSED and so cannot show which
+  // side of the containment comparison failed to canonicalise. This does.
+  const pathDetail = (file: string): string => `workdir=${workdir} workdirReal=${realpathSync(workdir)} file=${file} fileReal=${realpathSync(file)}`;
 
   it("writes the rows the file holds, with the same per-row results as inline items", async () => {
     const itemsFile = writeItemsFile("rows.json", [record("f1"), { id: "noname", status: "open" }]);
@@ -607,8 +612,9 @@ describe("manageCollection — putItems from itemsFile", () => {
 
   it("refuses an over-cap file WHOLE, leaving nothing written", async () => {
     const rows = Array.from({ length: MAX_PUT_ITEMS + 1 }, (_unused, index) => record(`cap${index}`));
-    const result = await run({ action: "putItems", slug: "portfolio", itemsFile: writeItemsFile("toomany.json", rows) });
-    assert.match(result, new RegExp(`over the putItems limit of ${MAX_PUT_ITEMS}`));
+    const itemsFile = writeItemsFile("toomany.json", rows);
+    const result = await run({ action: "putItems", slug: "portfolio", itemsFile });
+    assert.match(result, new RegExp(`over the putItems limit of ${MAX_PUT_ITEMS}`), pathDetail(itemsFile));
     assert.ok(!existsSync(path.join(workdir, "data/portfolio/items/cap0.json")), "an over-cap call must not write its first rows");
   });
 

--- a/test/workspace/collections/test_paths.ts
+++ b/test/workspace/collections/test_paths.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -43,6 +43,19 @@ describe("isContainedInRoot", () => {
     // yet, but its parent (workspace root) is real and contained.
     const sub = path.join(rootDir, "data", "clients", "items");
     assert.equal(isContainedInRoot(sub, rootDir), true);
+  });
+
+  // #2972: `manageCollection`'s `itemsFile` guard refuses a file the test wrote
+  // directly under its own `mkdtempSync` root — but only on Windows, where
+  // `os.tmpdir()` hands back the 8.3 short form (`C:\Users\RUNNER~1\...`).
+  // Every case above contains a DIRECTORY; this one contains a FILE, which is
+  // the shape that guard actually checks. The message names both realpaths so a
+  // failure says which side failed to canonicalise, rather than just "false".
+  it("accepts a FILE written directly under the root", () => {
+    const file = path.join(rootDir, "rows.json");
+    writeFileSync(file, "[]");
+    const detail = `root=${rootDir} rootReal=${realpathSync(rootDir)} file=${file} fileReal=${realpathSync(file)}`;
+    assert.equal(isContainedInRoot(file, rootDir), true, detail);
   });
 
   it("rejects a directory that IS a symlink pointing outside the root", () => {

--- a/test/workspace/collections/test_paths.ts
+++ b/test/workspace/collections/test_paths.ts
@@ -13,10 +13,11 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { isContainedInRoot, safeRecordId, safeSlugName } from "@mulmoclaude/core/collection/server";
+import { isContainedInRoot, isUnderRealRoot, safeRecordId, safeSlugName } from "@mulmoclaude/core/collection/server";
 
 let rootDir: string;
 let outsideDir: string;
@@ -29,6 +30,34 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(rootDir, { recursive: true, force: true });
   rmSync(outsideDir, { recursive: true, force: true });
+});
+
+// #2972: `manageCollection` resolved the itemsFile with `fs/promises.realpath`
+// and then handed the result to `isContainedInRoot`, which canonicalises the
+// ROOT with `fs.realpathSync`. On Windows those two APIs disagree — the async
+// one expands an 8.3 short name (`C:\Users\RUNNER~1\…`, which is what
+// `os.tmpdir()` hands back on a GitHub runner) and the sync one does not — so
+// every file under the workspace compared as if it were outside it.
+//
+// The rule these tests pin is not "the APIs agree" (they need not) but
+// "whatever resolves the two sides must be the SAME function".
+describe("realpath canonicalisation is api-dependent", () => {
+  it("compares equal only when both sides come from the same resolver", async () => {
+    const file = path.join(rootDir, "rows.json");
+    writeFileSync(file, "[]");
+    const [syncRoot, syncFile, asyncRoot, asyncFile] = [realpathSync(rootDir), realpathSync(file), await realpath(rootDir), await realpath(file)];
+
+    assert.equal(isUnderRealRoot(syncFile, syncRoot), true, `sync/sync: ${syncFile} under ${syncRoot}`);
+    assert.equal(isUnderRealRoot(asyncFile, asyncRoot), true, `async/async: ${asyncFile} under ${asyncRoot}`);
+    // The mixed pairing is the defect. It happens to hold where the two APIs
+    // agree (POSIX), so this documents the requirement rather than asserting a
+    // platform: what must never happen is code that MIXES them.
+    assert.equal(
+      isUnderRealRoot(asyncFile, syncRoot),
+      asyncRoot === syncRoot,
+      `mixing resolvers is only safe while they agree — syncRoot=${syncRoot} asyncRoot=${asyncRoot}`,
+    );
+  });
 });
 
 describe("isContainedInRoot", () => {


### PR DESCRIPTION
## Summary

Closes #2972.

Windows で `putItems` の `itemsFile` が**常に**「ワークスペース外」として拒否され、`test/agent/test_manageCollection.ts` の 5 件が失敗していました。テスト側の症状は `Unexpected token 'm', "manageColl"... is not valid JSON` ですが、これはツールが返したエラー文字列を `JSON.parse` に渡した**二次症状**です。

### 真因: 正規化 API の不一致

```ts
real = await realpath(hostPath);        // fs/promises → Windows では 8.3 短縮名を展開する
if (!isContainedInRoot(real, root))     // 内部で root を fs.realpathSync → 展開しない
```

`C:\Users\runneradmin\…` を `C:\Users\RUNNER~1\…` と比較していました。`os.tmpdir()` が短縮名を返すため、**ワークスペース配下のファイルが例外なく外側に見えます**。

短縮名そのものが原因ではありません。**両側を同じ resolver で正規化していれば、どちらの形でも一致します。**

### 修正

- 比較そのものを `isUnderRealRoot(realPath, realRoot)` として切り出し、`isContainedInRoot` と共有
- `verifyOpenedItemsFile` は root も `await realpath(root)` で解決し、**両側を同じ resolver に揃える**

`resolveItemsFilePath` 側（安価な事前チェック）は両側とも `realpathSync` なので元から一貫しており、変更していません。

## Items to Confirm / Review

1. **`isUnderRealRoot` を export したこと。** 「呼び出し側が既に解決済みのパスを持っているときに再解決させない」ための口です。誤用（未解決のパスを渡す）を招く懸念はありますが、doc comment に「両側を同じ方法で正規化してから来ること」を明記しています。内部関数に留めて `manageTool` 側に比較ロジックを複製するより良いと判断しました。
2. **TOCTOU の性質は変えていません。** `real` は open 済みの descriptor に対する検証の一部で、拘束力を持つのは `dev`/`ino` の比較だという既存のコメントどおりです。root の解決を async に揃えただけで、チェックの順序も対象も変えていません。
3. **`realpath(root)` の失敗は既存の `catch` で `openItemsFileRefusal` になります。** root が消えている状況なので、拒否として扱うのが妥当と判断しました。

## 検証

**この PR のパスでは PR CI が Windows を回しません**（`lint_test_windows.yaml` は `pull_request` では `server/utils/launcher/**` 等に限定）。そのため `workflow_dispatch` で手動実行しており、それが唯一の実証です。

**推測で直していません。** 診断を 2 往復取って仮説を 2 つ潰しています:

| 段階 | 仮説 | 結果 |
|---|---|---|
| 起票時 | JSON パースの問題 | ✗ 二次症状だった |
| 初回診断前 | 8.3 短縮名そのもの | ✗ **否定**。`realpathSync` は展開せず、両側とも短縮名で一致する |
| 診断後 | 正規化 API の不一致 | ✓ 修正で解消 |

診断で得た実値（[run 33034337999](https://github.com/receptron/mulmoclaude/actions/runs/33034337999)）:

```
workdirReal = C:\Users\RUNNER~1\...\manage-collection-D14yPZ      ← realpathSync は展開しない
fileReal    = C:\Users\RUNNER~1\...\manage-collection-D14yPZ\toomany.json
```

両側が一致しており、`isContainedInRoot` 単体は Windows でも pass します。ここで混在箇所の特定に至りました。

**修正後の Windows 実行**（[run 33035945853](https://github.com/receptron/mulmoclaude/actions/runs/33035945853)）— 22.x / 24.x とも:

```
✔ writes the rows the file holds, with the same per-row results as inline items
✔ honours mode, so a file can be a create-only batch
✔ translates a sandbox mount prefix back to the workspace root
✔ refuses an over-cap file WHOLE, leaving nothing written
✔ manageCollection — putItems from itemsFile
```

### 追加したテスト

- `isContainedInRoot` に「root 直下の**ファイル**」ケース。既存ケースは全て contained 側がディレクトリで、この guard が実際に見る形が抜けていました
- `realpath canonicalisation is api-dependent` — 固定するのは「2 つの api が一致すること」**ではなく**「両側が同じ resolver から来ること」です。api が一致するプラットフォーム（POSIX）でも要件は同じで、混在させた瞬間に壊れるため
- 失敗していた over-cap テストの assert に realpath の診断を添付（次に壊れたとき、どちら側が正規化に失敗したか即座に分かるように）

ローカル: 103 pass / 0 fail、`eslint` 0 error、`typecheck` / `build:packages` green。

## 2 件目: Windows の atomic rename が EPERM で諦めるのが早すぎる

当初「この PR とは無関係」として別 issue を提案した `test/workspace/collections/test_watcher.ts` の失敗も、同じ PR で直しました（`8fd2775bf`）。

```
ERROR [notifier] active write failed
  error="EPERM: operation not permitted, rename 'active.json.<hash>.tmp' -> 'active.json'"
→ timed out waiting for the listener to clear the bell after 10010ms
```

`writeFileAtomic` の Windows rename リトライは `[30, 100, 300]` の **~430ms** で打ち切ります。負荷の高いランナーではそれを使い切って throw し、待っている listener はその **10 秒後**にタイムアウトしていました。**リトライが吸収するはずの競合はとうに解消しているのに、予算が短すぎて操作ごと失敗する**という形です。

- **非同期ラダーを約 4 秒に拡張**（`[30,100,300,600,1000,2000]`）。非同期側は待つ間 yield するので、待ち時間はほぼ無料です
- **同期ラダーは ~430ms のまま据え置き**。`sleepSync` は `Atomics.wait` でスレッドごと止めるため、同じ予算はプロセスを 4 秒凍らせます。2 つのラダーが別物である理由をテストで固定しました（後から「統一」されないように）

### 1 件目とは確からしさが違います

| | itemsFile（#2972 本体） | watcher の EPERM |
|---|---|---|
| 再現性 | **決定的** — Windows で必ず失敗 | **フレーキー** — 通常 20〜30ms で pass、たまに 10 秒タイムアウト |
| 修正前の観測 | 5 件が確実に失敗 | main の 5 run では pass、私のブランチの 2 run で失敗 |
| 位置づけ | **証明済み** | **緩和**。機序は説明できるが、EPERM が実際に 4 秒以内で解消することは観測していない |

フレーキーな失敗は 1 回の緑では潰せたと言えないため、**Windows を 3 回サンプリング**しました。

| # | run | 結果 | watcher テスト |
|---|---|---|---|
| 1 | [33039525988](https://github.com/receptron/mulmoclaude/actions/runs/33039525988) | success | ✔ 26.5ms |
| 2 | [33040750444](https://github.com/receptron/mulmoclaude/actions/runs/33040750444) | success | ✔ 32.4ms |
| 3 | [33041864212](https://github.com/receptron/mulmoclaude/actions/runs/33041864212) | success | ✔ 21.3ms |

**3/3 で Windows run 全体が緑**です（22.x / 24.x 両方）。修正前は itemsFile の 5 件が必ず落ちていたので、この状態自体がこのブランチで初めて到達したものです。

ただし 3 サンプルでフレーキーの不在を証明したことにはなりません。**リトライ予算の拡張は機序に基づく緩和であり、証明された修正ではない**という位置づけで見てください。再発したら、EPERM が解消するまでの実時間を計測するのが次の一手です。

## Items to Confirm / Review（2 件目について）

4. **非同期と同期でラダーを分けたこと。** 同期側を伸ばさなかったのは `Atomics.wait` がスレッドを止めるからで、テストにその理由を書いています。「統一したほうが綺麗」という判断で後から揃えられると、プロセスが 4 秒固まる方向に倒れます。
5. **恒久的な EPERM の顕在化が ~430ms → ~4 秒に遅くなります。** 権限の問題などで永久に失敗するケースでは、エラーが出るまでの待ち時間が伸びます。書き込みが丸ごと失敗するより待つ方がましと判断しましたが、異論があれば聞かせてください。

## 参考: 当初「無関係」と書いた経緯

run 全体はまだ failure です。残るのは `test/workspace/collections/test_watcher.ts` の 1 件で、

```
EPERM: operation not permitted, rename 'active.json.<hash>.tmp' -> 'active.json'
→ timed out waiting for the listener to clear the bell after 10010ms
```

Windows の atomic rename が AV / インデクサとぶつかる既知の形です。**修正前の run（33035945853 の前、32978358404）にも同じ失敗が出ている**ことを確認済みで、この PR が持ち込んだものではありません。別 issue に切り出しますか？

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2972 なおせる？
- きいたらPR（＝Windows で効いていたら PR を作る）

work in mulmoclaude3

## Summary by Sourcery

Fix Windows workspace file validation and make asynchronous atomic renames more resilient to transient EPERM conflicts.

Bug Fixes:
- Fix Windows `itemsFile` validation so workspace files are no longer incorrectly rejected due to inconsistent path canonicalisation.
- Reduce flaky Windows atomic-write failures by allowing asynchronous rename retries more time to recover from transient permission conflicts.

Enhancements:
- Separate path containment checks for already-canonicalised paths and preserve distinct retry budgets for asynchronous and synchronous Windows renames.

Tests:
- Add coverage for resolver-consistent path containment, files directly under a workspace root, and Windows rename retry budgets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace file validation for symbolic links and canonical path resolution.
  * Prevented valid files from being rejected when resolved paths are within the workspace.
  * Added clearer diagnostics for path-related validation failures.
  * Improved Windows file replacement reliability with longer asynchronous retry handling.
  * Optimized synchronous Windows replacement retries with a dedicated retry window.
  * Improved consistency when validating paths across Windows path representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
