### PR TITLE
fix(changelog): [Unreleased] の Ships 行を core/collection-plugin 4.5.0 に合わせる

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,7 +71,7 @@ the baseline" where it now means "as well as". Both consumers here pass two argu
 unaffected, but the rename is a source break for anyone who read the published type. **2.1.0**
 follows with the narrowed inline-`$` rule described above.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.4.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.4.2`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.4.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.5.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.5.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.4.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 


### PR DESCRIPTION
## Summary

`main` が赤いので直します。PR #3011（core 4.5.0 / collection-plugin 4.5.0）が `docs/CHANGELOG.md` の `[Unreleased]` の `Ships` 行を更新し忘れていました。

```
[changelog:ships] the [Unreleased] `Ships` line disagrees with packages/mulmoclaude/package.json:
  - missing: @mulmoclaude/collection-plugin@4.5.0
  - missing: @mulmoclaude/core@4.5.0
  - not a current dependency: @mulmoclaude/collection-plugin@4.4.0
  - not a current dependency: @mulmoclaude/core@4.4.2
```

この行は「このランチャーがどのパッケージ版を引き込むか」を答えるものなので、チェッカーの言うとおり **manifest ではなく行の方**を直しました（1 行、2 箇所）。

**落ちていた範囲**: `Node.js CI` の `lint_test` 4 マトリクス（ubuntu 22/24・macOS 22/24）と `lint_test (Windows)` の 2 マトリクス、計 6 ジョブ。全部 `test/scripts/packages/test_changelogShips.ts:165` の同一 1 件で、他に失敗はありません（Windows のログも確認済み）。`73d7789de` では Windows も green だったので、退行の起点は `57fae471d`（#3011 のマージ）で確定です。

## Items to Confirm / Review

1. **`[Unreleased]` セクションを選んだ判断** — チェッカーは「`[Unreleased]` が `Ships` 行を持つならそちら、無ければランチャーの version のセクション」を見ます。今回は `[Unreleased]`（74 行目）が対象で、605 行目以降の過去リリースの `Ships` 行は**意図的に触っていません**。過去の行は当時出荷した版の記録なので書き換えると履歴が壊れます。
2. **publish を止めていること** — `npm publish` は取り消せないため、この PR が green になるまで core / collection-plugin の publish は保留しています。赤い main から publish すると、版番号を戻せないまま 4.5.1 を切り直すことになります。

## 検証

- `node scripts/packages/check-changelog-ships.mjs` → `OK — [Unreleased] lists all 13 @mulmoclaude/* dependencies.`
- `npx tsx --test ./test/scripts/packages/test_changelogShips.ts` → 20/20 pass

## User Prompt

- 「なおしてね」 — main の CI が赤いので直してほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCEYf43PwB4avHgZ5erQRY

work in mulmoclaude2

## Summary by Sourcery

Bug Fixes:
- Update the unreleased changelog Ships list to reflect the current core and collection-plugin 4.5.0 dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the unreleased changelog entry for TeX math support in the Markdown preview.
  * Refreshed the listed release information to reflect the latest package versions.
  * No other shipped package versions or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->