### PR TITLE
fix(build): core が名前を持つ Tailwind クラスを plugin の CSS に出す (#2989)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -135,6 +135,12 @@ jobs:
     # link still READS fine, so only a reader who clicks finds out. It took an
     # outside contributor to notice. Cheap to check, so check it every PR.
     - run: yarn run check:doc-links
+    # #2989: a plugin's Tailwind build scans only its own package, so classes
+    # declared in core (the shared enum palette) dropped out of the plugin's
+    # dist/style.css while the host app kept rendering them — invisible unless
+    # you load the plugin AS a package. The fix is one `@source` line; this is
+    # what makes the next shared palette fail loudly instead of silently.
+    - run: yarn run check:plugin-css
     - run: yarn run build
     # Bundle integrity: `yarn build` regenerates committed esbuild
     # artifacts (`server/workspace/wiki-history/hook/snapshot.mjs`

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "audit:releases": "node scripts/packages/audit-releases.mjs",
     "check:changelog-ships": "node scripts/packages/check-changelog-ships.mjs",
     "check:doc-links": "node scripts/docs/check-doc-links.mjs",
+    "check:plugin-css": "node scripts/packages/check-plugin-tailwind-source.mjs",
     "knip": "knip",
     "wait:backend": "tsx scripts/wait-for-backend.ts",
     "predev": "yarn plugins:codegen",

--- a/packages/plugins/collection-plugin/src/style.css
+++ b/packages/plugins/collection-plugin/src/style.css
@@ -1,1 +1,8 @@
 @import "tailwindcss";
+
+/* The enum palette spells its classes out in core, which this package's Vite root
+   does not cover — so they drop out of dist/style.css and only the host app, whose
+   root IS the repository, keeps rendering them (#2989). The FILE, not its directory:
+   scanning core/src harvests ordinary words out of the TypeScript (`contents`, `grow`,
+   `ring`) and emits utilities nothing asked for. */
+@source "../../../core/src/collection/core/enumColors.ts";

--- a/plans/fix-2989-plugin-tailwind-core-source.md
+++ b/plans/fix-2989-plugin-tailwind-core-source.md
@@ -1,0 +1,54 @@
+# fix(build): core が名前を持つ Tailwind クラスを plugin の dist/style.css に出す (#2989)
+
+## 症状（実測）
+
+`packages/core/src/collection/core/enumColors.ts` にしかリテラルが無い Tailwind クラスが、
+`collection-plugin` のパッケージビルドが出す `dist/style.css` に入らない。
+
+パレットが名前を持つ **76 クラス中 43 が欠落**していた（issue 本文の 3 例より広い）。
+欠落分には enum の配色だけでなく、通知 enum の重要度色（`bg-red-500` / `text-red-700` /
+`bg-amber-100` / `bg-amber-500` / `bg-slate-300`）も含まれる。
+
+## 原因
+
+Tailwind v4 の自動コンテンツ検出は **CSS エントリから見た「プロジェクト」** を走査する。
+
+- ホスト: vite の root がリポジトリルート → `packages/core/src` まで走査される → クラスが出る
+- プラグイン: vite の root がそのパッケージ → `packages/plugins/<name>/src` しか走査されない
+  → core 由来のクラスは誰も見ていないので落ちる
+
+`packages/plugins/collection-plugin/vite.config.ts` のコメントが
+「node_modules はホストの走査対象外なので、パッケージは自分のクラスを自分で出荷する」と
+書いているとおりで、その理屈は **core にも当てはまるのに core だけ抜けていた**。
+
+## 対処（issue の案 1 / 狭い @source + ガード）
+
+1. `packages/plugins/collection-plugin/src/style.css` に、パレットのファイルを名指しする
+   `@source` を 1 行足す。
+
+   実測: 欠けていた 43 クラスが全部出るようになり、増えたのは +4.5 KB（パレット本体のみ）。
+   ディレクトリごと（`@source "../../../core/src"`）だと `contents` `grow` `ring` `static`
+   など **無関係な語をクラスとして拾って** 8 個ほど余計に emit されるため、ファイル名指しを採る。
+
+2. ガード: `scripts/packages/check-plugin-tailwind-source.mjs` を追加し、CI に入れる。
+
+   規則: **core のソースに Tailwind の配色クラスが書かれていて、そのファイルの export を
+   使っているプラグインは、そのファイルを覆う `@source` を自分の CSS に持っていなければならない。**
+
+   これで #2987（コレクション／フィードのアクセントカラーを core に置く予定）が同じ穴に
+   落ちたとき、目視ではなく CI が落ちる。
+
+## 採らなかった案
+
+- **共有 CSS パーシャルに集約**: 将来 1 箇所で済むが、パレットを描画しないプラグインにも
+  4.5 KB の未使用 CSS が乗る。今日クラスを描画しているのは collection-plugin だけ。
+- **core が CSS を出力する（案 2）**: 依存の向きは正しいが core に Tailwind ビルドが増え、
+  ホストとプラグインで同じ CSS が二重化する。
+- **トークン化（案 3）**: 最も筋が良く、将来の方向としては残す。ただし 8 色 × 4 用途と
+  その全呼び出し側の移行になり、この不具合の修正としては大きすぎる。
+
+## 検証
+
+- `collection-plugin` を再ビルドし、パレット 76 クラスが `dist/style.css` に全部あることを確認
+- ガードを、@source を消した状態で走らせて **落ちること** を確認（規則が本当に効いているか）
+- 純粋関数（クラス抽出 / export 抽出 / @source 抽出 / 被覆判定 / 規則本体）に単体テスト

--- a/scripts/packages/check-plugin-tailwind-source.d.mts
+++ b/scripts/packages/check-plugin-tailwind-source.d.mts
@@ -38,7 +38,11 @@ export function colorClassesIn(source: string): Set<string>;
 /** Every symbol `source` exports by name. */
 export function exportedNamesIn(source: string): string[];
 
-/** Every path a CSS file hands to `@source`, in the order they appear. */
+/** `css` with every comment blanked to spaces (length preserved), so a
+ *  commented-out directive is never read as live. */
+export function withoutComments(css: string): string;
+
+/** Every path a CSS file hands to a LIVE `@source`, in the order they appear. */
 export function sourceTargetsIn(css: string): string[];
 
 /** Whether a resolved `@source` target covers `file` — the file itself, or a

--- a/scripts/packages/check-plugin-tailwind-source.d.mts
+++ b/scripts/packages/check-plugin-tailwind-source.d.mts
@@ -1,0 +1,49 @@
+// Type declarations for check-plugin-tailwind-source.mjs. Sidecar so the script
+// stays plain JS (runnable with `node` on a fresh clone) while tests get a typed
+// import surface — same arrangement as scripts/docs/check-doc-links.d.mts.
+
+/** A core source file that declares Tailwind classes, as the rule reads it. */
+export interface CoreClassFile {
+  /** Absolute path. */
+  file: string;
+  /** Every coloured Tailwind class the file names. */
+  classes: Set<string>;
+  /** Every symbol the file exports by name. */
+  exports: string[];
+}
+
+/** A plugin package's Tailwind entry, as the rule reads it. */
+export interface PluginCssEntry {
+  name: string;
+  /** Absolute path to the package's `src/style.css`. */
+  cssPath: string;
+  /** Every `@source` target, resolved against the CSS file. */
+  targets: string[];
+  /** The core exports this plugin's own sources mention. */
+  usedExports: string[];
+}
+
+/** A plugin rendering classes its own build never scans. */
+export interface TailwindSourceGap {
+  plugin: string;
+  cssPath: string;
+  coreFile: string;
+  symbols: string[];
+  classes: number;
+}
+
+/** Every coloured Tailwind class named in `source` (variants kept: `hover:bg-x-100`). */
+export function colorClassesIn(source: string): Set<string>;
+
+/** Every symbol `source` exports by name. */
+export function exportedNamesIn(source: string): string[];
+
+/** Every path a CSS file hands to `@source`, in the order they appear. */
+export function sourceTargetsIn(css: string): string[];
+
+/** Whether a resolved `@source` target covers `file` — the file itself, or a
+ *  directory above it. */
+export function sourceCovers(target: string, file: string): boolean;
+
+/** Which core files a plugin renders classes from but never scans. */
+export function findGaps(coreFiles: CoreClassFile[], plugins: PluginCssEntry[]): TailwindSourceGap[];

--- a/scripts/packages/check-plugin-tailwind-source.d.mts
+++ b/scripts/packages/check-plugin-tailwind-source.d.mts
@@ -10,6 +10,8 @@ export interface CoreClassFile {
   classes: Set<string>;
   /** Every symbol the file exports by name. */
   exports: string[];
+  /** Whether the file has a default export — a use this rule cannot follow. */
+  hasDefaultExport: boolean;
 }
 
 /** A plugin package's Tailwind entry, as the rule reads it. */
@@ -48,6 +50,13 @@ export function sourceTargetsIn(css: string): string[];
 /** Whether a resolved `@source` target covers `file` — the file itself, or a
  *  directory above it. */
 export function sourceCovers(target: string, file: string): boolean;
+
+/** Whether `source` has a default export. */
+export function hasDefaultExport(source: string): boolean;
+
+/** Class-carrying core files whose use cannot be detected: a default import
+ *  arrives under a name of the plugin's choosing. */
+export function undetectableCoreFiles(coreFiles: CoreClassFile[]): CoreClassFile[];
 
 /** Which core files a plugin renders classes from but never scans. */
 export function findGaps(coreFiles: CoreClassFile[], plugins: PluginCssEntry[]): TailwindSourceGap[];

--- a/scripts/packages/check-plugin-tailwind-source.mjs
+++ b/scripts/packages/check-plugin-tailwind-source.mjs
@@ -45,6 +45,10 @@ const EXPORT_LINE_RE = /^export (?:declare )?(?:const|function|class|interface|t
 // Whole-source rather than per-line because prettier wraps a long list.
 const EXPORT_LIST_RE = /export\s*\{([^}]*)\}/g;
 const NAME_RE = /^[A-Za-z_$][\w$]*$/;
+// A default export is the one shape this rule cannot follow: the importer picks
+// the local name, so there is nothing to match against. Refused rather than
+// ignored — see `undetectableCoreFiles`.
+const DEFAULT_EXPORT_RE = /^export default\b/m;
 const SOURCE_RE = /@source\s+"([^"]+)"/g;
 // A CSS comment. Tailwind's parser ignores what is inside one, so a gate that
 // does not would read a commented-out `@source` as live — passing while the
