### PR TITLE
docs: 壊れた相対リンクを直し、CI で検出するようにする (#2967)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -130,6 +130,11 @@ jobs:
     # this catches drift at PR time before it reaches an `npx
     # mulmoclaude` user.
     - run: yarn run check:launcher-sync
+    # #2967: a help file moved to packages/core/assets/ and a manifest was
+    # deleted, and the docs kept linking at the old paths for months — the
+    # link still READS fine, so only a reader who clicks finds out. It took an
+    # outside contributor to notice. Cheap to check, so check it every PR.
+    - run: yarn run check:doc-links
     - run: yarn run build
     # Bundle integrity: `yarn build` regenerates committed esbuild
     # artifacts (`server/workspace/wiki-history/hook/snapshot.mjs`

--- a/docs/plugin-runtime.md
+++ b/docs/plugin-runtime.md
@@ -63,7 +63,7 @@ Both sources merge into the same registry. The user-installed plugin sees preset
 
 There are three flavours of collision and the behaviour differs by source:
 
-1. **Runtime plugin name collides with a manifest-listed GUI plugin or a pure MCP tool** (everything fed into `MCP_PLUGIN_NAMES` plus `mcpToolDefs` keys: `notify`, `readXPost`, `searchX`, plus the manifest entries in [`config/plugins.registry.ts`](../config/plugins.registry.ts)). The runtime loader **rejects** the entry at registration time. The boot log records this:
+1. **Runtime plugin name collides with a manifest-listed GUI plugin or a pure MCP tool** (everything fed into `MCP_PLUGIN_NAMES` plus `mcpToolDefs` keys: `notify`, `readXPost`, `searchX`, plus the manifest entries in [`src/plugins/server.ts`](../src/plugins/server.ts)). The runtime loader **rejects** the entry at registration time. The boot log records this:
 
    ```text
    [plugins/registry] skipping runtime plugin — name collides with static tool plugin=@x/notify-clone tool=notify

--- a/docs/sandbox-credentials.md
+++ b/docs/sandbox-credentials.md
@@ -137,5 +137,5 @@ Extending the list is a code change, not a user config. This is deliberate — t
 ## Related
 
 - Issue [#259](https://github.com/receptron/mulmoclaude/issues/259) — the design discussion that led to this doc.
-- [server/workspace/helps/sandbox.md](../server/workspace/helps/sandbox.md) — general sandbox behaviour (what runs where, how to disable it).
+- [packages/core/assets/helps/sandbox.md](../packages/core/assets/helps/sandbox.md) — general sandbox behaviour (what runs where, how to disable it).
 - [docs/developer.md](./developer.md) — full list of env vars honoured by the server.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check:launcher-sync": "node scripts/mulmoclaude/launcherSync.mjs",
     "audit:releases": "node scripts/packages/audit-releases.mjs",
     "check:changelog-ships": "node scripts/packages/check-changelog-ships.mjs",
+    "check:doc-links": "node scripts/docs/check-doc-links.mjs",
     "knip": "knip",
     "sleep": "node -e \"setTimeout(()=>{},2000)\"",
     "predev": "yarn plugins:codegen",

--- a/scripts/docs/check-doc-links.d.mts
+++ b/scripts/docs/check-doc-links.d.mts
@@ -1,0 +1,18 @@
+// Type declarations for check-doc-links.mjs. Sidecar so the script stays plain
+// JS (runnable with `node` on a fresh clone) while tests get a typed import
+// surface — same arrangement as scripts/packages/audit-releases.d.mts.
+
+/** Every `.md` file under `dir`, recursively. */
+export function markdownFilesUnder(dir: string): string[];
+
+/** Whether a link target names something on disk this gate can resolve. False
+ *  for URLs, anchors, `data:` blobs, API routes, and the bare filenames docs
+ *  use as examples of what a USER would type. */
+export function isCheckableTarget(target: string): boolean;
+
+/** `text` with fenced blocks and code spans blanked to spaces (length
+ *  preserved), so markdown that is being SHOWN is never read as a link. */
+export function withoutCode(text: string): string;
+
+/** Every checkable link target in `text`, anchors stripped, code ignored. */
+export function linkTargetsIn(text: string): string[];

--- a/scripts/docs/check-doc-links.mjs
+++ b/scripts/docs/check-doc-links.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Do the relative links in `docs/` still point at files that exist?
+//
+// They did not. `docs/sandbox-credentials.md` pointed at
+// `server/workspace/helps/sandbox.md` months after the help assets moved to
+// `packages/core/assets/helps/`, and `docs/plugin-runtime.md` pointed at
+// `config/plugins.registry.ts` after that manifest was deleted outright
+// (df126abe4). Neither is the kind of thing a reviewer notices: the link reads
+// fine, the prose around it is still true, and only a reader who CLICKS finds
+// out. An outside contributor reported the first one (#2967, via PR #2965) —
+// which is to say it took someone from outside the project to notice.
+//
+// Usage: node scripts/docs/check-doc-links.mjs
+// Exit 0 = every relative link resolves. Exit 1 = at least one does not.
+//
+// What is NOT checked, and why: anchors (`#section`) and external URLs. An
+// anchor needs heading-slug rules that differ per renderer, and a URL needs the
+// network — both would make this gate answer "maybe", and a gate that is
+// sometimes wrong is one people learn to skip.
+
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+const DOCS_DIR = path.join(REPO_ROOT, "docs");
+
+// The TARGET half of a markdown link or image — `](target` — and nothing else.
+//
+// Matching the text half too (`\[[^\]]*\]\(…`) is what every naive version of
+// this does, and it is why eslint's `sonarjs/super-linear-regex` fires: a
+// variable-length run before the literal gives the engine somewhere to
+// backtrack, and a docs gate has no business being a ReDoS surface. The text
+// is not needed here — only where the link POINTS matters — so the cheapest
+// correct pattern is also the safest one. The target ends at the first space or
+// `)`, which drops a `"title"` suffix for free.
+const LINK_RE = /\]\(([^)\s]+)/g;
+// A fenced code block, and a `code span`. Both hold markdown that is being
+// SHOWN, not followed — `docs/image-path-routing.md` is a whole document about
+// how paths are rewritten, so its tables are full of `![](../../etc/passwd)`
+// and `![](./foo.png)`. Verifying those would make the gate demand that the
+// repository contain the very files the prose invents to explain a rule.
+const FENCE_RE = /^```[\s\S]*?^```/gm;
+const CODE_SPAN_RE = /`[^`\n]*`/g;
+
+/** Every `.md` file under `dir`, recursively. */
+export function markdownFilesUnder(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...markdownFilesUnder(full));
+    else if (entry.name.endsWith(".md")) found.push(full);
+  }
+  return found;
+}
+
+/** True when a link target names something on disk that this gate can verify.
+ *  Anything else — a URL, a bare anchor, a `data:` blob, an API route, a
+ *  placeholder in prose (`foo.png`, `<short-id>.png`) — is not a repository
+ *  path and would make the gate cry wolf. */
+export function isCheckableTarget(target) {
+  if (/^(https?:|mailto:|data:|#|\/api\/)/.test(target)) return false;
+  if (target.includes("<") || target.includes("…")) return false;
+  // A repository path is written relative to the doc (`./x`, `../x`) — a bare
+  // `foo.png` in these files is always an example of what a USER would type.
+  return target.startsWith("./") || target.startsWith("../");
+}
+
+/** `text` with every fenced block and code span blanked out, so a link inside
+ *  one is never read as a link to follow. Replaced with spaces rather than
+ *  removed, to keep the rest of the document's offsets intact. */
+export function withoutCode(text) {
+  const blank = (match) => " ".repeat(match.length);
+  return text.replace(FENCE_RE, blank).replace(CODE_SPAN_RE, blank);
+}
+
+/** Every checkable link target in `text`, ignoring anything inside code. */
+export function linkTargetsIn(text) {
+  return [...withoutCode(text).matchAll(LINK_RE)]
+    .map((match) => match[1])
+    .filter((target) => target !== undefined)
+    .map((target) => target.split("#")[0])
+    .filter((target) => target !== undefined && target.length > 0)
+    .filter(isCheckableTarget);
+}
+
+function brokenLinksIn(file) {
+  const fromDir = path.dirname(file);
+  return linkTargetsIn(readFileSync(file, "utf-8"))
+    .filter((target) => !existsSync(path.resolve(fromDir, target)))
+    .map((target) => ({ file: path.relative(REPO_ROOT, file), target }));
+}
+
+function main() {
+  const files = markdownFilesUnder(DOCS_DIR);
+  const broken = files.flatMap(brokenLinksIn);
+  if (broken.length === 0) {
+    console.log(`[docs:links] OK — every relative link in ${files.length} docs resolves.`);
+    return 0;
+  }
+  console.error(`[docs:links] FAIL — ${broken.length} relative link(s) point at nothing:`);
+  for (const { file, target } of broken) console.error(`  ${file} → ${target}`);
+  console.error("");
+  console.error("  A moved file leaves the link reading fine and pointing nowhere.");
+  console.error("  Update the link, or delete it if what it referenced is gone.");
+  return 1;
+}
+
+// Only run the CLI when invoked directly, so tests can import the helpers.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.exitCode = main();
+}

--- a/test/scripts/docs/test_docLinks.ts
+++ b/test/scripts/docs/test_docLinks.ts
@@ -1,0 +1,70 @@
+// The gate exists because two links rotted unnoticed for months: a help file
+// moved to `packages/core/assets/helps/` and a manifest was deleted outright,
+// and both links still read fine (#2967). What these tests pin is not "the
+// links are currently valid" — the gate itself checks that — but the two
+// judgements it makes, either of which silently disarms it if it drifts:
+// which targets are worth checking, and which text is prose rather than a link.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isCheckableTarget, linkTargetsIn, withoutCode } from "../../../scripts/docs/check-doc-links.mjs";
+
+const CHECKABLE: [string, string][] = [
+  ["a sibling doc", "./developer.md"],
+  ["a file one level up", "../package.json"],
+  ["a deep repository path", "../packages/core/assets/helps/sandbox.md"],
+];
+
+// Not "invalid" — not a repository path this gate can resolve. Flagging any of
+// these would make the gate cry wolf, and a noisy gate gets skipped.
+const NOT_CHECKABLE: [string, string][] = [
+  ["an external URL", "https://example.com/x.md"],
+  ["a mailto", "mailto:someone@example.com"],
+  ["a bare anchor", "#section"],
+  ["a data URI", "data:image/png;base64,AAAA"],
+  ["a server route", "/api/files/raw?path=foo"],
+  ["a placeholder with a wildcard", "../artifacts/<short-id>.png"],
+  ["a bare filename — always an example of what a USER types", "foo.png"],
+  ["a bare directory path", "data/wiki/sources/foo.png"],
+];
+
+describe("isCheckableTarget", () => {
+  CHECKABLE.forEach(([label, target]) => {
+    it(`checks ${label}`, () => assert.equal(isCheckableTarget(target), true, target));
+  });
+  NOT_CHECKABLE.forEach(([label, target]) => {
+    it(`skips ${label}`, () => assert.equal(isCheckableTarget(target), false, target));
+  });
+});
+
+// `docs/image-path-routing.md` is a document ABOUT path rewriting, so its
+// tables are full of `![](../../etc/passwd)`. Following those would have the
+// gate demand the repository contain the files the prose invents.
+describe("withoutCode — markdown that is shown, not followed", () => {
+  it("blanks a fenced block", () => {
+    assert.deepEqual(linkTargetsIn("```\n[x](../gone.md)\n```\n"), []);
+  });
+
+  it("blanks a code span", () => {
+    assert.deepEqual(linkTargetsIn("A table cell: `![](../../etc/passwd)` explains the trap.\n"), []);
+  });
+
+  it("keeps a real link that sits beside code", () => {
+    assert.deepEqual(linkTargetsIn("See `![](../fake.png)` and then [the doc](../real.md).\n"), ["../real.md"]);
+  });
+
+  it("preserves length, so the rest of the document is unshifted", () => {
+    const text = "before `[x](../a.md)` after";
+    assert.equal(withoutCode(text).length, text.length);
+  });
+});
+
+describe("linkTargetsIn", () => {
+  it("finds links and images, and drops the anchor", () => {
+    assert.deepEqual(linkTargetsIn("[a](./x.md#head) ![b](../y.png)\n"), ["./x.md", "../y.png"]);
+  });
+
+  it("ignores a link title", () => {
+    assert.deepEqual(linkTargetsIn('[a](./x.md "the title")\n'), ["./x.md"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2967.

外部コントリビュータ @kojilbj さんが PR #2965 で報告してくれた `docs/sandbox-credentials.md` のリンク切れを直します。**PR は plan-first ポリシー（#2966）でクローズしましたが、指摘は正当でした。**

issue の「あわせて `docs/` 配下に同種の壊れたリンクが他にないか確認する」に従い、**66 ファイル・236 本の相対リンクを全数走査**しました。実際に壊れていたのは 2 件です。

| ファイル | 壊れていたリンク | 修正後 | 原因 |
|---|---|---|---|
| `docs/sandbox-credentials.md` | `../server/workspace/helps/sandbox.md` | `../packages/core/assets/helps/sandbox.md` | help アセットを core へ切り出した際の取り残し |
| `docs/plugin-runtime.md` | `../config/plugins.registry.ts` | `../src/plugins/server.ts` | `df126abe4` で manifest ごと削除され、置き換わっていた |

**2 件目は issue に書かれていなかったもの**です。走査しなければ見つかりませんでした。

残る 26 件の検出はすべて**説明文中の例示**でリンク切れではありません（`foo.png`、`data:image/png;base64,…`、パストラバーサルの説明に出てくる `../../etc/passwd` など）。

## 検出をリポジトリに残しました

リンクを直すだけでは同じことがまた起きます — 今回も**両方ともリファクタで取り残されたもの**で、リンクは読める形のまま何も指していませんでした。**クリックした読者しか気づけない**種類の腐り方で、実際に気づいたのは外部の人でした。

- **`scripts/docs/check-doc-links.mjs`** — `docs/` 配下の相対リンクが実在するか検査
- **`yarn check:doc-links`** として登録し、**PR CI に配線**（`check:launcher-sync` の隣）
- **純粋関数をテストで固定**

### 何を検査しないか、なぜか

| 対象外 | 理由 |
|---|---|
| 外部 URL | ネットワークが要る。ゲートが「たぶん」と答えるようになる |
| アンカー（`#section`） | 見出しスラグの規則がレンダラごとに違う |
| `data:` / `/api/...` / 裸のファイル名（`foo.png`） | リポジトリのパスではない。追うとゲートが狼少年になる |
| **コードフェンス / コードスパンの中身** | そこにある markdown は**表示されているもので、辿るものではない**。`image-path-routing.md` はパス書き換えを説明する文書なので、表が `![](../../etc/passwd)` で埋まっている。検査すると、散文が説明のために作った架空のファイルをリポジトリに要求することになる |

