### PR TITLE
fix(test): wait-for-backend CLI テストを子プロセスの起動時間から切り離す (#3009)

### DIFF
--- a/plans/fix-3009-wait-for-backend-cli-flake.md
+++ b/plans/fix-3009-wait-for-backend-cli-flake.md
@@ -1,0 +1,40 @@
+# fix #3009 — wait-for-backend CLI テストの起動時間依存を消す
+
+## 問題
+
+`test/scripts/test_waitForBackendCli.ts` の publish が `spawn()` からの固定 400ms タイマーで、
+CLI 子プロセスの `tsx` cold boot と競合する。boot が 400ms を超えると publish が
+before スナップショットより先に着地し、以後 mtime が変わらないため `wasRepublished()` は
+（設計どおり）「この run の publish ではない」と判定 → `PORT` にフォールバックして timeout。
+
+ubuntu の CI でスイート先頭（最も cold な spawn）が落ちた。
+
+## 方針
+
+製品コード (`scripts/wait-for-backend.ts`, `scripts/lib/publishedPort.ts`) は変更しない。
+「スナップショット時に既にあるファイルは信用しない」は #2981 の意図した契約で、
+同スイートの `does not follow a leftover file from a dead run` が固定している。
+
+フィクスチャを **CLI 終了まで publish を撃ち続ける** 形にする:
+
+- `PUBLISH_INTERVAL_MS` で `.server-port` を書き直し続け、`runCli` の解決時に `clearInterval`
+- boot がいつ終わっても「スナップショット後の write」が必ず 1 回は起きる
+- `attributable=false` のケースはスナップショット後の write でしか成功しないので、
+  「publish を学んでから待つ」という証明対象の順序は保たれる
+
+## 適用範囲
+
+| テスト | 変更 | 理由 |
+|---|---|---|
+| `waits on the WALKED-TO port` | 置換 | 今回落ちた本体 |
+| `PORT=0 is usable now` | 置換 | 同じ競合を持つ（今回はたまたま通った） |
+| `never refuses to start Vite` | 置換 | 競合で 8s 空回りしていた（assert は緩いので落ちはしない） |
+| `--reset makes a later publish attributable` | 据え置き | 先行する `--reset` 実行で tsx が温まっており、かつ `attributable=true` の近道でどちらの順序でも通る |
+| `does not follow a leftover file from a dead run` | 据え置き | publish 前置きが仕様そのもの |
+| `never reports readiness for ...` | 据え置き | publish しないケース |
+
+## 検証
+
+1. `PUBLISH_DELAY_MS = 0`（boot > delay と等価）で現行テストが CI と同じメッセージで落ちることを確認（済）
+2. 修正後、同じ「publish がスナップショットより先に着地する」条件を強制しても通ることを確認
+3. `yarn tsx --test ./test/scripts/test_waitForBackendCli.ts` を複数回

--- a/plans/fix-3009-wait-for-backend-cli-flake.md
+++ b/plans/fix-3009-wait-for-backend-cli-flake.md
@@ -22,6 +22,18 @@ ubuntu の CI でスイート先頭（最も cold な spawn）が落ちた。
 - `attributable=false` のケースはスナップショット後の write でしか成功しないので、
   「publish を学んでから待つ」という証明対象の順序は保たれる
 
+## publish は本番と同じく atomic に
+
+CodeRabbit 指摘。素の `writeFileSync` は `O_TRUNC` で開くので、truncate と write の
+あいだに読んだ側は**空ファイル**、write 中に読んだ側は**前方一致の断片**を見る
+（`3002` が `300` になり、何も listen していないポートとして正常にパースされる）。
+CLI は mtime が動いた後に 1 回だけ読むので、torn read 1 回で wait 全体が落ちる。
+
+実サーバ (`server/workspace/serverPort.ts`) は `writeFileAtomic` で tmp→rename しており、
+まさにこの危険を潰すためだと冒頭コメントに書いてある。フェイクバックエンドが非 atomic に
+書くのは**本番が起こしえない危険をモデル化している**ことになるので、フィクスチャの publish も
+tmp→rename に揃える（`publishPort`）。テスト 3 の 1 発 publish も同じ経路に通す。
+
 ## 適用範囲
 
 | テスト | 変更 | 理由 |

--- a/test/scripts/test_waitForBackendCli.ts
+++ b/test/scripts/test_waitForBackendCli.ts
@@ -22,6 +22,7 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 const CLI = path.join(REPO_ROOT, "scripts", "wait-for-backend.ts");
 const CLI_BUDGET_MS = 8000;
 const PUBLISH_DELAY_MS = 400;
+const PUBLISH_INTERVAL_MS = 200;
 /** A port nothing is listening on, used as the `PORT` the run asked for. */
 const UNSERVED_PORT = 3999;
 
@@ -71,6 +72,30 @@ function runCli(fixture: Fixture, opts: { port: number; args?: string[] } = { po
   });
 }
 