@@ -100,6 +104,19 @@ export function sourceCovers(target, file) {
   return target === file || file.startsWith(target + path.sep);
 }
 
+/** Whether `source` has a default export. */
+export function hasDefaultExport(source) {
+  return DEFAULT_EXPORT_RE.test(source);
+}
+
+/** Class-carrying core files whose use this rule cannot detect at all: a default
+ *  import arrives under whatever local name the plugin chooses, so no name match
+ *  can see it. Reported as a failure so the blind spot is loud — a shared palette
+ *  is expected to use named exports. */
+export function undetectableCoreFiles(coreFiles) {
+  return coreFiles.filter((core) => core.classes.size > 0 && core.hasDefaultExport);
+}
+
 /** Which core files a plugin renders classes from but never scans.
  *
  *  Pure: `coreFiles` are `{ file, classes, exports }` and `plugins` are
@@ -133,7 +150,7 @@ function coreFilesWithClasses() {
   return sourceFilesUnder(CORE_SRC)
     .map((file) => {
       const source = readFileSync(file, "utf-8");
-      return { file, classes: colorClassesIn(source), exports: exportedNamesIn(source) };
+      return { file, classes: colorClassesIn(source), exports: exportedNamesIn(source), hasDefaultExport: hasDefaultExport(source) };
     })
     .filter((entry) => entry.classes.size > 0);
 }
@@ -170,7 +187,16 @@ function main() {
   const coreExports = coreFiles.flatMap((core) => core.exports);
   const plugins = pluginsWithCss(coreExports);
   const gaps = findGaps(coreFiles, plugins);
+  const undetectable = undetectableCoreFiles(coreFiles);
   const rel = (file) => path.relative(REPO_ROOT, file);
+  if (undetectable.length > 0) {
+    console.error(`[plugin-css] FAIL — ${undetectable.length} core file(s) declare Tailwind classes behind a default export:`);
+    for (const core of undetectable) console.error(`  ${rel(core.file)}`);
+    console.error("");
+    console.error("  A default import arrives under whatever name the plugin picks, so this");
+    console.error("  gate cannot tell who renders those classes. Export the palette by name.");
+    return 1;
+  }
   if (gaps.length === 0) {
     console.log(`[plugin-css] OK — ${plugins.length} plugin CSS entries, ${coreFiles.length} core file(s) declaring classes, no gaps.`);
     return 0;

--- a/scripts/packages/check-plugin-tailwind-source.mjs
+++ b/scripts/packages/check-plugin-tailwind-source.mjs
@@ -188,40 +188,46 @@ function pluginsWithCss(coreExports) {
     });
 }
 
-/** The `@source` line a gap needs, written relative to the plugin's CSS. */
-function fixLine(gap) {
-  return `@source "${path.relative(path.dirname(gap.cssPath), gap.coreFile)}";`;
+/** Path as it reads in a message: relative to the repository. */
+const rel = (file) => path.relative(REPO_ROOT, file);
+
+/** Report core files this rule cannot follow at all. */
+function reportUndetectable(files) {
+  console.error(`[plugin-css] FAIL — ${files.length} core file(s) declare Tailwind classes behind a default export:`);
+  for (const core of files) console.error(`  ${rel(core.file)}`);
+  console.error("");
+  console.error("  A default import arrives under whatever name the plugin picks, so this");
+  console.error("  gate cannot tell who renders those classes. Export the palette by name.");
 }
 
-function main() {
-  const coreFiles = coreFilesWithClasses();
-  const coreExports = coreFiles.flatMap((core) => core.exports);
-  const plugins = pluginsWithCss(coreExports);
-  const gaps = findGaps(coreFiles, plugins);
-  const undetectable = undetectableCoreFiles(coreFiles);
-  const rel = (file) => path.relative(REPO_ROOT, file);
-  if (undetectable.length > 0) {
-    console.error(`[plugin-css] FAIL — ${undetectable.length} core file(s) declare Tailwind classes behind a default export:`);
-    for (const core of undetectable) console.error(`  ${rel(core.file)}`);
-    console.error("");
-    console.error("  A default import arrives under whatever name the plugin picks, so this");
-    console.error("  gate cannot tell who renders those classes. Export the palette by name.");
-    return 1;
-  }
-  if (gaps.length === 0) {
-    console.log(`[plugin-css] OK — ${plugins.length} plugin CSS entries, ${coreFiles.length} core file(s) declaring classes, no gaps.`);
-    return 0;
-  }
+/** Report plugins rendering classes their own build never scans. */
+function reportGaps(gaps) {
   console.error(`[plugin-css] FAIL — ${gaps.length} plugin(s) render core classes their build never scans:`);
   for (const gap of gaps) {
     console.error(`  ${gap.plugin} uses ${gap.symbols.join(", ")} from ${rel(gap.coreFile)} (${gap.classes} classes)`);
-    console.error(`    add to ${rel(gap.cssPath)}:  ${fixLine(gap)}`);
+    console.error(`    add to ${rel(gap.cssPath)}:  @source "${path.relative(path.dirname(gap.cssPath), gap.coreFile)}";`);
   }
   console.error("");
   console.error("  Without it those classes are missing from the package's dist/style.css.");
   console.error("  The host app renders them anyway, so the gap only shows up for whoever");
   console.error("  loads the plugin as a package — which is why it needs a gate, not an eye.");
-  return 1;
+}
+
+function main() {
+  const coreFiles = coreFilesWithClasses();
+  const plugins = pluginsWithCss(coreFiles.flatMap((core) => core.exports));
+  const undetectable = undetectableCoreFiles(coreFiles);
+  const gaps = findGaps(coreFiles, plugins);
+  if (undetectable.length > 0) {
+    reportUndetectable(undetectable);
+    return 1;
+  }
+  if (gaps.length > 0) {
+    reportGaps(gaps);
+    return 1;
+  }
+  console.log(`[plugin-css] OK — ${plugins.length} plugin CSS entries, ${coreFiles.length} core file(s) declaring classes, no gaps.`);
+  return 0;
 }
 
 // Only run the CLI when invoked directly, so tests can import the helpers.

--- a/scripts/packages/check-plugin-tailwind-source.mjs
+++ b/scripts/packages/check-plugin-tailwind-source.mjs
@@ -40,6 +40,11 @@ const COLOR_CLASS_RE = /^(?:bg|text|border|ring|fill|from|via|to|outline|divide|
 // One line, single spaces: every source here is prettier-formatted, and a
 // whitespace run before an optional `declare` is the same backtracking shape.
 const EXPORT_LINE_RE = /^export (?:declare )?(?:const|function|class|interface|type|enum) ([A-Za-z_$][\w$]*)/;
+// `export { palette, ENUM_ALERT as ALERT }` — a file can declare its palette
+// locally and export it in a list, which no per-line declaration pattern sees.
+// Whole-source rather than per-line because prettier wraps a long list.
+const EXPORT_LIST_RE = /export\s*\{([^}]*)\}/g;
+const NAME_RE = /^[A-Za-z_$][\w$]*$/;
 const SOURCE_RE = /@source\s+"([^"]+)"/g;
 // A CSS comment. Tailwind's parser ignores what is inside one, so a gate that
 // does not would read a commented-out `@source` as live — passing while the
