### PR TITLE
feat(mulmoscript-plugin): stories の根を複数にできるようにする (#3014 実装順序 1)

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -92,24 +92,38 @@ interface SessionTag {
   chatSessionId?: string | undefined;
 }
 
-export type MulmoScriptDispatchArgs =
-  | ({ kind: "save" } & { filePath?: string; script?: unknown; filename?: string })
-  | { kind: "updateBeat"; filePath: string; beatIndex: number; beat: unknown; origin?: string }
-  | { kind: "updateScript"; filePath: string; script: unknown; origin?: string }
-  | ({ kind: "beatImage" } & BeatRef)
-  | ({ kind: "beatAudio" } & BeatRef)
-  | ({ kind: "beatMovie" } & BeatRef)
-  | ({ kind: "renderBeat" } & BeatRef & SessionTag & { force?: boolean })
-  | ({ kind: "generateBeatAudio" } & BeatRef & SessionTag & { force?: boolean })
-  | ({ kind: "uploadBeatImage" } & BeatRef & { imageData: string })
-  | ({ kind: "characterImage" } & CharacterRef)
-  | ({ kind: "renderCharacter" } & CharacterRef & SessionTag & { force?: boolean })
-  | ({ kind: "uploadCharacterImage" } & CharacterRef & { imageData: string })
-  | ({ kind: "movieStatus" } & { filePath: string })
-  | ({ kind: "pdfStatus" } & { filePath: string })
-  | ({ kind: "generateMovie" } & { filePath: string } & SessionTag)
-  | ({ kind: "generatePdf" } & { filePath: string } & SessionTag)
-  | { kind: "pendingGenerations"; filePath: string };
+/**
+ * Which registered stories root the named script lives in (#3014).
+ *
+ * Intersected into the whole union below, so every dispatch that names a
+ * `filePath` can name its root — a union member that could not would make
+ * root-aware calls untypeable while the handler happily read `args.root`
+ * off an untyped record (Codex P1 on #3015).
+ */
+interface RootTag {
+  root?: string | undefined;
+}
+
+export type MulmoScriptDispatchArgs = RootTag &
+  (
+    | ({ kind: "save" } & { filePath?: string; script?: unknown; filename?: string })
+    | { kind: "updateBeat"; filePath: string; beatIndex: number; beat: unknown; origin?: string }
+    | { kind: "updateScript"; filePath: string; script: unknown; origin?: string }
+    | ({ kind: "beatImage" } & BeatRef)
+    | ({ kind: "beatAudio" } & BeatRef)
+    | ({ kind: "beatMovie" } & BeatRef)
+    | ({ kind: "renderBeat" } & BeatRef & SessionTag & { force?: boolean })
+    | ({ kind: "generateBeatAudio" } & BeatRef & SessionTag & { force?: boolean })
+    | ({ kind: "uploadBeatImage" } & BeatRef & { imageData: string })
+    | ({ kind: "characterImage" } & CharacterRef)
+    | ({ kind: "renderCharacter" } & CharacterRef & SessionTag & { force?: boolean })
+    | ({ kind: "uploadCharacterImage" } & CharacterRef & { imageData: string })
+    | ({ kind: "movieStatus" } & { filePath: string })
+    | ({ kind: "pdfStatus" } & { filePath: string })
+    | ({ kind: "generateMovie" } & { filePath: string } & SessionTag)
+    | ({ kind: "generatePdf" } & { filePath: string } & SessionTag)
+    | { kind: "pendingGenerations"; filePath: string }
+  );
 
 export type MulmoScriptDispatchKind = MulmoScriptDispatchArgs["kind"];
 

--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -79,8 +79,16 @@ export const DEFAULT_ROOT = "";
  * `readCommandScope` in `@mulmoclaude/core/remote-host` — trims its value and
  * shares the "absent = the host's own root" convention. Without this,
  * `" repoA "` is one root there and a different one here.
+ *
+ * A non-string reads as the default root rather than throwing. The type says
+ * that cannot happen, but this package is published and its callers include
+ * untyped JavaScript: a subscription whose `root()` returns `42` reached
+ * `.trim()` and threw from INSIDE a pubsub callback, where nothing catches it
+ * and the View simply stops updating (Codex P2 on #3015). The guard belongs
+ * here rather than at the three call sites, because a rule enforced by
+ * enumerating its callers is what this PR got wrong repeatedly.
  */
-export const normalizeRoot = (root: string | undefined): string => root?.trim() ?? DEFAULT_ROOT;
+export const normalizeRoot = (root: string | undefined): string => (typeof root === "string" ? root.trim() : DEFAULT_ROOT);
 
 /**
  * Two roots are the same when they name the same one, with absent meaning the

--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -19,6 +19,10 @@ export interface MulmoScriptGenerationEvent {
   kind: "beatImage" | "beatAudio" | "characterImage" | "movie" | "pdf";
   /** Wire `stories/…` path of the script the generation belongs to. */
   filePath: string;
+  /** Which stories root `filePath` is relative to (#3014). Absent = the
+   *  host's default root, which is every event this package emitted before
+   *  roots existed. */
+  root?: string;
   /** beatIndex (as string) for beat*, character key for characterImage, "" for movie/pdf. */
   key: string;
   /** false = started, true = finished (reload the asset off disk). */
@@ -44,6 +48,8 @@ export const SCRIPT_CHANGED_EVENT = "scriptChanged";
  */
 export interface MulmoScriptChangedEvent {
   filePath: string;
+  /** Which stories root `filePath` is relative to (#3014). Absent = default. */
+  root?: string;
   origin?: string;
 }
 
@@ -54,8 +60,20 @@ export interface MulmoScriptChangedEvent {
  * the one that is invisible when it is wrong: a View acting on the echo of its own write
  * rebuilds the element the caret is in, on every keystroke.
  */
-export const shouldReloadForScriptChange = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string): boolean =>
-  watching !== "" && event.filePath === watching && event.origin !== ownOrigin;
+export const shouldReloadForScriptChange = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string, watchingRoot?: string): boolean =>
+  watching !== "" && event.filePath === watching && sameRoot(event.root, watchingRoot) && event.origin !== ownOrigin;
+
+/**
+ * Two roots are the same when they name the same one, with absent meaning the
+ * host's default (#3014).
+ *
+ * The identity of a script is the PAIR, not the path: `stories/deck.json` in
+ * two repositories is two files, and comparing paths alone would reload the
+ * View watching one because the other was saved. Absent normalises to the
+ * default so a pre-`root` event and a default-root watcher still match — that
+ * equivalence is what keeps every existing card working untouched.
+ */
+const sameRoot = (a: string | undefined, b: string | undefined): boolean => (a ?? "") === (b ?? "");
 
 interface BeatRef {
   filePath: string;

--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -63,6 +63,25 @@ export interface MulmoScriptChangedEvent {
 export const shouldReloadForScriptChange = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string, watchingRoot?: string): boolean =>
   watching !== "" && event.filePath === watching && sameRoot(event.root, watchingRoot) && event.origin !== ownOrigin;
 
+/** The default root: what a caller that names no root is asking for. */
+export const DEFAULT_ROOT = "";
+
+/**
+ * The one spelling of a root that every comparison and every key must use.
+ *
+ * It lives HERE, in the module both the server and the View import, because
+ * the server had its own copy and the browser side compared raw strings — so
+ * `publishGeneration` emitted `"repoA"` while a View watching `" repoA "`
+ * dropped every event of its own generation (CodeRabbit on #3015). A rule
+ * that two sides must agree on cannot live on one of the two sides.
+ *
+ * Trimmed, because the codebase's other opaque "which project root" reader —
+ * `readCommandScope` in `@mulmoclaude/core/remote-host` — trims its value and
+ * shares the "absent = the host's own root" convention. Without this,
+ * `" repoA "` is one root there and a different one here.
+ */
+export const normalizeRoot = (root: string | undefined): string => root?.trim() ?? DEFAULT_ROOT;
+
 /**
  * Two roots are the same when they name the same one, with absent meaning the
  * host's default (#3014).
@@ -73,7 +92,7 @@ export const shouldReloadForScriptChange = (event: MulmoScriptChangedEvent, watc
  * default so a pre-`root` event and a default-root watcher still match — that
  * equivalence is what keeps every existing card working untouched.
  */
-const sameRoot = (a: string | undefined, b: string | undefined): boolean => (a ?? "") === (b ?? "");
+export const sameRoot = (a: string | undefined, b: string | undefined): boolean => normalizeRoot(a) === normalizeRoot(b);
 
 interface BeatRef {
   filePath: string;

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -190,7 +190,12 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     if (kind === "pendingGenerations") {
       const filePath = str(args.filePath);
       if (!filePath) return invalidArgs(kind);
-      return { ok: true, pending: ops.pendingGenerations(filePath, str(args.root)) };
+      const root = str(args.root);
+      // An empty snapshot for an unknown root is indistinguishable from "no
+      // work is running" — see `guardStoryRootRegistered`.
+      const rootGuard = ops.guardStoryRootRegistered(root);
+      if (rootGuard) return fromOpFailure(rootGuard);
+      return { ok: true, pending: ops.pendingGenerations(filePath, root) };
     }
     return { ok: false, code: "bad_request", error: `unknown mulmoScript dispatch kind "${kind}"` };
   };

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -138,17 +138,22 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     return envelope(await BEAT_PROBE_OPS[kind as keyof typeof BEAT_PROBE_OPS](parsed.filePath, parsed.beatIndex, str(args.root)));
   }
 
+  /** Movie and PDF take the whole script; the other generate kinds take a beat
+   *  or a character within it. */
+  async function wholeScriptGenerationKind(kind: "generateMovie" | "generatePdf", args: Record<string, unknown>): Promise<unknown> {
+    const filePath = str(args.filePath);
+    if (!filePath) return invalidArgs(kind);
+    const chatSessionId = str(args.chatSessionId);
+    const root = str(args.root);
+    const result = kind === "generateMovie" ? await ops.generateMovieOp(filePath, chatSessionId, root) : await ops.generatePdfOp(filePath, chatSessionId, root);
+    return envelope(result);
+  }
+
   async function generateKind(kind: string, args: Record<string, unknown>): Promise<unknown> {
+    if (kind === "generateMovie" || kind === "generatePdf") return wholeScriptGenerationKind(kind, args);
     const chatSessionId = str(args.chatSessionId);
     const root = str(args.root);
     const force = args.force === true;
-    if (kind === "generateMovie" || kind === "generatePdf") {
-      const filePath = str(args.filePath);
-      if (!filePath) return invalidArgs(kind);
-      const result =
-        kind === "generateMovie" ? await ops.generateMovieOp(filePath, chatSessionId, root) : await ops.generatePdfOp(filePath, chatSessionId, root);
-      return envelope(result);
-    }
     if (kind === "renderCharacter") {
       const parsed = keyArgs(args);
       return parsed ? envelope(await ops.renderCharacterOp({ ...parsed, force, chatSessionId, root })) : invalidArgs(kind);

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -88,6 +88,12 @@ export type MulmoScriptDispatchHandler = (args: Record<string, unknown>) => Prom
  * FileOps, guarded by the instance's realpath containment
  * (`guardStoryWirePath`) — the core's own guard is lexical.
  */
+/** `undefined` when `root` is absent or a string; a failure envelope otherwise. */
+function guardSuppliedRoot(root: unknown): { ok: false; code: string; error: string } | undefined {
+  if (root === undefined || typeof root === "string") return undefined;
+  return { ok: false, code: "bad_request", error: `mulmoScript root must be a string, got ${typeof root}` };
+}
+
 export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): MulmoScriptDispatchHandler {
   const executeContext: MulmoScriptExecuteContext = { files: { artifacts: ops.backend.artifacts } };
 
@@ -182,6 +188,15 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
   return async (args: Record<string, unknown>): Promise<unknown> => {
     const kind = str(args.kind);
     if (!kind) return invalidArgs("<missing>");
+    // Once, at the only entry, so no per-kind reader can forget it. `str()`
+    // answers `undefined` for a number, `null`, an object — indistinguishable
+    // from a root that was never supplied, which every reader below then takes
+    // as the DEFAULT root. A host that serialises a root wrongly would have
+    // written to, and read from, the default root's identically-named script
+    // while believing it named another (Codex P2 on #3015). Absent stays
+    // default; present must be a string.
+    const malformedRoot = guardSuppliedRoot(args.root);
+    if (malformedRoot) return malformedRoot;
     if (kind === "save") return saveKind(args);
     if (kind === "updateBeat" || kind === "updateScript") return updateKind(kind, args);
     if (PROBE_KINDS.has(kind)) return probeKind(kind, args);

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -110,7 +110,7 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     if (!outcome.ok) return fromPackageFailure(outcome);
     // After the write landed, never before: a View that reloads on a failed write would
     // discard the user's edit and show the old file back.
-    ops.publishScriptChanged(str(args.filePath) ?? "", str(args.origin));
+    ops.publishScriptChanged(str(args.filePath) ?? "", str(args.origin), str(args.root));
     return { ok: true };
   }
 
@@ -121,34 +121,38 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     const statusOp = STATUS_OPS[kind as keyof typeof STATUS_OPS];
     if (statusOp) {
       const filePath = str(args.filePath);
-      return filePath ? envelope(await statusOp(filePath)) : invalidArgs(kind);
+      return filePath ? envelope(await statusOp(filePath, str(args.root))) : invalidArgs(kind);
     }
     if (kind === "characterImage") {
       const parsed = keyArgs(args);
-      return parsed ? envelope(await ops.characterImageOp(parsed.filePath, parsed.key)) : invalidArgs(kind);
+      return parsed ? envelope(await ops.characterImageOp(parsed.filePath, parsed.key, str(args.root))) : invalidArgs(kind);
     }
     const parsed = beatArgs(args);
     if (!parsed) return invalidArgs(kind);
-    return envelope(await BEAT_PROBE_OPS[kind as keyof typeof BEAT_PROBE_OPS](parsed.filePath, parsed.beatIndex));
+    return envelope(await BEAT_PROBE_OPS[kind as keyof typeof BEAT_PROBE_OPS](parsed.filePath, parsed.beatIndex, str(args.root)));
   }
 
   async function generateKind(kind: string, args: Record<string, unknown>): Promise<unknown> {
     const chatSessionId = str(args.chatSessionId);
+    const root = str(args.root);
     const force = args.force === true;
     if (kind === "generateMovie" || kind === "generatePdf") {
       const filePath = str(args.filePath);
       if (!filePath) return invalidArgs(kind);
-      const result = kind === "generateMovie" ? await ops.generateMovieOp(filePath, chatSessionId) : await ops.generatePdfOp(filePath, chatSessionId);
+      const result =
+        kind === "generateMovie" ? await ops.generateMovieOp(filePath, chatSessionId, root) : await ops.generatePdfOp(filePath, chatSessionId, root);
       return envelope(result);
     }
     if (kind === "renderCharacter") {
       const parsed = keyArgs(args);
-      return parsed ? envelope(await ops.renderCharacterOp({ ...parsed, force, chatSessionId })) : invalidArgs(kind);
+      return parsed ? envelope(await ops.renderCharacterOp({ ...parsed, force, chatSessionId, root })) : invalidArgs(kind);
     }
     const parsed = beatArgs(args);
     if (!parsed) return invalidArgs(kind);
     const result =
-      kind === "renderBeat" ? await ops.renderBeatOp({ ...parsed, force, chatSessionId }) : await ops.generateBeatAudioOp({ ...parsed, force, chatSessionId });
+      kind === "renderBeat"
+        ? await ops.renderBeatOp({ ...parsed, force, chatSessionId, root })
+        : await ops.generateBeatAudioOp({ ...parsed, force, chatSessionId, root });
     return envelope(result);
   }
 
@@ -157,11 +161,11 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     if (!imageData) return invalidArgs(kind);
     if (kind === "uploadCharacterImage") {
       const parsed = keyArgs(args);
-      return parsed ? envelope(await ops.uploadCharacterImageOp(parsed.filePath, parsed.key, imageData)) : invalidArgs(kind);
+      return parsed ? envelope(await ops.uploadCharacterImageOp(parsed.filePath, parsed.key, imageData, str(args.root))) : invalidArgs(kind);
     }
     const parsed = beatArgs(args);
     if (!parsed) return invalidArgs(kind);
-    return envelope(await ops.uploadBeatImageOp(parsed.filePath, parsed.beatIndex, imageData));
+    return envelope(await ops.uploadBeatImageOp(parsed.filePath, parsed.beatIndex, imageData, str(args.root)));
   }
 
   return async (args: Record<string, unknown>): Promise<unknown> => {
@@ -175,7 +179,7 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     if (kind === "pendingGenerations") {
       const filePath = str(args.filePath);
       if (!filePath) return invalidArgs(kind);
-      return { ok: true, pending: ops.pendingGenerations(filePath) };
+      return { ok: true, pending: ops.pendingGenerations(filePath, str(args.root)) };
     }
     return { ok: false, code: "bad_request", error: `unknown mulmoScript dispatch kind "${kind}"` };
   };

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -92,7 +92,11 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
   const executeContext: MulmoScriptExecuteContext = { files: { artifacts: ops.backend.artifacts } };
 
   async function saveKind(args: Record<string, unknown>): Promise<unknown> {
-    const guard = ops.guardStoryWirePath(args.filePath);
+    // Writes stay in the default root until step 2 gives the executors a
+    // per-root FileOps — see `guardStoryWriteRoot` (#3015 review G1).
+    const rootGuard = ops.guardStoryWriteRoot(str(args.root));
+    if (rootGuard) return fromOpFailure(rootGuard);
+    const guard = ops.guardStoryWirePath(args.filePath, str(args.root));
     if (guard) return fromOpFailure(guard);
     const outcome = await executeMulmoScriptSave(executeContext, {
       script: args.script,
@@ -104,7 +108,9 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
   }
 
   async function updateKind(kind: "updateBeat" | "updateScript", args: Record<string, unknown>): Promise<unknown> {
-    const guard = ops.guardStoryWirePath(args.filePath);
+    const rootGuard = ops.guardStoryWriteRoot(str(args.root));
+    if (rootGuard) return fromOpFailure(rootGuard);
+    const guard = ops.guardStoryWirePath(args.filePath, str(args.root));
     if (guard) return fromOpFailure(guard);
     const outcome = kind === "updateBeat" ? await executeUpdateBeat(executeContext, args) : await executeUpdateScript(executeContext, args);
     if (!outcome.ok) return fromPackageFailure(outcome);

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -185,6 +185,20 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     return envelope(await ops.uploadBeatImageOp(parsed.filePath, parsed.beatIndex, imageData, str(args.root)));
   }
 
+  async function pendingKind(kind: string, args: Record<string, unknown>): Promise<unknown> {
+    const filePath = str(args.filePath);
+    if (!filePath) return invalidArgs(kind);
+    const root = str(args.root);
+    // An empty snapshot for an unknown root is indistinguishable from "no
+    // work is running" — see `guardStoryRootRegistered`.
+    const rootGuard = ops.guardStoryRootRegistered(root);
+    if (rootGuard) return fromOpFailure(rootGuard);
+    return { ok: true, pending: ops.pendingGenerations(filePath, root) };
+  }
+
+  // Nothing but routing below: every kind resolves to one named handler, so
+  // reading it answers "where does this kind go" without also having to read
+  // what any of them do.
   return async (args: Record<string, unknown>): Promise<unknown> => {
     const kind = str(args.kind);
     if (!kind) return invalidArgs("<missing>");
@@ -202,16 +216,7 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     if (PROBE_KINDS.has(kind)) return probeKind(kind, args);
     if (GENERATE_KINDS.has(kind)) return generateKind(kind, args);
     if (UPLOAD_KINDS.has(kind)) return uploadKind(kind, args);
-    if (kind === "pendingGenerations") {
-      const filePath = str(args.filePath);
-      if (!filePath) return invalidArgs(kind);
-      const root = str(args.root);
-      // An empty snapshot for an unknown root is indistinguishable from "no
-      // work is running" — see `guardStoryRootRegistered`.
-      const rootGuard = ops.guardStoryRootRegistered(root);
-      if (rootGuard) return fromOpFailure(rootGuard);
-      return { ok: true, pending: ops.pendingGenerations(filePath, root) };
-    }
+    if (kind === "pendingGenerations") return pendingKind(kind, args);
     return { ok: false, code: "bad_request", error: `unknown mulmoScript dispatch kind "${kind}"` };
   };
 }

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -907,6 +907,16 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   }
 
   function triggerAutoBackgroundMovie(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined, root?: string): void {
+    // The same refusal as the foreground generation ops, reached the only way
+    // a `void` entry point can reach it. This one takes a `root` but never
+    // returned an `OpResult`, so the guard that covers every other generation
+    // did not cover the one generation nobody is waiting on — which is the
+    // worse half: a detached run corrupting the other root's pending state
+    // has no caller to see the failure (Codex P1 on #3015).
+    if (guardStoryGenerationRoot(root)) {
+      log.warn("refused an auto background movie in a non-default stories root", { filePath: wireFilePath, root });
+      return;
+    }
     if (inFlightMovies.has(absoluteFilePath)) return;
     inFlightMovies.add(absoluteFilePath);
     void runBackgroundMovieGeneration(absoluteFilePath, wireFilePath, chatSessionId, root);

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -197,10 +197,13 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     // every pre-roots caller at someone else's directory. Dropping it quietly
     // would hide the host's misconfiguration until a read returned the wrong
     // file, and this runs at boot, where throwing is the cheap failure.
-    if (id === DEFAULT_ROOT) {
+    // Trim on registration too: a lookup normalizes, so an untrimmed key would
+    // be unreachable.
+    const trimmed = id.trim();
+    if (trimmed === DEFAULT_ROOT) {
       throw new Error("mulmoScript: extraRoots key must not be empty — the empty id is reserved for the default stories root");
     }
-    rootDirs.set(id, path.resolve(dir));
+    rootDirs.set(trimmed, path.resolve(dir));
   }
 
   /** The registered directory for a wire `root`, or null when the host never
@@ -208,7 +211,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    *  unknown root must not quietly read the workspace's file of the same
    *  name. */
   function rootDir(root: string | undefined): string | null {
-    return rootDirs.get(root ?? DEFAULT_ROOT) ?? null;
+    return rootDirs.get(normalizeRoot(root)) ?? null;
   }
 
   // ── Story path infrastructure ─────────────────────────────────
@@ -396,7 +399,13 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    *  snapshot filter and a tracker entry compare equal whichever the caller
    *  used. */
   function normalizeRoot(root: string | undefined): string {
-    return root ?? DEFAULT_ROOT;
+    // Trimmed, because the codebase's other opaque "which project root" reader
+    // — `readCommandScope` in `@mulmoclaude/core/remote-host` — trims its value
+    // and shares the "absent = the host's own root" convention. Without this,
+    // `" repoA "` is one root there and a different one here, which is a live
+    // divergence between two parallel scope identifiers rather than a
+    // hypothetical one (#3015 review).
+    return root?.trim() ?? DEFAULT_ROOT;
   }
 
   /** Emit `root` only when it names a non-default one: an event carrying
@@ -417,15 +426,28 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     return normalizeStoryPath(filePath) ?? filePath;
   }
 
+  /**
+   * `error` and `root` travel in an options object, NOT as two trailing
+   * optional positionals.
+   *
+   * They were positional once, and appending `root` to the sixteen call sites
+   * put it in `error`'s slot at the nine that pass no error: every start event
+   * carried `error: "<root>"`, the root was dropped from the key, the tracker
+   * entry was filed under the default root — and because the matching finish
+   * DID pass both, its key differed and the entry was never deleted, leaking
+   * one row per generation for the life of the process. Two adjacent optional
+   * strings cannot be told apart by the type checker, so the shape is the only
+   * thing that can prevent it (#3015 review).
+   */
   function publishGeneration(
     chatSessionId: string | undefined,
     kind: GenerationKind,
     filePath: string,
     key: string,
     finished: boolean,
-    error?: string,
-    root?: string,
+    opts: { error?: string | undefined; root?: string | undefined } = {},
   ): void {
+    const { error, root } = opts;
     const wirePath = canonicalWirePath(filePath);
     const mapKey = generationMapKey(kind, wirePath, key, root);
     const existing = inFlightGenerations.get(mapKey);
@@ -614,7 +636,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     if (ffmpeg) return ffmpeg;
 
     const mapKey = String(beatIndex);
-    publishGeneration(chatSessionId, "beatImage", filePath, mapKey, false, root);
+    publishGeneration(chatSessionId, "beatImage", filePath, mapKey, false, { root });
     let genError: string | undefined;
     try {
       const result = await runStoryOp<{ image: string }>(filePath, { force, operation: "render-beat", root }, async ({ context }) => {
@@ -632,14 +654,14 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       if (!result.ok) genError = result.error;
       return result;
     } finally {
-      publishGeneration(chatSessionId, "beatImage", filePath, mapKey, true, genError, root);
+      publishGeneration(chatSessionId, "beatImage", filePath, mapKey, true, { error: genError, root });
     }
   }
 
   async function generateBeatAudioOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ audio: string }>> {
     const { filePath, beatIndex, force, chatSessionId, root } = args;
     const mapKey = String(beatIndex);
-    publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, false, root);
+    publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, false, { root });
     let genError: string | undefined;
     try {
       const result = await runStoryOp<{ audio: string }>(filePath, { force, operation: "generate-beat-audio", root }, async ({ context }) => {
@@ -673,13 +695,13 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       if (!result.ok) genError = result.error;
       return result;
     } finally {
-      publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, true, genError, root);
+      publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, true, { error: genError, root });
     }
   }
 
   async function renderCharacterOp(args: GenerateOpArgsWith<"filePath" | "key">): Promise<OpResult<{ image: string }>> {
     const { filePath, key, force, chatSessionId, root } = args;
-    publishGeneration(chatSessionId, "characterImage", filePath, key, false, root);
+    publishGeneration(chatSessionId, "characterImage", filePath, key, false, { root });
     let genError: string | undefined;
     try {
       const result = await runStoryOp<{ image: string }>(filePath, { force, operation: "render-character", root }, async ({ context }) => {
@@ -710,7 +732,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       if (!result.ok) genError = result.error;
       return result;
     } finally {
-      publishGeneration(chatSessionId, "characterImage", filePath, key, true, genError, root);
+      publishGeneration(chatSessionId, "characterImage", filePath, key, true, { error: genError, root });
     }
   }
 
@@ -807,12 +829,12 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
 
     inFlightMovies.add(absoluteFilePath);
-    publishGeneration(chatSessionId, "movie", filePath, "", false, root);
+    publishGeneration(chatSessionId, "movie", filePath, "", false, { root });
     let genError: string | undefined;
     try {
       const result = await runMovieGeneration(absoluteFilePath, (event) => {
         const eventKind = event.kind === "image" ? "beatImage" : "beatAudio";
-        publishGeneration(chatSessionId, eventKind, filePath, String(event.beatIndex), true, root);
+        publishGeneration(chatSessionId, eventKind, filePath, String(event.beatIndex), true, { root });
       });
       if (!result.ok) {
         genError = result.error;
@@ -826,7 +848,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       return opServerError(genError);
     } finally {
       inFlightMovies.delete(absoluteFilePath);
-      publishGeneration(chatSessionId, "movie", filePath, "", true, genError, root);
+      publishGeneration(chatSessionId, "movie", filePath, "", true, { error: genError, root });
     }
   }
 
@@ -856,7 +878,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       // intentional: ENOENT is the common case, others non-fatal
     }
 
-    publishGeneration(chatSessionId, "movie", wireFilePath, "", false, root);
+    publishGeneration(chatSessionId, "movie", wireFilePath, "", false, { root });
     let genError: string | undefined;
     try {
       const result = await runMovieGeneration(absoluteFilePath, (event) => {
@@ -868,8 +890,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
         // the reload.
         const eventKind = event.kind === "image" ? "beatImage" : "beatAudio";
         const key = String(event.beatIndex);
-        publishGeneration(chatSessionId, eventKind, wireFilePath, key, false, root);
-        setImmediate(() => publishGeneration(chatSessionId, eventKind, wireFilePath, key, true, undefined, root));
+        publishGeneration(chatSessionId, eventKind, wireFilePath, key, false, { root });
+        setImmediate(() => publishGeneration(chatSessionId, eventKind, wireFilePath, key, true, { root }));
       });
 
       if (!result.ok) {
@@ -888,7 +910,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       log.error("background movie generation crashed", { filePath: wireFilePath, error: genError });
     } finally {
       inFlightMovies.delete(absoluteFilePath);
-      publishGeneration(chatSessionId, "movie", wireFilePath, "", true, genError, root);
+      publishGeneration(chatSessionId, "movie", wireFilePath, "", true, { error: genError, root });
     }
   }
 
@@ -947,7 +969,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
 
     inFlightPdfs.add(absoluteFilePath);
-    publishGeneration(chatSessionId, "pdf", filePath, "", false, root);
+    publishGeneration(chatSessionId, "pdf", filePath, "", false, { root });
     let genError: string | undefined;
     try {
       const context = await buildContext(absoluteFilePath);
@@ -956,7 +978,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
         return opServerError(genError);
       }
       const result = await runPdfGeneration(context, (beatIndex) => {
-        publishGeneration(chatSessionId, "beatImage", filePath, String(beatIndex), true, root);
+        publishGeneration(chatSessionId, "beatImage", filePath, String(beatIndex), true, { root });
       });
       if (!result.ok) {
         genError = result.error;
@@ -970,7 +992,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       return opServerError(genError);
     } finally {
       inFlightPdfs.delete(absoluteFilePath);
-      publishGeneration(chatSessionId, "pdf", filePath, "", true, genError, root);
+      publishGeneration(chatSessionId, "pdf", filePath, "", true, { error: genError, root });
     }
   }
 

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -41,6 +41,7 @@ import {
   removeSessionProgressCallback,
 } from "mulmocast";
 import type { MulmoBeat, MulmoImagePromptMedia, MulmoStudioContext } from "@mulmocast/types";
+import { DEFAULT_ROOT, normalizeRoot } from "../core/contract";
 import type { MulmoScriptGenerationEvent } from "../core/contract";
 import { normalizeStoryPath } from "../core/paths";
 import { errorMessage } from "@mulmoclaude/common";
@@ -190,7 +191,6 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // Root registry: the default (pre-#3014, wire `root` absent) plus whatever
   // the host registered. Resolved once — the host owns the ids, this package
   // only ever looks them up.
-  const DEFAULT_ROOT = "";
   const rootDirs = new Map<string, string>([[DEFAULT_ROOT, path.resolve(backend.storiesDir)]]);
   for (const [id, dir] of Object.entries(backend.extraRoots ?? {})) {
     // An empty id is the default root's own key: accepting it would re-point
@@ -402,6 +402,18 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     return opBadRequest("generating in a non-default stories root is not supported yet");
   }
 
+  /**
+   * The write half of the same fail-closed rule.
+   *
+   * It lives in the ops that write rather than at their dispatch sites,
+   * because a per-site guard is a list someone has to remember to extend:
+   * `save` / `updateBeat` / `updateScript` were guarded and the two upload
+   * kinds were not, so an image could still land in a named root
+   * (CodeRabbit on #3015). `save` / `update* ` cannot follow suit — they run
+   * through the package executors, not through these ops — so
+   * `test_server_roots.ts` walks the whole ops surface and fails on any op
+   * that is neither in the read-only allowlist nor refusing.
+   */
   function guardStoryWriteRoot(root: string | undefined): OpFailure | null {
     if (normalizeRoot(root) === DEFAULT_ROOT) return null;
     return opBadRequest("writing to a non-default stories root is not supported yet");
@@ -433,19 +445,6 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // A finish with no tracked start (the movie/PDF pipelines' per-beat
   // completion pulses) always publishes.
   const inFlightGenerations = new Map<string, { kind: GenerationKind; filePath: string; key: string; root: string; count: number }>();
-
-  /** The default root's two spellings (absent, `""`) collapse to one, so a
-   *  snapshot filter and a tracker entry compare equal whichever the caller
-   *  used. */
-  function normalizeRoot(root: string | undefined): string {
-    // Trimmed, because the codebase's other opaque "which project root" reader
-    // — `readCommandScope` in `@mulmoclaude/core/remote-host` — trims its value
-    // and shares the "absent = the host's own root" convention. Without this,
-    // `" repoA "` is one root there and a different one here, which is a live
-    // divergence between two parallel scope identifiers rather than a
-    // hypothetical one (#3015 review).
-    return root?.trim() ?? DEFAULT_ROOT;
-  }
 
   /** Emit `root` only when it names a non-default one: an event carrying
    *  `root: ""` and one carrying nothing must stay indistinguishable to every
@@ -788,6 +787,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // ── Upload ops ────────────────────────────────────────────────
 
   async function uploadBeatImageOp(filePath: string, beatIndex: number, imageData: string, root?: string): Promise<OpResult<{ image: string }>> {
+    const rootGuard = guardStoryWriteRoot(root);
+    if (rootGuard) return rootGuard;
     return runStoryOp<{ image: string }>(filePath, { operation: "upload-beat-image", root }, async ({ context }) => {
       const { imagePath } = getBeatPngImagePath(context, beatIndex);
       // writeFileAtomic creates parent dirs and prevents a half-
@@ -799,6 +800,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   }
 
   async function uploadCharacterImageOp(filePath: string, key: string, imageData: string, root?: string): Promise<OpResult<{ image: string }>> {
+    const rootGuard = guardStoryWriteRoot(root);
+    if (rootGuard) return rootGuard;
     return runStoryOp<{ image: string }>(filePath, { operation: "upload-character-image", root }, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
       const base64 = stripDataUri(imageData);

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -208,6 +208,15 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     if (trimmed === DEFAULT_ROOT) {
       throw new Error("mulmoScript: extraRoots key must not be empty — the empty id is reserved for the default stories root");
     }
+    // Two ids that trim to one key: `set` would silently keep the LAST
+    // directory, so every read for `repoA` would answer from a directory the
+    // card never named, with the host given no signal (CodeRabbit on #3015).
+    // Same reasoning as the empty id above — a misconfiguration is cheapest to
+    // fail on at boot, and silently resolving the wrong directory is the
+    // failure this package refuses everywhere else.
+    if (rootDirs.has(trimmed)) {
+      throw new Error(`mulmoScript: extraRoots keys must be distinct after trimming — "${trimmed}" is registered twice`);
+    }
     rootDirs.set(trimmed, path.resolve(dir));
   }
   if (rootDirs.size > 1) {

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -219,7 +219,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     // person who has to widen their session key, and they see this at boot
     // rather than discovering it from a stuck spinner.
     log.warn(
-      "extra stories roots registered — the host's per-session generation key must include the root, or two roots running the same generation in one session will collapse to one entry (#3014 step 2)",
+      "extra stories roots registered — generation and writes are REFUSED in them until the host's per-session generation key includes the root (`generationKey` in @mulmobridge/protocol); reads work today (#3014 step 2)",
       { roots: [...rootDirs.keys()].filter((id) => id !== DEFAULT_ROOT) },
     );
   }
@@ -381,6 +381,27 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    *
    * Step 2 replaces this with a per-root FileOps rather than removing it.
    */
+  /**
+   * Whether a GENERATION may run in this root.
+   *
+   * The pair identity is complete inside this package but stops at the host
+   * boundary: a host's per-session store keys pending work by
+   * `(kind, filePath, key)` — `generationKey` in `@mulmobridge/protocol`,
+   * which bridges also consume. Two roots running the same generation in one
+   * session would collapse to one entry, and either completion would clear the
+   * other root's indicator (Codex P1 on #3015).
+   *
+   * Widening that key is a protocol change with its own consumers, so it is not
+   * this package's to make. Refusing the generation is: a named root that
+   * cannot be tracked correctly must not start, rather than start and corrupt
+   * the other root's state. Same fail-closed shape as `guardStoryWriteRoot`,
+   * and step 2 replaces both once the protocol carries the root.
+   */
+  function guardStoryGenerationRoot(root: string | undefined): OpFailure | null {
+    if (normalizeRoot(root) === DEFAULT_ROOT) return null;
+    return opBadRequest("generating in a non-default stories root is not supported yet");
+  }
+
   function guardStoryWriteRoot(root: string | undefined): OpFailure | null {
     if (normalizeRoot(root) === DEFAULT_ROOT) return null;
     return opBadRequest("writing to a non-default stories root is not supported yet");
@@ -654,6 +675,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
 
   async function renderBeatOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ image: string }>> {
     const { filePath, beatIndex, force, chatSessionId, root } = args;
+    const rootGuard = guardStoryGenerationRoot(root);
+    if (rootGuard) return rootGuard;
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
 
@@ -682,6 +705,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
 
   async function generateBeatAudioOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ audio: string }>> {
     const { filePath, beatIndex, force, chatSessionId, root } = args;
+    const rootGuard = guardStoryGenerationRoot(root);
+    if (rootGuard) return rootGuard;
     const mapKey = String(beatIndex);
     publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, false, { root });
     let genError: string | undefined;
@@ -723,6 +748,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
 
   async function renderCharacterOp(args: GenerateOpArgsWith<"filePath" | "key">): Promise<OpResult<{ image: string }>> {
     const { filePath, key, force, chatSessionId, root } = args;
+    const rootGuard = guardStoryGenerationRoot(root);
+    if (rootGuard) return rootGuard;
     publishGeneration(chatSessionId, "characterImage", filePath, key, false, { root });
     let genError: string | undefined;
     try {
@@ -840,6 +867,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * as they land — the successor of the SSE per-beat events.
    */
   async function generateMovieOp(filePath: string, chatSessionId: string | undefined, root?: string): Promise<OpResult<{ moviePath: string }>> {
+    const rootGuard = guardStoryGenerationRoot(root);
+    if (rootGuard) return rootGuard;
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
     const resolved = resolveStory(filePath, root);
@@ -980,6 +1009,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   /** Long-held foreground PDF generation (the package View's `generatePdf`
    *  dispatch) — the PDF sibling of `generateMovieOp`. */
   async function generatePdfOp(filePath: string, chatSessionId: string | undefined, root?: string): Promise<OpResult<{ pdfPath: string }>> {
+    const rootGuard = guardStoryGenerationRoot(root);
+    if (rootGuard) return rootGuard;
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
     const resolved = resolveStory(filePath, root);
@@ -1024,6 +1055,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     resolveStory,
     guardStoryWirePath,
     guardStoryWriteRoot,
+    guardStoryGenerationRoot,
     ffmpegGuard,
     runStoryOp,
     publishGeneration,

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -174,10 +174,15 @@ async function withBeatProgress<T>(beats: MulmoBeat[], onBeat: (sessionType: str
 /** Map identity for the in-flight tracker. JSON array keeps the three
  *  fields unambiguous (a human-visible delimiter could collide). */
 function generationMapKey(kind: GenerationKind, filePath: string, key: string, root?: string): string {
+  // Normalised HERE rather than by the caller. A start keyed `" repoA "` and a
+  // finish keyed `"repoA"` never match, and the tracker entry then leaks for
+  // the life of the process — so the one place that builds the key is the one
+  // place that must not be able to get the spelling wrong (Codex on #3015).
+  const normalized = normalizeRoot(root);
   // `root` is the LAST element so a call site that omits it produces exactly
   // the pre-#3014 key — the default root's entries keep their identity across
   // an upgrade, and a running generation is not orphaned by one.
-  return root === undefined || root === "" ? JSON.stringify([kind, filePath, key]) : JSON.stringify([kind, filePath, key, root]);
+  return normalized === DEFAULT_ROOT ? JSON.stringify([kind, filePath, key]) : JSON.stringify([kind, filePath, key, normalized]);
 }
 
 /**
@@ -265,13 +270,19 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // instance creation because the directory may not exist yet (it's
   // created on demand by the save route). The cache is invalidated
   // never — once the dir exists, its realpath is stable.
+  //
+  // Keyed by the resolved DIRECTORY rather than the root id, so there is no
+  // normalisation left to forget: `rootDir` already collapses every spelling of
+  // a root to one absolute path, and two ids pointing at the same directory
+  // share one entry instead of allocating a second. Keying on the raw id let
+  // `" repoA "` and `"repoA"` both resolve and then cache separately, in a map
+  // that is never evicted (Codex P2 on #3015).
   const storiesRealCache = new Map<string, string>();
   function ensureStoriesReal(root?: string): string | null {
-    const key = root ?? DEFAULT_ROOT;
-    const cached = storiesRealCache.get(key);
-    if (cached) return cached;
     const dir = rootDir(root);
     if (dir === null) return null;
+    const cached = storiesRealCache.get(dir);
+    if (cached) return cached;
     try {
       // Only the DEFAULT root is created on demand. An extra root is a
       // directory the user already owns — often a git worktree — and creating
@@ -280,7 +291,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       // responsible for it existing (#3015 review F3).
       if (normalizeRoot(root) === DEFAULT_ROOT) mkdirSync(dir, { recursive: true });
       const real = realpathSync(dir);
-      storiesRealCache.set(key, real);
+      storiesRealCache.set(dir, real);
       return real;
     } catch {
       return null;
@@ -491,7 +502,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     // emitted event both normalize, so keying on the raw text made a start
     // written `" repoA "` and its finish written `"repoA"` two entries: the
     // finish deleted nothing and the start leaked (Codex P2 on #3015).
-    const mapKey = generationMapKey(kind, wirePath, key, normalizeRoot(root));
+    const mapKey = generationMapKey(kind, wirePath, key, root);
     const existing = inFlightGenerations.get(mapKey);
     if (finished) {
       if (existing && existing.count > 1) {

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -596,10 +596,14 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   }
 
   async function pdfStatusOp(filePath: string, root?: string): Promise<OpResult<{ pdfPath: string | null }>> {
-    return runStoryOp(filePath, { operation: "pdf-status", root, onContextMissing: () => ({ ok: true, pdfPath: null }) }, async ({ absoluteFilePath, context }) => ({
-      ok: true,
-      pdfPath: freshOutputRef(pdfFilePath(context, PDF_MODE), absoluteFilePath, root),
-    }));
+    return runStoryOp(
+      filePath,
+      { operation: "pdf-status", root, onContextMissing: () => ({ ok: true, pdfPath: null }) },
+      async ({ absoluteFilePath, context }) => ({
+        ok: true,
+        pdfPath: freshOutputRef(pdfFilePath(context, PDF_MODE), absoluteFilePath, root),
+      }),
+    );
   }
 
   // ── Generation ops ────────────────────────────────────────────

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -102,12 +102,15 @@ export async function buildContext(absoluteFilePath: string, force = false): Pro
 export type StoryContext = NonNullable<Awaited<ReturnType<typeof buildContext>>>;
 
 export interface RunStoryOpDeps {
-  resolveStory?: (filePath: string) => { ok: true; absolutePath: string } | OpFailure;
+  resolveStory?: (filePath: string, root?: string) => { ok: true; absolutePath: string } | OpFailure;
   buildContext?: (absoluteFilePath: string, force?: boolean) => Promise<StoryContext | undefined>;
 }
 
 export interface RunStoryOpOptions<T> {
   force?: boolean | undefined;
+  /** Which registered stories root `filePath` is relative to (#3014).
+   *  Absent = the host's default root, i.e. exactly the pre-roots path. */
+  root?: string | undefined;
   /**
    * Op-specific tag included in the failure log so dashboards can
    * distinguish which op is failing (e.g. `"generate-beat-audio"`).
@@ -169,8 +172,11 @@ async function withBeatProgress<T>(beats: MulmoBeat[], onBeat: (sessionType: str
 
 /** Map identity for the in-flight tracker. JSON array keeps the three
  *  fields unambiguous (a human-visible delimiter could collide). */
-function generationMapKey(kind: GenerationKind, filePath: string, key: string): string {
-  return JSON.stringify([kind, filePath, key]);
+function generationMapKey(kind: GenerationKind, filePath: string, key: string, root?: string): string {
+  // `root` is the LAST element so a call site that omits it produces exactly
+  // the pre-#3014 key — the default root's entries keep their identity across
+  // an upgrade, and a running generation is not orphaned by one.
+  return root === undefined || root === "" ? JSON.stringify([kind, filePath, key]) : JSON.stringify([kind, filePath, key, root]);
 }
 
 /**
@@ -181,7 +187,24 @@ function generationMapKey(kind: GenerationKind, filePath: string, key: string): 
 export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   const log = backend.log ?? NOOP_LOG;
   setMulmoErrorCaptureLogger(log);
-  const storiesDir = path.resolve(backend.storiesDir);
+  // Root registry: the default (pre-#3014, wire `root` absent) plus whatever
+  // the host registered. Resolved once — the host owns the ids, this package
+  // only ever looks them up.
+  const DEFAULT_ROOT = "";
+  const rootDirs = new Map<string, string>([[DEFAULT_ROOT, path.resolve(backend.storiesDir)]]);
+  for (const [id, dir] of Object.entries(backend.extraRoots ?? {})) {
+    // An empty id would shadow the default root and silently re-point every
+    // pre-roots caller at someone else's directory.
+    if (id !== DEFAULT_ROOT) rootDirs.set(id, path.resolve(dir));
+  }
+
+  /** The registered directory for a wire `root`, or null when the host never
+   *  registered it. Null is a REJECTION, not a fallback to the default: an
+   *  unknown root must not quietly read the workspace's file of the same
+   *  name. */
+  function rootDir(root: string | undefined): string | null {
+    return rootDirs.get(root ?? DEFAULT_ROOT) ?? null;
+  }
 
   // ── Story path infrastructure ─────────────────────────────────
 
@@ -192,9 +215,10 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // paths under the link's target, and relativizing against the link
   // itself would produce a traversal-like "stories/../../…" ref that
   // resolveStory then rejects (CodeRabbit on #2137).
-  function toStoryRef(absolutePath: string): string {
-    const root = ensureStoriesReal() ?? storiesDir;
-    const rel = path.relative(root, absolutePath).split(path.sep).join("/");
+  function toStoryRef(absolutePath: string, root?: string): string {
+    const dir = rootDir(root);
+    const base = (dir === null ? null : ensureStoriesReal(root)) ?? dir ?? rootDirs.get(DEFAULT_ROOT)!;
+    const rel = path.relative(base, absolutePath).split(path.sep).join("/");
     return rel ? `stories/${rel}` : "stories";
   }
 
@@ -202,13 +226,18 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // instance creation because the directory may not exist yet (it's
   // created on demand by the save route). The cache is invalidated
   // never — once the dir exists, its realpath is stable.
-  let storiesRealCache: string | null = null;
-  function ensureStoriesReal(): string | null {
-    if (storiesRealCache) return storiesRealCache;
+  const storiesRealCache = new Map<string, string>();
+  function ensureStoriesReal(root?: string): string | null {
+    const key = root ?? DEFAULT_ROOT;
+    const cached = storiesRealCache.get(key);
+    if (cached) return cached;
+    const dir = rootDir(root);
+    if (dir === null) return null;
     try {
-      mkdirSync(storiesDir, { recursive: true });
-      storiesRealCache = realpathSync(storiesDir);
-      return storiesRealCache;
+      mkdirSync(dir, { recursive: true });
+      const real = realpathSync(dir);
+      storiesRealCache.set(key, real);
+      return real;
     } catch {
       return null;
     }
@@ -225,8 +254,14 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * stories/ is a regular directory or a legitimate symlink to another
    * location. ENOENT and traversal are distinguished (404 vs 400).
    */
-  function resolveStory(filePath: string): { ok: true; absolutePath: string } | OpFailure {
-    const storiesReal = ensureStoriesReal();
+  function resolveStory(filePath: string, root?: string): { ok: true; absolutePath: string } | OpFailure {
+    // An unregistered root is a bad request, not a fall back to the default:
+    // resolving it against the workspace would hand the caller a DIFFERENT
+    // file that happens to share the name.
+    if (rootDir(root) === null) {
+      return opBadRequest("Unknown stories root");
+    }
+    const storiesReal = ensureStoriesReal(root);
     if (!storiesReal) {
       return opServerError("stories directory not available");
     }
@@ -327,9 +362,17 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     return normalizeStoryPath(filePath) ?? filePath;
   }
 
-  function publishGeneration(chatSessionId: string | undefined, kind: GenerationKind, filePath: string, key: string, finished: boolean, error?: string): void {
+  function publishGeneration(
+    chatSessionId: string | undefined,
+    kind: GenerationKind,
+    filePath: string,
+    key: string,
+    finished: boolean,
+    error?: string,
+    root?: string,
+  ): void {
     const wirePath = canonicalWirePath(filePath);
-    const mapKey = generationMapKey(kind, wirePath, key);
+    const mapKey = generationMapKey(kind, wirePath, key, root);
     const existing = inFlightGenerations.get(mapKey);
     if (finished) {
       if (existing && existing.count > 1) {
@@ -384,7 +427,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   ): Promise<OpResult<T>> {
     const resolver = deps.resolveStory ?? resolveStory;
     const build = deps.buildContext ?? buildContext;
-    const resolved = resolver(filePath);
+    const resolved = resolver(filePath, options.root);
     if (!resolved.ok) return resolved;
     try {
       const context = await build(resolved.absolutePath, options.force ?? false);

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -205,6 +205,24 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
     rootDirs.set(trimmed, path.resolve(dir));
   }
+  if (rootDirs.size > 1) {
+    // The pair identity is complete INSIDE this package, and stops at the host
+    // boundary. A host's per-session generation store keys on
+    // `(kind, filePath, key)` — `generationKey` in `@mulmobridge/protocol`,
+    // which bridges also consume — so two roots running the same generation in
+    // one session collapse to one entry and either finish clears the other's
+    // pending state (Codex P1 on #3015).
+    //
+    // Widening that key is a protocol change with its own consumers, so it is
+    // not this package's to make. Unreachable until a host registers a root,
+    // which is exactly the moment this fires: whoever first does it is the
+    // person who has to widen their session key, and they see this at boot
+    // rather than discovering it from a stuck spinner.
+    log.warn(
+      "extra stories roots registered — the host's per-session generation key must include the root, or two roots running the same generation in one session will collapse to one entry (#3014 step 2)",
+      { roots: [...rootDirs.keys()].filter((id) => id !== DEFAULT_ROOT) },
+    );
+  }
 
   /** The registered directory for a wire `root`, or null when the host never
    *  registered it. Null is a REJECTION, not a fallback to the default: an

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -374,6 +374,20 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * validation (including the script-vs-filePath mode check) belongs to
    * the core.
    */
+  /**
+   * Whether this root is one the host registered.
+   *
+   * Every other root-aware op learns this from `resolveStory`, which needs a
+   * file. `pendingGenerations` needs none — it only filters an in-memory map —
+   * so an unregistered root produced `{ ok: true, pending: [] }`, and a host
+   * typo or a stale card read back as "no work is running" (Codex P2 on
+   * #3015). An unknown root is a question this package cannot answer, and the
+   * answer it must not give is a confident empty one.
+   */
+  function guardStoryRootRegistered(root: string | undefined): OpFailure | null {
+    return rootDir(root) === null ? opBadRequest(`unknown stories root "${normalizeRoot(root)}"`) : null;
+  }
+
   function guardStoryWirePath(filePath: unknown, root?: string): OpFailure | null {
     if (typeof filePath !== "string" || filePath === "") return null;
     const resolved = resolveStory(filePath, root);
@@ -1078,6 +1092,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     toStoryRef,
     resolveStory,
     guardStoryWirePath,
+    guardStoryRootRegistered,
     guardStoryWriteRoot,
     guardStoryGenerationRoot,
     ffmpegGuard,

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -342,10 +342,27 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * validation (including the script-vs-filePath mode check) belongs to
    * the core.
    */
-  function guardStoryWirePath(filePath: unknown): OpFailure | null {
+  function guardStoryWirePath(filePath: unknown, root?: string): OpFailure | null {
     if (typeof filePath !== "string" || filePath === "") return null;
-    const resolved = resolveStory(filePath);
+    const resolved = resolveStory(filePath, root);
     return resolved.ok ? null : resolved;
+  }
+
+  /**
+   * Whether a WRITE may target this root.
+   *
+   * Reads are root-aware; writes are not. `executeMulmoScriptSave` and the
+   * update executors run against one `FileOps`, bound by the host to the
+   * default root, so a write naming another root would rewrite the DEFAULT
+   * root's identically-named file and then announce the other one as changed
+   * (#3015 review G1). Closing it here is fail-closed: "readable but not yet
+   * writable" beats "wrote somewhere else and said so".
+   *
+   * Step 2 replaces this with a per-root FileOps rather than removing it.
+   */
+  function guardStoryWriteRoot(root: string | undefined): OpFailure | null {
+    if (normalizeRoot(root) === DEFAULT_ROOT) return null;
+    return opBadRequest("writing to a non-default stories root is not supported yet");
   }
 
   // mulmocast shells out to ffmpeg for movie / beat rendering. When the
@@ -777,7 +794,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   async function generateMovieOp(filePath: string, chatSessionId: string | undefined, root?: string): Promise<OpResult<{ moviePath: string }>> {
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
-    const resolved = resolveStory(filePath);
+    const resolved = resolveStory(filePath, root);
     if (!resolved.ok) return resolved;
     const absoluteFilePath = resolved.absolutePath;
 
@@ -917,7 +934,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   async function generatePdfOp(filePath: string, chatSessionId: string | undefined, root?: string): Promise<OpResult<{ pdfPath: string }>> {
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
-    const resolved = resolveStory(filePath);
+    const resolved = resolveStory(filePath, root);
     if (!resolved.ok) return resolved;
     const absoluteFilePath = resolved.absolutePath;
 
@@ -958,6 +975,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     toStoryRef,
     resolveStory,
     guardStoryWirePath,
+    guardStoryWriteRoot,
     ffmpegGuard,
     runStoryOp,
     publishGeneration,

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -193,9 +193,14 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   const DEFAULT_ROOT = "";
   const rootDirs = new Map<string, string>([[DEFAULT_ROOT, path.resolve(backend.storiesDir)]]);
   for (const [id, dir] of Object.entries(backend.extraRoots ?? {})) {
-    // An empty id would shadow the default root and silently re-point every
-    // pre-roots caller at someone else's directory.
-    if (id !== DEFAULT_ROOT) rootDirs.set(id, path.resolve(dir));
+    // An empty id is the default root's own key: accepting it would re-point
+    // every pre-roots caller at someone else's directory. Dropping it quietly
+    // would hide the host's misconfiguration until a read returned the wrong
+    // file, and this runs at boot, where throwing is the cheap failure.
+    if (id === DEFAULT_ROOT) {
+      throw new Error("mulmoScript: extraRoots key must not be empty — the empty id is reserved for the default stories root");
+    }
+    rootDirs.set(id, path.resolve(dir));
   }
 
   /** The registered directory for a wire `root`, or null when the host never
@@ -215,10 +220,23 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // paths under the link's target, and relativizing against the link
   // itself would produce a traversal-like "stories/../../…" ref that
   // resolveStory then rejects (CodeRabbit on #2137).
-  function toStoryRef(absolutePath: string, root?: string): string {
+  function toStoryRef(absolutePath: string, root?: string): string | null {
+    // An unregistered root gets null, not the default root's base. Relativizing
+    // against the default would mint a wire ref that READS BACK as a different
+    // file — the same silent-substitution failure `resolveStory` rejects, and
+    // this function is on the ops object, so a host can reach it directly
+    // without passing through that guard (#3015 review F2).
     const dir = rootDir(root);
-    const base = (dir === null ? null : ensureStoriesReal(root)) ?? dir ?? rootDirs.get(DEFAULT_ROOT)!;
+    if (dir === null) return null;
+    const base = ensureStoriesReal(root) ?? dir;
     const rel = path.relative(base, absolutePath).split(path.sep).join("/");
+    // A path outside the base relativizes to `../…`, which would be handed
+    // out as the traversal-shaped ref `stories/../../…` that `resolveStory`
+    // then rejects — a wire path that cannot be read back. It happens for
+    // real: a root whose directory does not exist yet has no realpath, so the
+    // base falls back to the unresolved directory and every absolute path
+    // looks outside it.
+    if (rel === ".." || rel.startsWith("../")) return null;
     return rel ? `stories/${rel}` : "stories";
   }
 
@@ -234,7 +252,12 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     const dir = rootDir(root);
     if (dir === null) return null;
     try {
-      mkdirSync(dir, { recursive: true });
+      // Only the DEFAULT root is created on demand. An extra root is a
+      // directory the user already owns — often a git worktree — and creating
+      // it here would grow `artifacts/stories/` inside their repository as a
+      // side effect of a status poll. A host that registers a root is
+      // responsible for it existing (#3015 review F3).
+      if (normalizeRoot(root) === DEFAULT_ROOT) mkdirSync(dir, { recursive: true });
       const real = realpathSync(dir);
       storiesRealCache.set(key, real);
       return real;
@@ -350,7 +373,22 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // can't clear subscribers' spinners while a duplicate run is active.
   // A finish with no tracked start (the movie/PDF pipelines' per-beat
   // completion pulses) always publishes.
-  const inFlightGenerations = new Map<string, { kind: GenerationKind; filePath: string; key: string; count: number }>();
+  const inFlightGenerations = new Map<string, { kind: GenerationKind; filePath: string; key: string; root: string; count: number }>();
+
+  /** The default root's two spellings (absent, `""`) collapse to one, so a
+   *  snapshot filter and a tracker entry compare equal whichever the caller
+   *  used. */
+  function normalizeRoot(root: string | undefined): string {
+    return root ?? DEFAULT_ROOT;
+  }
+
+  /** Emit `root` only when it names a non-default one: an event carrying
+   *  `root: ""` and one carrying nothing must stay indistinguishable to every
+   *  pre-#3014 consumer. */
+  function rootField(root: string | undefined): { root?: string } {
+    const normalized = normalizeRoot(root);
+    return normalized === DEFAULT_ROOT ? {} : { root: normalized };
+  }
 
   /** Tracker state and events key on the canonical `stories/<rel>` wire
    *  form: subscribers (the View's pubsub filter, `pendingGenerations`
@@ -385,9 +423,16 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
         existing.count += 1;
         return; // already reported as started
       }
-      inFlightGenerations.set(mapKey, { kind, filePath: wirePath, key, count: 1 });
+      inFlightGenerations.set(mapKey, { kind, filePath: wirePath, key, root: normalizeRoot(root), count: 1 });
     }
-    const event: MulmoScriptGenerationEvent = { kind, filePath: wirePath, key, done: finished, ...(error ? { error } : {}) };
+    const event: MulmoScriptGenerationEvent = {
+      kind,
+      filePath: wirePath,
+      key,
+      done: finished,
+      ...(error ? { error } : {}),
+      ...rootField(root),
+    };
     backend.onGenerationEvent?.(chatSessionId, event);
   }
 
@@ -398,17 +443,29 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * save — reloading there would rebuild the element the caret is in, mid-keystroke. A write
    * from the agent carries no origin, so everyone reloads.
    */
-  function publishScriptChanged(filePath: string, origin?: string): void {
-    backend.onScriptChanged?.({ filePath: canonicalWirePath(filePath), ...(origin === undefined ? {} : { origin }) });
+  function publishScriptChanged(filePath: string, origin?: string, root?: string): void {
+    backend.onScriptChanged?.({
+      filePath: canonicalWirePath(filePath),
+      ...(origin === undefined ? {} : { origin }),
+      ...rootField(root),
+    });
   }
 
-  /** Snapshot of generations currently in flight for one script — the
-   *  View's mount-time catch-up, filtered to its wire `filePath`. */
-  function pendingGenerations(filePath: string): MulmoScriptGenerationEvent[] {
+  /**
+   * Snapshot of generations currently in flight for one script — the View's
+   * mount-time catch-up.
+   *
+   * Filtered on the PAIR. Filtering on `filePath` alone hands a View watching
+   * `repoB/stories/deck.json` the run started for `repoA`'s identically-named
+   * deck, and the caller cannot discard it because the returned event would
+   * carry no root either (Codex P1 / CodeRabbit on #3015).
+   */
+  function pendingGenerations(filePath: string, root?: string): MulmoScriptGenerationEvent[] {
     const wirePath = canonicalWirePath(filePath);
+    const wanted = normalizeRoot(root);
     return [...inFlightGenerations.values()]
-      .filter((entry) => entry.filePath === wirePath)
-      .map(({ kind, key }) => ({ kind, filePath: wirePath, key, done: false }));
+      .filter((entry) => entry.filePath === wirePath && entry.root === wanted)
+      .map(({ kind, key }) => ({ kind, filePath: wirePath, key, done: false, ...rootField(root) }));
   }
 
   // ── Op scaffolding ────────────────────────────────────────────
@@ -453,8 +510,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
 
   // ── Probe ops ─────────────────────────────────────────────────
 
-  async function beatImageOp(filePath: string, beatIndex: number): Promise<OpResult<{ image: string | null }>> {
-    return runStoryOp<{ image: string | null }>(filePath, { operation: "beat-image" }, async ({ context }) => {
+  async function beatImageOp(filePath: string, beatIndex: number, root?: string): Promise<OpResult<{ image: string | null }>> {
+    return runStoryOp<{ image: string | null }>(filePath, { operation: "beat-image", root }, async ({ context }) => {
       const { imagePath } = getBeatPngImagePath(context, beatIndex);
       if (!existsSync(imagePath)) return { ok: true, image: null };
       return { ok: true, image: await fileToDataUri(imagePath, "image/png") };
@@ -464,10 +521,10 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // beatAudio is a probe — the frontend polls it expecting `{ audio: null }`
   // when nothing has been generated yet. Override the default
   // server_error-on-context-missing so the soft-fail contract is preserved.
-  async function beatAudioOp(filePath: string, beatIndex: number): Promise<OpResult<{ audio: string | null }>> {
+  async function beatAudioOp(filePath: string, beatIndex: number, root?: string): Promise<OpResult<{ audio: string | null }>> {
     return runStoryOp<{ audio: string | null }>(
       filePath,
-      { operation: "beat-audio", onContextMissing: () => ({ ok: true, audio: null }) },
+      { operation: "beat-audio", root, onContextMissing: () => ({ ok: true, audio: null }) },
       async ({ context }) => {
         const beat = context.studio.script.beats[beatIndex];
         // Probe contract: a beat index the script doesn't have soft-fails
@@ -485,17 +542,17 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // sound effect > raw movie clip > animated html_tailwind render. The
   // response is the "stories/…" wire path so the client can stream it
   // through the host's authenticated media download.
-  async function beatMovieOp(filePath: string, beatIndex: number): Promise<OpResult<{ moviePath: string | null }>> {
-    return runStoryOp<{ moviePath: string | null }>(filePath, { operation: "beat-movie" }, async ({ context }) => {
+  async function beatMovieOp(filePath: string, beatIndex: number, root?: string): Promise<OpResult<{ moviePath: string | null }>> {
+    return runStoryOp<{ moviePath: string | null }>(filePath, { operation: "beat-movie", root }, async ({ context }) => {
       const { movieFile, soundEffectFile, lipSyncFile } = getBeatMoviePaths(context, beatIndex);
       const candidates = [lipSyncFile, soundEffectFile, movieFile, getBeatAnimatedVideoPath(context, beatIndex)];
       const existing = candidates.find((candidate) => existsSync(candidate));
-      return { ok: true, moviePath: existing ? toStoryRef(existing) : null };
+      return { ok: true, moviePath: existing ? toStoryRef(existing, root) : null };
     });
   }
 
-  async function characterImageOp(filePath: string, key: string): Promise<OpResult<{ image: string | null }>> {
-    return runStoryOp<{ image: string | null }>(filePath, { operation: "character-image" }, async ({ context }) => {
+  async function characterImageOp(filePath: string, key: string, root?: string): Promise<OpResult<{ image: string | null }>> {
+    return runStoryOp<{ image: string | null }>(filePath, { operation: "character-image", root }, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
       if (!existsSync(imagePath)) return { ok: true, image: null };
       return { ok: true, image: await fileToDataUri(imagePath, "image/png") };
@@ -505,41 +562,41 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   /** Shared "output exists and is newer than the source script" gate for
    *  movie / PDF status. A stale artifact (script edited after it was
    *  generated) reports null so the UI re-offers the Generate button. */
-  function freshOutputRef(outputPath: string, absoluteFilePath: string): string | null {
+  function freshOutputRef(outputPath: string, absoluteFilePath: string, root?: string): string | null {
     if (!existsSync(outputPath)) return null;
     const outputMtime = statSync(outputPath).mtimeMs;
     const sourceMtime = statSync(absoluteFilePath).mtimeMs;
     if (outputMtime < sourceMtime) return null;
-    return toStoryRef(outputPath);
+    return toStoryRef(outputPath, root);
   }
 
-  async function movieStatusOp(filePath: string): Promise<OpResult<{ moviePath: string | null }>> {
+  async function movieStatusOp(filePath: string, root?: string): Promise<OpResult<{ moviePath: string | null }>> {
     return runStoryOp(
       filePath,
-      { operation: "movie-status", onContextMissing: () => ({ ok: true, moviePath: null }) },
-      async ({ absoluteFilePath, context }) => ({ ok: true, moviePath: freshOutputRef(movieFilePath(context), absoluteFilePath) }),
+      { operation: "movie-status", root, onContextMissing: () => ({ ok: true, moviePath: null }) },
+      async ({ absoluteFilePath, context }) => ({ ok: true, moviePath: freshOutputRef(movieFilePath(context), absoluteFilePath, root) }),
     );
   }
 
-  async function pdfStatusOp(filePath: string): Promise<OpResult<{ pdfPath: string | null }>> {
-    return runStoryOp(filePath, { operation: "pdf-status", onContextMissing: () => ({ ok: true, pdfPath: null }) }, async ({ absoluteFilePath, context }) => ({
+  async function pdfStatusOp(filePath: string, root?: string): Promise<OpResult<{ pdfPath: string | null }>> {
+    return runStoryOp(filePath, { operation: "pdf-status", root, onContextMissing: () => ({ ok: true, pdfPath: null }) }, async ({ absoluteFilePath, context }) => ({
       ok: true,
-      pdfPath: freshOutputRef(pdfFilePath(context, PDF_MODE), absoluteFilePath),
+      pdfPath: freshOutputRef(pdfFilePath(context, PDF_MODE), absoluteFilePath, root),
     }));
   }
 
   // ── Generation ops ────────────────────────────────────────────
 
   async function renderBeatOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ image: string }>> {
-    const { filePath, beatIndex, force, chatSessionId } = args;
+    const { filePath, beatIndex, force, chatSessionId, root } = args;
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
 
     const mapKey = String(beatIndex);
-    publishGeneration(chatSessionId, "beatImage", filePath, mapKey, false);
+    publishGeneration(chatSessionId, "beatImage", filePath, mapKey, false, root);
     let genError: string | undefined;
     try {
-      const result = await runStoryOp<{ image: string }>(filePath, { force, operation: "render-beat" }, async ({ context }) => {
+      const result = await runStoryOp<{ image: string }>(filePath, { force, operation: "render-beat", root }, async ({ context }) => {
         await generateBeatImage({
           index: beatIndex,
           context,
@@ -554,17 +611,17 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       if (!result.ok) genError = result.error;
       return result;
     } finally {
-      publishGeneration(chatSessionId, "beatImage", filePath, mapKey, true, genError);
+      publishGeneration(chatSessionId, "beatImage", filePath, mapKey, true, genError, root);
     }
   }
 
   async function generateBeatAudioOp(args: GenerateOpArgsWith<"filePath" | "beatIndex">): Promise<OpResult<{ audio: string }>> {
-    const { filePath, beatIndex, force, chatSessionId } = args;
+    const { filePath, beatIndex, force, chatSessionId, root } = args;
     const mapKey = String(beatIndex);
-    publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, false);
+    publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, false, root);
     let genError: string | undefined;
     try {
-      const result = await runStoryOp<{ audio: string }>(filePath, { force, operation: "generate-beat-audio" }, async ({ context }) => {
+      const result = await runStoryOp<{ audio: string }>(filePath, { force, operation: "generate-beat-audio", root }, async ({ context }) => {
         await generateBeatAudio(beatIndex, context, {
           settings: process.env as Record<string, string>,
         } as Parameters<typeof generateBeatAudio>[2]);
@@ -595,16 +652,16 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       if (!result.ok) genError = result.error;
       return result;
     } finally {
-      publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, true, genError);
+      publishGeneration(chatSessionId, "beatAudio", filePath, mapKey, true, genError, root);
     }
   }
 
   async function renderCharacterOp(args: GenerateOpArgsWith<"filePath" | "key">): Promise<OpResult<{ image: string }>> {
-    const { filePath, key, force, chatSessionId } = args;
-    publishGeneration(chatSessionId, "characterImage", filePath, key, false);
+    const { filePath, key, force, chatSessionId, root } = args;
+    publishGeneration(chatSessionId, "characterImage", filePath, key, false, root);
     let genError: string | undefined;
     try {
-      const result = await runStoryOp<{ image: string }>(filePath, { force, operation: "render-character" }, async ({ context }) => {
+      const result = await runStoryOp<{ image: string }>(filePath, { force, operation: "render-character", root }, async ({ context }) => {
         // `imageEntries` (not `images`) to avoid shadowing mulmocast's
         // imported `images()` pipeline stage.
         const imageEntries = context.studio.script.imageParams?.images ?? {};
@@ -632,14 +689,14 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       if (!result.ok) genError = result.error;
       return result;
     } finally {
-      publishGeneration(chatSessionId, "characterImage", filePath, key, true, genError);
+      publishGeneration(chatSessionId, "characterImage", filePath, key, true, genError, root);
     }
   }
 
   // ── Upload ops ────────────────────────────────────────────────
 
-  async function uploadBeatImageOp(filePath: string, beatIndex: number, imageData: string): Promise<OpResult<{ image: string }>> {
-    return runStoryOp<{ image: string }>(filePath, { operation: "upload-beat-image" }, async ({ context }) => {
+  async function uploadBeatImageOp(filePath: string, beatIndex: number, imageData: string, root?: string): Promise<OpResult<{ image: string }>> {
+    return runStoryOp<{ image: string }>(filePath, { operation: "upload-beat-image", root }, async ({ context }) => {
       const { imagePath } = getBeatPngImagePath(context, beatIndex);
       // writeFileAtomic creates parent dirs and prevents a half-
       // written PNG from surviving a crash mid-write (#881 v2).
@@ -649,8 +706,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     });
   }
 
-  async function uploadCharacterImageOp(filePath: string, key: string, imageData: string): Promise<OpResult<{ image: string }>> {
-    return runStoryOp<{ image: string }>(filePath, { operation: "upload-character-image" }, async ({ context }) => {
+  async function uploadCharacterImageOp(filePath: string, key: string, imageData: string, root?: string): Promise<OpResult<{ image: string }>> {
+    return runStoryOp<{ image: string }>(filePath, { operation: "upload-character-image", root }, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
       const base64 = stripDataUri(imageData);
       await backend.writeFileAtomic(imagePath, Buffer.from(base64, "base64"));
@@ -717,7 +774,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * initiating View (and any other mounted View) reloads assets off disk
    * as they land — the successor of the SSE per-beat events.
    */
-  async function generateMovieOp(filePath: string, chatSessionId: string | undefined): Promise<OpResult<{ moviePath: string }>> {
+  async function generateMovieOp(filePath: string, chatSessionId: string | undefined, root?: string): Promise<OpResult<{ moviePath: string }>> {
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
     const resolved = resolveStory(filePath);
@@ -729,31 +786,33 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
 
     inFlightMovies.add(absoluteFilePath);
-    publishGeneration(chatSessionId, "movie", filePath, "", false);
+    publishGeneration(chatSessionId, "movie", filePath, "", false, root);
     let genError: string | undefined;
     try {
       const result = await runMovieGeneration(absoluteFilePath, (event) => {
         const eventKind = event.kind === "image" ? "beatImage" : "beatAudio";
-        publishGeneration(chatSessionId, eventKind, filePath, String(event.beatIndex), true);
+        publishGeneration(chatSessionId, eventKind, filePath, String(event.beatIndex), true, root);
       });
       if (!result.ok) {
         genError = result.error;
         return opServerError(result.error);
       }
-      return { ok: true, moviePath: toStoryRef(result.outputPath) };
+      const movieRef = toStoryRef(result.outputPath, root);
+      if (movieRef === null) return opServerError("generated movie is outside the registered stories root");
+      return { ok: true, moviePath: movieRef };
     } catch (err) {
       genError = errorMessage(err);
       return opServerError(genError);
     } finally {
       inFlightMovies.delete(absoluteFilePath);
-      publishGeneration(chatSessionId, "movie", filePath, "", true, genError);
+      publishGeneration(chatSessionId, "movie", filePath, "", true, genError, root);
     }
   }
 
-  function triggerAutoBackgroundMovie(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined): void {
+  function triggerAutoBackgroundMovie(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined, root?: string): void {
     if (inFlightMovies.has(absoluteFilePath)) return;
     inFlightMovies.add(absoluteFilePath);
-    void runBackgroundMovieGeneration(absoluteFilePath, wireFilePath, chatSessionId);
+    void runBackgroundMovieGeneration(absoluteFilePath, wireFilePath, chatSessionId, root);
   }
 
   // Detached movie generation. Reports progress through the generation
@@ -765,7 +824,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // stale sidecar from a previous run is cleared on each new attempt.
   // Triggered server-side from the unified save route when the caller
   // passes `autoGenerateMovie: true`.
-  async function runBackgroundMovieGeneration(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined): Promise<void> {
+  async function runBackgroundMovieGeneration(absoluteFilePath: string, wireFilePath: string, chatSessionId: string | undefined, root?: string): Promise<void> {
     const errorSidecarPath = `${absoluteFilePath}.error.txt`;
     // Clear stale error from a previous failed run before starting; if it
     // doesn't exist that's fine. Catch any unexpected fs errors silently —
@@ -776,7 +835,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       // intentional: ENOENT is the common case, others non-fatal
     }
 
-    publishGeneration(chatSessionId, "movie", wireFilePath, "", false);
+    publishGeneration(chatSessionId, "movie", wireFilePath, "", false, root);
     let genError: string | undefined;
     try {
       const result = await runMovieGeneration(absoluteFilePath, (event) => {
@@ -788,8 +847,8 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
         // the reload.
         const eventKind = event.kind === "image" ? "beatImage" : "beatAudio";
         const key = String(event.beatIndex);
-        publishGeneration(chatSessionId, eventKind, wireFilePath, key, false);
-        setImmediate(() => publishGeneration(chatSessionId, eventKind, wireFilePath, key, true));
+        publishGeneration(chatSessionId, eventKind, wireFilePath, key, false, root);
+        setImmediate(() => publishGeneration(chatSessionId, eventKind, wireFilePath, key, true, undefined, root));
       });
 
       if (!result.ok) {
@@ -808,7 +867,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
       log.error("background movie generation crashed", { filePath: wireFilePath, error: genError });
     } finally {
       inFlightMovies.delete(absoluteFilePath);
-      publishGeneration(chatSessionId, "movie", wireFilePath, "", true, genError);
+      publishGeneration(chatSessionId, "movie", wireFilePath, "", true, genError, root);
     }
   }
 
@@ -855,7 +914,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
 
   /** Long-held foreground PDF generation (the package View's `generatePdf`
    *  dispatch) — the PDF sibling of `generateMovieOp`. */
-  async function generatePdfOp(filePath: string, chatSessionId: string | undefined): Promise<OpResult<{ pdfPath: string }>> {
+  async function generatePdfOp(filePath: string, chatSessionId: string | undefined, root?: string): Promise<OpResult<{ pdfPath: string }>> {
     const ffmpeg = ffmpegGuard();
     if (ffmpeg) return ffmpeg;
     const resolved = resolveStory(filePath);
@@ -867,7 +926,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
 
     inFlightPdfs.add(absoluteFilePath);
-    publishGeneration(chatSessionId, "pdf", filePath, "", false);
+    publishGeneration(chatSessionId, "pdf", filePath, "", false, root);
     let genError: string | undefined;
     try {
       const context = await buildContext(absoluteFilePath);
@@ -876,19 +935,21 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
         return opServerError(genError);
       }
       const result = await runPdfGeneration(context, (beatIndex) => {
-        publishGeneration(chatSessionId, "beatImage", filePath, String(beatIndex), true);
+        publishGeneration(chatSessionId, "beatImage", filePath, String(beatIndex), true, root);
       });
       if (!result.ok) {
         genError = result.error;
         return opServerError(result.error);
       }
-      return { ok: true, pdfPath: toStoryRef(result.outputPath) };
+      const pdfRef = toStoryRef(result.outputPath, root);
+      if (pdfRef === null) return opServerError("generated PDF is outside the registered stories root");
+      return { ok: true, pdfPath: pdfRef };
     } catch (err) {
       genError = errorMessage(err);
       return opServerError(genError);
     } finally {
       inFlightPdfs.delete(absoluteFilePath);
-      publishGeneration(chatSessionId, "pdf", filePath, "", true, genError);
+      publishGeneration(chatSessionId, "pdf", filePath, "", true, genError, root);
     }
   }
 

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -449,7 +449,11 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   ): void {
     const { error, root } = opts;
     const wirePath = canonicalWirePath(filePath);
-    const mapKey = generationMapKey(kind, wirePath, key, root);
+    // The NORMALIZED root, not the raw spelling. The tracker value and the
+    // emitted event both normalize, so keying on the raw text made a start
+    // written `" repoA "` and its finish written `"repoA"` two entries: the
+    // finish deleted nothing and the start leaked (Codex P2 on #3015).
+    const mapKey = generationMapKey(kind, wirePath, key, normalizeRoot(root));
     const existing = inFlightGenerations.get(mapKey);
     if (finished) {
       if (existing && existing.count > 1) {

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -372,18 +372,6 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   }
 
   /**
-   * Realpath containment pre-guard for wire paths handed to the phase-1
-   * core's save/reopen/update executes. The core's own path guard is
-   * lexical (it runs against the generic FileOps, whose read/write follows
-   * symlinks), so hosts re-assert the realpath boundary here before
-   * invoking it — a symlink planted below the stories dir can't read or
-   * write outside the tree (Codex P1 on MulmoClaude#2133).
-   *
-   * Returns null when `filePath` isn't a non-empty string — shape
-   * validation (including the script-vs-filePath mode check) belongs to
-   * the core.
-   */
-  /**
    * Whether this root is one the host registered.
    *
    * Every other root-aware op learns this from `resolveStory`, which needs a
@@ -397,24 +385,24 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     return rootDir(root) === null ? opBadRequest(`unknown stories root "${normalizeRoot(root)}"`) : null;
   }
 
+  /**
+   * Realpath containment pre-guard for wire paths handed to the phase-1
+   * core's save/reopen/update executes. The core's own path guard is
+   * lexical (it runs against the generic FileOps, whose read/write follows
+   * symlinks), so hosts re-assert the realpath boundary here before
+   * invoking it — a symlink planted below the stories dir can't read or
+   * write outside the tree (Codex P1 on MulmoClaude#2133).
+   *
+   * Returns null when `filePath` isn't a non-empty string — shape
+   * validation (including the script-vs-filePath mode check) belongs to
+   * the core.
+   */
   function guardStoryWirePath(filePath: unknown, root?: string): OpFailure | null {
     if (typeof filePath !== "string" || filePath === "") return null;
     const resolved = resolveStory(filePath, root);
     return resolved.ok ? null : resolved;
   }
 
-  /**
-   * Whether a WRITE may target this root.
-   *
-   * Reads are root-aware; writes are not. `executeMulmoScriptSave` and the
-   * update executors run against one `FileOps`, bound by the host to the
-   * default root, so a write naming another root would rewrite the DEFAULT
-   * root's identically-named file and then announce the other one as changed
-   * (#3015 review G1). Closing it here is fail-closed: "readable but not yet
-   * writable" beats "wrote somewhere else and said so".
-   *
-   * Step 2 replaces this with a per-root FileOps rather than removing it.
-   */
   /**
    * Whether a GENERATION may run in this root.
    *
@@ -447,6 +435,18 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * through the package executors, not through these ops — so
    * `test_server_roots.ts` walks the whole ops surface and fails on any op
    * that is neither in the read-only allowlist nor refusing.
+   */
+  /**
+   * Whether a WRITE may target this root.
+   *
+   * Reads are root-aware; writes are not. `executeMulmoScriptSave` and the
+   * update executors run against one `FileOps`, bound by the host to the
+   * default root, so a write naming another root would rewrite the DEFAULT
+   * root's identically-named file and then announce the other one as changed
+   * (#3015 review G1). Closing it here is fail-closed: "readable but not yet
+   * writable" beats "wrote somewhere else and said so".
+   *
+   * Step 2 replaces this with a per-root FileOps rather than removing it.
    */
   function guardStoryWriteRoot(root: string | undefined): OpFailure | null {
     if (normalizeRoot(root) === DEFAULT_ROOT) return null;

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -23,6 +23,9 @@ export interface GenerateOpArgs {
   key?: string | undefined;
   force?: boolean | undefined;
   chatSessionId?: string | undefined;
+  /** Which registered stories root `filePath` is relative to (#3014).
+   *  Absent = the host's default root. */
+  root?: string | undefined;
 }
 
 /** `GenerateOpArgs` with `K` promoted to genuinely required. `Required<Pick<…>>`

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -49,9 +49,29 @@ export type MulmoScriptServerLog = MinimalLogger;
  * containment, and generation-state tracking are all in-package.
  */
 export interface MulmoScriptServerBackend {
-  /** Absolute path of the stories directory (`<workspace>/artifacts/stories`).
-   *  May not exist yet — the ops lazily create + realpath it. */
+  /** Absolute path of the DEFAULT stories directory
+   *  (`<workspace>/artifacts/stories`). May not exist yet — the ops lazily
+   *  create + realpath it. A wire path with no `root` resolves here, which
+   *  is what makes every pre-`root` caller keep its exact behaviour. */
   storiesDir: string;
+  /**
+   * Additional stories roots, keyed by the id the wire `root` names
+   * (#3014). Absent or empty = the single-root world this package shipped
+   * with, byte for byte.
+   *
+   * The KEY IS OPAQUE TO THIS PACKAGE. It is looked up here and never
+   * parsed, so the host owns what a root id means — a declared name, a
+   * hash of the directory, an assigned handle. That decision is persisted
+   * in the host's cards, so it belongs to whoever has to keep it stable,
+   * and pinning it here would freeze it for every host at once.
+   *
+   * Registration is the containment boundary. `filePath` is a field the
+   * MODEL fills (`core/definition.ts`), so the agent must never be able to
+   * name a root: it may only address what the host already registered. The
+   * tool definition is unchanged for exactly this reason — a host adds a
+   * root, an agent cannot.
+   */
+  extraRoots?: Record<string, string>;
   /** Shared artifacts FileOps (rooted at `<workspace>/artifacts`) for the
    *  save / reopen / update dispatch kinds (phase-1 core executes). */
   artifacts: FileOps;

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -1255,13 +1255,13 @@ watch(() => props.selectedResult, initializeScript);
 // plugin pubsub channel (started + finished, per beat and per artifact);
 // on start we mirror the local "rendering" state so spinners show even
 // after a remount, on finish we reload the relevant asset off disk.
-const unsubscribeGenerationEvents = api.onGenerationEvent(
-  () => filePath.value,
+const unsubscribeGenerationEvents = api.onGenerationEvent({
+  filePath: () => filePath.value,
   // The View is opened from the host's default root today; step 2 gives it a
   // root of its own. Written out rather than left to a default so the pair
   // filter is visible at the call site (#3014).
-  () => undefined,
-  (event) => {
+  root: () => undefined,
+  handler: (event) => {
     if (!event.done) {
       reflectGenerationStart(event);
       return;
@@ -1272,7 +1272,7 @@ const unsubscribeGenerationEvents = api.onGenerationEvent(
       console.error("[presentMulmoScript] reload on finish failed:", err);
     });
   },
-);
+});
 
 function reflectGenerationStart(entry: MulmoScriptGenerationEvent): void {
   if (entry.kind === "beatImage") {

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -1257,6 +1257,10 @@ watch(() => props.selectedResult, initializeScript);
 // after a remount, on finish we reload the relevant asset off disk.
 const unsubscribeGenerationEvents = api.onGenerationEvent(
   () => filePath.value,
+  // The View is opened from the host's default root today; step 2 gives it a
+  // root of its own. Written out rather than left to a default so the pair
+  // filter is visible at the call site (#3014).
+  () => undefined,
   (event) => {
     if (!event.done) {
       reflectGenerationStart(event);

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -85,16 +85,16 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
    * flushing cannot clobber it out of order.
    */
   function watchForeignWrites(reload: () => void): () => void {
-    return api.onScriptChanged(
-      () => filePath.value,
+    return api.onScriptChanged({
+      filePath: () => filePath.value,
       // Default root until step 2 — see the note in View.vue.
-      () => undefined,
-      EDITOR_ORIGIN,
-      () => {
+      root: () => undefined,
+      ownOrigin: EDITOR_ORIGIN,
+      handler: () => {
         flushPendingDeckSave();
         reload();
       },
-    );
+    });
   }
 
   return { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -87,6 +87,8 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
   function watchForeignWrites(reload: () => void): () => void {
     return api.onScriptChanged(
       () => filePath.value,
+      // Default root until step 2 — see the note in View.vue.
+      () => undefined,
       EDITOR_ORIGIN,
       () => {
         flushPendingDeckSave();

--- a/packages/plugins/mulmoscript-plugin/src/vue/index.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/index.ts
@@ -23,7 +23,13 @@ export type { MulmoScriptDispatchArgs, MulmoScriptDispatchResult, MulmoScriptGen
 export { GENERATION_EVENT, SCRIPT_CHANGED_EVENT } from "../core/contract";
 export { TOOL_NAME, TOOL_DEFINITION } from "../core/definition";
 export { MULMOSCRIPT_HOST_ADAPTER_KEY, useHostAdapter, type MulmoScriptHostAdapter } from "./hostAdapter";
-export { useMulmoScriptTransport, type MulmoScriptTransport, type TransportResult } from "./transport";
+export {
+  useMulmoScriptTransport,
+  type MulmoScriptTransport,
+  type TransportResult,
+  type GenerationSubscription,
+  type ScriptChangedSubscription,
+} from "./transport";
 export { View, Preview };
 
 export default { plugin };

--- a/packages/plugins/mulmoscript-plugin/src/vue/subscription.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/subscription.ts
@@ -32,11 +32,35 @@ export interface ScriptChangedSubscription {
 /** A caller that predates roots is asking for the host's default root. */
 const DEFAULT_ROOT_GETTER = (): string | undefined => undefined;
 
+/**
+ * The object form is checked at runtime, not only by the type.
+ *
+ * This package is published, so a JavaScript consumer reaches these functions
+ * with no call-site checking at all. An object missing `root` type-checks
+ * nowhere and passed through here unchanged, and the failure surfaced much
+ * later as `sub.root is not a function` — thrown inside a pubsub delivery,
+ * where there is no caller left to catch it and the only symptom is a View
+ * that silently stops updating (CodeRabbit on #3015).
+ *
+ * A missing `root` is the one field with a safe answer: absent means the
+ * default root, which is exactly what a caller who did not think about roots
+ * intended. A missing `filePath` or `handler` has no such answer, so it
+ * throws HERE, at the subscribe call, where the stack points at the bug.
+ */
+function checkedSubscription<T extends { filePath: unknown; handler: unknown; root?: unknown }>(subscription: T, label: string): T {
+  if (typeof subscription.filePath !== "function" || typeof subscription.handler !== "function") {
+    throw new TypeError(`${label}: filePath and handler must both be functions`);
+  }
+  if (subscription.root === undefined) return { ...subscription, root: DEFAULT_ROOT_GETTER };
+  if (typeof subscription.root !== "function") throw new TypeError(`${label}: root must be a function returning the root id, or be omitted`);
+  return subscription;
+}
+
 export function normalizeGenerationSubscription(
   first: GenerationSubscription | (() => string),
   legacyHandler?: (event: MulmoScriptGenerationEvent) => void,
 ): GenerationSubscription {
-  if (typeof first !== "function") return first;
+  if (typeof first !== "function") return checkedSubscription(first, "onGenerationEvent(subscription)");
   if (!legacyHandler) throw new TypeError("onGenerationEvent(filePath, handler): handler is required");
   return { filePath: first, root: DEFAULT_ROOT_GETTER, handler: legacyHandler };
 }
@@ -46,7 +70,11 @@ export function normalizeScriptChangedSubscription(
   legacyOwnOrigin?: string,
   legacyHandler?: () => void,
 ): ScriptChangedSubscription {
-  if (typeof first !== "function") return first;
+  if (typeof first !== "function") {
+    const checked = checkedSubscription(first, "onScriptChanged(subscription)");
+    if (typeof checked.ownOrigin !== "string") throw new TypeError("onScriptChanged(subscription): ownOrigin must be a string");
+    return checked;
+  }
   if (typeof legacyOwnOrigin !== "string" || !legacyHandler) {
     throw new TypeError("onScriptChanged(filePath, ownOrigin, handler): ownOrigin and handler are required");
   }

--- a/packages/plugins/mulmoscript-plugin/src/vue/subscription.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/subscription.ts
@@ -1,0 +1,54 @@
+// One subscription shape from two call forms (#3015).
+//
+// `MulmoScriptTransport` is exported from `/vue` on a package already
+// published to npm, so the two-argument calls that predate roots must keep
+// working: a third positional parameter binds an existing caller's `handler`
+// to `root`, and the event path then calls a handler as `root()` (Codex +
+// CodeRabbit on #3015). But an OPTIONAL root is the shape that shipped broken
+// twice on the server side of this same PR — the pair filter compares
+// `undefined` against every named root and silently drops the events it exists
+// to route.
+//
+// An options object satisfies both, and the discrimination is total: the
+// legacy form's first argument is a function, which an options object never
+// is. It lives here, as a pure function, because it is the part with a wrong
+// answer available — the pubsub wiring around it has none.
+import type { MulmoScriptGenerationEvent } from "../core/contract";
+
+export interface GenerationSubscription {
+  filePath: () => string;
+  root: () => string | undefined;
+  handler: (event: MulmoScriptGenerationEvent) => void;
+}
+
+export interface ScriptChangedSubscription {
+  filePath: () => string;
+  root: () => string | undefined;
+  /** This View's id — its own writes echo back and must not be acted on. */
+  ownOrigin: string;
+  handler: () => void;
+}
+
+/** A caller that predates roots is asking for the host's default root. */
+const DEFAULT_ROOT_GETTER = (): string | undefined => undefined;
+
+export function normalizeGenerationSubscription(
+  first: GenerationSubscription | (() => string),
+  legacyHandler?: (event: MulmoScriptGenerationEvent) => void,
+): GenerationSubscription {
+  if (typeof first !== "function") return first;
+  if (!legacyHandler) throw new TypeError("onGenerationEvent(filePath, handler): handler is required");
+  return { filePath: first, root: DEFAULT_ROOT_GETTER, handler: legacyHandler };
+}
+
+export function normalizeScriptChangedSubscription(
+  first: ScriptChangedSubscription | (() => string),
+  legacyOwnOrigin?: string,
+  legacyHandler?: () => void,
+): ScriptChangedSubscription {
+  if (typeof first !== "function") return first;
+  if (typeof legacyOwnOrigin !== "string" || !legacyHandler) {
+    throw new TypeError("onScriptChanged(filePath, ownOrigin, handler): ownOrigin and handler are required");
+  }
+  return { filePath: first, root: DEFAULT_ROOT_GETTER, ownOrigin: legacyOwnOrigin, handler: legacyHandler };
+}

--- a/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
@@ -21,16 +21,25 @@ type ArgsFor<K extends MulmoScriptDispatchArgs["kind"]> = Omit<Extract<MulmoScri
 
 const GENERATION_EVENT_KINDS: ReadonlySet<string> = new Set(["beatImage", "beatAudio", "characterImage", "movie", "pdf"]);
 
-function parseScriptChangedEvent(payload: unknown): MulmoScriptChangedEvent | null {
+// These parsers are the boundary the pair identity has to survive. Rebuilding
+// the event field by field means a field nobody listed is silently dropped —
+// which is how `(root, filePath)` checks were added downstream and compared
+// `undefined` against every named root, filtering out the very events they
+// were written to route (Codex P1 on #3015).
+export function parseScriptChangedEvent(payload: unknown): MulmoScriptChangedEvent | null {
   if (!isRecord(payload)) return null;
-  const { filePath, origin } = payload;
+  const { filePath, origin, root } = payload;
   if (typeof filePath !== "string") return null;
-  return { filePath, ...(typeof origin === "string" ? { origin } : {}) };
+  return {
+    filePath,
+    ...(typeof origin === "string" ? { origin } : {}),
+    ...(typeof root === "string" ? { root } : {}),
+  };
 }
 
-function parseGenerationEvent(payload: unknown): MulmoScriptGenerationEvent | null {
+export function parseGenerationEvent(payload: unknown): MulmoScriptGenerationEvent | null {
   if (!isRecord(payload)) return null;
-  const { kind, filePath, key, done, error } = payload;
+  const { kind, filePath, key, done, error, root } = payload;
   if (typeof kind !== "string" || !GENERATION_EVENT_KINDS.has(kind)) return null;
   if (typeof filePath !== "string" || typeof key !== "string" || typeof done !== "boolean") return null;
   return {
@@ -39,6 +48,7 @@ function parseGenerationEvent(payload: unknown): MulmoScriptGenerationEvent | nu
     key,
     done,
     ...(typeof error === "string" ? { error } : {}),
+    ...(typeof root === "string" ? { root } : {}),
   };
 }
 

--- a/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
@@ -11,7 +11,7 @@
 
 import { useRuntime } from "gui-chat-protocol/vue";
 import type { MulmoScriptChangedEvent, MulmoScriptDispatchArgs, MulmoScriptDispatchResult, MulmoScriptGenerationEvent } from "../core/contract";
-import { GENERATION_EVENT, SCRIPT_CHANGED_EVENT, shouldReloadForScriptChange } from "../core/contract";
+import { GENERATION_EVENT, SCRIPT_CHANGED_EVENT, sameRoot, shouldReloadForScriptChange } from "../core/contract";
 import { errorMessage } from "@mulmoclaude/common";
 import { isRecord } from "./support";
 
@@ -92,7 +92,7 @@ export function useMulmoScriptTransport(): MulmoScriptTransport {
       // View (Codex P1 on #3015). `root` is a required parameter rather than an
       // optional one because a forgotten optional is exactly how the server
       // side of this shipped broken twice.
-      if (!current || event.filePath !== current || (event.root ?? "") !== (root() ?? "")) return;
+      if (!current || event.filePath !== current || !sameRoot(event.root, root())) return;
       handler(event);
     });
   }

--- a/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
@@ -44,12 +44,15 @@ function parseGenerationEvent(payload: unknown): MulmoScriptGenerationEvent | nu
 
 export interface MulmoScriptTransport {
   call<K extends MulmoScriptDispatchArgs["kind"]>(kind: K, args: ArgsFor<K>): Promise<TransportResult<MulmoScriptDispatchResult[K]>>;
-  /** Subscribe to the host's generation channel, pre-filtered to one
-   *  script's wire path. Returns the unsubscribe function. */
-  onGenerationEvent(filePath: () => string, handler: (event: MulmoScriptGenerationEvent) => void): () => void;
+  /** Subscribe to the host's generation channel, pre-filtered to one script —
+   *  identified by the PAIR `(root, filePath)`, since the same wire path
+   *  exists in every registered root (#3014). Returns the unsubscribe
+   *  function. */
+  onGenerationEvent(filePath: () => string, root: () => string | undefined, handler: (event: MulmoScriptGenerationEvent) => void): () => void;
   /** Subscribe to writes of one script, skipping the echo of this View's own
-   *  (`ownOrigin`). Returns the unsubscribe function. */
-  onScriptChanged(filePath: () => string, ownOrigin: string, handler: () => void): () => void;
+   *  (`ownOrigin`). Same pair identity as above. Returns the unsubscribe
+   *  function. */
+  onScriptChanged(filePath: () => string, root: () => string | undefined, ownOrigin: string, handler: () => void): () => void;
 }
 
 export function useMulmoScriptTransport(): MulmoScriptTransport {
@@ -69,12 +72,17 @@ export function useMulmoScriptTransport(): MulmoScriptTransport {
     return { ok: true, data: result as MulmoScriptDispatchResult[K] };
   }
 
-  function onGenerationEvent(filePath: () => string, handler: (event: MulmoScriptGenerationEvent) => void): () => void {
+  function onGenerationEvent(filePath: () => string, root: () => string | undefined, handler: (event: MulmoScriptGenerationEvent) => void): () => void {
     return runtime.pubsub.subscribe(GENERATION_EVENT, (payload: unknown) => {
       const event = parseGenerationEvent(payload);
       if (!event) return;
       const current = filePath();
-      if (!current || event.filePath !== current) return;
+      // The PAIR, not the path: `stories/deck.json` exists in every root, so
+      // filtering on the path alone puts another repository's spinners on this
+      // View (Codex P1 on #3015). `root` is a required parameter rather than an
+      // optional one because a forgotten optional is exactly how the server
+      // side of this shipped broken twice.
+      if (!current || event.filePath !== current || (event.root ?? "") !== (root() ?? "")) return;
       handler(event);
     });
   }
@@ -86,11 +94,11 @@ export function useMulmoScriptTransport(): MulmoScriptTransport {
    * on them would rebuild the element the caret is in on every keystroke, so they are dropped
    * here. A write from the agent carries no origin and always reaches the handler.
    */
-  function onScriptChanged(filePath: () => string, ownOrigin: string, handler: () => void): () => void {
+  function onScriptChanged(filePath: () => string, root: () => string | undefined, ownOrigin: string, handler: () => void): () => void {
     return runtime.pubsub.subscribe(SCRIPT_CHANGED_EVENT, (payload: unknown) => {
       const event = parseScriptChangedEvent(payload);
       if (!event) return;
-      if (!shouldReloadForScriptChange(event, filePath(), ownOrigin)) return;
+      if (!shouldReloadForScriptChange(event, filePath(), ownOrigin, root())) return;
       handler();
     });
   }

--- a/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
@@ -29,14 +29,35 @@ const GENERATION_EVENT_KINDS: ReadonlySet<string> = new Set(["beatImage", "beatA
 // which is how `(root, filePath)` checks were added downstream and compared
 // `undefined` against every named root, filtering out the very events they
 // were written to route (Codex P1 on #3015).
+/**
+ * A field that is absent, or a string.
+ *
+ * `undefined` is a legitimate answer for both `root` and `origin`, so a
+ * present-but-wrong-typed value CANNOT be flattened into it: `root: 42` read
+ * as "no root" makes a named root's event look like a default-root one, and
+ * the subscriber then routes another repository's script to this View
+ * (CodeRabbit on #3015 — the same shape the dispatch boundary was just fixed
+ * for). Malformed means malformed; the caller rejects the payload.
+ */
+function optionalString(value: unknown): { ok: true; value: string | undefined } | { ok: false } {
+  if (value === undefined) return { ok: true, value: undefined };
+  return typeof value === "string" ? { ok: true, value } : { ok: false };
+}
+
 export function parseScriptChangedEvent(payload: unknown): MulmoScriptChangedEvent | null {
   if (!isRecord(payload)) return null;
   const { filePath, origin, root } = payload;
   if (typeof filePath !== "string") return null;
+  // `origin` decides whether this View acts on the echo of its OWN write.
+  // Read as absent, a malformed one makes every keystroke rebuild the element
+  // the caret is in — so it is identity too, and rejected the same way.
+  const parsedOrigin = optionalString(origin);
+  const parsedRoot = optionalString(root);
+  if (!parsedOrigin.ok || !parsedRoot.ok) return null;
   return {
     filePath,
-    ...(typeof origin === "string" ? { origin } : {}),
-    ...(typeof root === "string" ? { root } : {}),
+    ...(parsedOrigin.value !== undefined ? { origin: parsedOrigin.value } : {}),
+    ...(parsedRoot.value !== undefined ? { root: parsedRoot.value } : {}),
   };
 }
 
@@ -45,13 +66,19 @@ export function parseGenerationEvent(payload: unknown): MulmoScriptGenerationEve
   const { kind, filePath, key, done, error, root } = payload;
   if (typeof kind !== "string" || !GENERATION_EVENT_KINDS.has(kind)) return null;
   if (typeof filePath !== "string" || typeof key !== "string" || typeof done !== "boolean") return null;
+  const parsedRoot = optionalString(root);
+  if (!parsedRoot.ok) return null;
   return {
     kind: kind as MulmoScriptGenerationEvent["kind"],
     filePath,
     key,
     done,
+    // `error` is the one field a malformed value may be dropped from rather
+    // than rejected with: it is a message shown beside a finished generation,
+    // and rejecting the whole event would drop the FINISH — leaving the
+    // spinner running forever, which is worse than losing the text.
     ...(typeof error === "string" ? { error } : {}),
-    ...(typeof root === "string" ? { root } : {}),
+    ...(parsedRoot.value !== undefined ? { root: parsedRoot.value } : {}),
   };
 }
 

--- a/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/transport.ts
@@ -12,6 +12,9 @@
 import { useRuntime } from "gui-chat-protocol/vue";
 import type { MulmoScriptChangedEvent, MulmoScriptDispatchArgs, MulmoScriptDispatchResult, MulmoScriptGenerationEvent } from "../core/contract";
 import { GENERATION_EVENT, SCRIPT_CHANGED_EVENT, sameRoot, shouldReloadForScriptChange } from "../core/contract";
+import { normalizeGenerationSubscription, normalizeScriptChangedSubscription } from "./subscription";
+import type { GenerationSubscription, ScriptChangedSubscription } from "./subscription";
+export type { GenerationSubscription, ScriptChangedSubscription } from "./subscription";
 import { errorMessage } from "@mulmoclaude/common";
 import { isRecord } from "./support";
 
@@ -58,11 +61,16 @@ export interface MulmoScriptTransport {
    *  identified by the PAIR `(root, filePath)`, since the same wire path
    *  exists in every registered root (#3014). Returns the unsubscribe
    *  function. */
-  onGenerationEvent(filePath: () => string, root: () => string | undefined, handler: (event: MulmoScriptGenerationEvent) => void): () => void;
+  onGenerationEvent(subscription: GenerationSubscription): () => void;
+  /** The pre-#3014 form: no root named, so the host's default root. Kept
+   *  because this interface is exported from `/vue` on a published package. */
+  onGenerationEvent(filePath: () => string, handler: (event: MulmoScriptGenerationEvent) => void): () => void;
   /** Subscribe to writes of one script, skipping the echo of this View's own
    *  (`ownOrigin`). Same pair identity as above. Returns the unsubscribe
    *  function. */
-  onScriptChanged(filePath: () => string, root: () => string | undefined, ownOrigin: string, handler: () => void): () => void;
+  onScriptChanged(subscription: ScriptChangedSubscription): () => void;
+  /** The pre-#3014 form — see `onGenerationEvent` above. */
+  onScriptChanged(filePath: () => string, ownOrigin: string, handler: () => void): () => void;
 }
 
 export function useMulmoScriptTransport(): MulmoScriptTransport {
@@ -82,16 +90,17 @@ export function useMulmoScriptTransport(): MulmoScriptTransport {
     return { ok: true, data: result as MulmoScriptDispatchResult[K] };
   }
 
-  function onGenerationEvent(filePath: () => string, root: () => string | undefined, handler: (event: MulmoScriptGenerationEvent) => void): () => void {
+  function onGenerationEvent(first: GenerationSubscription | (() => string), legacyHandler?: (event: MulmoScriptGenerationEvent) => void): () => void {
+    const { filePath, root, handler } = normalizeGenerationSubscription(first, legacyHandler);
     return runtime.pubsub.subscribe(GENERATION_EVENT, (payload: unknown) => {
       const event = parseGenerationEvent(payload);
       if (!event) return;
       const current = filePath();
       // The PAIR, not the path: `stories/deck.json` exists in every root, so
       // filtering on the path alone puts another repository's spinners on this
-      // View (Codex P1 on #3015). `root` is a required parameter rather than an
-      // optional one because a forgotten optional is exactly how the server
-      // side of this shipped broken twice.
+      // View (Codex P1 on #3015). `root` is a required FIELD rather than an
+      // optional parameter because a forgotten optional is exactly how the
+      // server side of this shipped broken twice — see `GenerationSubscription`.
       if (!current || event.filePath !== current || !sameRoot(event.root, root())) return;
       handler(event);
     });
@@ -104,7 +113,8 @@ export function useMulmoScriptTransport(): MulmoScriptTransport {
    * on them would rebuild the element the caret is in on every keystroke, so they are dropped
    * here. A write from the agent carries no origin and always reaches the handler.
    */
-  function onScriptChanged(filePath: () => string, root: () => string | undefined, ownOrigin: string, handler: () => void): () => void {
+  function onScriptChanged(first: ScriptChangedSubscription | (() => string), legacyOwnOrigin?: string, legacyHandler?: () => void): () => void {
+    const { filePath, root, ownOrigin, handler } = normalizeScriptChangedSubscription(first, legacyOwnOrigin, legacyHandler);
     return runtime.pubsub.subscribe(SCRIPT_CHANGED_EVENT, (payload: unknown) => {
       const event = parseScriptChangedEvent(payload);
       if (!event) return;

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -117,10 +117,9 @@ describe("swept over generated arguments, a named root never gets a mutation thr
   const KEYS = [undefined, "", "alice"];
   const INVALID_ARGS = /invalid arguments|unknown mulmoScript dispatch kind/;
 
-  it("answers every generated named-root mutation with a refusal", async () => {
-    const dispatch = makeDispatch();
-    let refusedForRoot = 0;
-    let rejectedForArgs = 0;
+  /** Every mutating call the generator can build with a named root. */
+  function namedRootMutations(): Record<string, unknown>[] {
+    const calls: Record<string, unknown>[] = [];
     for (const [kind] of MUTATING_KINDS)
       for (const root of NAMED_ROOTS)
         for (const filePath of FILE_PATHS)
@@ -130,17 +129,26 @@ describe("swept over generated arguments, a named root never gets a mutation thr
               if (filePath !== undefined) args.filePath = filePath;
               if (beatIndex !== undefined) args.beatIndex = beatIndex;
               if (key !== undefined) args.key = key;
-              const result = await dispatch(args);
-              const where = JSON.stringify(args);
-              assert.ok(isFailure(result), `${where} must not succeed`);
-              if (REFUSAL.test(result.error)) refusedForRoot += 1;
-              else if (INVALID_ARGS.test(result.error)) rejectedForArgs += 1;
-              else assert.fail(`${where} failed for neither the root nor its arguments: ${result.error}`);
+              calls.push(args);
             }
+    return calls;
+  }
+
+  it("answers every generated named-root mutation with a refusal", async () => {
+    const dispatch = makeDispatch();
+    const reasons = { root: 0, args: 0 };
+    for (const args of namedRootMutations()) {
+      const result = await dispatch(args);
+      const where = JSON.stringify(args);
+      assert.ok(isFailure(result), `${where} must not succeed`);
+      if (REFUSAL.test(result.error)) reasons.root += 1;
+      else if (INVALID_ARGS.test(result.error)) reasons.args += 1;
+      else assert.fail(`${where} failed for neither the root nor its arguments: ${result.error}`);
+    }
     // Neither branch may be vacuous: all-args-rejected would pass while the
     // root guard did nothing at all.
-    assert.ok(refusedForRoot > 100, `the sweep must exercise the root refusal, saw ${refusedForRoot}`);
-    assert.ok(rejectedForArgs > 100, `the sweep must exercise argument rejection, saw ${rejectedForArgs}`);
+    assert.ok(reasons.root > 100, `the sweep must exercise the root refusal, saw ${reasons.root}`);
+    assert.ok(reasons.args > 100, `the sweep must exercise argument rejection, saw ${reasons.args}`);
   });
 
   it("lets the same generated calls through when no root is named", async () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -1,0 +1,154 @@
+// The dispatch layer is what the agent's tool call actually reaches, and it
+// had no test at all — the root guards were only ever exercised by calling the
+// ops directly (#3015).
+//
+// That gap is why `uploadKind` could forward a root past `guardStoryWriteRoot`
+// while `saveKind` and `updateKind` were guarded: nothing drove the kinds
+// through the handler that routes them.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { FileOps } from "gui-chat-protocol";
+import { createMulmoScriptServerOps } from "../src/server/ops";
+import { createMulmoScriptDispatchHandler } from "../src/server/dispatch";
+
+const stubFileOps: FileOps = {
+  read: async () => {
+    throw new Error("unused");
+  },
+  readBytes: async () => new Uint8Array(),
+  write: async () => {},
+  readDir: async () => [],
+  stat: async () => ({ mtimeMs: 0, size: 0 }),
+  exists: async () => false,
+  unlink: async () => {},
+};
+
+const NAMED_ROOT = "repoA";
+const REFUSAL = /^(writing to|generating in) a non-default stories root is not supported yet$/;
+
+function makeDispatch() {
+  const ops = createMulmoScriptServerOps({
+    storiesDir: "/nonexistent/for-tests/artifacts/stories",
+    extraRoots: { [NAMED_ROOT]: "/tmp/a" },
+    artifacts: stubFileOps,
+    writeFileAtomic: async () => {},
+    log: { info: () => {}, warn: () => {}, error: () => {} },
+  });
+  return createMulmoScriptDispatchHandler(ops);
+}
+
+const isFailure = (value: unknown): value is { ok: false; code?: string; error: string } =>
+  typeof value === "object" && value !== null && "ok" in value && (value as { ok: unknown }).ok === false;
+
+/** Every kind that changes something, with the minimum args to reach the guard. */
+const MUTATING_KINDS: ReadonlyArray<[string, Record<string, unknown>]> = [
+  ["save", { filename: "deck.json", script: {} }],
+  ["updateBeat", { filePath: "stories/deck.json", beatIndex: 0, beat: {} }],
+  ["updateScript", { filePath: "stories/deck.json", script: {} }],
+  ["uploadBeatImage", { filePath: "stories/deck.json", beatIndex: 0, imageData: "data:image/png;base64,AA==" }],
+  ["uploadCharacterImage", { filePath: "stories/deck.json", key: "alice", imageData: "data:image/png;base64,AA==" }],
+  ["generateMovie", { filePath: "stories/deck.json" }],
+  ["generatePdf", { filePath: "stories/deck.json" }],
+  ["renderBeat", { filePath: "stories/deck.json", beatIndex: 0 }],
+  ["generateBeatAudio", { filePath: "stories/deck.json", beatIndex: 0 }],
+  ["renderCharacter", { filePath: "stories/deck.json", key: "alice" }],
+];
+
+describe("dispatch refuses every mutating kind in a named root", () => {
+  for (const [kind, args] of MUTATING_KINDS) {
+    it(`${kind} is refused BECAUSE of the root`, async () => {
+      const result = await makeDispatch()({ kind, ...args, root: NAMED_ROOT });
+      assert.ok(isFailure(result), `${kind} must fail for a named root`);
+      assert.equal(result.code, "bad_request", `${kind} must fail with bad_request`);
+      // The reason, not just the failure: each of these also fails for an
+      // unrelated reason here (no such script), so asserting failure alone
+      // stays green with the guard gone.
+      assert.match(result.error, REFUSAL, `${kind} must be refused for the ROOT`);
+    });
+  }
+
+  it("covers every kind the handler routes as mutating", async () => {
+    // The list above is an enumeration, and an enumeration is what let
+    // `uploadKind` through. A kind the handler accepts but nobody listed is
+    // exactly that hole, so ask the handler which kinds it knows.
+    const unknown = await makeDispatch()({ kind: "definitelyNotAKind" });
+    assert.ok(isFailure(unknown) && /unknown mulmoScript dispatch kind/.test(unknown.error));
+    for (const [kind] of MUTATING_KINDS) {
+      const routed = await makeDispatch()({ kind, root: NAMED_ROOT });
+      assert.ok(isFailure(routed), `${kind} must be routed, not fall through`);
+      assert.ok(!/unknown mulmoScript dispatch kind/.test(routed.error), `${kind} is not routed by the handler any more`);
+    }
+  });
+});
+
+describe("dispatch still serves the default root", () => {
+  it("does not refuse a mutating kind that names no root", async () => {
+    for (const [kind, args] of MUTATING_KINDS) {
+      const result = await makeDispatch()({ kind, ...args });
+      // It fails for its own reasons in this fixture, but never for the root.
+      if (isFailure(result)) assert.doesNotMatch(result.error, REFUSAL, `${kind} must be allowed in the default root`);
+    }
+  });
+
+  it("reads are allowed in a named root — that is the feature", async () => {
+    const result = await makeDispatch()({ kind: "beatImage", filePath: "stories/deck.json", beatIndex: 0, root: NAMED_ROOT });
+    if (isFailure(result)) assert.doesNotMatch(result.error, REFUSAL, "a read must never be refused for naming a root");
+  });
+});
+
+describe("swept over generated arguments, a named root never gets a mutation through", () => {
+  // Harvested from the differential harness that proved the `generateKind`
+  // extraction (20250 generated argument combinations, 0 differences; a
+  // swapped movie/PDF ternary produced 4860 and a dropped `root` 2430).
+  //
+  // The harness itself cannot survive — half of it is the pre-extraction
+  // router. What outlives it is the GENERATOR (which argument shapes matter
+  // here) and the PROPERTY, which needs no old code.
+  //
+  // The property is about the ANSWER, not about which function ran: the guards
+  // live inside the ops, so `generateMovieOp` is legitimately entered and then
+  // refuses. What must hold is that a named root never gets a mutation
+  // through — every call is either refused for the root or rejected for its
+  // arguments, and never anything else. Enumerating the guarded call sites is
+  // what this PR got wrong five times; a sweep asserts the rule instead.
+  const NAMED_ROOTS = ["repoA", " repoA ", "repoB"];
+  const FILE_PATHS = [undefined, "", "stories/deck.json", "stories/../escape.json", "deck.json"];
+  const BEATS = [undefined, 0, -1, "x"];
+  const KEYS = [undefined, "", "alice"];
+  const INVALID_ARGS = /invalid arguments|unknown mulmoScript dispatch kind/;
+
+  it("answers every generated named-root mutation with a refusal", async () => {
+    const dispatch = makeDispatch();
+    let refusedForRoot = 0;
+    let rejectedForArgs = 0;
+    for (const [kind] of MUTATING_KINDS)
+      for (const root of NAMED_ROOTS)
+        for (const filePath of FILE_PATHS)
+          for (const beatIndex of BEATS)
+            for (const key of KEYS) {
+              const args: Record<string, unknown> = { kind, root };
+              if (filePath !== undefined) args.filePath = filePath;
+              if (beatIndex !== undefined) args.beatIndex = beatIndex;
+              if (key !== undefined) args.key = key;
+              const result = await dispatch(args);
+              const where = JSON.stringify(args);
+              assert.ok(isFailure(result), `${where} must not succeed`);
+              if (REFUSAL.test(result.error)) refusedForRoot += 1;
+              else if (INVALID_ARGS.test(result.error)) rejectedForArgs += 1;
+              else assert.fail(`${where} failed for neither the root nor its arguments: ${result.error}`);
+            }
+    // Neither branch may be vacuous: all-args-rejected would pass while the
+    // root guard did nothing at all.
+    assert.ok(refusedForRoot > 100, `the sweep must exercise the root refusal, saw ${refusedForRoot}`);
+    assert.ok(rejectedForArgs > 100, `the sweep must exercise argument rejection, saw ${rejectedForArgs}`);
+  });
+
+  it("lets the same generated calls through when no root is named", async () => {
+    // Without this the sweep above passes by refusing everything everywhere.
+    const dispatch = makeDispatch();
+    const result = await dispatch({ kind: "generateMovie", filePath: "stories/deck.json" });
+    assert.ok(isFailure(result), "no script on disk, so it still fails");
+    assert.doesNotMatch(result.error, REFUSAL, "but never for the root");
+    assert.doesNotMatch(result.error, INVALID_ARGS, "and its arguments were fine");
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -152,3 +152,44 @@ describe("swept over generated arguments, a named root never gets a mutation thr
     assert.doesNotMatch(result.error, INVALID_ARGS, "and its arguments were fine");
   });
 });
+
+describe("an unregistered root is refused by every kind that takes one", () => {
+  // The rule was enforced by whichever ops happened to call `resolveStory`,
+  // which needs a file to exist. `pendingGenerations` needs none — it filters
+  // an in-memory map — so `root: "nope"` answered `{ ok: true, pending: [] }`,
+  // and a host typo or a stale card was indistinguishable from "no work is
+  // running" (Codex P2 on #3015).
+  //
+  // That is the eleventh finding on this PR of one rule holding at the sites
+  // that happened to reach it, so the check is over the SURFACE rather than
+  // over a list: every kind the handler routes, called with a root nobody
+  // registered, must fail. A new kind that forgets is red here.
+  const READ_KINDS: ReadonlyArray<[string, Record<string, unknown>]> = [
+    ["beatImage", { filePath: "stories/deck.json", beatIndex: 0 }],
+    ["beatAudio", { filePath: "stories/deck.json", beatIndex: 0 }],
+    ["beatMovie", { filePath: "stories/deck.json", beatIndex: 0 }],
+    ["characterImage", { filePath: "stories/deck.json", key: "alice" }],
+    ["movieStatus", { filePath: "stories/deck.json" }],
+    ["pdfStatus", { filePath: "stories/deck.json" }],
+    ["pendingGenerations", { filePath: "stories/deck.json" }],
+  ];
+
+  for (const [kind, args] of [...READ_KINDS, ...MUTATING_KINDS]) {
+    it(`${kind} refuses root "nope"`, async () => {
+      const result = await makeDispatch()({ kind, ...args, root: "nope" });
+      assert.ok(isFailure(result), `${kind} must never answer successfully for a root nobody registered`);
+      assert.equal(result.code, "bad_request", `${kind} must refuse an unknown root with bad_request`);
+    });
+  }
+
+  it("the same kinds answer when the root IS registered", async () => {
+    // Otherwise the sweep above passes by refusing everything unconditionally.
+    const registered = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json", root: NAMED_ROOT });
+    assert.equal(isFailure(registered), false, "a registered root must get its (empty) snapshot");
+  });
+
+  it("and answer when no root is named at all", async () => {
+    const bare = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json" });
+    assert.equal(isFailure(bare), false);
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -182,6 +182,30 @@ describe("an unregistered root is refused by every kind that takes one", () => {
     });
   }
 
+  // A root that is PRESENT but not a string. `str()` flattens all of these to
+  // `undefined`, which every reader below took as "no root named" — the
+  // default root. A host serialising a root wrongly would then read and write
+  // the default root's identically-named script while believing it named
+  // another (Codex P2 on #3015).
+  const MALFORMED_ROOTS: ReadonlyArray<[string, unknown]> = [
+    ["null", null],
+    ["number", 1],
+    ["object", {}],
+    ["array", ["repoA"]],
+    ["boolean", true],
+  ];
+
+  for (const [label, root] of MALFORMED_ROOTS) {
+    it(`every kind refuses a ${label} root`, async () => {
+      for (const [kind, args] of [...READ_KINDS, ...MUTATING_KINDS]) {
+        const result = await makeDispatch()({ kind, ...args, root });
+        assert.ok(isFailure(result), `${kind} must refuse a ${label} root`);
+        assert.equal(result.code, "bad_request", `${kind} must refuse a ${label} root with bad_request`);
+        assert.match(result.error, /root must be a string/, `${kind} must say WHY — a ${label} root is not a missing one`);
+      }
+    });
+  }
+
   it("the same kinds answer when the root IS registered", async () => {
     // Otherwise the sweep above passes by refusing everything unconditionally.
     const registered = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json", root: NAMED_ROOT });

--- a/packages/plugins/mulmoscript-plugin/test/test_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_roots.ts
@@ -126,3 +126,30 @@ describe("one spelling of a root, shared by both sides", () => {
     assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA" }, watching, "me", " repoA "), true);
   });
 });
+
+describe("a non-string root never throws out of a pubsub callback", () => {
+  // The type forbids it, but this package is published and its callers include
+  // untyped JavaScript. A subscription whose `root()` returns `42` reached
+  // `.trim()` and threw from INSIDE the pubsub callback — nothing catches it
+  // there, and the only symptom is a View that stops updating
+  // (Codex P2 on #3015).
+  const MALFORMED = [42, null, {}, ["repoA"], true];
+
+  it("reads a non-string root as the default root", () => {
+    for (const root of MALFORMED) {
+      assert.equal(normalizeRoot(root as never), "", `normalizeRoot(${JSON.stringify(root)})`);
+    }
+  });
+
+  it("matches a malformed root against the default root, not against a named one", () => {
+    for (const root of MALFORMED) {
+      assert.equal(sameRoot(root as never, undefined), true, `${JSON.stringify(root)} vs default`);
+      assert.equal(sameRoot(root as never, "repoA"), false, `${JSON.stringify(root)} vs repoA`);
+    }
+  });
+
+  it("does not throw from the reload rule either", () => {
+    const watching = "stories/deck.json";
+    assert.doesNotThrow(() => shouldReloadForScriptChange({ filePath: watching, root: 42 as never }, watching, "me", "repoA"));
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_roots.ts
@@ -9,7 +9,7 @@
 //   - two roots holding the same wire path are two different scripts
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { shouldReloadForScriptChange, type MulmoScriptChangedEvent } from "../src/core/contract.js";
+import { normalizeRoot, sameRoot, shouldReloadForScriptChange, type MulmoScriptChangedEvent } from "../src/core/contract.js";
 
 // The inputs that mattered in the differential run: the wire spellings the
 // module accepts, both "no root" spellings (absent and empty — they must be
@@ -81,5 +81,37 @@ describe("shouldReloadForScriptChange — two roots are two scripts", () => {
     // A View ignores its own write whatever root it is watching — otherwise a
     // keystroke rebuilds the element the caret is in.
     assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA", origin: "me" }, watching, "me", "repoA"), false);
+  });
+});
+
+describe("one spelling of a root, shared by both sides", () => {
+  // The server trims when it emits and keys; the View compares. When the two
+  // used different rules, `publishGeneration` emitted `"repoA"` while a View
+  // watching `" repoA "` dropped every event of its own generation
+  // (CodeRabbit on #3015). Sixth finding of the same family on this PR — a
+  // rule two sides must agree on, living on one of the two sides.
+  it("collapses the default root's spellings", () => {
+    assert.equal(normalizeRoot(undefined), "");
+    assert.equal(normalizeRoot(""), "");
+    assert.equal(normalizeRoot("   "), "");
+  });
+
+  it("trims a named root", () => {
+    assert.equal(normalizeRoot(" repoA "), "repoA");
+  });
+
+  it("equates roots that differ only in surrounding whitespace", () => {
+    assert.equal(sameRoot(" repoA ", "repoA"), true);
+    assert.equal(sameRoot(undefined, "  "), true);
+  });
+
+  it("still separates two different named roots", () => {
+    assert.equal(sameRoot("repoA", "repoB"), false);
+    assert.equal(sameRoot("repoA", undefined), false);
+  });
+
+  it("carries the trim into the reload rule", () => {
+    const watching = "stories/deck.json";
+    assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA" }, watching, "me", " repoA "), true);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_roots.ts
@@ -19,38 +19,49 @@ const ORIGINS: (string | undefined)[] = [undefined, "", "view-1", "view-2"];
 const ABSENT_ROOTS: (string | undefined)[] = [undefined, ""];
 
 describe("shouldReloadForScriptChange — the pre-roots world is unchanged", () => {
-  it("matches the pre-#3014 rule for every call that names no root", () => {
-    // The rule as it stood before roots: path equality plus the echo guard.
-    const before = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string) =>
-      watching !== "" && event.filePath === watching && event.origin !== ownOrigin;
+  /** The rule as it stood before roots: path equality plus the echo guard. */
+  const beforeRoots = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string): boolean =>
+    watching !== "" && event.filePath === watching && event.origin !== ownOrigin;
 
-    let compared = 0;
-    for (const filePath of PATHS) {
-      for (const watching of PATHS) {
-        for (const origin of ORIGINS) {
-          for (const ownOrigin of ORIGINS) {
-            for (const eventRoot of ABSENT_ROOTS) {
+  interface NoRootCase {
+    event: MulmoScriptChangedEvent;
+    watching: string;
+    ownOrigin: string;
+    watchingRoot: string | undefined;
+  }
+
+  /** Every combination in which neither side names a root. */
+  function noRootCases(): NoRootCase[] {
+    const cases: NoRootCase[] = [];
+    for (const filePath of PATHS)
+      for (const watching of PATHS)
+        for (const origin of ORIGINS)
+          for (const ownOrigin of ORIGINS)
+            for (const eventRoot of ABSENT_ROOTS)
               for (const watchingRoot of ABSENT_ROOTS) {
-                // `exactOptionalPropertyTypes` is on: an optional field is either
-                // present with a value or absent, never explicitly `undefined`.
+                // `exactOptionalPropertyTypes` is on: an optional field is
+                // either present with a value or absent, never explicitly
+                // `undefined`.
                 const event: MulmoScriptChangedEvent = {
                   filePath,
                   ...(origin === undefined ? {} : { origin }),
                   ...(eventRoot === undefined ? {} : { root: eventRoot }),
                 };
-                assert.equal(
-                  shouldReloadForScriptChange(event, watching, ownOrigin ?? "", watchingRoot),
-                  before(event, watching, ownOrigin ?? ""),
-                  `diverged for ${JSON.stringify({ filePath, watching, origin, ownOrigin, eventRoot, watchingRoot })}`,
-                );
-                compared += 1;
+                cases.push({ event, watching, ownOrigin: ownOrigin ?? "", watchingRoot });
               }
-            }
-          }
-        }
-      }
+    return cases;
+  }
+
+  it("matches the pre-#3014 rule for every call that names no root", () => {
+    const cases = noRootCases();
+    for (const { event, watching, ownOrigin, watchingRoot } of cases) {
+      assert.equal(
+        shouldReloadForScriptChange(event, watching, ownOrigin, watchingRoot),
+        beforeRoots(event, watching, ownOrigin),
+        `diverged for ${JSON.stringify({ event, watching, ownOrigin, watchingRoot })}`,
+      );
     }
-    assert.ok(compared >= 1000, `expected a real sweep, compared ${compared}`);
+    assert.ok(cases.length >= 1000, `expected a real sweep, compared ${cases.length}`);
   });
 
   it("treats an absent root and an empty root as the same root", () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_roots.ts
@@ -1,0 +1,85 @@
+// The identity of a script is the PAIR (root, filePath) — #3014.
+//
+// The generator and the property here are what survived the differential
+// harness that proved the widening was behaviour-preserving: the harness
+// itself could not, because half of it was the pre-#3014 code this replaced.
+//
+// What the harness established, and what these keep true:
+//   - every call that names no root behaves exactly as it did before roots
+//   - two roots holding the same wire path are two different scripts
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { shouldReloadForScriptChange, type MulmoScriptChangedEvent } from "../src/core/contract.js";
+
+// The inputs that mattered in the differential run: the wire spellings the
+// module accepts, both "no root" spellings (absent and empty — they must be
+// the same root), and the origin cases that drive the echo rule.
+const PATHS = ["", "stories/a.json", "stories/b.json", "stories/x/y.json", "artifacts/stories/a.json"];
+const ORIGINS: (string | undefined)[] = [undefined, "", "view-1", "view-2"];
+const ABSENT_ROOTS: (string | undefined)[] = [undefined, ""];
+
+describe("shouldReloadForScriptChange — the pre-roots world is unchanged", () => {
+  it("matches the pre-#3014 rule for every call that names no root", () => {
+    // The rule as it stood before roots: path equality plus the echo guard.
+    const before = (event: MulmoScriptChangedEvent, watching: string, ownOrigin: string) =>
+      watching !== "" && event.filePath === watching && event.origin !== ownOrigin;
+
+    let compared = 0;
+    for (const filePath of PATHS) {
+      for (const watching of PATHS) {
+        for (const origin of ORIGINS) {
+          for (const ownOrigin of ORIGINS) {
+            for (const eventRoot of ABSENT_ROOTS) {
+              for (const watchingRoot of ABSENT_ROOTS) {
+                // `exactOptionalPropertyTypes` is on: an optional field is either
+                // present with a value or absent, never explicitly `undefined`.
+                const event: MulmoScriptChangedEvent = {
+                  filePath,
+                  ...(origin === undefined ? {} : { origin }),
+                  ...(eventRoot === undefined ? {} : { root: eventRoot }),
+                };
+                assert.equal(
+                  shouldReloadForScriptChange(event, watching, ownOrigin ?? "", watchingRoot),
+                  before(event, watching, ownOrigin ?? ""),
+                  `diverged for ${JSON.stringify({ filePath, watching, origin, ownOrigin, eventRoot, watchingRoot })}`,
+                );
+                compared += 1;
+              }
+            }
+          }
+        }
+      }
+    }
+    assert.ok(compared >= 1000, `expected a real sweep, compared ${compared}`);
+  });
+
+  it("treats an absent root and an empty root as the same root", () => {
+    const watching = "stories/deck.json";
+    assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "" }, watching, "me", undefined), true);
+    assert.equal(shouldReloadForScriptChange({ filePath: watching }, watching, "me", ""), true);
+  });
+});
+
+describe("shouldReloadForScriptChange — two roots are two scripts", () => {
+  const watching = "stories/deck.json";
+
+  it("does not reload a View watching another root's identically-named script", () => {
+    assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA" }, watching, "me", "repoB"), false);
+  });
+
+  it("still reloads the View watching the root that changed", () => {
+    assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA" }, watching, "me", "repoA"), true);
+  });
+
+  it("does not reload the default-root View when a named root changed", () => {
+    // The case that makes the pair load-bearing: before #3014 this was a
+    // path match, so a repository save redrew the workspace's canvas.
+    assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA" }, watching, "me", undefined), false);
+  });
+
+  it("keeps the echo guard independent of the root", () => {
+    // A View ignores its own write whatever root it is watching — otherwise a
+    // keystroke rebuilds the element the caret is in.
+    assert.equal(shouldReloadForScriptChange({ filePath: watching, root: "repoA", origin: "me" }, watching, "me", "repoA"), false);
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -8,7 +8,7 @@
 // is a legal call. Only a test that asserts on the OUTPUT can.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
@@ -235,26 +235,58 @@ describe("the whole ops surface is classified for named roots", () => {
   // added without classifying it fails `every op is classified`, and one
   // classified as mutating must actually refuse.
   const namedRoot = "repoA";
-  const NOT_AN_OP = new Set([
-    "backend",
+  /**
+   * Which members must be classified, read off the source rather than listed.
+   *
+   * The first version of this test had a hand-written "not an op" exclusion
+   * set, and `triggerAutoBackgroundMovie` sat in it — a member that takes a
+   * `root` and starts a full generation, exempted by the very list meant to
+   * catch it (Codex P1 on #3015). A hand-maintained exemption list is the same
+   * failure as a hand-maintained guard list, one level up.
+   *
+   * So the rule is derived: a member whose declaration accepts a `root` is a
+   * root-aware entry point and must be classified. Adding one and forgetting
+   * turns this red without anyone editing an exemption.
+   */
+  function rootAwareMembers(): string[] {
+    const source = readFileSync(new URL("../src/server/ops.ts", import.meta.url), "utf8");
+    const returned = /\n {2}return \{\n([\s\S]*?)\n {2}\};/.exec(source);
+    assert.ok(returned, "could not find the ops object literal in ops.ts");
+    const keys = returned[1]!
+      .split("\n")
+      .map((line) => line.trim().replace(/,$/, ""))
+      .filter((key) => /^[A-Za-z][A-Za-z0-9]*$/.test(key));
+    assert.ok(keys.length > 10, "the ops object literal parsed to too few keys — the regex has drifted");
+    return keys.filter((key) => {
+      const decl = new RegExp(`function ${key}\\(([^)]*)\\)`).exec(source);
+      // `root?: string` directly, or an args object that carries one
+      // (`GenerateOpArgsWith<…>`) — the second form is how `renderBeatOp` and
+      // its siblings take theirs, and a check that saw only the first would
+      // exempt every generation op it exists to police.
+      return decl !== null && /\broot\??:|GenerateOpArgs|StoryOpOptions/.test(decl[1]!);
+    });
+  }
+
+  /** Ops that only read. A named root is legal for them — that is the feature. */
+  const READ_ONLY = ["beatImageOp", "beatAudioOp", "beatMovieOp", "characterImageOp", "movieStatusOp", "pdfStatusOp"] as const;
+  /**
+   * Root-aware members that are not `OpResult` ops, so the generic invoker
+   * below cannot drive them — each has its own test in this file instead.
+   * They still have to be named, because being unnamed is what let
+   * `triggerAutoBackgroundMovie` through.
+   */
+  const GUARDED_ELSEWHERE = [
     "toStoryRef",
     "resolveStory",
     "guardStoryWirePath",
     "guardStoryWriteRoot",
     "guardStoryGenerationRoot",
-    "ffmpegGuard",
     "runStoryOp",
     "publishGeneration",
     "publishScriptChanged",
     "pendingGenerations",
-    "inFlightMovies",
-    "inFlightPdfs",
-    "runMovieGeneration",
-    "runPdfGeneration",
     "triggerAutoBackgroundMovie",
-  ]);
-  /** Ops that only read. A named root is legal for them — that is the feature. */
-  const READ_ONLY = ["beatImageOp", "beatAudioOp", "beatMovieOp", "characterImageOp", "movieStatusOp", "pdfStatusOp"] as const;
+  ] as const;
   /** Ops that write or generate. A named root must be refused, fail-closed. */
   const REFUSAL = /^(writing to|generating in) a non-default stories root is not supported yet$/;
   const MUTATING: ReadonlyArray<[string, (ops: ReturnType<typeof makeOps>["ops"]) => Promise<OpResult<unknown>>]> = [
@@ -267,11 +299,29 @@ describe("the whole ops surface is classified for named roots", () => {
     ["generatePdfOp", (ops) => ops.generatePdfOp("stories/d.json", undefined, namedRoot)],
   ];
 
-  it("every op is classified as read-only or mutating", () => {
-    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
-    const classified = new Set<string>([...READ_ONLY, ...MUTATING.map(([name]) => name)]);
-    const unclassified = Object.keys(ops).filter((key) => !NOT_AN_OP.has(key) && !classified.has(key));
+  it("the derivation actually finds the root-aware members", () => {
+    // Without this the classification test passes vacuously the moment the
+    // regex stops matching — a silent green is the failure mode of every
+    // check that reads source.
+    const found = rootAwareMembers();
+    assert.ok(found.length >= 19, `expected the ops surface to expose many root-aware members, found ${found.length}`);
+    for (const expected of ["triggerAutoBackgroundMovie", "renderBeatOp", "uploadBeatImageOp", "beatImageOp"]) {
+      assert.ok(found.includes(expected), `${expected} takes a root but the derivation missed it`);
+    }
+  });
+
+  it("every root-aware member is classified as read-only or mutating", () => {
+    const classified = new Set<string>([...READ_ONLY, ...MUTATING.map(([name]) => name), ...GUARDED_ELSEWHERE]);
+    const unclassified = rootAwareMembers().filter((key) => !classified.has(key));
     assert.deepEqual(unclassified, [], `classify these in test_server_roots.ts: ${unclassified.join(", ")}`);
+  });
+
+  it("the classification names members that actually exist", () => {
+    // The derivation reads source; this pins it to the real object, so a
+    // renamed op cannot leave a classification pointing at nothing.
+    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const missing = [...READ_ONLY, ...MUTATING.map(([name]) => name), ...GUARDED_ELSEWHERE].filter((name) => !(name in ops));
+    assert.deepEqual(missing, []);
   });
 
   for (const [name, invoke] of MUTATING) {
@@ -290,6 +340,26 @@ describe("the whole ops surface is classified for named roots", () => {
       assert.equal(generations.length, 0, `${name} must not publish anything when refused`);
     });
   }
+});
+
+describe("the detached background movie is refused in a named root too", () => {
+  // It returns `void`, so it can carry no `OpResult` — and that is exactly why
+  // it was the one generation the guard missed. A detached run corrupting the
+  // other root's pending state has no caller to see the failure.
+  const namedRoot = "repoA";
+
+  it("starts nothing and publishes nothing for a named root", () => {
+    const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
+    ops.triggerAutoBackgroundMovie("/tmp/a/stories/d.json", "stories/d.json", "session-1", namedRoot);
+    assert.equal(generations.length, 0, "a refused background movie must announce nothing");
+    assert.equal(ops.inFlightMovies.has("/tmp/a/stories/d.json"), false, "a refused background movie must not be marked in flight");
+  });
+
+  it("still starts for the default root", () => {
+    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    ops.triggerAutoBackgroundMovie("/tmp/x/stories/d.json", "stories/d.json", "session-1");
+    assert.equal(ops.inFlightMovies.has("/tmp/x/stories/d.json"), true, "the default root must still generate");
+  });
 });
 
 describe("generations stay in the default root until step 2", () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -50,6 +50,35 @@ describe("root registry", () => {
     assert.equal(result.ok === false && result.code, "bad_request");
   });
 
+  it("warns at boot that the host's session key must be widened", () => {
+    // The pair identity stops at the host boundary: `generationKey` in
+    // `@mulmobridge/protocol` keys on `(kind, filePath, key)`. Widening it is a
+    // protocol change with its own consumers, so this package cannot make it —
+    // but it can make sure the first host to register a root is told, at boot,
+    // instead of finding out from a stuck spinner (Codex P1 on #3015).
+    const warnings: string[] = [];
+    createMulmoScriptServerOps({
+      storiesDir: "/nonexistent/for-tests/artifacts/stories",
+      extraRoots: { repoA: "/tmp/a" },
+      artifacts: stubFileOps,
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!, /session generation key must include the root|generation key must include the root/);
+  });
+
+  it("says nothing at boot when only the default root is registered", () => {
+    const warnings: string[] = [];
+    createMulmoScriptServerOps({
+      storiesDir: "/nonexistent/for-tests/artifacts/stories",
+      artifacts: stubFileOps,
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+    });
+    assert.equal(warnings.length, 0, "the single-root world must stay silent");
+  });
+
   it("normalizes a root id by trimming, matching readCommandScope", () => {
     // Two parallel "which project root" identifiers must agree on what one
     // root is, or the same string names different roots in different layers.

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -119,6 +119,49 @@ describe("pendingGenerations is scoped by the pair", () => {
   });
 });
 
+describe("every read resolves in the root it was asked for", () => {
+  // `runStoryOp` forwards the root for the ops that go through it, but the
+  // movie and PDF generators call `resolveStory` DIRECTLY — a call site the
+  // first round's "count the forwards" check missed because it only counted
+  // `runStoryOp` options (CodeRabbit on #3015). An unregistered root must
+  // therefore fail HERE too, not silently resolve in the default root.
+  const unregistered = "nope";
+
+  it("fails generateMovie for an unregistered root instead of using the default", async () => {
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const result = await ops.generateMovieOp("stories/deck.json", undefined, unregistered);
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.code, "bad_request");
+  });
+
+  it("fails generatePdf for an unregistered root instead of using the default", async () => {
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const result = await ops.generatePdfOp("stories/deck.json", undefined, unregistered);
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.code, "bad_request");
+  });
+});
+
+describe("writes stay in the default root until step 2", () => {
+  // Reads became root-aware in this PR; writes did not. `executeMulmoScriptSave`
+  // and the update executors run against one FileOps bound to the default root,
+  // so a write naming another root would rewrite the DEFAULT root's
+  // identically-named file and then announce the other one as changed
+  // (#3015 review G1). Fail closed until step 2 supplies a per-root FileOps.
+  it("refuses a write that names a non-default root", () => {
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const guard = ops.guardStoryWriteRoot("repoA");
+    assert.ok(guard, "a named root must not be writable yet");
+    assert.equal(guard?.code, "bad_request");
+  });
+
+  it("still allows every write that names no root", () => {
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    assert.equal(ops.guardStoryWriteRoot(undefined), null);
+    assert.equal(ops.guardStoryWriteRoot(""), null, "the empty spelling is the default root");
+  });
+});
+
 describe("script-changed events carry their root", () => {
   it("names the root a write happened in", () => {
     const { ops, changes } = makeOps({ repoA: "/tmp/a" });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -279,6 +279,7 @@ describe("the whole ops surface is classified for named roots", () => {
     "toStoryRef",
     "resolveStory",
     "guardStoryWirePath",
+    "guardStoryRootRegistered",
     "guardStoryWriteRoot",
     "guardStoryGenerationRoot",
     "runStoryOp",

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -50,6 +50,18 @@ describe("root registry", () => {
     assert.equal(result.ok === false && result.code, "bad_request");
   });
 
+  it("normalizes a root id by trimming, matching readCommandScope", () => {
+    // Two parallel "which project root" identifiers must agree on what one
+    // root is, or the same string names different roots in different layers.
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    assert.equal(ops.guardStoryWriteRoot("  "), null, "whitespace is the default root, not a named one");
+    assert.equal(ops.toStoryRef("/tmp/a/x.json", " repoA "), ops.toStoryRef("/tmp/a/x.json", "repoA"));
+  });
+
+  it("refuses a whitespace-only extraRoots id at construction", () => {
+    assert.throws(() => makeOps({ "   ": "/somewhere" }), /must not be empty/);
+  });
+
   it("refuses an empty extraRoots id at construction", () => {
     // The empty id is the default root's own key; accepting it would re-point
     // every pre-roots caller. Boot is the cheap place to fail.
@@ -79,7 +91,7 @@ describe("root registry", () => {
 describe("generation events carry their root", () => {
   it("puts the root on the published event", () => {
     const { ops, generations } = makeOps({ repoA: "/tmp/a" });
-    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoA");
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
     assert.equal(generations.length, 1);
     assert.equal(generations[0]?.root, "repoA");
   });
@@ -92,10 +104,38 @@ describe("generation events carry their root", () => {
   });
 });
 
+describe("a start event carries its root and no error", () => {
+  // The shape of `publishGeneration` used to end in two adjacent optional
+  // strings, `error` then `root`. Appending `root` to the call sites that pass
+  // no error put it in `error`'s slot: the start event announced
+  // `error: "repoA"`, the root was dropped, the tracker entry was filed under
+  // the default root, and — because the matching finish passed both — its key
+  // differed and the entry was never deleted. One leaked row per generation,
+  // for the life of the process (#3015 review).
+  it("does not report an error when a generation starts in a named root", () => {
+    const { ops, generations } = makeOps({ repoA: "/tmp/a" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
+    const started = generations[0]!;
+    assert.equal(started.done, false);
+    assert.equal(started.root, "repoA");
+    assert.ok(!("error" in started), `a start must carry no error, got ${JSON.stringify(started)}`);
+  });
+
+  it("clears the tracker when the matching finish arrives", () => {
+    // Start and finish must produce the SAME key. When they did not, the
+    // snapshot kept reporting a finished run forever.
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
+    assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", true, { root: "repoA" });
+    assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 0, "the finish must delete the entry it started");
+  });
+});
+
 describe("pendingGenerations is scoped by the pair", () => {
   it("does not hand one root's in-flight run to another root's View", () => {
     const { ops } = makeOps({ repoA: "/tmp/a", repoB: "/tmp/b" });
-    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoA");
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
 
     assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
     assert.equal(ops.pendingGenerations("stories/deck.json", "repoB").length, 0, "repoB must not see repoA's run");
@@ -112,8 +152,8 @@ describe("pendingGenerations is scoped by the pair", () => {
 
   it("dedups per root — the same deck in two roots is two runs", () => {
     const { ops, generations } = makeOps({ repoA: "/tmp/a", repoB: "/tmp/b" });
-    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoA");
-    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoB");
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoB" });
     // Two starts, not one start plus a suppressed duplicate.
     assert.equal(generations.filter((e) => !e.done).length, 2);
   });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -121,6 +121,17 @@ describe("a start event carries its root and no error", () => {
     assert.ok(!("error" in started), `a start must carry no error, got ${JSON.stringify(started)}`);
   });
 
+  it("matches a start and finish written with different spellings of one root", () => {
+    // The tracker value and the event normalize; the KEY did not, so
+    // `" repoA "` started an entry that `"repoA"` could never delete
+    // (Codex P2 on #3015).
+    const { ops } = makeOps({ repoA: "/tmp/a" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: " repoA " });
+    assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", true, { root: "repoA" });
+    assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 0, "the finish must delete the entry the untrimmed start created");
+  });
+
   it("clears the tracker when the matching finish arrives", () => {
     // Start and finish must produce the SAME key. When they did not, the
     // snapshot kept reporting a finished run forever.

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -494,7 +494,15 @@ describe("one root, one cache entry, whatever the spelling", () => {
   after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
 
   /** Non-null unless this platform refuses to create the symlink. */
-  function makeSymlinkedRoot(): { ops: ReturnType<typeof createMulmoScriptServerOps>; realStories: string; realTree: string } | null {
+  interface SymlinkedTree {
+    realTree: string;
+    realStoriesDir: string;
+    linkedStoriesDir: string;
+    defaultStoriesDir: string;
+  }
+
+  /** `null` when the platform refuses the symlink; the caller reports a skip. */
+  function makeSymlinkedTree(): SymlinkedTree | null {
     const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-rootcache-"));
     workspaces.push(workspace);
     const realTree = path.join(workspace, "real");
@@ -507,14 +515,25 @@ describe("one root, one cache entry, whatever the spelling", () => {
     } catch {
       return null;
     }
+    return {
+      realTree,
+      realStoriesDir,
+      linkedStoriesDir: path.join(link, "artifacts", "stories"),
+      defaultStoriesDir: path.join(workspace, "default", "artifacts", "stories"),
+    };
+  }
+
+  function makeSymlinkedRoot(): { ops: ReturnType<typeof createMulmoScriptServerOps>; realStories: string; realTree: string } | null {
+    const tree = makeSymlinkedTree();
+    if (!tree) return null;
     const ops = createMulmoScriptServerOps({
-      storiesDir: path.join(workspace, "default", "artifacts", "stories"),
-      extraRoots: { repoA: path.join(link, "artifacts", "stories") },
+      storiesDir: tree.defaultStoriesDir,
+      extraRoots: { repoA: tree.linkedStoriesDir },
       artifacts: stubFileOps,
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: () => {}, error: () => {} },
     });
-    return { ops, realStories: realpathSync(realStoriesDir), realTree };
+    return { ops, realStories: realpathSync(tree.realStoriesDir), realTree: tree.realTree };
   }
 
   it("resolves every spelling of one root to the same file", (t) => {

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -388,11 +388,16 @@ describe("generations stay in the default root until step 2", () => {
     }
   });
 
-  it("publishes nothing for a refused generation", () => {
+  it("publishes nothing for a refused generation", async () => {
     // The refusal must come BEFORE the start event: a start with no matching
     // finish is the stuck-spinner this guard exists to prevent.
+    //
+    // Awaited, not fired and forgotten: on the same tick `generations` is
+    // empty whether the guard ran or the op merely had not reached its
+    // publish yet, so the un-awaited version stayed green for the wrong
+    // reason (CodeRabbit on #3015).
     const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
-    void ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
+    await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
     assert.equal(generations.length, 0);
   });
 

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -50,7 +50,7 @@ describe("root registry", () => {
     assert.equal(result.ok === false && result.code, "bad_request");
   });
 
-  it("warns at boot that the host's session key must be widened", () => {
+  it("warns at boot that named roots are read-only until the protocol carries the root", () => {
     // The pair identity stops at the host boundary: `generationKey` in
     // `@mulmobridge/protocol` keys on `(kind, filePath, key)`. Widening it is a
     // protocol change with its own consumers, so this package cannot make it —
@@ -65,7 +65,7 @@ describe("root registry", () => {
       log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
     });
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0]!, /session generation key must include the root|generation key must include the root/);
+    assert.match(warnings[0]!, /generation and writes are REFUSED in them/);
   });
 
   it("says nothing at boot when only the default root is registered", () => {
@@ -219,6 +219,48 @@ describe("every read resolves in the root it was asked for", () => {
     const result = await ops.generatePdfOp("stories/deck.json", undefined, unregistered);
     assert.equal(result.ok, false);
     assert.equal(result.ok === false && result.code, "bad_request");
+  });
+});
+
+describe("generations stay in the default root until step 2", () => {
+  // The host's per-session store keys pending work by `(kind, filePath, key)`
+  // — `generationKey` in `@mulmobridge/protocol`. Two roots running the same
+  // generation in one session would collapse to one entry, and either
+  // completion would clear the other root's indicator. Widening that key is a
+  // protocol change with its own consumers, so the generation is refused
+  // instead: a run that cannot be tracked correctly must not start
+  // (Codex P1 on #3015).
+  const namedRoot = "repoA";
+
+  it("refuses every generation kind in a named root", async () => {
+    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const results = [
+      await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot),
+      await ops.generatePdfOp("stories/deck.json", "session-1", namedRoot),
+      await ops.renderBeatOp({ filePath: "stories/deck.json", beatIndex: 0, chatSessionId: "session-1", root: namedRoot }),
+      await ops.generateBeatAudioOp({ filePath: "stories/deck.json", beatIndex: 0, chatSessionId: "session-1", root: namedRoot }),
+      await ops.renderCharacterOp({ filePath: "stories/deck.json", key: "alice", chatSessionId: "session-1", root: namedRoot }),
+    ];
+    for (const result of results) {
+      assert.equal(result.ok, false);
+      assert.equal(result.ok === false && result.code, "bad_request");
+    }
+  });
+
+  it("publishes nothing for a refused generation", () => {
+    // The refusal must come BEFORE the start event: a start with no matching
+    // finish is the stuck-spinner this guard exists to prevent.
+    const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
+    void ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
+    assert.equal(generations.length, 0);
+  });
+
+  it("still allows generation that names no root", async () => {
+    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const result = await ops.generateMovieOp("stories/deck.json", "session-1");
+    // It fails for an unrelated reason (no such script), but NOT with the
+    // root refusal — the default root is still generatable.
+    assert.ok(result.ok === false && result.error !== "generating in a non-default stories root is not supported yet");
   });
 });
 

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -69,6 +69,38 @@ describe("root registry", () => {
     assert.match(warnings[0]!, /generation and writes are REFUSED in them/);
   });
 
+  it("refuses two extraRoots ids that trim to the same key", () => {
+    // `set` would keep the LAST directory, so every read for `repoA` would
+    // answer from a directory the card never named — with the host given no
+    // signal at all (CodeRabbit on #3015). A misconfiguration is cheapest to
+    // fail on at boot, and silently resolving the wrong directory is exactly
+    // what this package refuses everywhere else.
+    assert.throws(
+      () =>
+        createMulmoScriptServerOps({
+          storiesDir: "/nonexistent/for-tests/artifacts/stories",
+          extraRoots: { repoA: "/tmp/a", " repoA ": "/tmp/b" },
+          artifacts: stubFileOps,
+          writeFileAtomic: async () => {},
+          log: { info: () => {}, warn: () => {}, error: () => {} },
+        }),
+      /registered twice/,
+    );
+  });
+
+  it("still accepts two distinct roots pointing at different directories", () => {
+    // The throw must be about the KEY, not about having more than one root.
+    assert.doesNotThrow(() =>
+      createMulmoScriptServerOps({
+        storiesDir: "/nonexistent/for-tests/artifacts/stories",
+        extraRoots: { repoA: "/tmp/a", repoB: "/tmp/b" },
+        artifacts: stubFileOps,
+        writeFileAtomic: async () => {},
+        log: { info: () => {}, warn: () => {}, error: () => {} },
+      }),
+    );
+  });
+
   it("says nothing at boot when only the default root is registered", () => {
     const warnings: string[] = [];
     createMulmoScriptServerOps({
@@ -485,9 +517,11 @@ describe("one root, one cache entry, whatever the spelling", () => {
     return { ops, realStories: realpathSync(realStoriesDir), realTree };
   }
 
-  it("resolves every spelling of one root to the same file", () => {
+  it("resolves every spelling of one root to the same file", (t) => {
     const fixture = makeSymlinkedRoot();
-    if (!fixture) return;
+    // Reported rather than returned: a silent early return is a green test
+    // that exercised nothing, which is the shape this file argues against.
+    if (!fixture) return t.skip("this platform refuses to create the symlink");
     const canonical = fixture.ops.resolveStory("stories/foo.json", "repoA");
     assert.ok(canonical.ok);
     for (const spelling of [" repoA ", "repoA  ", "  repoA"]) {
@@ -497,14 +531,16 @@ describe("one root, one cache entry, whatever the spelling", () => {
     }
   });
 
-  it("shares the memoised realpath across spellings", () => {
+  it("shares the memoised realpath across spellings", (t) => {
     // The only externally visible difference between one cache entry and two:
     // once the directory is gone, a SHARED entry still answers from memory,
     // while a second spelling with its own key would re-realpath a missing
     // directory and fall back to the SYMLINK path, which the real file is not
     // under. Deleting the directory is what makes the cache observable.
     const fixture = makeSymlinkedRoot();
-    if (!fixture) return;
+    // Reported rather than returned: a silent early return is a green test
+    // that exercised nothing, which is the shape this file argues against.
+    if (!fixture) return t.skip("this platform refuses to create the symlink");
     assert.ok(fixture.ops.resolveStory("stories/foo.json", "repoA").ok, "warm the cache under one spelling");
     rmSync(fixture.realTree, { recursive: true, force: true });
     assert.equal(
@@ -514,12 +550,14 @@ describe("one root, one cache entry, whatever the spelling", () => {
     );
   });
 
-  it("returns null for a cold cache once the directory is gone", () => {
+  it("returns null for a cold cache once the directory is gone", (t) => {
     // Without this the test above means nothing: it has to be possible to
     // fail. Nothing memoised, the directory gone, so the base falls back to
     // the symlink path and the ref comes out traversal-shaped.
     const fixture = makeSymlinkedRoot();
-    if (!fixture) return;
+    // Reported rather than returned: a silent early return is a green test
+    // that exercised nothing, which is the shape this file argues against.
+    if (!fixture) return t.skip("this platform refuses to create the symlink");
     rmSync(fixture.realTree, { recursive: true, force: true });
     assert.equal(fixture.ops.toStoryRef(path.join(fixture.realStories, "foo.json"), "repoA"), null);
   });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "os";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
 import { createMulmoScriptServerOps } from "../src/server/ops";
+import type { OpResult } from "../src/server/types";
 import type { MulmoScriptGenerationEvent, MulmoScriptChangedEvent } from "../src/core/contract";
 
 const stubFileOps: FileOps = {
@@ -220,6 +221,75 @@ describe("every read resolves in the root it was asked for", () => {
     assert.equal(result.ok, false);
     assert.equal(result.ok === false && result.code, "bad_request");
   });
+});
+
+describe("the whole ops surface is classified for named roots", () => {
+  // The per-site guard was a list, and a list is something someone has to
+  // remember to extend: `save` / `updateBeat` / `updateScript` were guarded
+  // while the two upload kinds were not, so an image could still be written
+  // into a named root (CodeRabbit on #3015). That is the fifth finding of the
+  // same shape on this PR — a rule enforced by enumerating its sites.
+  //
+  // So the enumeration moves here, where being incomplete is a RED TEST rather
+  // than a hole: every key the ops object exposes must appear below. A new op
+  // added without classifying it fails `every op is classified`, and one
+  // classified as mutating must actually refuse.
+  const namedRoot = "repoA";
+  const NOT_AN_OP = new Set([
+    "backend",
+    "toStoryRef",
+    "resolveStory",
+    "guardStoryWirePath",
+    "guardStoryWriteRoot",
+    "guardStoryGenerationRoot",
+    "ffmpegGuard",
+    "runStoryOp",
+    "publishGeneration",
+    "publishScriptChanged",
+    "pendingGenerations",
+    "inFlightMovies",
+    "inFlightPdfs",
+    "runMovieGeneration",
+    "runPdfGeneration",
+    "triggerAutoBackgroundMovie",
+  ]);
+  /** Ops that only read. A named root is legal for them — that is the feature. */
+  const READ_ONLY = ["beatImageOp", "beatAudioOp", "beatMovieOp", "characterImageOp", "movieStatusOp", "pdfStatusOp"] as const;
+  /** Ops that write or generate. A named root must be refused, fail-closed. */
+  const REFUSAL = /^(writing to|generating in) a non-default stories root is not supported yet$/;
+  const MUTATING: ReadonlyArray<[string, (ops: ReturnType<typeof makeOps>["ops"]) => Promise<OpResult<unknown>>]> = [
+    ["renderBeatOp", (ops) => ops.renderBeatOp({ filePath: "stories/d.json", beatIndex: 0, root: namedRoot })],
+    ["generateBeatAudioOp", (ops) => ops.generateBeatAudioOp({ filePath: "stories/d.json", beatIndex: 0, root: namedRoot })],
+    ["renderCharacterOp", (ops) => ops.renderCharacterOp({ filePath: "stories/d.json", key: "alice", root: namedRoot })],
+    ["uploadBeatImageOp", (ops) => ops.uploadBeatImageOp("stories/d.json", 0, "data:image/png;base64,AA==", namedRoot)],
+    ["uploadCharacterImageOp", (ops) => ops.uploadCharacterImageOp("stories/d.json", "alice", "data:image/png;base64,AA==", namedRoot)],
+    ["generateMovieOp", (ops) => ops.generateMovieOp("stories/d.json", undefined, namedRoot)],
+    ["generatePdfOp", (ops) => ops.generatePdfOp("stories/d.json", undefined, namedRoot)],
+  ];
+
+  it("every op is classified as read-only or mutating", () => {
+    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const classified = new Set<string>([...READ_ONLY, ...MUTATING.map(([name]) => name)]);
+    const unclassified = Object.keys(ops).filter((key) => !NOT_AN_OP.has(key) && !classified.has(key));
+    assert.deepEqual(unclassified, [], `classify these in test_server_roots.ts: ${unclassified.join(", ")}`);
+  });
+
+  for (const [name, invoke] of MUTATING) {
+    it(`${name} refuses a named root`, async () => {
+      const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
+      const result = await invoke(ops);
+      // The REASON, not just `ok === false`. Every one of these also fails for
+      // an unrelated reason in this fixture (no such script on disk), so
+      // asserting failure alone stays green with the guard deleted — which is
+      // exactly what removing it proved before this line was tightened.
+      assert.equal(result.ok, false, `${name} must refuse a named root`);
+      assert.equal(result.ok === false && result.code, "bad_request", `${name} must refuse with bad_request`);
+      assert.match(result.ok === false ? result.error : "", REFUSAL, `${name} must refuse BECAUSE of the root`);
+      // Refused BEFORE any announcement: a start with no matching finish is
+      // the stuck indicator these guards exist to prevent.
+      assert.equal(generations.length, 0, `${name} must not publish anything when refused`);
+    });
+  }
 });
 
 describe("generations stay in the default root until step 2", () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -8,7 +8,7 @@
 // is a legal call. Only a test that asserts on the OUTPUT can.
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
@@ -445,31 +445,47 @@ describe("one root, one cache entry, whatever the spelling", () => {
   // then cached separately, so a never-evicted map grew one entry per spelling
   // (Codex P2 on #3015). It is keyed by the resolved DIRECTORY now, which
   // leaves no normalisation for a caller to forget.
+  //
+  // The root is registered THROUGH A SYMLINK so its configured path and its
+  // realpath differ on every platform. A first version leaned on macOS
+  // resolving the temp dir through `/var` → `/private/var`, which made the
+  // discrimination real there and vacuous on Linux — where the two are the
+  // same string, a cold cache and a warm one produce identical output and the
+  // test passed while proving nothing. It failed on ubuntu in CI.
   const workspaces: string[] = [];
   after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
 
-  function makeRootedOps() {
+  /** Non-null unless this platform refuses to create the symlink. */
+  function makeSymlinkedRoot(): { ops: ReturnType<typeof createMulmoScriptServerOps>; realStories: string; realTree: string } | null {
     const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-rootcache-"));
     workspaces.push(workspace);
-    const extra = path.join(workspace, "repoA", "artifacts", "stories");
-    mkdirSync(extra, { recursive: true });
-    writeFileSync(path.join(extra, "foo.json"), "{}");
+    const realTree = path.join(workspace, "real");
+    const realStoriesDir = path.join(realTree, "artifacts", "stories");
+    mkdirSync(realStoriesDir, { recursive: true });
+    writeFileSync(path.join(realStoriesDir, "foo.json"), "{}");
+    const link = path.join(workspace, "link");
+    try {
+      symlinkSync(realTree, link, "junction");
+    } catch {
+      return null;
+    }
     const ops = createMulmoScriptServerOps({
       storiesDir: path.join(workspace, "default", "artifacts", "stories"),
-      extraRoots: { repoA: extra },
+      extraRoots: { repoA: path.join(link, "artifacts", "stories") },
       artifacts: stubFileOps,
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: () => {}, error: () => {} },
     });
-    return { ops, extra };
+    return { ops, realStories: realpathSync(realStoriesDir), realTree };
   }
 
   it("resolves every spelling of one root to the same file", () => {
-    const { ops } = makeRootedOps();
-    const canonical = ops.resolveStory("stories/foo.json", "repoA");
+    const fixture = makeSymlinkedRoot();
+    if (!fixture) return;
+    const canonical = fixture.ops.resolveStory("stories/foo.json", "repoA");
     assert.ok(canonical.ok);
     for (const spelling of [" repoA ", "repoA  ", "  repoA"]) {
-      const resolved = ops.resolveStory("stories/foo.json", spelling);
+      const resolved = fixture.ops.resolveStory("stories/foo.json", spelling);
       assert.ok(resolved.ok, `expected ${JSON.stringify(spelling)} to resolve`);
       assert.equal(resolved.absolutePath, canonical.absolutePath);
     }
@@ -479,42 +495,26 @@ describe("one root, one cache entry, whatever the spelling", () => {
     // The only externally visible difference between one cache entry and two:
     // once the directory is gone, a SHARED entry still answers from memory,
     // while a second spelling with its own key would re-realpath a missing
-    // directory and fail. Deleting the directory is what makes the cache
-    // observable at all.
-    const { ops, extra } = makeRootedOps();
-    // Resolved while the directory still exists — on macOS the temp dir is
-    // reached through a `/var` → `/private/var` symlink, so the configured
-    // path and its realpath differ and only the realpath relativizes cleanly.
-    const realExtra = realpathSync(extra);
-    assert.ok(ops.resolveStory("stories/foo.json", "repoA").ok, "warm the cache under one spelling");
-    rmSync(path.dirname(path.dirname(extra)), { recursive: true, force: true });
-    assert.equal(ops.toStoryRef(path.join(realExtra, "foo.json"), " repoA "), "stories/foo.json", "a second spelling must hit the entry the first one filled");
+    // directory and fall back to the SYMLINK path, which the real file is not
+    // under. Deleting the directory is what makes the cache observable.
+    const fixture = makeSymlinkedRoot();
+    if (!fixture) return;
+    assert.ok(fixture.ops.resolveStory("stories/foo.json", "repoA").ok, "warm the cache under one spelling");
+    rmSync(fixture.realTree, { recursive: true, force: true });
+    assert.equal(
+      fixture.ops.toStoryRef(path.join(fixture.realStories, "foo.json"), " repoA "),
+      "stories/foo.json",
+      "a second spelling must hit the entry the first one filled",
+    );
   });
-});
-
-describe("the cache-sharing test can tell the two cases apart", () => {
-  // Its assertion means nothing unless a COLD cache actually fails it. With
-  // the directory gone and nothing memoised, `ensureStoriesReal` returns null,
-  // the base falls back to the unresolved configured path, and the ref comes
-  // out traversal-shaped — so it is rejected. That is the state the shared
-  // entry rescues.
-  const workspaces: string[] = [];
-  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
 
   it("returns null for a cold cache once the directory is gone", () => {
-    const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-coldcache-"));
-    workspaces.push(workspace);
-    const extra = path.join(workspace, "repoA", "artifacts", "stories");
-    mkdirSync(extra, { recursive: true });
-    const realExtra = realpathSync(extra);
-    const ops = createMulmoScriptServerOps({
-      storiesDir: path.join(workspace, "default", "artifacts", "stories"),
-      extraRoots: { repoA: extra },
-      artifacts: stubFileOps,
-      writeFileAtomic: async () => {},
-      log: { info: () => {}, warn: () => {}, error: () => {} },
-    });
-    rmSync(path.dirname(path.dirname(extra)), { recursive: true, force: true });
-    assert.equal(ops.toStoryRef(path.join(realExtra, "foo.json"), "repoA"), null);
+    // Without this the test above means nothing: it has to be possible to
+    // fail. Nothing memoised, the directory gone, so the base falls back to
+    // the symlink path and the ref comes out traversal-shaped.
+    const fixture = makeSymlinkedRoot();
+    if (!fixture) return;
+    rmSync(fixture.realTree, { recursive: true, force: true });
+    assert.equal(fixture.ops.toStoryRef(path.join(fixture.realStories, "foo.json"), "repoA"), null);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -1,0 +1,134 @@
+// The ops layer's half of #3014: a `root` that reaches the registry, the
+// tracker and the published events.
+//
+// These exist because the first cut of #3015 widened the KEY functions and
+// left the data behind — `root` was a parameter nobody passed, so the wire
+// field existed and the collisions it was meant to end were all still there.
+// Type-checking cannot catch that: `root` is optional, so a forgotten forward
+// is a legal call. Only a test that asserts on the OUTPUT can.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import type { FileOps } from "gui-chat-protocol";
+import { createMulmoScriptServerOps } from "../src/server/ops";
+import type { MulmoScriptGenerationEvent, MulmoScriptChangedEvent } from "../src/core/contract";
+
+const stubFileOps: FileOps = {
+  read: async () => {
+    throw new Error("unused");
+  },
+  readBytes: async () => new Uint8Array(),
+  write: async () => {},
+  readDir: async () => [],
+  stat: async () => ({ mtimeMs: 0, size: 0 }),
+  exists: async () => false,
+  unlink: async () => {},
+};
+
+function makeOps(extraRoots?: Record<string, string>) {
+  const generations: MulmoScriptGenerationEvent[] = [];
+  const changes: MulmoScriptChangedEvent[] = [];
+  const ops = createMulmoScriptServerOps({
+    storiesDir: "/nonexistent/for-tests/artifacts/stories",
+    ...(extraRoots ? { extraRoots } : {}),
+    artifacts: stubFileOps,
+    writeFileAtomic: async () => {},
+    onGenerationEvent: (_session, event) => generations.push(event),
+    onScriptChanged: (event) => changes.push(event),
+  });
+  return { ops, generations, changes };
+}
+
+describe("root registry", () => {
+  it("rejects an unregistered root rather than falling back to the default", () => {
+    const { ops } = makeOps();
+    const result = ops.resolveStory("stories/deck.json", "nope");
+    assert.equal(result.ok, false);
+    // A fallback would resolve a DIFFERENT file that happens to share the name.
+    assert.equal(result.ok === false && result.code, "bad_request");
+  });
+
+  it("refuses an empty extraRoots id at construction", () => {
+    // The empty id is the default root's own key; accepting it would re-point
+    // every pre-roots caller. Boot is the cheap place to fail.
+    assert.throws(() => makeOps({ "": "/somewhere" }), /must not be empty/);
+  });
+
+  it("does not create an extra root's directory as a side effect", () => {
+    // "Put the deck in the repository" must not grow `artifacts/stories/`
+    // inside the user's worktree because something polled a status.
+    const tmp = mkdtempSync(path.join(tmpdir(), "mulmoscript-roots-"));
+    const missing = path.join(tmp, "not-created");
+    try {
+      const { ops } = makeOps({ repo: missing });
+      ops.resolveStory("stories/deck.json", "repo");
+      assert.equal(ops.toStoryRef("/anything", "repo"), null, "an unrealizable root has no wire ref");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("gives an unregistered root no wire ref instead of the default root's", () => {
+    const { ops } = makeOps();
+    assert.equal(ops.toStoryRef("/nonexistent/for-tests/artifacts/stories/a.json", "nope"), null);
+  });
+});
+
+describe("generation events carry their root", () => {
+  it("puts the root on the published event", () => {
+    const { ops, generations } = makeOps({ repoA: "/tmp/a" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoA");
+    assert.equal(generations.length, 1);
+    assert.equal(generations[0]?.root, "repoA");
+  });
+
+  it("omits the root for the default one, so pre-#3014 consumers see no change", () => {
+    const { ops, generations } = makeOps();
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false);
+    assert.equal(generations.length, 1);
+    assert.ok(!("root" in generations[0]!), "default root must not appear on the wire");
+  });
+});
+
+describe("pendingGenerations is scoped by the pair", () => {
+  it("does not hand one root's in-flight run to another root's View", () => {
+    const { ops } = makeOps({ repoA: "/tmp/a", repoB: "/tmp/b" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoA");
+
+    assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
+    assert.equal(ops.pendingGenerations("stories/deck.json", "repoB").length, 0, "repoB must not see repoA's run");
+    assert.equal(ops.pendingGenerations("stories/deck.json").length, 0, "the default root must not see it either");
+  });
+
+  it("keeps the default root's snapshot exactly as it was", () => {
+    const { ops } = makeOps();
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false);
+    const pending = ops.pendingGenerations("stories/deck.json");
+    assert.equal(pending.length, 1);
+    assert.ok(!("root" in pending[0]!));
+  });
+
+  it("dedups per root — the same deck in two roots is two runs", () => {
+    const { ops, generations } = makeOps({ repoA: "/tmp/a", repoB: "/tmp/b" });
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoA");
+    ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, undefined, "repoB");
+    // Two starts, not one start plus a suppressed duplicate.
+    assert.equal(generations.filter((e) => !e.done).length, 2);
+  });
+});
+
+describe("script-changed events carry their root", () => {
+  it("names the root a write happened in", () => {
+    const { ops, changes } = makeOps({ repoA: "/tmp/a" });
+    ops.publishScriptChanged("stories/deck.json", "view-1", "repoA");
+    assert.equal(changes[0]?.root, "repoA");
+  });
+
+  it("omits it for the default root", () => {
+    const { ops, changes } = makeOps();
+    ops.publishScriptChanged("stories/deck.json", "view-1");
+    assert.ok(!("root" in changes[0]!));
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -6,9 +6,9 @@
 // field existed and the collisions it was meant to end were all still there.
 // Type-checking cannot catch that: `root` is optional, so a forgotten forward
 // is a legal call. Only a test that asserts on the OUTPUT can.
-import { describe, it } from "node:test";
+import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
@@ -435,5 +435,86 @@ describe("script-changed events carry their root", () => {
     const { ops, changes } = makeOps();
     ops.publishScriptChanged("stories/deck.json", "view-1");
     assert.ok(!("root" in changes[0]!));
+  });
+});
+
+describe("one root, one cache entry, whatever the spelling", () => {
+  // `ensureStoriesReal` memoises the realpath forever — the directory's real
+  // path is stable once it exists, so nothing evicts it. Keyed by the raw root
+  // id, `" repoA "` and `"repoA"` both resolved (the LOOKUP normalises) and
+  // then cached separately, so a never-evicted map grew one entry per spelling
+  // (Codex P2 on #3015). It is keyed by the resolved DIRECTORY now, which
+  // leaves no normalisation for a caller to forget.
+  const workspaces: string[] = [];
+  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+  function makeRootedOps() {
+    const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-rootcache-"));
+    workspaces.push(workspace);
+    const extra = path.join(workspace, "repoA", "artifacts", "stories");
+    mkdirSync(extra, { recursive: true });
+    writeFileSync(path.join(extra, "foo.json"), "{}");
+    const ops = createMulmoScriptServerOps({
+      storiesDir: path.join(workspace, "default", "artifacts", "stories"),
+      extraRoots: { repoA: extra },
+      artifacts: stubFileOps,
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    return { ops, extra };
+  }
+
+  it("resolves every spelling of one root to the same file", () => {
+    const { ops } = makeRootedOps();
+    const canonical = ops.resolveStory("stories/foo.json", "repoA");
+    assert.ok(canonical.ok);
+    for (const spelling of [" repoA ", "repoA  ", "  repoA"]) {
+      const resolved = ops.resolveStory("stories/foo.json", spelling);
+      assert.ok(resolved.ok, `expected ${JSON.stringify(spelling)} to resolve`);
+      assert.equal(resolved.absolutePath, canonical.absolutePath);
+    }
+  });
+
+  it("shares the memoised realpath across spellings", () => {
+    // The only externally visible difference between one cache entry and two:
+    // once the directory is gone, a SHARED entry still answers from memory,
+    // while a second spelling with its own key would re-realpath a missing
+    // directory and fail. Deleting the directory is what makes the cache
+    // observable at all.
+    const { ops, extra } = makeRootedOps();
+    // Resolved while the directory still exists — on macOS the temp dir is
+    // reached through a `/var` → `/private/var` symlink, so the configured
+    // path and its realpath differ and only the realpath relativizes cleanly.
+    const realExtra = realpathSync(extra);
+    assert.ok(ops.resolveStory("stories/foo.json", "repoA").ok, "warm the cache under one spelling");
+    rmSync(path.dirname(path.dirname(extra)), { recursive: true, force: true });
+    assert.equal(ops.toStoryRef(path.join(realExtra, "foo.json"), " repoA "), "stories/foo.json", "a second spelling must hit the entry the first one filled");
+  });
+});
+
+describe("the cache-sharing test can tell the two cases apart", () => {
+  // Its assertion means nothing unless a COLD cache actually fails it. With
+  // the directory gone and nothing memoised, `ensureStoriesReal` returns null,
+  // the base falls back to the unresolved configured path, and the ref comes
+  // out traversal-shaped — so it is rejected. That is the state the shared
+  // entry rescues.
+  const workspaces: string[] = [];
+  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+  it("returns null for a cold cache once the directory is gone", () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-coldcache-"));
+    workspaces.push(workspace);
+    const extra = path.join(workspace, "repoA", "artifacts", "stories");
+    mkdirSync(extra, { recursive: true });
+    const realExtra = realpathSync(extra);
+    const ops = createMulmoScriptServerOps({
+      storiesDir: path.join(workspace, "default", "artifacts", "stories"),
+      extraRoots: { repoA: extra },
+      artifacts: stubFileOps,
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    rmSync(path.dirname(path.dirname(extra)), { recursive: true, force: true });
+    assert.equal(ops.toStoryRef(path.join(realExtra, "foo.json"), "repoA"), null);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_subscription.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_subscription.ts
@@ -66,3 +66,42 @@ describe("onScriptChanged accepts both call forms", () => {
     assert.equal(subscription.ownOrigin, "");
   });
 });
+
+describe("the object form is checked at the subscribe call, not at delivery", () => {
+  // This package is published, so a JavaScript consumer reaches these
+  // functions with no call-site checking. An object missing `root` passed
+  // straight through, and the failure surfaced later as
+  // `sub.root is not a function` — thrown inside a pubsub delivery, where
+  // there is no caller left to catch it and the only symptom is a View that
+  // silently stops updating (CodeRabbit on #3015).
+  const filePath = (): string => "stories/deck.json";
+  const handler = (): void => {};
+
+  it("treats an object with no root as the default root", () => {
+    // The one field with a safe answer: a caller who did not think about
+    // roots meant the default one.
+    const subscription = normalizeGenerationSubscription({ filePath, handler } as never);
+    assert.equal(typeof subscription.root, "function");
+    assert.equal(subscription.root(), undefined);
+  });
+
+  it("treats a script-changed object with no root the same way", () => {
+    const subscription = normalizeScriptChangedSubscription({ filePath, ownOrigin: "view-1", handler } as never);
+    assert.equal(subscription.root(), undefined);
+    assert.equal(subscription.ownOrigin, "view-1");
+  });
+
+  it("throws at the subscribe call for a non-function root", () => {
+    assert.throws(() => normalizeGenerationSubscription({ filePath, root: "repoA", handler } as never), /root must be a function/);
+  });
+
+  it("throws at the subscribe call for a missing filePath or handler", () => {
+    assert.throws(() => normalizeGenerationSubscription({ handler } as never), /filePath and handler/);
+    assert.throws(() => normalizeGenerationSubscription({ filePath } as never), /filePath and handler/);
+    assert.throws(() => normalizeScriptChangedSubscription({ ownOrigin: "view-1", handler } as never), /filePath and handler/);
+  });
+
+  it("throws for a script-changed object with no ownOrigin", () => {
+    assert.throws(() => normalizeScriptChangedSubscription({ filePath, handler } as never), /ownOrigin must be a string/);
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_subscription.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_subscription.ts
@@ -8,6 +8,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { normalizeGenerationSubscription, normalizeScriptChangedSubscription } from "../src/vue/subscription";
+import { sameRoot } from "../src/core/contract";
 import type { MulmoScriptGenerationEvent } from "../src/core/contract";
 
 const filePath = (): string => "stories/deck.json";
@@ -103,5 +104,33 @@ describe("the object form is checked at the subscribe call, not at delivery", ()
 
   it("throws for a script-changed object with no ownOrigin", () => {
     assert.throws(() => normalizeScriptChangedSubscription({ filePath, handler } as never), /ownOrigin must be a string/);
+  });
+});
+
+describe("a root getter that returns a non-string cannot break delivery", () => {
+  // The exact path Codex named (P2 on #3015): the object form only checks that
+  // `root` is CALLABLE, so an untyped caller can pass `{ root: () => 42 }`.
+  // The subscriber then evaluates it during pubsub delivery and hands the
+  // result to `sameRoot` — which used to throw from inside the callback, where
+  // nothing catches it and the View just stops updating.
+  //
+  // Evaluating the getter at subscribe time would not help: it is a getter
+  // precisely because its answer changes. So the value is made safe where it
+  // is USED, and this test drives that boundary the way the subscriber does.
+  const filePath = (): string => "stories/deck.json";
+  const handler = (): void => {};
+
+  it("accepts the subscription and never throws when the getter is evaluated", () => {
+    const subscription = normalizeGenerationSubscription({ filePath, root: () => 42, handler } as never);
+    assert.doesNotThrow(() => sameRoot("repoA", subscription.root()));
+    assert.doesNotThrow(() => sameRoot(undefined, subscription.root()));
+  });
+
+  it("treats the malformed answer as the default root", () => {
+    // Not as a match for every named root, which is the failure that would
+    // route another repository's events to this View.
+    const subscription = normalizeGenerationSubscription({ filePath, root: () => 42, handler } as never);
+    assert.equal(sameRoot("repoA", subscription.root()), false);
+    assert.equal(sameRoot(undefined, subscription.root()), true);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_subscription.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_subscription.ts
@@ -1,0 +1,68 @@
+// Both call forms of the transport subscribers reach the same shape (#3015).
+//
+// `MulmoScriptTransport` is exported from `/vue` on a published package, so
+// the pre-root two-argument calls must keep working — and they must mean the
+// DEFAULT root, which is what a caller written before roots existed was
+// asking for. New callers pass an object, which cannot omit `root` and has no
+// positions to transpose.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeGenerationSubscription, normalizeScriptChangedSubscription } from "../src/vue/subscription";
+import type { MulmoScriptGenerationEvent } from "../src/core/contract";
+
+const filePath = (): string => "stories/deck.json";
+const seen: MulmoScriptGenerationEvent[] = [];
+const genHandler = (event: MulmoScriptGenerationEvent): void => {
+  seen.push(event);
+};
+const handler = (): void => {};
+
+describe("onGenerationEvent accepts both call forms", () => {
+  it("keeps the pre-root two-argument form working, on the default root", () => {
+    // The break these tests exist for: a third positional parameter bound this
+    // caller's `handler` to `root`, and the event path then called it as
+    // `root()` — every event lost, at the first one.
+    const subscription = normalizeGenerationSubscription(filePath, genHandler);
+    assert.equal(subscription.filePath, filePath);
+    assert.equal(subscription.handler, genHandler);
+    assert.equal(subscription.root(), undefined, "a caller that predates roots means the default root");
+  });
+
+  it("passes an options object through untouched", () => {
+    const root = (): string => "repoA";
+    const subscription = normalizeGenerationSubscription({ filePath, root, handler: genHandler });
+    assert.equal(subscription.root(), "repoA");
+    assert.equal(subscription.handler, genHandler);
+  });
+
+  it("rejects the legacy form with no handler instead of subscribing a broken listener", () => {
+    assert.throws(() => normalizeGenerationSubscription(filePath), TypeError);
+  });
+});
+
+describe("onScriptChanged accepts both call forms", () => {
+  it("keeps the pre-root three-argument form working, on the default root", () => {
+    const subscription = normalizeScriptChangedSubscription(filePath, "view-1", handler);
+    assert.equal(subscription.ownOrigin, "view-1");
+    assert.equal(subscription.handler, handler);
+    assert.equal(subscription.root(), undefined);
+  });
+
+  it("passes an options object through untouched", () => {
+    const subscription = normalizeScriptChangedSubscription({ filePath, root: () => "repoA", ownOrigin: "view-1", handler });
+    assert.equal(subscription.root(), "repoA");
+    assert.equal(subscription.ownOrigin, "view-1");
+  });
+
+  it("rejects a legacy call missing ownOrigin or handler", () => {
+    assert.throws(() => normalizeScriptChangedSubscription(filePath, "view-1"), TypeError);
+    assert.throws(() => normalizeScriptChangedSubscription(filePath), TypeError);
+  });
+
+  it("never treats an empty ownOrigin as a missing one", () => {
+    // `""` is a falsy but legitimate origin; a truthiness check here would
+    // throw on a caller that is doing nothing wrong.
+    const subscription = normalizeScriptChangedSubscription(filePath, "", handler);
+    assert.equal(subscription.ownOrigin, "");
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_transport_parsers.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_transport_parsers.ts
@@ -1,0 +1,43 @@
+// The pubsub boundary must not drop `root` (#3014).
+//
+// Four separate rounds of #3015 had the same shape: a comparison or a key was
+// widened to the pair `(root, filePath)`, while the path that CARRIES the root
+// to it was not. The parsers here are the last such path — they rebuild each
+// event field by field, so any field nobody listed is silently discarded, and
+// a downstream pair check then compares `undefined` against every named root
+// and filters out exactly the events it was written to route.
+//
+// A round trip is the only assertion that catches that class: it fails when a
+// field is added to the contract and not to the parser.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseGenerationEvent, parseScriptChangedEvent } from "../src/vue/transport";
+import type { MulmoScriptChangedEvent, MulmoScriptGenerationEvent } from "../src/core/contract";
+
+describe("the pubsub boundary preserves the root", () => {
+  it("keeps `root` on a generation event", () => {
+    const wire: MulmoScriptGenerationEvent = { kind: "movie", filePath: "stories/deck.json", key: "", done: false, root: "repoA" };
+    assert.deepEqual(parseGenerationEvent(wire), wire);
+  });
+
+  it("keeps `root` on a script-changed event", () => {
+    const wire: MulmoScriptChangedEvent = { filePath: "stories/deck.json", origin: "view-1", root: "repoA" };
+    assert.deepEqual(parseScriptChangedEvent(wire), wire);
+  });
+
+  it("omits `root` when the server omitted it, so the default root round-trips unchanged", () => {
+    // A pre-#3014 event must survive byte for byte: the downstream comparison
+    // normalizes absent to the default, and an invented `root: ""` would be a
+    // different shape on the wire for no reason.
+    const generation = { kind: "movie", filePath: "stories/deck.json", key: "", done: true };
+    assert.deepEqual(parseGenerationEvent(generation), generation);
+    const changed = { filePath: "stories/deck.json" };
+    assert.deepEqual(parseScriptChangedEvent(changed), changed);
+  });
+
+  it("drops a non-string root rather than passing it through", () => {
+    const parsed = parseGenerationEvent({ kind: "movie", filePath: "stories/deck.json", key: "", done: false, root: 42 });
+    assert.ok(parsed);
+    assert.ok(!("root" in parsed), "a malformed root must not reach the comparison");
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_transport_parsers.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_transport_parsers.ts
@@ -35,9 +35,36 @@ describe("the pubsub boundary preserves the root", () => {
     assert.deepEqual(parseScriptChangedEvent(changed), changed);
   });
 
-  it("drops a non-string root rather than passing it through", () => {
-    const parsed = parseGenerationEvent({ kind: "movie", filePath: "stories/deck.json", key: "", done: false, root: 42 });
-    assert.ok(parsed);
-    assert.ok(!("root" in parsed), "a malformed root must not reach the comparison");
+  it("rejects a payload whose root is present but not a string", () => {
+    // This test used to assert the OPPOSITE — that a malformed root was
+    // dropped and the rest of the event kept. That is wrong, and it is wrong
+    // in the direction this whole PR keeps failing in: `undefined` is a
+    // meaningful value here (the default root), so flattening `42` into it
+    // does not discard information, it CHANGES WHICH FILE the event is about.
+    // A default-root View would then act on a named root's event
+    // (CodeRabbit on #3015).
+    for (const root of [42, null, {}, ["repoA"], true]) {
+      assert.equal(parseGenerationEvent({ kind: "movie", filePath: "stories/deck.json", key: "", done: false, root }), null, `root: ${JSON.stringify(root)}`);
+      assert.equal(parseScriptChangedEvent({ filePath: "stories/deck.json", root }), null, `root: ${JSON.stringify(root)}`);
+    }
+  });
+
+  it("rejects a payload whose origin is present but not a string", () => {
+    // `origin` is identity too: read as absent, a View acts on the echo of its
+    // own write and rebuilds the element the caret is in on every keystroke.
+    for (const origin of [42, null, {}, true]) {
+      assert.equal(parseScriptChangedEvent({ filePath: "stories/deck.json", origin }), null, `origin: ${JSON.stringify(origin)}`);
+    }
+  });
+
+  it("keeps a finish event whose error field is malformed", () => {
+    // The one field that is dropped rather than rejected. It is a message
+    // shown beside a finished generation; rejecting the event would drop the
+    // FINISH and leave the spinner running forever, which is worse than
+    // losing the text.
+    const parsed = parseGenerationEvent({ kind: "movie", filePath: "stories/deck.json", key: "", done: true, error: 42 });
+    assert.ok(parsed, "a finish must still arrive");
+    assert.equal(parsed.done, true);
+    assert.ok(!("error" in parsed));
   });
 });

--- a/plans/feat-3014-mulmoscript-roots.md
+++ b/plans/feat-3014-mulmoscript-roots.md
@@ -1,0 +1,81 @@
+# feat #3014 — stories の根を複数にする（実装順序 1: プラグイン）
+
+## この段階のスコープ
+
+契約と ops に `root` を通す。**ホストは workspace だけ登録するので挙動は変わらない。**
+同一性の鍵を `(root, filePath)` の対に広げるのもここ。
+
+MulmoTerminal 側の宣言・UI（順序 2/3）は別 PR。
+
+## 調査でわかったこと（issue にコメント済み）
+
+制限は性質の違う 2 つの合成だった:
+
+| | 正体 | 変えてよいか |
+|---|---|---|
+| 封じ込め | エージェント供給パス（`filePath` は `definition.ts:109` の tool schema）に対する二層ガード。字句 `normalizeStoryPath` + realpath `resolveWithinRoot` | **不可** |
+| 根が 1 個 | `MulmoScriptServerBackend.storiesDir` が文字列 1 本という実装都合 | **可** |
+
+Docker 由来ではない（plugin の `src/` に docker/container/sandbox の記述ゼロ）。
+`stories/` の wire form も歴史的な遺産で、セキュリティ上の意味は無い。
+
+## 決めたこと / 先送りにしたこと
+
+**決めた: `root` はホストが埋める。エージェントには渡させない。**
+`definition.ts` は無変更。これが封じ込めの境界そのもの。エージェントが root を
+名指しできると (a) が消え、プロンプトインジェクション 1 回で任意のファイルに届く。
+「MulmoTerminal を起動したディレクトリ以下」はホストが根として登録すれば足りる。
+
+**先送り: `root` 識別子の具体的な形。**
+プラグインは `root` を**不透明な文字列キー**として扱い、`roots: Record<string, …>`
+の索きにしか使わない。id の採番規則（宣言キー／realpath ハッシュ／不透明 id）は
+ホストの持ち物なので、順序 2 で決めればよい。カードに永続化される決定を、
+必要になる前に固めない。
+
+**先送り: 成果物（動画・PDF）の置き場所。**
+根が 1 個の現状ではスクリプト置き場と出力置き場が同一で、挙動不変の要件を満たす。
+型は「1 根 = スクリプト dir」のまま置き、出力先を分ける必要が出た順序 2 で
+`{ scriptsDir, outputsDir }` へ広げる。今わけると使われない分岐が増えるだけ。
+
+## 変更
+
+### `src/server/types.ts`
+
+**追加型にする（置き換えではなく）。** 当初は `storiesDir` を `roots` へ
+移すつもりだったが、`@mulmoclaude/mulmoscript-plugin` は npm 公開済みで、
+消費者の MulmoTerminal は**別リポジトリ**にある。置き換えると、プラグインを
+publish した瞬間に MulmoTerminal が壊れ、同一 PR で追随させることもできない。
+
+- `storiesDir: string` は**そのまま**。これが「既定の根」になる
+- `extraRoots?: Record<string, string>` を足す。id → 絶対パス
+- wire の `root` が無ければ `storiesDir`、あれば `extraRoots` を索く
+
+後方互換が定義から出る（`root` 無し = 既定の根 = 今の挙動）うえ、
+MulmoTerminal は 1 行も変えずに動き続ける。minor で出せる。
+
+### `src/core/contract.ts`
+- `MulmoScriptGenerationEvent` / `MulmoScriptChangedEvent` に `root?: string`
+- `shouldReloadForScriptChange` を `(root, filePath)` の対で比較
+- dispatch args の各 kind に `root?: string`
+
+### `src/server/ops.ts`
+- `toStoryRef` / `resolveStory` / `ensureStoriesReal` を根ごとに
+- `inFlightGenerations` の鍵に root を含める
+- `canonicalWirePath` は wire path だけを正規化（root は別軸なので無変更）
+
+## 「挙動が同じ」の証明
+
+CLAUDE.md の規則どおり、旧実装をそのまま別ハーネスに写して新実装と
+突き合わせる。対象は純粋な判定 2 つ:
+
+1. `shouldReloadForScriptChange` — root 無しの入力で旧＝新
+2. `canonicalWirePath` / `normalizeStoryPath` — 無変更を確認（回帰の網）
+
+`resolveStory` は fs に触るので、生成した根の下で
+「封じ込めが破れない」性質テストを別に置く（絶対パス・`..`・シンボリックリンク脱出）。
+
+## 検証
+
+- 既存テスト（`test/test_paths.ts`, `test_server_ops.ts`, `test_plugin.ts`）が無改変で緑
+- 上の差分ハーネスで旧＝新
+- ホスト 2 つ（mulmoclaude / MulmoTerminal）が `roots` に追随してビルド緑

--- a/plans/feat-3014-mulmoscript-roots.md
+++ b/plans/feat-3014-mulmoscript-roots.md
@@ -53,6 +53,28 @@ publish した瞬間に MulmoTerminal が壊れ、同一 PR で追随させる�
 後方互換が定義から出る（`root` 無し = 既定の根 = 今の挙動）うえ、
 MulmoTerminal は 1 行も変えずに動き続ける。minor で出せる。
 
+### この段階で決めた 2 つの制限（レビューで確定）
+
+**1. 未登録の `root` は既定の根へ fallback せず `bad_request` で拒否する。**
+fallback は「名前だけ合った別ファイル」を黙って返す。読み違いは書き違いより
+発見が遅いので、落とす方を選ぶ。空文字列・空白のみは既定の根（`root` 無しと
+同じ）— これは既存の呼び出しを無改変で通すために必要。
+
+**2. 名前付きの根は「読み取り専用」。書き込みと生成は拒否する。**
+この段階で最大の機能制限。理由が 2 つあり、どちらもこのパッケージの外にある:
+
+- **書き**: `executeMulmoScriptSave` と update 系の executor は 1 つの `FileOps`
+  で動き、ホストが既定の根に束縛している。別の根を名乗る書きは**既定の根の
+  同名ファイルを書き換えて、別の根が変わったと announce する**。
+- **生成**: ホストのセッションストアは `generationKey`
+  （`@mulmobridge/protocol`）で `(kind, filePath, key)` を鍵にする。1 セッションで
+  2 つの根が同じ生成を始めると 1 エントリに潰れ、どちらかの完了が
+  他方のインジケータを消す。protocol の変更は消費者を持つので順序 1 の範囲外。
+
+どちらも `guardStoryWriteRoot` / `guardStoryGenerationRoot` が `bad_request` で
+閉じ、根を登録したホストには boot で警告する。順序 2 が `generationKey` に
+root を通したら、両方まとめて外れる。
+
 ### `src/core/contract.ts`
 - `MulmoScriptGenerationEvent` / `MulmoScriptChangedEvent` に `root?: string`
 - `shouldReloadForScriptChange` を `(root, filePath)` の対で比較
@@ -77,5 +99,8 @@ CLAUDE.md の規則どおり、旧実装をそのまま別ハーネスに写し�
 ## 検証
 
 - 既存テスト（`test/test_paths.ts`, `test_server_ops.ts`, `test_plugin.ts`）が無改変で緑
+- 新規テスト（`test_roots.ts`, `test_server_roots.ts`, `test_dispatch_roots.ts`,
+  `test_subscription.ts`, `test_transport_parsers.ts`）が緑
 - 上の差分ハーネスで旧＝新
-- ホスト 2 つ（mulmoclaude / MulmoTerminal）が `roots` に追随してビルド緑
+- ホスト 2 つ（mulmoclaude / MulmoTerminal）が**無改変で**ビルド緑
+  — 追加型を選んだので `roots` への追随作業は発生しない（上の「追加型にする」参照）

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -291,7 +291,7 @@ bindRoute(router, API_ROUTES.mulmoScript.generateMovie, async (req: Request<obje
     send({ type: "error", message: genError });
   } finally {
     mulmoScriptOps.inFlightMovies.delete(absoluteFilePath);
-    mulmoScriptOps.publishGeneration(chatSessionId, GENERATION_KINDS.movie, filePath, "", true, genError);
+    mulmoScriptOps.publishGeneration(chatSessionId, GENERATION_KINDS.movie, filePath, "", true, { error: genError });
     res.end();
   }
 });
@@ -457,7 +457,7 @@ async function handleGeneratePdf(req: Request<object, object, { filePath: string
     send({ type: "error", message: genError });
   } finally {
     mulmoScriptOps.inFlightPdfs.delete(absoluteFilePath);
-    mulmoScriptOps.publishGeneration(chatSessionId, GENERATION_KINDS.pdf, filePath, "", true, genError);
+    mulmoScriptOps.publishGeneration(chatSessionId, GENERATION_KINDS.pdf, filePath, "", true, { error: genError });
     res.end();
   }
 }


### PR DESCRIPTION
## Summary

#3014 の実装順序 1。**契約と ops に `root` を通し、同一性の鍵を `(root, filePath)` の対に広げます。ホストは既定の根しか登録しないので、挙動は一切変わりません。**

MulmoTerminal 側の宣言・UI（順序 2 / 3）は別 PR です。

### 名前付き root で今できること — **読める・書けない・生成できない**

レビューで判明した理由により、追加 root は**読み取り専用**で入ります。

| | 名前付き root | なぜ |
|---|---|---|
| 読み | ✅ できる | #3014 の依頼（「起動している path 以下が**見える**」）はこれ |
| 書き | ❌ `bad_request` | save / update / upload。executor が根ごとの FileOps を持つのは順序 2 |
| 生成 | ❌ `bad_request` | ホストのセッション鍵 `generationKey`（`@mulmobridge/protocol`）が `(kind, filePath, key)` のままで、1 セッション 2 root が 1 エントリに潰れる。**追跡できない実行は開始させない** |

どちらも fail-closed です。**警告して通すのではなく拒否する**のは、通した場合の
被害が「他 root のスピナーが消える／別 root の状態を壊す」で、しかも
detached な生成には失敗を見る呼び出し元がいないためです。

順序 2 が `generationKey` に root を通したら、この 2 つのガードは一緒に外れます。

### 「そもそもの制限は何だったのか」を先に調べました

Docker 由来ではありませんでした。**エージェントが渡すパスの封じ込め**です。`filePath` は `src/core/definition.ts:109` の tool schema にあり、モデルが書いた文字列がそのままファイルシステムに届きます。だから字句ガード（`normalizeStoryPath`）と realpath 封じ込め（`resolveWithinRoot`、core 側に "security-critical primitive must not drift per consumer" と明記）の二層で受けています。plugin の `src/` に docker / container / sandbox の記述はゼロでした。

そのうえで、制限が**性質の違う 2 つの合成**であることが分かりました:

| | 正体 | 変えてよいか |
|---|---|---|
| 封じ込め | エージェント供給パスに対するセキュリティ本体 | **不可** |
| 根が 1 個 | `storiesDir` が文字列 1 本という実装都合 | **可** |

`stories/` という wire form もセキュリティではなく歴史的な遺産（物理ディレクトリが `artifacts/` へ移ったとき、既存参照を壊さないよう wire だけ据え置いた）。この PR は後者だけを緩め、前者に一切触れません。詳細は issue のコメントに残してあります。

## Items to Confirm / Review

1. **置き換えではなく追加型にした判断 — 消費者の実ソースで確認済み。** 計画では `storiesDir` → `roots` に移すつもりでしたが撤回しました。このパッケージは npm 公開済み（`4.4.0`）で、消費者の **MulmoTerminal は別リポジトリ**です。`storiesDir` を消すと publish した瞬間に壊れ、同一 PR で追随させることもできません。

   ラウンド 10 のチェックポイントで、論じる代わりに **MulmoTerminal の `server/backends/mulmoscript.ts` を実際に読みました**:

   | 確認項目 | 結果 |
   |---|---|
   | `publishGeneration` の呼び出し（オプションオブジェクト化した関数） | **無し** |
   | `triggerAutoBackgroundMovie` | `(abs, wire, undefined)` の 3 引数 → root 既定 → ガード通過 |
   | `createMulmoScriptServerOps` の config | `storiesDir` のみ、`extraRoots` 無し |
   | 依存レンジ | `^4.4.0`（4.x のキャレットは minor を跨ぐ） |

2. **未登録 root は既定への fallback ではなく `bad_request`。** fallback にすると、名前だけ合った**別ファイル**を黙って返します。ここは落とす方が安全という判断です。

3. **`root` 識別子の形は決めていません（意図的）。** プラグインは `root` を**不透明なキー**として `extraRoots` を索くだけで、パースしません。id の採番規則はカードに永続化される決定なので、それを保守するホスト側（順序 2）の持ち物です。ここで固めると全ホストに対して凍結してしまいます。issue の「決めること」1 番目は開いたままにしてあります。

4. **`root` をエージェントに渡させない方針。** `definition.ts` は無変更です。ここが封じ込めの境界そのもので、エージェントが root を名指しできると二層ガードが意味を失います。「MulmoTerminal を起動したディレクトリ以下を見たい」はホストが根として登録すれば足り、エージェントに渡させる必要はありません。

## 「挙動が同じ」の証明

CLAUDE.md の規則どおり、**旧実装を逐語コピーした使い捨てハーネス**で新実装と突き合わせました。

- 生成入力 **1800 ケースで差分ゼロ**（wire の綴り 5 種 × watching 5 種 × origin 4 種 × ownOrigin 4 種 × 「root 無し」の 2 綴り × 2、および生成鍵 kind 5 × path 5 × key 4 × 2）
- 「root 無し」は `undefined` と `""` の両方を掃いています。両者が同じ根に正規化されることが、既存カードが無改変で動く根拠だからです

ハーネスは捨て、**生成器と性質を恒久テストに残しました**（`test/test_roots.ts`、6 件）。ハーネス自体は半分が削除対象の旧コードなので残せません。

**リバートで赤くなることを確認済み**: `sameRoot(...)` の比較を外して #3014 以前の式に戻すと **2 件が赤**になり、復元で緑に戻ります。

### 残るリスク（チェックポイントで特定）

`toStoryRef` は根が違っても同じ wire ref（`stories/deck.json`）を返すので、
**ref 単体では root が分かりません**。今はイベントが必ず `root` を併せて運び、
鍵も対で持つので問題になりませんが、「ref だけを保存する消費者」が現れると壊れます。
root 識別子の書式は順序 2 まで未確定なので、そこで ref 側に持たせるかを決めるのが自然です。

### そのほか

- 既存 147 テストが**無改変で緑**（後方互換の一次証拠）。レビュー 9 ラウンドを経て **199 件**に増加
- レビュー由来の修正はすべて**リバートで赤になることを確認**してから commit しています（各コミットメッセージに件数を記載）
- `yarn typecheck` / `eslint` / pre-commit の全ゲート緑
- ホスト `server/plugins/mulmoscript-server.ts` は変更なし

## User Prompt

- 「https://github.com/receptron/mulmoclaude/issues/3014 これよろしく！！ そもそもの制限って、なんであったんだろう？docker向けかな。optionalで任意の（というかmulmoterminalで起動してるpath以下が見えるのが理想）パスをみれるようにしよう」
- 「3014戻る」

Closes #3014 は付けていません（この PR は 3 段階のうち 1 段階目です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCEYf43PwB4avHgZ5erQRY

work in mulmoclaude2

## Summary by Sourcery

Extend the MulmoScript plugin to recognize multiple stories roots while keeping existing default-root behavior fully backward compatible.

New Features:
- Support registering additional stories roots and carry root identifiers through MulmoScript contracts, dispatch operations, filesystem resolution, and UI subscriptions.
- Scope script identity, generation tracking, pending state, and change notifications by the `(root, filePath)` pair while preserving default-root behavior.

Bug Fixes:
- Reject unknown or malformed roots instead of silently falling back to the default root.
- Prevent named-root writes and generations from modifying files or corrupting cross-root generation state before host-level support is available.
- Preserve root information through event parsing and maintain compatibility with existing subscription call forms.

Enhancements:
- Normalize root identifiers consistently and enforce realpath containment independently for each registered root.
- Fail fast on conflicting root registrations and warn hosts that named-root writes and generation are currently unavailable.

Documentation:
- Document the staged multi-root design, security boundaries, compatibility decisions, and current read-only limitations for additional roots.

Tests:
- Add coverage for root identity, dispatch safeguards, root-scoped server operations, subscription compatibility, and transport event parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple registered story roots with root-aware script identity, events, and generation tracking.
  * Added root-aware subscriptions while preserving legacy subscription formats.
  * Added secure path resolution and validation for registered roots.

* **Bug Fixes**
  * Improved reload and pending-generation tracking across roots while preserving default-root behavior.
  * Rejected unknown, invalid, and unsupported non-default-root operations.
  * Normalized root identifiers for consistent synchronization.
  * Improved handling of malformed generation event data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