## Items to Confirm / Review

1. **`docs/plugin-runtime.md` の差し替え先。** `config/plugins.registry.ts` は `df126abe4`（"drop plugin-registry codegen; barrel definitions in src/plugins/server.ts"）で削除され、`src/plugins/server.ts` に置き換わっています。文脈は「manifest に載った GUI プラグイン」の列挙なので、そこが妥当だと判断しました。より適切な参照先があれば指摘してください。
2. **CI ゲートを足したこと。** issue はリンク修正しか求めていないので、スコープを広げています。「同種のものが他にないか確認する」という指示に応えるには全数走査が要り、その走査を捨てるくらいなら残したほうが安いと判断しました。不要なら 2 コミット目を落とせます（リンク修正と分けてあります）。
3. **正規表現がリンクの「行き先」半分だけを見ていること** — `\]\(([^)\s]+)` です。テキスト半分も含めると `sonarjs/super-linear-regex` が発火します（可変長のランが backtrack の余地になる）。行き先しか要らないので、最も安いパターンが最も安全なパターンでもあります。

## 検証

- **ゲートが元の欠陥を検出することを確認済み**: 修正を戻すと `exit 1` になり、直すと `exit 0` になります。「今たまたま通る」だけのゲートを置いていないことの確認です

```
$ node scripts/docs/check-doc-links.mjs      # 壊れたリンクに戻した状態
[docs:links] FAIL — 1 relative link(s) point at nothing:
  docs/sandbox-credentials.md → ../server/workspace/helps/sandbox.md
exit=1
```

- テスト 17 件（検査対象の判定、コード内 markdown の除外、アンカー/タイトルの扱い）
- `actionlint` — workflow clean
- `yarn lint` 0 error / `yarn typecheck` / `yarn build` / `yarn test` **11,970 pass / 0 fail**
- `origin/main` を取り込み済み

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/2967 なおせる？

work in mulmoclaude3

## Summary by Sourcery

Prevent documentation link rot by correcting stale references and enforcing relative-link validation in pull request CI.

Bug Fixes:
- Fix two broken relative documentation links in `docs/sandbox-credentials.md` and `docs/plugin-runtime.md`.

Enhancements:
- Add a documentation link checker that validates applicable relative links under `docs/` while ignoring external URLs, anchors, examples, and code content.

Build:
- Register the documentation link checker as the `check:doc-links` package script.

CI:
- Run documentation link validation in pull request CI.

Tests:
- Add tests covering documentation link target classification and Markdown code exclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated check that validates relative links in documentation and reports broken file references.

* **Documentation**
  * Updated documentation links to point to their current locations.

* **Tests**
  * Added coverage for link detection, including code blocks, anchors, external URLs, and other non-file targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->