+/**
+ * Run the CLI while the fake backend publishes its port over and over.
+ *
+ * A single timed write raced the child's `tsx` boot. The CLI snapshots
+ * `.server-port` only once it has booted, and a file that is already there at
+ * the snapshot and never rewritten is — by design (#2981) — NOT a publish this
+ * run may claim, so a boot slower than the delay left the wait falling back to
+ * `PORT` forever. That is the leftover-file contract working, pinned on its own
+ * below; it was the fixture that depended on the boot winning a race.
+ *
+ * Publishing until the child exits removes the dependency without weakening
+ * anything: these cases have no `--reset` marker, so the only way they can pass
+ * is a write that lands AFTER the snapshot — which is exactly the ordering they
+ * exist to prove.
+ */
+async function runCliWhilePublishing(fixture: Fixture, opts?: { port: number; args?: string[] }): Promise<{ code: number | null; out: string }> {
+  const publishing = setInterval(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_INTERVAL_MS);
+  try {
+    return await runCli(fixture, opts);
+  } finally {
+    clearInterval(publishing);
+  }
+}
+
 describe("wait-for-backend CLI — follows the port the backend published", () => {
   let fixture: Fixture;
 
@@ -86,10 +111,8 @@ describe("wait-for-backend CLI — follows the port the backend published", () =
     // bound another and published that. Nothing is listening on UNSERVED_PORT,
     // so a wait that watched it would time out; following the publish succeeds.
     rmSync(fixture.portFile, { force: true });
-    const publish = setTimeout(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_DELAY_MS);
 
-    const { code, out } = await runCli(fixture);
-    clearTimeout(publish);
+    const { code, out } = await runCliWhilePublishing(fixture);
 
     assert.equal(code, 0, out);
     assert.match(out, new RegExp(`backend ready on :${fixture.boundPort}`));
@@ -118,6 +141,9 @@ describe("wait-for-backend CLI — follows the port the backend published", () =
     assert.equal(reset.code, 0);
     assert.equal(existsSync(fixture.portFile), false, "--reset must remove the stale port file");
 
+    // One timed write is safe here where it was not above: the marker makes the
+    // file attributable, so a publish landing on EITHER side of the snapshot is
+    // credited to this run. Nothing rides on which side wins.
     const publish = setTimeout(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_DELAY_MS);
     const { code, out } = await runCli(fixture);
     clearTimeout(publish);
@@ -131,10 +157,8 @@ describe("wait-for-backend CLI — follows the port the backend published", () =
     // OS-assigned port was unknowable when Vite evaluated its config. It is
     // knowable now: the backend binds it and says so.
     rmSync(fixture.portFile, { force: true });
-    const publish = setTimeout(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_DELAY_MS);
 
-    const { code, out } = await runCli(fixture, { port: 0 });
-    clearTimeout(publish);
+    const { code, out } = await runCliWhilePublishing(fixture, { port: 0 });
 
     assert.equal(code, 0, out);
     assert.match(out, new RegExp(`backend ready on :${fixture.boundPort}`));
@@ -158,10 +182,8 @@ describe("wait-for-backend CLI — follows the port the backend published", () =
     // proxy target. Vite follows now, so disagreement is not a state that
     // exists; nothing here should ever stop the client pane.
     rmSync(fixture.portFile, { force: true });
-    const publish = setTimeout(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_DELAY_MS);
 
-    const { code, out } = await runCli(fixture);
-    clearTimeout(publish);
+    const { code, out } = await runCliWhilePublishing(fixture);
 
     assert.equal(code, 0, out);
     assert.doesNotMatch(out, /REFUS/i);

--- a/test/scripts/test_waitForBackendCli.ts
+++ b/test/scripts/test_waitForBackendCli.ts
@@ -12,7 +12,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { createServer, type Server } from "node:net";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -32,6 +32,24 @@ interface Fixture {
   workspace: string;
   portFile: string;
   close: () => Promise<void>;
+}
+
+/**
+ * Publish the port the way the real backend does — tmp file, then rename.
+ *
+ * `server/workspace/serverPort.ts` writes `.server-port` atomically precisely
+ * because the waiter reads it while it is being written: a plain write opens
+ * with `O_TRUNC`, so a reader landing between the truncate and the write sees an
+ * EMPTY file and one landing mid-write sees a PREFIX — `3002` cut to `300`
+ * parses as a perfectly valid port nothing is listening on. The CLI reads the
+ * file once after the mtime moves, so a single torn read loses the whole wait.
+ * A fake backend writing non-atomically would model a hazard the real one cannot
+ * produce (CodeRabbit).
+ */
+function publishPort(fixture: Fixture): void {
+  const tmp = `${fixture.portFile}.tmp`;
+  writeFileSync(tmp, `${fixture.boundPort}\n`);
+  renameSync(tmp, fixture.portFile);
 }
 
 async function startFakeBackend(): Promise<Fixture> {
@@ -88,7 +106,7 @@ function runCli(fixture: Fixture, opts: { port: number; args?: string[] } = { po
  * exist to prove.
  */
 async function runCliWhilePublishing(fixture: Fixture, opts?: { port: number; args?: string[] }): Promise<{ code: number | null; out: string }> {
-  const publishing = setInterval(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_INTERVAL_MS);
+  const publishing = setInterval(() => publishPort(fixture), PUBLISH_INTERVAL_MS);
   try {
     return await runCli(fixture, opts);
   } finally {
@@ -124,7 +142,7 @@ describe("wait-for-backend CLI — follows the port the backend published", () =
     // Present before the wait begins and never rewritten, so it cannot speak for
     // this startup. Falling back to `PORT` is right: at least that is what Vite
     // will fall back to as well, so the two still agree.
-    writeFileSync(fixture.portFile, `${fixture.boundPort}\n`);
+    publishPort(fixture);
 
     const { code, out } = await runCli(fixture);
 
@@ -144,7 +162,7 @@ describe("wait-for-backend CLI — follows the port the backend published", () =
     // One timed write is safe here where it was not above: the marker makes the
     // file attributable, so a publish landing on EITHER side of the snapshot is
     // credited to this run. Nothing rides on which side wins.
-    const publish = setTimeout(() => writeFileSync(fixture.portFile, `${fixture.boundPort}\n`), PUBLISH_DELAY_MS);
+    const publish = setTimeout(() => publishPort(fixture), PUBLISH_DELAY_MS);
     const { code, out } = await runCli(fixture);
     clearTimeout(publish);
 


### PR DESCRIPTION
## Summary

`main` の CI (`lint_test (22.x, ubuntu-latest)`) を落としていた [run 33268806039](https://github.com/receptron/mulmoclaude/actions/runs/33268806039/job/99143477942) の flake を潰す。テストのみの変更で、製品コードは触っていない。

**原因**: `test/scripts/test_waitForBackendCli.ts` は CLI を `spawn` した後、**親の時計で 400ms 後**に `.server-port` を書いていた。CLI 子プロセスは `tsx` の cold boot を終えてから `.server-port` の before スナップショットを取るので、boot が 400ms を超えると publish がスナップショットより先に着地する。その後ファイルは書き直されないため `wasRepublished()` は「この run の publish ではない」と判定し（#2981 で意図した leftover 対策そのもの）、`PORT` (=3999) にフォールバックして timeout する。

落ちたのは**スイート先頭＝最も cold な spawn**。同じ 400ms を使う後続テストは module cache が温まっていて通っていた（`PORT=0` のケースは 569ms で完走）。macOS ジョブが green だったのもこれで説明がつく。

**修正**: 固定 delay を一発撃つのをやめ、**CLI が終了するまで publish を撃ち続ける** (`runCliWhilePublishing`)。boot がいつ終わっても「スナップショット後の write」が必ず 1 回は起きる。

## Items to Confirm / Review

- **性質が弱まっていないか**: 置き換えた 3 ケースは `--reset` マーカーを持たない (`attributable=false`) ので、**スナップショット後の write でしか成功しない**。つまり「publish を学んでから待つ」という証明対象の順序はそのまま保たれている、という理屈です。ここが今回の判断の肝なのでレビューしてほしい点。
- **`--reset makes a later publish attributable` を据え置いた判断**: あれはマーカーがあるので publish がスナップショットのどちら側に落ちても credit される（`alreadyPublished` の近道 or `awaitRepublish`）。どちらの順序でも通るので競合ではない、と判断してコメントだけ足しました。
- **製品コードを直さない判断**: 「スナップショット時に既にあり書き直されないファイルは信用しない」は #2981 の意図した契約で、同スイートの `does not follow a leftover file from a dead run` が別途固定しています。直すべきはフィクスチャ側、という判断です。

## 検証

1. **再現**: `PUBLISH_DELAY_MS = 0`（boot が delay を超えた状態と等価）にすると、CI と**バイト単位で同じ**メッセージで落ちることを確認。`PORT=0` のケースも同時に落ちた（＝今回はたまたま通っていただけ）。

   ```
   ✖ waits on the WALKED-TO port, not the one PORT asked for
     The input did not match the regular expression /backend ready on :62543/. Input:
     `[wait-for-backend] backend still not listening on :3999 after 0.0s — ...`
   ✖ PORT=0 is usable now — the published port is the answer config time could not compute
   ```

2. **修正の確認（負け条件を強制）**: publish を `spawn()` より**前**に撃つ（どんな boot 遅延よりも厳しい条件）変種で 6/6 pass。

3. **テストがまだバグを捕まえるか（mutation）**: `scripts/wait-for-backend.ts` を #2650 のバグ形（`waitOn(published, …)` → `waitOn(resolution.port, …)`）に壊すと **3 ケースが red**。フィクスチャは弱まっていない。壊した後 `git checkout --` で pristine に戻し、コピーと `diff` で一致を確認済み。

4. 通常実行 3 回すべて 6/6 pass。副次的に速くもなった（先頭ケース 436ms → 約 280ms、`never refuses…` は競合に負けると 8s 空回りしていたのが約 380ms）。

5. `yarn format` / `eslint`（対象ファイル）/ `yarn typecheck:test` clean。

## User Prompt

- 「なおせる？？」 — 添付された失敗ジョブ https://github.com/receptron/mulmoclaude/actions/runs/33268806039/job/99143477942 を直してほしい。

Closes #3009

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCEYf43PwB4avHgZ5erQRY

work in mulmoclaude2

## Summary by Sourcery

Make wait-for-backend CLI tests independent of child-process startup timing while preserving their coverage of published-port behavior.

Bug Fixes:
- Eliminate flakiness in wait-for-backend CLI tests caused by fixed-delay port publication racing with child-process startup.

Enhancements:
- Keep the tests’ publish-order guarantees while making repeated port publication atomic like the production backend.

Tests:
- Update the wait-for-backend CLI fixtures to publish until the child process exits and cover cold-start timing reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of backend CLI startup checks involving dynamic ports and Vite.
  * Prevented intermittent failures caused by startup timing and incomplete port-file updates.
* **Tests**
  * Updated startup scenarios to consistently publish backend port information while the CLI initializes.
* **Documentation**
  * Added a plan documenting the intermittent test issue, affected scenarios, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->