### PR TITLE
chore: raise lint_test timeout to 30 min so macOS stops timing out (#3007)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -71,11 +71,14 @@ jobs:
     # (ubuntu p90 13.9-15.5), and 5 of those runs had a macOS cell killed
     # at exactly 20 min while every ubuntu sibling passed. Runner speed
     # also drifts day to day - on 2026-08-28 the macOS median was 17.7.
-    # A lockfile-touching PR is worst: both caches below key on
-    # hashFiles('yarn.lock'), so a dep bump pays a cold install AND a cold
-    # build:packages (#3005 measured +3-4 min). Matches the 30 already used
-    # by the Windows sibling job. A cap is a runaway guard, not a perf
-    # budget - raising it costs nothing on a healthy run. (#3007)
+    # A lockfile-touching PR is the worst case: setup-node's yarn cache
+    # and the packages/dist cache below both key on the lockfile with no
+    # restore-key, so a dep bump pays a cold install AND a cold
+    # build:packages (#3005: 42s -> 2m26s and 1m11s -> 2m25s). The
+    # puppeteer cache has a restore-key and stays warm, so it is not part
+    # of this. 30 matches the Windows sibling job. A cap is a runaway
+    # guard, not a perf budget - raising it costs nothing on a healthy
+    # run. (#3007)
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -66,7 +66,17 @@ jobs:
   # is covered daily and on every main push instead.
   lint_test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # 30, not 20: the macOS cells sit far closer to the cap than ubuntu.
+    # Over 60 runs the macOS p90 was 18.0-19.3 min against a 20 min cap
+    # (ubuntu p90 13.9-15.5), and 5 of those runs had a macOS cell killed
+    # at exactly 20 min while every ubuntu sibling passed. Runner speed
+    # also drifts day to day - on 2026-08-28 the macOS median was 17.7.
+    # A lockfile-touching PR is worst: both caches below key on
+    # hashFiles('yarn.lock'), so a dep bump pays a cold install AND a cold
+    # build:packages (#3005 measured +3-4 min). Matches the 30 already used
+    # by the Windows sibling job. A cap is a runaway guard, not a perf
+    # budget - raising it costs nothing on a healthy run. (#3007)
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/plans/chore-3007-macos-lint-test-timeout.md
+++ b/plans/chore-3007-macos-lint-test-timeout.md
@@ -1,0 +1,99 @@
+# CI: macOS の `lint_test` が 20 分のタイムアウトで落ちる（#3007）
+
+## 症状
+
+`pull_request.yaml` の `lint_test` の **macOS セルだけ**が `timeout-minutes: 20` に達して cancel される。
+テストが落ちているのではなく `test:coverage` の途中で打ち切られる（`##[error]The operation was canceled.`）。
+同じランの ubuntu セルは全て成功しているので、コード側の問題ではない。
+
+## 実測 — 上限に対する余裕が macOS だけ無い
+
+直近 60 ランの `lint_test` を Actions API から step 単位で取得した（成功セルのみ、n はセル数）。
+
+| セル | n | p50 | p90 | max | 上限までの余裕 (p90) |
+|---|---:|---:|---:|---:|---:|
+| `lint_test (22.x, macos-latest)` | 60 | 14.5 | **19.3** | 20.6 | **0.7 分** |
+| `lint_test (24.x, macos-latest)` | 60 | 14.2 | **18.0** | 20.2 | 2.0 分 |
+| `lint_test (22.x, ubuntu-latest)` | 60 | 13.6 | 15.5 | 16.4 | 4.5 分 |
+| `lint_test (24.x, ubuntu-latest)` | 60 | 12.3 | 13.9 | 14.7 | 6.1 分 |
+
+実際にタイムアウト kill されたラン（macOS セルが 20 分ちょうどで cancel、ubuntu 兄弟は全て成功）:
+
+| run | 22.x macos | 24.x macos | 22.x ubuntu | 24.x ubuntu |
+|---|---|---|---|---|
+| 33250382799 (#3005) | **cancel 20.4** | **cancel 20.1** | ok 13.1 | ok 14.1 |
+| 33223509289 | ok 13.8 | **cancel 20.2** | ok 14.5 | ok 13.6 |
+| 33218655575 | **cancel 20.1** | ok 18.0 | ok 16.4 | ok 14.2 |
+| 33216423367 | **cancel 20.2** | ok 17.7 | ok 15.5 | ok 14.3 |
+| 33212805307 | **cancel 20.6** | ok 19.0 | ok 15.8 | ok 14.6 |
+
+**60 ラン中 5 ランで発生**。単発の flake ではない。
+
+runner の速さ自体が日単位で動いている:
+
+| 日 | macOS 成功セル n | p50 | max |
+|---|---:|---:|---:|
+| 2026-08-28 | 21 | **17.7** | 20.0 |
+| 2026-08-29 | 56 | 14.8 | 19.3 |
+
+8/28 は**中央値が 17.7 分**で、半分のセルが上限まで 2.3 分を切っていた。
+
+## `yarn.lock` を触る PR が特に危ない
+
+`lint_test` の 2 つのキャッシュはどちらもキーに `hashFiles('yarn.lock')` を含む:
+
+- `Cache puppeteer browsers` — `puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}`（`restore-keys` あり）
+- `Cache packages/dist` — キー末尾が `'yarn.lock', 'package.json'`（**`restore-keys` 無し**）
+
+依存更新 PR は必ず両方ミスし、cold install + cold build が上乗せされる。#3005（依存の
+バージョン上げのみ）で実際に出た差:
+
+| ステップ | #3005 (macos 22.x) | 同日の main (macos 22.x) |
+|---|---:|---:|
+| `yarn install` | 2m26s | 42s |
+| `build:packages` | 2m25s | 1m11s |
+| `typecheck` | 2m39s | 1m23s |
+| `lint` | 7m08s | 4m42s |
+| `build` | 2m55s | 1m40s |
+| `test:coverage` | **2m08s で cancel** | 3m37s (pass) |
+
+全ステップが 1.5〜1.7 倍になっており、cold cache だけでなく runner 自体も遅い日だった。
+
+#2857 の調査で判明しているとおり、このリポジトリの Actions キャッシュは既に 10 GB の上限を
+超えて LRU 追い出しが起きているため、キャッシュヒット率自体も安定しない。
+
+## やること
+
+`.github/workflows/pull_request.yaml` の `lint_test` の `timeout-minutes` を **20 → 30**。
+
+根拠:
+
+- Windows 版の同等ジョブ `lint_test_windows.yaml` は既に `timeout-minutes: 30`。揃えるだけ。
+- 観測最大 20.6 分に対して 9 分以上の余裕ができる。8/28 のような遅い日（p50 17.7）でも
+  cold cache 分（実測 +3〜4 分）を吸収できる。
+- タイムアウトは暴走ジョブを止める保険であって性能予算ではない。上げても正常なジョブの
+  実行時間は変わらず、課金も実時間に対してなので無駄は出ない。
+
+なぜ上限を測定値で決めたのかがコメントから読めるよう、ワークフローに実測を残す。
+
+## やらないこと（独立した判断なので分ける）
+
+- **ジョブ本体の高速化**。`lint` が macOS で 4.7〜7.1 分と最大の項目で、短縮する価値はある。
+  `Cache packages/dist` に `restore-keys` を足せば依存更新 PR の cold build も減らせる。
+  どちらも上限引き上げとは独立に評価すべきなので別 issue にする。
+- `e2e` ジョブ（`timeout-minutes: 15`、実測 11m3s / 11m27s）。余裕 3.5 分でタイムアウト
+  kill の実績も無いため今回は触らない。
+
+## 検証方法
+
+ワークフロー自身の変更なので、この PR の CI で新しい上限が適用されたジョブが走る。
+確認するのは次の 2 点:
+
+1. `lint_test` の 4 セルが全て成功すること。
+2. **所要時間が変わっていないこと** — 上限引き上げはジョブを速くも遅くもしない。
+   変わっていたら別の要因が混ざっている。
+
+```sh
+gh api "repos/receptron/mulmoclaude/actions/runs/<RUN_ID>/jobs?per_page=50" \
+  --jq '.jobs[] | select(.name|test("lint_test")) | [.name,.conclusion,.started_at,.completed_at] | @tsv'
+```

--- a/plans/chore-3007-macos-lint-test-timeout.md
+++ b/plans/chore-3007-macos-lint-test-timeout.md
@@ -40,13 +40,18 @@ runner の速さ自体が日単位で動いている:
 
 ## `yarn.lock` を触る PR が特に危ない
 
-`lint_test` の 2 つのキャッシュはどちらもキーに `hashFiles('yarn.lock')` を含む:
+`lint_test` はロックファイルのハッシュをキーに含むキャッシュを 3 つ使うが、**依存更新 PR で
+実際にコールドになるのは 2 つだけ**。#3005 の macOS ジョブのログで確認した:
 
-- `Cache puppeteer browsers` — `puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}`（`restore-keys` あり）
-- `Cache packages/dist` — キー末尾が `'yarn.lock', 'package.json'`（**`restore-keys` 無し**）
+| キャッシュ | キー | `restore-keys` | #3005 での結果 |
+|---|---|---|---|
+| setup-node の yarn キャッシュ (`cache: yarn`) | `node-cache-<OS>-<arch>-yarn-<lock ハッシュ>` | 無し | `yarn cache is not found` → **ミス** |
+| `Cache packages/dist` | 末尾に `'yarn.lock', 'package.json'` | **無し** | `Cache not found for input keys` → **ミス** |
+| `Cache puppeteer browsers` | `puppeteer-<OS>-<lock ハッシュ>` | `puppeteer-<OS>-` あり | `Cache hit for restore-key` → **ヒット（warm）** |
 
-依存更新 PR は必ず両方ミスし、cold install + cold build が上乗せされる。#3005（依存の
-バージョン上げのみ）で実際に出た差:
+つまり上乗せされるのは **cold install（setup-node のキャッシュ）と cold build:packages
+（`packages/dist`）の 2 つ**で、puppeteer の chrome 再ダウンロードは起きていない。
+#3005（依存のバージョン上げのみ）で実際に出た差:
 
 | ステップ | #3005 (macos 22.x) | 同日の main (macos 22.x) |
 |---|---:|---:|
@@ -57,7 +62,10 @@ runner の速さ自体が日単位で動いている:
 | `build` | 2m55s | 1m40s |
 | `test:coverage` | **2m08s で cancel** | 3m37s (pass) |
 
-全ステップが 1.5〜1.7 倍になっており、cold cache だけでなく runner 自体も遅い日だった。
+比較できる 5 ステップの倍率は **1.5〜3.5 倍**（install 3.5x / build:packages 2.0x /
+typecheck 1.9x / lint 1.5x / build 1.75x）。`test:coverage` は cancel されたので比較対象外。
+最大の install は cold cache で説明がつくが、キャッシュと無関係な typecheck・lint・build まで
+1.5〜1.9 倍になっているので、この日は runner 自体も遅かった。
 
 #2857 の調査で判明しているとおり、このリポジトリの Actions キャッシュは既に 10 GB の上限を
 超えて LRU 追い出しが起きているため、キャッシュヒット率自体も安定しない。
@@ -79,7 +87,8 @@ runner の速さ自体が日単位で動いている:
 ## やらないこと（独立した判断なので分ける）
 
 - **ジョブ本体の高速化**。`lint` が macOS で 4.7〜7.1 分と最大の項目で、短縮する価値はある。
-  `Cache packages/dist` に `restore-keys` を足せば依存更新 PR の cold build も減らせる。
+  `Cache packages/dist` に `restore-keys` を足せば依存更新 PR の cold build も減らせる
+  （puppeteer キャッシュが実際にそうやって warm を保っている）。
   どちらも上限引き上げとは独立に評価すべきなので別 issue にする。
 - `e2e` ジョブ（`timeout-minutes: 15`、実測 11m3s / 11m27s）。余裕 3.5 分でタイムアウト
   kill の実績も無いため今回は触らない。


### PR DESCRIPTION
## Summary

`pull_request.yaml` の `lint_test` の `timeout-minutes` を **20 → 30** に上げる。

macOS セルだけが上限に張り付いており、テストが落ちたわけでもないのに 20 分で cancel される
事故が起きている。直近 60 ラン中 **5 ラン**で発生し、同じランの ubuntu セルは全て成功していた。

成功セルの所要時間（直近 60 ラン、Actions API から step 単位で取得）:

| セル | n | p50 | p90 | max | 上限までの余裕 (p90) |
|---|---:|---:|---:|---:|---:|
| `lint_test (22.x, macos-latest)` | 60 | 14.5 | **19.3** | 20.6 | **0.7 分** |
| `lint_test (24.x, macos-latest)` | 60 | 14.2 | **18.0** | 20.2 | 2.0 分 |
| `lint_test (22.x, ubuntu-latest)` | 60 | 13.6 | 15.5 | 16.4 | 4.5 分 |
| `lint_test (24.x, ubuntu-latest)` | 60 | 12.3 | 13.9 | 14.7 | 6.1 分 |

タイムアウト kill されたラン:

| run | 22.x macos | 24.x macos | 22.x ubuntu | 24.x ubuntu |
|---|---|---|---|---|
| 33250382799 (#3005) | **cancel 20.4** | **cancel 20.1** | ok 13.1 | ok 14.1 |
| 33223509289 | ok 13.8 | **cancel 20.2** | ok 14.5 | ok 13.6 |
| 33218655575 | **cancel 20.1** | ok 18.0 | ok 16.4 | ok 14.2 |
| 33216423367 | **cancel 20.2** | ok 17.7 | ok 15.5 | ok 14.3 |
| 33212805307 | **cancel 20.6** | ok 19.0 | ok 15.8 | ok 14.6 |

runner の速さは日単位でも動いており、2026-08-28 は macOS の**中央値が 17.7 分**（n=21、max 20.0）
＝半分のセルが上限まで 2.3 分を切っていた（8/29 は p50 14.8、n=56）。

さらに `lint_test` はロックファイルのハッシュをキーに含むキャッシュを 3 つ使い、そのうち
**2 つが依存更新 PR で必ずコールドになる**（#3005 の macOS ジョブのログで確認）:

| キャッシュ | `restore-keys` | #3005 での結果 |
|---|---|---|
| setup-node の yarn キャッシュ (`cache: yarn`) | 無し | `yarn cache is not found` → **ミス** |
| `Cache packages/dist` | **無し** | `Cache not found for input keys` → **ミス** |
| `Cache puppeteer browsers` | `puppeteer-<OS>-` あり | `Cache hit for restore-key` → **ヒット（warm）** |

上乗せされるのは cold install と cold build:packages の 2 つ。#3005 で実測した差:

| ステップ | #3005 (macos 22.x) | 同日の main (macos 22.x) |
|---|---:|---:|
| `yarn install` | 2m26s | 42s |
| `build:packages` | 2m25s | 1m11s |
| `typecheck` | 2m39s | 1m23s |
| `lint` | 7m08s | 4m42s |
| `build` | 2m55s | 1m40s |
| `test:coverage` | **2m08s で cancel** | 3m37s (pass) |

30 分にする理由は、Windows 版の同等ジョブ `lint_test_windows.yaml` が既に
`timeout-minutes: 30` で揃うこと、観測最大 20.6 分に対して 9 分以上の余裕ができ、
遅い日 + cold cache（実測 +3〜4 分）を同時に食らっても収まること。
タイムアウトは暴走ジョブを止める保険であって性能予算ではないので、**上げても正常な
ジョブの実行時間は変わらず、課金も実時間に対してなので無駄は出ない**。

## Items to Confirm / Review

- **上限を上げるのが正しい対処か（高速化すべきでないか）。** `lint` が macOS で 4.7〜7.1 分と
  最大の項目で、短縮の余地はある。ただし高速化は上限の妥当性とは独立した判断なので、
  この PR ではやらず別 issue にする方針にした。この分割で良いか。
- **30 という値。** 観測最大 20.6 分 + cold cache 3〜4 分 = 約 24 分を想定し、Windows 側と
  揃えて 30 にした。25 でも足りるが、Windows と値が揃っている方が読みやすいと判断した。
- **`e2e` ジョブは触っていない**（`timeout-minutes: 15`、実測 11m3s / 11m27s = 余裕 3.5 分）。
  タイムアウト kill の実績が無いため今回は対象外にしたが、macOS ほどではないにせよ
  余裕が薄い部類ではある。
- **検証は CI 自身**。`.github/**` を触るので `workflow-lint`（actionlint + zizmor）が走る。
  ローカルでも `actionlint` は exit 0 を確認済み。`lint_test` 4 セルが全て成功し、かつ
  **所要時間が変わっていない**ことを見れば足りる（上限引き上げはジョブを速くも遅くもしない）。

## User Prompt

> なおして
> https://github.com/receptron/mulmoclaude/pull/3005

#3005（依存バージョン上げのみ）の CI 失敗の調査を依頼された。原因は macOS `lint_test` の
20 分タイムアウトで、#3005 固有ではなく再発しているものだったため、対処方針を確認したうえで
「CI の上限を上げてから #3005 を再実行する」を選択してもらった。本 PR はその 1 本目。

Closes #3007

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CN4TWXyzTfZ1N6wHQYMK5s

work in mulmoclaude

## Summary by Sourcery

Increase the pull request lint_test timeout to reduce recurring macOS CI cancellations.

Bug Fixes:
- Prevent macOS lint_test jobs from being cancelled by increasing their timeout from 20 to 30 minutes.

CI:
- Align the pull request lint_test timeout with the existing Windows workflow to provide additional headroom for slow runners and cold caches.

Documentation:
- Document the observed macOS timeout failures and the rationale for increasing the CI limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the pull request validation time limit to reduce cancellations on slower macOS runs.
  * Improved reliability for checks affected by cold caches or variable build performance.

* **Documentation**
  * Added documentation explaining the validation timeout issue, supporting measurements, and verification approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
