### PR TITLE
fix(collection-plugin): IconGlyph の CSS ソースを宣言する（main が赤い）

### DIFF
--- a/packages/plugins/collection-plugin/src/style.css
+++ b/packages/plugins/collection-plugin/src/style.css
@@ -6,3 +6,10 @@
    scanning core/src harvests ordinary words out of the TypeScript (`contents`, `grow`,
    `ring`) and emits utilities nothing asked for. */
 @source "../../../core/src/collection/core/enumColors.ts";
+
+/* IconGlyph does the same thing one file over: it spells out the classes that
+   size and colour a collection's icon, and it lives in core rather than here
+   (#2986). Same reasoning as above, including naming the FILE — the gate in
+   `scripts/packages/check-plugin-tailwind-source.mjs` went red the moment the
+   two landed together. */
+@source "../../../core/src/plugin-vue/IconGlyph.ts";


### PR DESCRIPTION
## Summary

**main が赤いので、それを直す 1 行の PR です。**

`yarn check:plugin-css` が落ちています:

```
[plugin-css] FAIL — 1 plugin(s) render core classes their build never scans:
  collection-plugin uses IconGlyph from packages/core/src/plugin-vue/IconGlyph.ts (1 classes)
    add to packages/plugins/collection-plugin/src/style.css:  @source "../../../core/src/plugin-vue/IconGlyph.ts";
```

`main`（`34a867dba`）で再現します。

## なぜどちらのレビューでも見えなかったか

**#2986（collection の IconGlyph）と #2989（プラグイン CSS のゲート）が別々に入り、組み合わせで初めて落ちました。** どちらの PR も単体では緑だったので、双方のレビューからは見えません。CI がその組み合わせを実行するのはマージ後です。

## 修正

`IconGlyph` は core にあってアイコンのサイズと色のクラスを直書きしていますが、collection-plugin の Vite root はそこを走査しないので `dist/style.css` から落ちます。ホストアプリは root がリポジトリなので描画でき、**パッケージとして読み込んだ人にだけ**欠けます —— ゲートが検出したのはまさにそれです。

隣の `enumColors.ts` と同じ形で、ディレクトリではなく**ファイル**を指定しています（`core/src` を丸ごと走査すると TypeScript の普通の語（`contents` / `grow` / `ring`）を拾って要らないユーティリティを生むため。既存コメントに理由が書かれています）。

## 検証

- `yarn check:plugin-css` → `OK — 7 plugin CSS entries, 2 core file(s) declaring classes, no gaps.`
- `test/scripts/packages/test_pluginTailwindSource.ts` 23 件 pass
- `yarn lint` 0 errors

## Items to Confirm / Review

- `@source` にファイルを指定する形が意図どおりか（ディレクトリを避ける理由は隣のコメントに従いました）
- IconGlyph が出すクラスが 1 つだけ、という検出結果が実態と合っているか

## User Prompt

- #2995

（#2995 に着手したところ main が赤く、切ったブランチが全部これを引き継ぐため先に分離して直しています）

work in mulmoclaude2

## Summary by Sourcery

Bug Fixes:
- Ensure collection-plugin packages the CSS classes emitted by IconGlyph so its published styles render collection icons correctly.