@@ -56,12 +61,26 @@ export function colorClassesIn(source) {
   return new Set(tokens.filter((token) => COLOR_CLASS_RE.test(withoutVariants(token))));
 }
 
-/** Every symbol `source` exports by name. */
+/** The name an export-list entry makes available: the alias of `a as b`, the
+ *  symbol of `type Foo`, the entry itself otherwise. */
+const exportedAs = (entry) => entry.trim().split(/\s+/).pop() ?? "";
+
+/** Every symbol `source` exports by name, from declarations and from lists.
+ *
+ *  A braced RE-export (`export { helper } from "./b"`) counts too. It names a
+ *  symbol this file hands out, and over-reporting only ever asks a plugin for an
+ *  `@source` it may not need — the other direction is the bug this gate exists
+ *  for. */
 export function exportedNamesIn(source) {
-  return source
+  const declared = source
     .split("\n")
     .map((line) => EXPORT_LINE_RE.exec(line)?.[1])
     .filter((name) => name !== undefined);
+  const listed = [...source.matchAll(EXPORT_LIST_RE)]
+    .flatMap((match) => (match[1] ?? "").split(","))
+    .map(exportedAs)
+    .filter((name) => NAME_RE.test(name));
+  return [...new Set([...declared, ...listed])];
 }
 
 /** `css` with every comment blanked out. Spaces rather than removal, so the rest

--- a/scripts/packages/check-plugin-tailwind-source.mjs
+++ b/scripts/packages/check-plugin-tailwind-source.mjs
@@ -47,8 +47,12 @@ const EXPORT_LIST_RE = /export\s*\{([^}]*)\}/g;
 const NAME_RE = /^[A-Za-z_$][\w$]*$/;
 // A default export is the one shape this rule cannot follow: the importer picks
 // the local name, so there is nothing to match against. Refused rather than
-// ignored — see `undetectableCoreFiles`.
+// ignored — see `undetectableCoreFiles`. Two spellings reach it (`export default
+// X` and `export { x as default }`), so the check asks ONE question of the parse
+// — "is `default` among the names this module hands out?" — rather than
+// enumerating the ways to write it.
 const DEFAULT_EXPORT_RE = /^export default\b/m;
+const DEFAULT_NAME = "default";
 const SOURCE_RE = /@source\s+"([^"]+)"/g;
 // A CSS comment. Tailwind's parser ignores what is inside one, so a gate that
 // does not would read a commented-out `@source` as live — passing while the
@@ -76,6 +80,12 @@ const exportedAs = (entry) => entry.trim().split(/\s+/).pop() ?? "";
  *  `@source` it may not need — the other direction is the bug this gate exists
  *  for. */
 export function exportedNamesIn(source) {
+  return allExportedNames(source).filter((name) => name !== DEFAULT_NAME);
+}
+
+/** Every name the module hands out, `default` included — the parse both public
+ *  questions are asked of. */
+function allExportedNames(source) {
   const declared = source
     .split("\n")
     .map((line) => EXPORT_LINE_RE.exec(line)?.[1])
@@ -104,9 +114,10 @@ export function sourceCovers(target, file) {
   return target === file || file.startsWith(target + path.sep);
 }
 
-/** Whether `source` has a default export. */
+/** Whether `source` hands anything out under a name the importer chooses —
+ *  `export default X` or `export { x as default }`. */
 export function hasDefaultExport(source) {
-  return DEFAULT_EXPORT_RE.test(source);
+  return DEFAULT_EXPORT_RE.test(source) || allExportedNames(source).includes(DEFAULT_NAME);
 }
 
 /** Class-carrying core files whose use this rule cannot detect at all: a default

--- a/scripts/packages/check-plugin-tailwind-source.mjs
+++ b/scripts/packages/check-plugin-tailwind-source.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// Does every plugin that RENDERS a core-owned Tailwind class also SCAN the file
+// that declares it?
+//
+// Tailwind v4 finds classes by scanning the project its CSS entry belongs to.
+// The host's vite root is the repository, so `packages/core/src` is scanned and
+// core's classes land in the app's CSS. A plugin's vite root is its own package,
+// so the same classes are invisible to its build and drop out of the package's
+// `dist/style.css` — silently, because the host renders them anyway. Anyone
+// loading the plugin AS A PACKAGE (a runtime plugin, another host) gets unstyled
+// output: 43 of the 76 enum-palette classes were missing this way (#2989).
+//
+// The fix is an `@source` in the plugin's CSS naming the core file. This gate is
+// what keeps the next palette from repeating it — core is where shared colour
+// tables belong, and nothing about adding one tells you a plugin's CSS needs a
+// line too.
+//
+// Usage: node scripts/packages/check-plugin-tailwind-source.mjs
+// Exit 0 = every such plugin scans what it renders. Exit 1 = at least one does not.
+
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "..", "..");
+const CORE_SRC = path.join(REPO_ROOT, "packages", "core", "src");
+const PLUGINS_DIR = path.join(REPO_ROOT, "packages", "plugins");
+
+// A Tailwind utility that names a palette colour (`bg-lime-50`,
+// `hover:bg-teal-100`). Only the coloured ones matter: they are the classes a
+// shared palette spells out, and a bare utility (`flex`, `grow`) is emitted by
+// every package's own sources anyway.
+//
+// Split into "find a token" + "is this token one" rather than one pattern that
+// also matches the variant prefix: a `[a-z-]+:` run in front of the alternation
+// gives the engine somewhere to backtrack, which is a ReDoS surface a build gate
+// has no business carrying (eslint security/detect-unsafe-regex).
+const TOKEN_RE = /[A-Za-z0-9:_-]+/g;
+const COLOR_CLASS_RE = /^(?:bg|text|border|ring|fill|from|via|to|outline|divide|accent|caret|decoration|shadow)-[a-z]+-\d{2,3}$/;
+// One line, single spaces: every source here is prettier-formatted, and a
+// whitespace run before an optional `declare` is the same backtracking shape.
+const EXPORT_LINE_RE = /^export (?:declare )?(?:const|function|class|interface|type|enum) ([A-Za-z_$][\w$]*)/;
+const SOURCE_RE = /@source\s+"([^"]+)"/g;
+const SOURCE_EXTS = [".ts", ".tsx", ".vue"];
+
+/** The utility a class token names, with any variant prefix (`hover:`) removed. */
+const withoutVariants = (token) => token.slice(token.lastIndexOf(":") + 1);
+
+/** Every coloured Tailwind class named in `source`. */
+export function colorClassesIn(source) {
+  const tokens = source.match(TOKEN_RE) ?? [];
+  return new Set(tokens.filter((token) => COLOR_CLASS_RE.test(withoutVariants(token))));
+}
+
+/** Every symbol `source` exports by name. */
+export function exportedNamesIn(source) {
+  return source
+    .split("\n")
+    .map((line) => EXPORT_LINE_RE.exec(line)?.[1])
+    .filter((name) => name !== undefined);
+}
+
+/** Every path a CSS file hands to `@source`, in the order they appear. */
+export function sourceTargetsIn(css) {
+  return [...css.matchAll(SOURCE_RE)].map((match) => match[1]);
+}
+
+/** Does a resolved `@source` target cover `file`? A target is either the file
+ *  itself or a directory above it — Tailwind walks a directory target. */
+export function sourceCovers(target, file) {
+  return target === file || file.startsWith(target + path.sep);
+}
+
+/** Which core files a plugin renders classes from but never scans.
+ *
+ *  Pure: `coreFiles` are `{ file, classes, exports }` and `plugins` are
+ *  `{ name, cssPath, targets, usedExports }`, both already read off disk. */
+export function findGaps(coreFiles, plugins) {
+  const gaps = [];
+  for (const plugin of plugins) {
+    for (const core of coreFiles) {
+      const used = core.exports.filter((name) => plugin.usedExports.includes(name));
+      if (core.classes.size === 0 || used.length === 0) continue;
+      if (plugin.targets.some((target) => sourceCovers(target, core.file))) continue;
+      gaps.push({ plugin: plugin.name, cssPath: plugin.cssPath, coreFile: core.file, symbols: used, classes: core.classes.size });
+    }
+  }
+  return gaps;
+}
+
+/** Every file under `dir` whose extension one of these builds would scan. */
+function sourceFilesUnder(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === "node_modules" || entry.name === "dist") return [];
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFilesUnder(full);
+    return SOURCE_EXTS.includes(path.extname(entry.name)) ? [full] : [];
+  });
+}
+
+/** The core files that declare coloured classes, with the symbols they export. */
+function coreFilesWithClasses() {
+  return sourceFilesUnder(CORE_SRC)
+    .map((file) => {
+      const source = readFileSync(file, "utf-8");
+      return { file, classes: colorClassesIn(source), exports: exportedNamesIn(source) };
+    })
+    .filter((entry) => entry.classes.size > 0);
+}
+
+/** Which of `names` a plugin's own sources mention. Word-bounded, so a symbol
+ *  that merely appears inside a longer identifier does not count. */
+function usedExportsOf(pluginSrc, names) {
+  const text = sourceFilesUnder(pluginSrc)
+    .map((file) => readFileSync(file, "utf-8"))
+    .join("\n");
+  return names.filter((name) => new RegExp(`\\b${name}\\b`).test(text));
+}
+
+/** Every plugin package that ships a Tailwind entry, with what it scans and uses. */
+function pluginsWithCss(coreExports) {
+  return readdirSync(PLUGINS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({ name: entry.name, cssPath: path.join(PLUGINS_DIR, entry.name, "src", "style.css") }))
+    .filter((plugin) => existsSync(plugin.cssPath))
+    .map((plugin) => {
+      const cssDir = path.dirname(plugin.cssPath);
+      const targets = sourceTargetsIn(readFileSync(plugin.cssPath, "utf-8")).map((target) => path.resolve(cssDir, target));
+      return { ...plugin, targets, usedExports: usedExportsOf(cssDir, coreExports) };
+    });
+}
+
+/** The `@source` line a gap needs, written relative to the plugin's CSS. */
+function fixLine(gap) {
+  return `@source "${path.relative(path.dirname(gap.cssPath), gap.coreFile)}";`;
+}
+
+function main() {
+  const coreFiles = coreFilesWithClasses();
+  const coreExports = coreFiles.flatMap((core) => core.exports);
+  const plugins = pluginsWithCss(coreExports);
+  const gaps = findGaps(coreFiles, plugins);
+  const rel = (file) => path.relative(REPO_ROOT, file);
+  if (gaps.length === 0) {
+    console.log(`[plugin-css] OK — ${plugins.length} plugin CSS entries, ${coreFiles.length} core file(s) declaring classes, no gaps.`);
+    return 0;
+  }
+  console.error(`[plugin-css] FAIL — ${gaps.length} plugin(s) render core classes their build never scans:`);
+  for (const gap of gaps) {
+    console.error(`  ${gap.plugin} uses ${gap.symbols.join(", ")} from ${rel(gap.coreFile)} (${gap.classes} classes)`);
+    console.error(`    add to ${rel(gap.cssPath)}:  ${fixLine(gap)}`);
+  }
+  console.error("");
+  console.error("  Without it those classes are missing from the package's dist/style.css.");
+  console.error("  The host app renders them anyway, so the gap only shows up for whoever");
+  console.error("  loads the plugin as a package — which is why it needs a gate, not an eye.");
+  return 1;
+}
+
+// Only run the CLI when invoked directly, so tests can import the helpers.
+if (process.argv[1] && statSync(process.argv[1]).isFile() && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exit(main());
+}

