### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.15.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,62 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+---
+
+## [1.15.0] - 2026-08-30
+
+**TeX math in the markdown preview, and icons that no longer overlap their neighbour.**
+
+### Fixed
+
+#### An emoji icon rendered at the icon font's metrics and overlapped the button beside it (#2986, PR #2988; #3003, PR #3006)
+
+A `schema.icon` that is not a Material Symbols name — an emoji, most often — was handed to the
+icon font anyway. The font drew it at its own metrics, which pushed the glyph outside its box
+and over whatever sat next to it. Icons are now classified before anything renders them:
+`iconGlyph.ts` decides what a given string *is*, and the shared `IconGlyph` component is the one
+path every surface goes through — the collections index, the collection header, the related
+menu, action buttons, feeds, the roles screen and the launcher's shortcut rail.
+
+Emoji are supported deliberately rather than by accident, the icon-font path carries a11y
+attributes, a blank fallback no longer leaves an empty glyph, and the containment that keeps an
+oversized glyph inside its box no longer depends on the build configuration. Two Tailwind
+`@source` directives were needed alongside it (#2989, PR #2994): the classes that size and
+colour a glyph are spelled out in `@mulmoclaude/core`, which the collection plugin's Vite root
+does not cover, so they fell out of the plugin's own stylesheet and only the host app kept
+rendering them.
+
+#### The dev client proxied to a port the backend was not on (#2975, PR #2977; #2981, PR #2982; #2995, PR #2997)
+
+`yarn dev` starts two panes with no ordering guarantee, and the backend does not always get the
+port `PORT` asked for — a busy default makes it walk forward. The client half derived its proxy
+target from `PORT` regardless, so whenever the request could not be honoured the two addressed
+different ports and the UI sat on "Can't reach the backend".
+
+The wait now FOLLOWS the port the backend published rather than the one it was asked for, and
+Vite re-aims itself when a late publish arrives. `.server-port` is cleared before either pane
+starts so a leftover file from a dead run cannot be mistaken for this startup's, and it is
+written atomically — a reader arriving between the truncate and the write used to see an empty
+file, and one arriving mid-write could see `3002` cut to `300`, which parses as a perfectly
+valid port nothing is listening on. `PORT=0` is usable now: the OS-assigned port was unknowable
+when Vite evaluated its config, and it is knowable once the backend binds it and says so.
+
+#### A write could lose its rename on a loaded Windows runner (#2972, PR #2974)
+
+`writeFileAtomic` retried a Windows rename for about 430 ms. That was not enough under
+contention: the notifier's `active.json` write threw, and the listener waiting on it timed out
+ten seconds later — while the contention it was retrying through had long since cleared. The
+async ladder now runs to about four seconds, because waiting there is nearly free: the call
+yields. The synchronous ladder deliberately stays at 430 ms, since `sleepSync` parks the whole
+thread and a longer budget would not delay one write, it would freeze the process.
+
 ### Added
+
+#### Collections and feeds carry an accent colour (#2987, PR #2998)
+
+A collection or feed can name an accent colour, which the launcher draws as a pale ground
+behind its pinned shortcut. The colour survives a reload, and an invalid one falls back
+instead of taking the whole collection down with it.
 
 #### TeX math in the markdown preview
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.13.2",
+  "version": "1.15.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

`/publish-mulmoclaude` の §5 / §5.5 / §9a。ランチャーを npm に出す前の version bump と CHANGELOG です。

- `packages/mulmoclaude/package.json` 1.14.0 → **1.15.0**（npm に載る identity）
- ルート `package.json` 1.13.2 → **1.15.0**

**ルートが 2 版ぶん取り残されていました。** skill §5.5 は「ランチャーの npm 版と `/release-app` が打つ v タグは常に一致する」ことを不変条件にしていますが、ルートは 1.13.2 のまま `mulmoclaude@1.14.0` が npm に出ていました。今回で揃えます。`bin/mulmoclaude.js` は `package.json` から version を動的に読むので編集不要です（`require(join(PKG_DIR, "package.json"))`）。

**CHANGELOG**: `[Unreleased]` を `## [1.15.0] - 2026-08-30` に確定。既存の記述は TeX 数式だけだったので、1.14.0 以降にマージされた user-visible な変更を補いました:

| 追記した項目 | PR |
|---|---|
| 絵文字アイコンが隣のボタンに重なる問題（アイコン分類 + `IconGlyph` + Tailwind `@source`） | #2988 / #3006 / #2994 |
| dev クライアントがバックエンドの実バインドポートを追従する | #2977 / #2982 / #2997 |
| Windows の loaded runner で atomic write が rename を落とす | #2974 |
| コレクション／フィードのアクセントカラー | #2998 |

## Items to Confirm / Review

1. **`v1.14.0` のタグとリリースが存在しません。** `docs/CHANGELOG.md` には `## [1.14.0] - 2026-08-26` があり npm にも `mulmoclaude@1.14.0` が出ているのに、`git tag -l v1.14.0` は空で GitHub リリースもありません。今回の 1.15.0 とは別件なので**この PR では触っていません**。遡ってタグを打つか、このまま 1.15.0 に進むか、判断をお願いします（markdown-utils の 2.0.0/2.1.0 では遡及タグを打ちました）。
2. **1.15.0 という刻み（minor）** — 新機能はアクセントカラーと TeX 数式で、破壊的変更は見当たりません。
3. **CHANGELOG に補った 4 項目の粒度** — release-plumbing と依存 bump の PR は意図的に省いています。落とすべきでないものが漏れていないか見てください。

## 検証

- `yarn check:changelog-ships` → `OK — [1.15.0] lists all 13 @mulmoclaude/* dependencies.`
- §1 `node scripts/mulmoclaude/deps.mjs` → `OK — no missing dependencies.`
- §2 `node scripts/mulmoclaude/drift.mjs` → `OK — no workspace drift detected.`（4 パッケージとも src == published）
- §6 事前チェック: ランチャーの内部 dep 全件が npm の公開版に解決（⚠ なし）
- `yarn install` → `yarn build` 成功、`yarn package` で `mulmoclaude-1.15.0.tgz`（1049 ファイル）を生成

### ローカルで回せなかったもの

§4 のタールボール実機ブートは**この環境では実行できません**。サンドボックスの npm ポリシーが 2 箇所で止めます:

- `npm pack packages/chat-service` の相対パスが git spec と解釈され `EALLOWGIT`
- クリーンインストールが `xlsx@https://cdn.sheetjs.com/...` の remote tarball で `EALLOWREMOTE`

どちらも環境側の制約で、リリース物の欠陥ではありません（パッケージ単体の `npm pack` は正常）。担保はこの PR の `MulmoClaude publish smoke` に委ねます。main の `0753c8792` では green で、このブランチの差分はバージョン文字列 3 箇所と CHANGELOG だけです。**smoke が green になるまで publish しません。**

## User Prompt

- 「さてpublishかな。」→ 範囲は「5つ全部」「今すぐ回す」
- 「ci直ったらpublishにすすんで」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCEYf43PwB4avHgZ5erQRY

work in mulmoclaude2

## Summary by Sourcery

Release version 1.15.0 with launcher version alignment and documented user-facing improvements.

New Features:
- Add accent colors for collections and feeds in the launcher.
- Add TeX math rendering to the markdown preview.

Bug Fixes:
- Prevent emoji icons from overlapping adjacent controls.
- Keep the development client aligned with the backend's actual bound port.
- Improve atomic writes on busy Windows runners.

Documentation:
- Finalize the 1.15.0 changelog with user-visible changes since the previous release.

Chores:
- Synchronize the monorepo and launcher package versions at 1.15.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections and feeds can now use an accent colour, displayed behind pinned shortcuts and preserved after reload.
  * Invalid accent-colour values now fall back safely.

* **Bug Fixes**
  * Improved emoji icon rendering and prevented icons from overlapping nearby buttons.
  * Fixed development connections when the backend starts on a different or dynamically assigned port.
  * Improved reliability when saving files on Windows under heavy load.

* **Chores**
  * Updated the application release version to 1.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->