### PR TITLE
docs(roles): 意図的に containment を外した 3 箇所に追跡 issue を紐づける

### DIFF
--- a/src/utils/role/icon.ts
+++ b/src/utils/role/icon.ts
@@ -58,7 +58,7 @@ const FALLBACK_ICON = "smart_toy";
  *  `components/RolesView.vue`): those screens bypass this function to show
  *  what you actually typed, emoji included, and an emoji is 1.25em — this cap
  *  would crop it. Bounding them needs the classify-then-render treatment in
- *  `collection/core/iconGlyph.ts`, not this. */
+ *  `collection/core/iconGlyph.ts`, not this — tracked in #3003. */
 export const ROLE_ICON_CONTAINMENT = "inline-block w-[1em] overflow-hidden";
 
 export function roleIcon(roles: Role[], roleId: string): string {


### PR DESCRIPTION
<!-- lang: ja -->
## Summary

`src/utils/role/icon.ts` のコメントに **#3003 への参照を 1 行足すだけ**の変更です。

#3001 で「ロール管理画面（`manageRoles/View.vue` / `manageRoles/Preview.vue` /
`RolesView.vue`）の生 `role.icon` 描画は、1em で切ると**絵文字が欠ける**ので
containment の対象外」と理由付きで書きましたが、**追跡先が無いまま**でした。

意図的な先送りに行き先が無いのは、そのまま忘れられる形そのものなので、
起票した #3003 を指すようにします。

## Items to Confirm / Review

- コメント 1 行のみ。挙動の変更はありません。
- `yarn lint` / `yarn typecheck` / `test_icon.ts`（7 passed）で確認済み。

refs #3003, #3001

work in mulmoclaude3

## Summary by Sourcery

Enhancements:
- Link the intentionally excluded role icon containment cases to tracking issue #3003 for future follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for raw role-icon renderers and their handling.
  * Added a reference to issue `#3003`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->