--- a/scripts/packages/check-plugin-tailwind-source.mjs
+++ b/scripts/packages/check-plugin-tailwind-source.mjs
@@ -41,6 +41,10 @@ const COLOR_CLASS_RE = /^(?:bg|text|border|ring|fill|from|via|to|outline|divide|
 // whitespace run before an optional `declare` is the same backtracking shape.
 const EXPORT_LINE_RE = /^export (?:declare )?(?:const|function|class|interface|type|enum) ([A-Za-z_$][\w$]*)/;
 const SOURCE_RE = /@source\s+"([^"]+)"/g;
+// A CSS comment. Tailwind's parser ignores what is inside one, so a gate that
+// does not would read a commented-out `@source` as live — passing while the
+// build omits the palette again, which is the exact failure it exists to catch.
+const COMMENT_RE = /\/\*[\s\S]*?\*\//g;
 const SOURCE_EXTS = [".ts", ".tsx", ".vue"];
 
 /** The utility a class token names, with any variant prefix (`hover:`) removed. */
@@ -60,9 +64,15 @@ export function exportedNamesIn(source) {
     .filter((name) => name !== undefined);
 }
 
-/** Every path a CSS file hands to `@source`, in the order they appear. */
+/** `css` with every comment blanked out. Spaces rather than removal, so the rest
+ *  of the file keeps its offsets. */
+export function withoutComments(css) {
+  return css.replace(COMMENT_RE, (match) => " ".repeat(match.length));
+}
+
+/** Every path a CSS file hands to a LIVE `@source`, in the order they appear. */
 export function sourceTargetsIn(css) {
-  return [...css.matchAll(SOURCE_RE)].map((match) => match[1]);
+  return [...withoutComments(css).matchAll(SOURCE_RE)].map((match) => match[1]);
 }
 
 /** Does a resolved `@source` target cover `file`? A target is either the file

--- a/test/scripts/packages/test_pluginTailwindSource.ts
+++ b/test/scripts/packages/test_pluginTailwindSource.ts
@@ -44,8 +44,20 @@ describe("exportedNamesIn", () => {
     assert.deepEqual(exportedNamesIn(source), ["EnumColorClasses", "ENUM_ALERT", "resolveEnumColor", "Palette"]);
   });
 
-  it("ignores a re-export and a local declaration — neither names a symbol THIS file owns", () => {
+  it("ignores a star re-export and a local declaration — neither names a symbol this file hands out", () => {
     assert.deepEqual(exportedNamesIn('export * from "./core/enumColors";\nconst PALETTE = [];'), []);
+  });
+
+  // A palette declared locally and exported in a list is invisible to a
+  // per-declaration pattern, so the gate would not know the plugin uses it
+  // (Codex review iter-2).
+  it("reads a named export list, including an alias and a type entry", () => {
+    assert.deepEqual(exportedNamesIn("const palette = 1;\nexport { palette };"), ["palette"]);
+    assert.deepEqual(exportedNamesIn("export {\n  ENUM_ALERT as ALERT,\n  type EnumColorClasses,\n};"), ["ALERT", "EnumColorClasses"]);
+  });
+
+  it("names a symbol once when it is both declared and listed", () => {
+    assert.deepEqual(exportedNamesIn("export const A = 1;\nexport { A };"), ["A"]);
   });
 });
 

--- a/test/scripts/packages/test_pluginTailwindSource.ts
+++ b/test/scripts/packages/test_pluginTailwindSource.ts
@@ -1,0 +1,103 @@
+// The gate exists because a plugin's Tailwind build scans only its own package,
+// so 43 of the 76 classes the shared enum palette spells out in core were absent
+// from `collection-plugin/dist/style.css` while the host app rendered them fine
+// (#2989). What these tests pin is not "the plugins are currently wired" — the
+// gate itself checks that — but the four judgements that would silently disarm
+// it: which strings are palette classes, what a file exports, what a plugin
+// scans, and when a scan actually covers a file.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { colorClassesIn, exportedNamesIn, findGaps, sourceCovers, sourceTargetsIn } from "../../../scripts/packages/check-plugin-tailwind-source.mjs";
+
+describe("colorClassesIn", () => {
+  it("takes the coloured utilities a palette spells out, variants included", () => {
+    const found = colorClassesIn('card: "border-indigo-200 bg-indigo-50 text-indigo-600 hover:bg-indigo-100"');
+    assert.deepEqual([...found].sort(), ["bg-indigo-50", "border-indigo-200", "hover:bg-indigo-100", "text-indigo-600"]);
+  });
+
+  it("ignores utilities that carry no colour, which every package emits for itself", () => {
+    assert.equal(colorClassesIn('class="flex grow rounded-full p-2 text-sm"').size, 0);
+  });
+
+  it("does not read a bare word as a class — that is what makes a directory scan noisy", () => {
+    assert.equal(colorClassesIn("const contents = ring(shrink);").size, 0);
+  });
+});
+
+describe("exportedNamesIn", () => {
+  it("names every exported declaration kind", () => {
+    const source = [
+      "export interface EnumColorClasses { card: string }",
+      "export const ENUM_ALERT: EnumColorClasses = { card: 'x' };",
+      "export function resolveEnumColor() {}",
+      "export type Palette = readonly string[];",
+    ].join("\n");
+    assert.deepEqual(exportedNamesIn(source), ["EnumColorClasses", "ENUM_ALERT", "resolveEnumColor", "Palette"]);
+  });
+
+  it("ignores a re-export and a local declaration — neither names a symbol THIS file owns", () => {
+    assert.deepEqual(exportedNamesIn('export * from "./core/enumColors";\nconst PALETTE = [];'), []);
+  });
+});
+
+describe("sourceTargetsIn", () => {
+  it("reads every @source target in order", () => {
+    const css = '@import "tailwindcss";\n@source "../a.ts";\n@source "../../b";\n';
+    assert.deepEqual(sourceTargetsIn(css), ["../a.ts", "../../b"]);
+  });
+
+  it("finds nothing in a plain entry — the state that produced the bug", () => {
+    assert.deepEqual(sourceTargetsIn('@import "tailwindcss";\n'), []);
+  });
+});
+
+describe("sourceCovers", () => {
+  const file = path.join("/repo", "packages", "core", "src", "collection", "enumColors.ts");
+
+  it("covers the file named directly", () => {
+    assert.equal(sourceCovers(file, file), true);
+  });
+
+  it("covers a file under a directory target", () => {
+    assert.equal(sourceCovers(path.join("/repo", "packages", "core", "src"), file), true);
+  });
+
+  it("does not let a sibling with a shared prefix pass as a parent", () => {
+    // `/repo/packages/core/src-old` is not above `/repo/packages/core/src/…`,
+    // and a plain startsWith would say it is.
+    assert.equal(sourceCovers(path.join("/repo", "packages", "core", "src-old"), file), false);
+  });
+});
+
+describe("findGaps", () => {
+  const coreFile = path.join("/repo", "packages", "core", "src", "enumColors.ts");
+  const palette = { file: coreFile, classes: new Set(["bg-lime-50"]), exports: ["resolveEnumColor"] };
+  const plugin = (targets: string[], usedExports: string[]) => ({
+    name: "collection-plugin",
+    cssPath: "/repo/packages/plugins/collection-plugin/src/style.css",
+    targets,
+    usedExports,
+  });
+
+  it("flags a plugin that renders the palette and scans nothing", () => {
+    const gaps = findGaps([palette], [plugin([], ["resolveEnumColor"])]);
+    assert.equal(gaps.length, 1);
+    assert.deepEqual(gaps[0]?.symbols, ["resolveEnumColor"]);
+  });
+
+  it("passes when the file is named directly, and when a directory above it is", () => {
+    assert.deepEqual(findGaps([palette], [plugin([coreFile], ["resolveEnumColor"])]), []);
+    assert.deepEqual(findGaps([palette], [plugin([path.dirname(coreFile)], ["resolveEnumColor"])]), []);
+  });
+
+  it("ignores a plugin that imports nothing from the file", () => {
+    assert.deepEqual(findGaps([palette], [plugin([], ["fieldVisible"])]), []);
+  });
+
+  it("ignores a core file that declares no classes — most of core", () => {
+    const plain = { file: coreFile, classes: new Set<string>(), exports: ["resolveEnumColor"] };
+    assert.deepEqual(findGaps([plain], [plugin([], ["resolveEnumColor"])]), []);
+  });
+});

--- a/test/scripts/packages/test_pluginTailwindSource.ts
+++ b/test/scripts/packages/test_pluginTailwindSource.ts
@@ -9,7 +9,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { colorClassesIn, exportedNamesIn, findGaps, sourceCovers, sourceTargetsIn } from "../../../scripts/packages/check-plugin-tailwind-source.mjs";
+import {
+  colorClassesIn,
+  exportedNamesIn,
+  findGaps,
+  sourceCovers,
+  sourceTargetsIn,
+  withoutComments,
+} from "../../../scripts/packages/check-plugin-tailwind-source.mjs";
 
 describe("colorClassesIn", () => {
   it("takes the coloured utilities a palette spells out, variants included", () => {
@@ -50,6 +57,23 @@ describe("sourceTargetsIn", () => {
 
   it("finds nothing in a plain entry — the state that produced the bug", () => {
     assert.deepEqual(sourceTargetsIn('@import "tailwindcss";\n'), []);
+  });
+
+  // Tailwind's parser ignores comments, so a gate that reads one as live would
+  // pass on a CSS whose build emits nothing (Codex review iter-1).
+  it("does not read a commented-out directive as live", () => {
+    assert.deepEqual(sourceTargetsIn('@import "tailwindcss";\n/* @source "../a.ts"; */\n'), []);
+  });
+
+  it("still reads a live directive that a comment merely sits beside", () => {
+    assert.deepEqual(sourceTargetsIn('/* why this is here */\n@source "../a.ts";\n'), ["../a.ts"]);
+  });
+});
+
+describe("withoutComments", () => {
+  it("keeps the length, so nothing after a comment shifts", () => {
+    const css = "a/* xx */b";
+    assert.equal(withoutComments(css), "a        b");
   });
 });
 

--- a/test/scripts/packages/test_pluginTailwindSource.ts
+++ b/test/scripts/packages/test_pluginTailwindSource.ts
@@ -13,8 +13,10 @@ import {
   colorClassesIn,
   exportedNamesIn,
   findGaps,
+  hasDefaultExport,
   sourceCovers,
   sourceTargetsIn,
+  undetectableCoreFiles,
   withoutComments,
 } from "../../../scripts/packages/check-plugin-tailwind-source.mjs";
 
@@ -107,9 +109,31 @@ describe("sourceCovers", () => {
   });
 });
 
+// A default import arrives under a name the plugin picks, so no name match can
+// see the use. The gate refuses the shape rather than passing blind on it
+// (Codex review iter-3). `packages/core/src` has no default export today.
+describe("undetectableCoreFiles", () => {
+  const withDefault = (classes: string[]) => ({ file: "/repo/core/palette.ts", classes: new Set(classes), exports: [], hasDefaultExport: true });
+
+  it("refuses a class-carrying file behind a default export", () => {
+    assert.equal(undetectableCoreFiles([withDefault(["bg-lime-50"])]).length, 1);
+  });
+
+  it("says nothing about a default export that declares no classes", () => {
+    assert.deepEqual(undetectableCoreFiles([withDefault([])]), []);
+  });
+
+  it("reads the shape off the source", () => {
+    assert.equal(hasDefaultExport("export default PALETTE;"), true);
+    assert.equal(hasDefaultExport("export const PALETTE = 1;"), false);
+    // Prose about the shape is not the shape.
+    assert.equal(hasDefaultExport("// never export default from here\n"), false);
+  });
+});
+
 describe("findGaps", () => {
   const coreFile = path.join("/repo", "packages", "core", "src", "enumColors.ts");
-  const palette = { file: coreFile, classes: new Set(["bg-lime-50"]), exports: ["resolveEnumColor"] };
+  const palette = { file: coreFile, classes: new Set(["bg-lime-50"]), exports: ["resolveEnumColor"], hasDefaultExport: false };
   const plugin = (targets: string[], usedExports: string[]) => ({
     name: "collection-plugin",
     cssPath: "/repo/packages/plugins/collection-plugin/src/style.css",
@@ -133,7 +157,7 @@ describe("findGaps", () => {
   });
 
   it("ignores a core file that declares no classes — most of core", () => {
-    const plain = { file: coreFile, classes: new Set<string>(), exports: ["resolveEnumColor"] };
+    const plain = { file: coreFile, classes: new Set<string>(), exports: ["resolveEnumColor"], hasDefaultExport: false };
     assert.deepEqual(findGaps([plain], [plugin([], ["resolveEnumColor"])]), []);
   });
 });

--- a/test/scripts/packages/test_pluginTailwindSource.ts
+++ b/test/scripts/packages/test_pluginTailwindSource.ts
@@ -123,11 +123,18 @@ describe("undetectableCoreFiles", () => {
     assert.deepEqual(undetectableCoreFiles([withDefault([])]), []);
   });
 
-  it("reads the shape off the source", () => {
+  it("reads the shape off the source, in either spelling", () => {
     assert.equal(hasDefaultExport("export default PALETTE;"), true);
+    // `export { x as default }` leaves under a name the importer picks too, so
+    // both spellings answer the same question of the parse (Codex review iter-4).
+    assert.equal(hasDefaultExport("const p = 1;\nexport { p as default };"), true);
     assert.equal(hasDefaultExport("export const PALETTE = 1;"), false);
     // Prose about the shape is not the shape.
     assert.equal(hasDefaultExport("// never export default from here\n"), false);
+  });
+
+  it("does not offer `default` as a name a plugin could be matched against", () => {
+    assert.deepEqual(exportedNamesIn("export { p as default, ENUM_ALERT };"), ["ENUM_ALERT"]);
   });
 });
 


### PR DESCRIPTION
## Summary

`packages/core` にしかリテラルが無い Tailwind クラスが、プラグインのパッケージビルドが出す
`dist/style.css` に入らない問題（#2989）の修正。

**実測: パレットが名前を持つ 76 クラス中 43 が欠落していた**（issue 本文の 3 例より広い）。
enum の配色だけでなく、通知 enum の重要度色（`bg-red-500` / `text-red-700` / `bg-amber-100` /
`bg-amber-500` / `bg-slate-300`）も落ちていた。

原因は Tailwind v4 の自動コンテンツ検出が **CSS エントリの属する「プロジェクト」** を走査すること:

| | vite の root | core/src を走査するか |
|---|---|---|
| ホストアプリ | リポジトリルート | する → クラスが出る |
| プラグインのビルド | そのパッケージ | **しない → 落ちる** |

`collection-plugin/vite.config.ts` のコメントが「node_modules はホストの走査対象外なので
パッケージは自分のクラスを自分で出荷する」と書いているとおりで、その理屈が **core にだけ
適用されていなかった**、という形の穴です。

### 変更

1. **`collection-plugin/src/style.css` に `@source` を 1 行**（パレットのファイルを名指し）
2. **ガード `scripts/packages/check-plugin-tailwind-source.mjs` を追加し CI に投入**
   規則: *core のソースに配色クラスが書かれていて、そのファイルの export を使っている
   プラグインは、そのファイルを覆う `@source` を自分の CSS に持っていなければならない。*

### 検証

- 再ビルドして **パレット 76 クラスが全部 `dist/style.css` にあること**を確認（欠落 0）。増加は
  +4,534 バイト＝パレット本体のみ
- **ガードが本当に効くか**: `@source` を消した状態で走らせて落ちることを確認。出力は不足している
  プラグイン名・使っている symbol・追加すべき `@source` 行までを名指しする
- 純粋関数（クラス抽出 / export 抽出 / `@source` 抽出 / 被覆判定 / 規則本体）に単体テスト 14 件
- `typecheck:test` / `eslint` / `prettier --check` 済み

## Items to Confirm / Review

1. **ファイル名指しにした判断**。`@source "../../../core/src"`（ディレクトリごと）でも直りますが、
   実測すると core の TypeScript から `contents` `grow` `ring` `static` などを**クラスとして拾い**、
   関係のないユーティリティを 8 個ほど余計に emit しました。将来 core にパレットが増えたときは
   ガードが落ちて `@source` の追加を促す、という設計にしています
2. **採らなかった案**（issue の 2 / 3）: 共有 CSS パーシャルへの集約はパレットを描画しない
   プラグインにも 4.5 KB の未使用 CSS が乗るため見送り。core 自身が CSS を出力する案は core に
   Tailwind ビルドを増やしホストと二重化するため見送り。**トークン化（案 3）は方向としては
   残す**べきだと思いますが、8 色 × 4 用途と全呼び出し側の移行になり、この不具合の修正としては
   大きすぎると判断しました
3. **ガードの規則の粒度**: 「export を名前で参照しているか」で判定しています。型だけ import して
   クラスを描画しないプラグインがあれば偽陽性になりますが、その場合も `@source` を足せば消えます
   （現状 7 プラグイン中 collection-plugin のみ該当）
4. **`@source` のパスは相対**です。core のパレットファイルを移動／改名すると Tailwind は黙って
   拾わなくなりますが、そのときはガードが落ちます

## 影響範囲

- ランタイムプラグイン経路 / `mulmoterminal` など**別ホストで enum の配色が無地になっていた**のが直ります
- ホストアプリ内の見た目は変わりません（元から出ていたため）
- **未観測**: 別ホストの実機で配色が落ちている画面は確認していません（issue と同じく、検査したのは
  ビルド成果物の CSS のみ）。パッケージ CSS に 43 クラスが存在しないこと・修正後に存在することは
  実測済みです

## Codex レビュー対応（iter-1〜4、いずれもガードの検出漏れ）

ガードそのものに 4 件の穴を指摘され、すべて実測で「塞ぐ前は落ちる」ことを確認して修正しました。

| iter | 指摘 | 対応 |
|---|---|---|
| 1 | コメントアウトされた `@source` を live と読む | `withoutComments` でコメントを潰してから走査（Tailwind の parser と同じ扱い） |
| 2 | `const p = ...; export { p };` 形式の named export list を読めない | ソース全体から `export { ... }` を読み、別名と `type` エントリも解決 |
| 3 | default export の配色ファイルを検出できない | **検出できない形として FAIL させる**（名前付き export を規約として強制。core の default export は現在 0 件） |
| 4 | `export { palette as default }`（間接 default）を見落とす | 綴りの列挙をやめ、**「渡す名前に `default` が含まれるか」という 1 つの問い**に集約 |

iter-4 の時点で「export の書き方を 1 つずつ塞ぐ」形になっていたので、規則の側を言い直しています
（規則は「importer が名前を決める形は追えない」で、両方の綴りがそこへ合流する）。

現在の head で **CODEX VERDICT: LGTM**。

## User Prompt

> https://github.com/receptron/mulmoclaude/issues/2989
> つぎこれ

方針は 4 択（狭い `@source` + ガード / 共有パーシャル / core が CSS 出力 / トークン化）で確認し、
**「狭い `@source` + ガード」**を選択いただきました。

Closes #2989

work in mulmoclaude4

## Summary by Sourcery

Ensure plugins ship all core-owned Tailwind palette styles and prevent future omissions with CI validation.

Bug Fixes:
- Ensure Tailwind palette classes declared in core are included in the collection plugin's packaged CSS, restoring missing enum and notification colors for plugin consumers.

Enhancements:
- Add a validation rule that detects plugins using core-owned color classes without scanning their source files and reports the required CSS source directive.
- Add focused tests covering palette extraction, export detection, comment handling, source coverage, default exports, and missing-source detection.

CI:
- Run the plugin Tailwind source validation check on every pull request.

Documentation:
- Document the cause, selected fix, alternatives, and verification for the missing plugin CSS classes.