### PR TITLE
fix(mulmoscript-plugin): ドライブをまたぐ相対パスが封じ込めをすり抜けていた（main の Windows CI 赤）

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/core/paths.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/paths.ts
@@ -9,11 +9,16 @@
 // (which every mulmoScript endpoint keys on) are the SAME string. Stories are
 // NOT `YYYY/MM`-partitioned, so `storyFilePath` opts out of partitioning.
 
-import nodePath from "node:path";
 import { ARTIFACTS_ROOT, buildArtifactRelPath, hasUnsafePathSegment, slugifyArtifact } from "@mulmoclaude/core/artifacts";
 
-/** The slice of `node:path` this module needs — injected so the win32 rules
- *  can be driven from a POSIX machine (`path.win32`). */
+/**
+ * The slice of `node:path` this rule needs.
+ *
+ * Injected with no default, and this module imports no `node:*` builtin: it is
+ * reached from the browser entry through `core/plugin`, so a `node:path`
+ * import here lands in the Vue bundle (Codex on #3017). The server passes its
+ * own `path`; tests pass `path.win32` to reach the case below.
+ */
 export interface PathRules {
   relative: (from: string, to: string) => string;
   isAbsolute: (p: string) => boolean;
@@ -34,7 +39,7 @@ export interface PathRules {
  * is the substitution this function exists to refuse. Only Windows CI caught
  * it; here there is one root and always a relative route (#3015 post-merge).
  */
-export function storyRefWithin(base: string, absolutePath: string, rules: PathRules = nodePath): string | null {
+export function storyRefWithin(base: string, absolutePath: string, rules: PathRules): string | null {
   const relative = rules.relative(base, absolutePath);
   if (rules.isAbsolute(relative)) return null;
   const rel = relative.split(rules.sep).join("/");

--- a/packages/plugins/mulmoscript-plugin/src/core/paths.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/paths.ts
@@ -9,7 +9,38 @@
 // (which every mulmoScript endpoint keys on) are the SAME string. Stories are
 // NOT `YYYY/MM`-partitioned, so `storyFilePath` opts out of partitioning.
 
+import nodePath from "node:path";
 import { ARTIFACTS_ROOT, buildArtifactRelPath, hasUnsafePathSegment, slugifyArtifact } from "@mulmoclaude/core/artifacts";
+
+/** The slice of `node:path` this module needs — injected so the win32 rules
+ *  can be driven from a POSIX machine (`path.win32`). */
+export interface PathRules {
+  relative: (from: string, to: string) => string;
+  isAbsolute: (p: string) => boolean;
+  sep: string;
+}
+
+/**
+ * The wire ref for an absolute path inside a stories root, or `null` when it
+ * is not inside one.
+ *
+ * Pure, and taking its path rules as an argument, because the case that
+ * matters is unreachable on the machine this is written on. `path.relative`
+ * says "not under the base" in TWO ways and only one looks like an escape:
+ * `../…` is the familiar one, and across Windows DRIVES there is no relative
+ * path at all, so `relative("C:\\base", "D:\\x")` answers `"D:\\x"` —
+ * absolute, with no `..` for the escape check to catch. That minted
+ * `stories/D:/anything`, a wire ref that reads back as a DIFFERENT file, which
+ * is the substitution this function exists to refuse. Only Windows CI caught
+ * it; here there is one root and always a relative route (#3015 post-merge).
+ */
+export function storyRefWithin(base: string, absolutePath: string, rules: PathRules = nodePath): string | null {
+  const relative = rules.relative(base, absolutePath);
+  if (rules.isAbsolute(relative)) return null;
+  const rel = relative.split(rules.sep).join("/");
+  if (rel === ".." || rel.startsWith("../")) return null;
+  return rel ? `${STORIES_DIR}/${rel}` : STORIES_DIR;
+}
 
 const STORIES_DIR = "stories";
 const STORY_FALLBACK_SLUG = "story";

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -267,7 +267,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     // The relativizing rule is a pure function in `core/paths.ts` so it can be
     // driven with `path.win32` from a POSIX machine — the case it guards
     // (no relative route across drives) is unreachable here.
-    return storyRefWithin(base, absolutePath);
+    return storyRefWithin(base, absolutePath, path);
   }
 
   // Lazily realpath the stories dir on first use. We can't realpath at

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -43,7 +43,7 @@ import {
 import type { MulmoBeat, MulmoImagePromptMedia, MulmoStudioContext } from "@mulmocast/types";
 import { DEFAULT_ROOT, normalizeRoot } from "../core/contract";
 import type { MulmoScriptGenerationEvent } from "../core/contract";
-import { normalizeStoryPath } from "../core/paths";
+import { normalizeStoryPath, storyRefWithin } from "../core/paths";
 import { errorMessage } from "@mulmoclaude/common";
 import { resolveWithinRoot } from "@mulmoclaude/core/files";
 import { fileToDataUri, stripDataUri } from "./support";
@@ -264,15 +264,10 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     const dir = rootDir(root);
     if (dir === null) return null;
     const base = ensureStoriesReal(root) ?? dir;
-    const rel = path.relative(base, absolutePath).split(path.sep).join("/");
-    // A path outside the base relativizes to `../…`, which would be handed
-    // out as the traversal-shaped ref `stories/../../…` that `resolveStory`
-    // then rejects — a wire path that cannot be read back. It happens for
-    // real: a root whose directory does not exist yet has no realpath, so the
-    // base falls back to the unresolved directory and every absolute path
-    // looks outside it.
-    if (rel === ".." || rel.startsWith("../")) return null;
-    return rel ? `stories/${rel}` : "stories";
+    // The relativizing rule is a pure function in `core/paths.ts` so it can be
+    // driven with `path.win32` from a POSIX machine — the case it guards
+    // (no relative route across drives) is unreachable here.
+    return storyRefWithin(base, absolutePath);
   }
 
   // Lazily realpath the stories dir on first use. We can't realpath at

--- a/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
@@ -7,47 +7,64 @@
 // bundler does, or worse, ships a broken chunk. So the rule is checked rather
 // than remembered: `core/` takes its platform pieces as arguments.
 //
-// The list of builtins comes from NODE, not from this file. The first version
-// matched `node:*` only, and `import path from "path"` — equally valid, and
-// what most of this repo actually writes — would have put the dependency
-// straight back with the guard green (Codex on #3017). A rule enforced by a
-// list someone maintains is the failure this whole line of work keeps hitting.
+// **Parsed, not pattern-matched.** Four rounds of review went into a regex
+// that kept being almost right: it missed bare `import path from "path"`, then
+// side-effect `import "path"`, then multiline `import {\n…\n} from "node:fs"`,
+// while also flagging `export const label = "node:fs"` — a string that is not
+// an import at all. Every fix enumerated one more form, and the forms are
+// open-ended. TypeScript already knows what a module specifier is, so it is
+// asked (Codex + CodeRabbit on #3017).
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
 import { builtinModules } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const CORE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src", "core");
 const BUILTINS = new Set(builtinModules);
 
 /**
- * Every module specifier the line imports, however it spells it.
+ * Every module specifier the source imports — from the parser, not a pattern.
  *
- * Two rules rather than a list of syntactic forms. The first version listed
- * `from` / `require(` / `import(`, and `import "path";` — which has none of
- * them — walked straight past it, twice (Codex + CodeRabbit on #3017). The
- * forms are open-ended; what is closed is WHERE a specifier can appear.
- *
- * 1. On an `import` / `export` statement, every string literal is a specifier.
- *    That covers the side-effect form for free, because there is nothing else
- *    a quoted string can be there.
- * 2. Anywhere at all, the argument of `require(…)` or a dynamic `import(…)`.
+ * `forEachChild` walks the real tree, so a specifier is found wherever the
+ * grammar allows one and nowhere else: static and side-effect imports,
+ * `export … from`, `import type`, `require()` and dynamic `import()`, however
+ * they are spread across lines. A quoted builtin name that is NOT a specifier
+ * (`const which = "path"`) is not a node this visitor stops on.
  */
-function importedSpecifiers(line: string): string[] {
+export function importedSpecifiers(source: string): string[] {
+  const file = ts.createSourceFile("probe.ts", source, ts.ScriptTarget.Latest, true);
   const specifiers: string[] = [];
-  if (/^\s*(?:import|export)\b/.test(line)) {
-    for (const match of line.matchAll(/["']([^"']+)["']/g)) specifiers.push(match[1]!);
-  }
-  for (const match of line.matchAll(/(?:require|import)\(\s*["']([^"']+)["']/g)) {
-    specifiers.push(match[1]!);
-  }
+  const visit = (node: ts.Node): void => {
+    const specifier = moduleSpecifierOf(node);
+    if (specifier !== undefined) specifiers.push(specifier);
+    ts.forEachChild(node, visit);
+  };
+  visit(file);
   return specifiers;
 }
 
+function moduleSpecifierOf(node: ts.Node): string | undefined {
+  if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+    return node.moduleSpecifier.text;
+  }
+  if (ts.isCallExpression(node) && isModuleLoadCall(node.expression)) {
+    const [first] = node.arguments;
+    if (first && ts.isStringLiteral(first)) return first.text;
+  }
+  return undefined;
+}
+
+/** `require(…)` or a dynamic `import(…)` — the identifier itself, so
+ *  `myrequire("path")` is not one of them. */
+function isModuleLoadCall(expression: ts.Expression): boolean {
+  return expression.kind === ts.SyntaxKind.ImportKeyword || (ts.isIdentifier(expression) && expression.text === "require");
+}
+
 /** A Node builtin, whether written `node:path` or bare `path`. */
-function isNodeBuiltin(specifier: string): boolean {
+export function isNodeBuiltin(specifier: string): boolean {
   const bare = specifier.startsWith("node:") ? specifier.slice("node:".length) : specifier;
   return BUILTINS.has(bare) || BUILTINS.has(`node:${bare}`);
 }
@@ -56,9 +73,8 @@ function coreModules(): string[] {
   return readdirSync(CORE_DIR).filter((name) => name.endsWith(".ts"));
 }
 
-function findBuiltinImport(name: string): string | undefined {
-  const source = readFileSync(path.join(CORE_DIR, name), "utf8");
-  return source.split("\n").find((line) => importedSpecifiers(line).some(isNodeBuiltin));
+function builtinImportsIn(name: string): string[] {
+  return importedSpecifiers(readFileSync(path.join(CORE_DIR, name), "utf8")).filter(isNodeBuiltin);
 }
 
 describe("the browser-facing core imports no Node builtin", () => {
@@ -71,55 +87,61 @@ describe("the browser-facing core imports no Node builtin", () => {
 
   for (const name of coreModules()) {
     it(`${name} imports no Node builtin`, () => {
-      const offender = findBuiltinImport(name);
-      assert.equal(offender, undefined, `${name} reaches the browser bundle — take the platform piece as an argument instead of importing it`);
+      const offenders = builtinImportsIn(name);
+      assert.deepEqual(offenders, [], `${name} reaches the browser bundle — take the platform piece as an argument instead of importing it`);
     });
   }
 });
 
-describe("the guard recognises every spelling of a builtin import", () => {
-  // The detection IS the test, so it is pinned directly — including the bare
-  // form the first version missed.
-  const CAUGHT = [
-    'import nodePath from "node:path";',
-    'import path from "path";',
-    'import { readFileSync } from "node:fs";',
-    'import { readFileSync } from "fs";',
-    // Side-effect imports: no `from`, no call — the form that slipped past two
-    // versions of this guard.
-    'import "path";',
-    'import "node:path";',
-    '  import "node:crypto";',
-    'const p = require("path");',
-    'const p = require("node:path");',
-    'export { sep } from "path";',
-    'export * from "node:path";',
-    'const mod = await import("node:os");',
-    'import type { Stats } from "node:fs";',
-  ];
-  const ALLOWED = [
-    " * The slice of `node:path` this rule needs.",
-    'import { ARTIFACTS_ROOT } from "@mulmoclaude/core/artifacts";',
-    'import { normalizeStoryPath } from "./paths";',
-    'import type { MulmoBeat } from "@mulmocast/types";',
-    // A package whose name merely CONTAINS a builtin's name is not one.
-    'import { join } from "path-browserify";',
-    'import x from "node-fetch";',
-    'import "./styles.css";',
-    // A quoted builtin name OUTSIDE an import statement is not an import.
-    'const which = "path";',
-    'log.info("fs", "wrote the file");',
+describe("the guard finds a specifier wherever the grammar allows one", () => {
+  // The detection IS the test, so it is pinned directly — every form that
+  // walked past an earlier version of it included.
+  const CAUGHT: ReadonlyArray<[string, string]> = [
+    ["default import", 'import nodePath from "node:path";'],
+    ["bare default import", 'import path from "path";'],
+    ["named import", 'import { readFileSync } from "node:fs";'],
+    ["bare named import", 'import { readFileSync } from "fs";'],
+    ["side-effect import", 'import "path";'],
+    ["side-effect import, prefixed", 'import "node:path";'],
+    ["multiline import", 'import {\n  readFileSync,\n  writeFileSync,\n} from "node:fs";'],
+    ["multiline default import", 'import\n  nodePath\nfrom "path";'],
+    ["type-only import", 'import type { Stats } from "node:fs";'],
+    ["namespace import", 'import * as os from "node:os";'],
+    ["re-export", 'export { sep } from "path";'],
+    ["star re-export", 'export * from "node:path";'],
+    ["require", 'const p = require("path");'],
+    ["dynamic import", 'const mod = await import("node:os");'],
   ];
 
-  for (const line of CAUGHT) {
-    it(`catches ${line}`, () => {
-      assert.ok(importedSpecifiers(line).some(isNodeBuiltin), line);
+  for (const [label, source] of CAUGHT) {
+    it(`catches a ${label}`, () => {
+      assert.ok(importedSpecifiers(source).some(isNodeBuiltin), `${label} must be recognised: ${JSON.stringify(source)}`);
     });
   }
+});
 
-  for (const line of ALLOWED) {
-    it(`allows ${line.trim().slice(0, 48)}`, () => {
-      assert.ok(!importedSpecifiers(line).some(isNodeBuiltin), line);
+describe("the guard does not flag things that only look like imports", () => {
+  const ALLOWED: ReadonlyArray<[string, string]> = [
+    ["a comment", "/** The slice of `node:path` this rule needs. */"],
+    ["a workspace import", 'import { ARTIFACTS_ROOT } from "@mulmoclaude/core/artifacts";'],
+    ["a relative import", 'import { normalizeStoryPath } from "./paths";'],
+    ["a stylesheet", 'import "./styles.css";'],
+    // Packages whose NAME contains a builtin's name.
+    ["path-browserify", 'import { join } from "path-browserify";'],
+    ["node-fetch", 'import x from "node-fetch";'],
+    // Strings that are not specifiers — the false positives a line-based
+    // regex produced.
+    ["an exported constant", 'export const label = "node:fs";'],
+    ["a local constant", 'const which = "path";'],
+    ["a log argument", 'log.info("fs", "wrote the file");'],
+    ["require-looking text inside a string", "const sample = 'require(\"node:fs\")';"],
+    ["an identifier ending in require", 'myrequire("path");'],
+  ];
+
+  for (const [label, source] of ALLOWED) {
+    it(`allows ${label}`, () => {
+      const found = importedSpecifiers(source).filter(isNodeBuiltin);
+      assert.deepEqual(found, [], `${label} must not be flagged: ${JSON.stringify(source)}`);
     });
   }
 

--- a/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
@@ -54,6 +54,13 @@ function moduleSpecifierOf(node: ts.Node): string | undefined {
     const [first] = node.arguments;
     if (first) return staticSpecifierText(first);
   }
+  // `import fs = require("node:fs")` — TypeScript's own import form. It keeps
+  // its specifier in an `ExternalModuleReference`, not in a call expression,
+  // so a visitor looking only for calls walks straight past it (CodeRabbit on
+  // #3017).
+  if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+    return staticSpecifierText(node.moduleReference.expression);
+  }
   return undefined;
 }
 
@@ -129,6 +136,8 @@ describe("the guard finds a specifier wherever the grammar allows one", () => {
     // `isStringLiteral`.
     ["dynamic import with a template literal", "const mod = await import(`node:path`);"],
     ["require with a template literal", "const p = require(`path`);"],
+    ["import-equals", 'import fs = require("node:fs");'],
+    ["bare import-equals", 'import fs = require("fs");'],
   ];
 
   for (const [label, source] of CAUGHT) {

--- a/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
@@ -1,0 +1,44 @@
+// `src/core/` must not import a Node builtin (#3017).
+//
+// The browser entry reaches it: `src/vue/index.ts` → `core/plugin` →
+// `core/paths`. A `node:path` import added there — as one was, to give a path
+// helper a convenient default argument — lands in the Vue bundle, where the
+// builtin does not exist. The build does not complain; the consumer's bundler
+// does, or worse, ships a broken chunk.
+//
+// So the rule is checked rather than remembered: `core/` takes its platform
+// pieces as arguments.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CORE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src", "core");
+/** `import x from "node:y"` / `require("node:y")` — not the word inside a comment. */
+const NODE_BUILTIN_IMPORT = /(?:from\s*|require\(\s*)["']node:[a-z_/]+["']/;
+
+describe("the browser-facing core imports no Node builtin", () => {
+  const files = readdirSync(CORE_DIR).filter((name) => name.endsWith(".ts"));
+
+  it("finds the core modules to check", () => {
+    // Without this the sweep below passes by checking nothing.
+    assert.ok(files.length >= 3, `expected several modules under src/core, found ${files.length}`);
+    assert.ok(files.includes("paths.ts") && files.includes("plugin.ts"), `expected paths.ts and plugin.ts, got ${files.join(", ")}`);
+  });
+
+  for (const name of readdirSync(CORE_DIR).filter((f) => f.endsWith(".ts"))) {
+    it(`${name} imports no node: builtin`, () => {
+      const source = readFileSync(path.join(CORE_DIR, name), "utf8");
+      const offender = source.split("\n").find((line) => NODE_BUILTIN_IMPORT.test(line));
+      assert.equal(offender, undefined, `${name} reaches the browser bundle — take the platform piece as an argument instead of importing it`);
+    });
+  }
+
+  it("the check can actually fail", () => {
+    // The regex is the whole test; pin that it matches what it is meant to.
+    assert.ok(NODE_BUILTIN_IMPORT.test('import nodePath from "node:path";'));
+    assert.ok(NODE_BUILTIN_IMPORT.test('const p = require("node:fs");'));
+    assert.ok(!NODE_BUILTIN_IMPORT.test(" * The slice of `node:path` this rule needs."));
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
@@ -3,42 +3,106 @@
 // The browser entry reaches it: `src/vue/index.ts` → `core/plugin` →
 // `core/paths`. A `node:path` import added there — as one was, to give a path
 // helper a convenient default argument — lands in the Vue bundle, where the
-// builtin does not exist. The build does not complain; the consumer's bundler
-// does, or worse, ships a broken chunk.
+// builtin does not exist. Neither the build nor lint complains; the consumer's
+// bundler does, or worse, ships a broken chunk. So the rule is checked rather
+// than remembered: `core/` takes its platform pieces as arguments.
 //
-// So the rule is checked rather than remembered: `core/` takes its platform
-// pieces as arguments.
+// The list of builtins comes from NODE, not from this file. The first version
+// matched `node:*` only, and `import path from "path"` — equally valid, and
+// what most of this repo actually writes — would have put the dependency
+// straight back with the guard green (Codex on #3017). A rule enforced by a
+// list someone maintains is the failure this whole line of work keeps hitting.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
+import { builtinModules } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const CORE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src", "core");
-/** `import x from "node:y"` / `require("node:y")` — not the word inside a comment. */
-const NODE_BUILTIN_IMPORT = /(?:from\s*|require\(\s*)["']node:[a-z_/]+["']/;
+const BUILTINS = new Set(builtinModules);
+
+/** Every module specifier the line imports from, however it spells it. */
+function importedSpecifiers(line: string): string[] {
+  const specifiers: string[] = [];
+  for (const match of line.matchAll(/(?:from\s*|require\(\s*|import\(\s*)["']([^"']+)["']/g)) {
+    specifiers.push(match[1]!);
+  }
+  return specifiers;
+}
+
+/** A Node builtin, whether written `node:path` or bare `path`. */
+function isNodeBuiltin(specifier: string): boolean {
+  const bare = specifier.startsWith("node:") ? specifier.slice("node:".length) : specifier;
+  return BUILTINS.has(bare) || BUILTINS.has(`node:${bare}`);
+}
+
+function coreModules(): string[] {
+  return readdirSync(CORE_DIR).filter((name) => name.endsWith(".ts"));
+}
+
+function findBuiltinImport(name: string): string | undefined {
+  const source = readFileSync(path.join(CORE_DIR, name), "utf8");
+  return source.split("\n").find((line) => importedSpecifiers(line).some(isNodeBuiltin));
+}
 
 describe("the browser-facing core imports no Node builtin", () => {
-  const files = readdirSync(CORE_DIR).filter((name) => name.endsWith(".ts"));
-
   it("finds the core modules to check", () => {
     // Without this the sweep below passes by checking nothing.
+    const files = coreModules();
     assert.ok(files.length >= 3, `expected several modules under src/core, found ${files.length}`);
     assert.ok(files.includes("paths.ts") && files.includes("plugin.ts"), `expected paths.ts and plugin.ts, got ${files.join(", ")}`);
   });
 
-  for (const name of readdirSync(CORE_DIR).filter((f) => f.endsWith(".ts"))) {
-    it(`${name} imports no node: builtin`, () => {
-      const source = readFileSync(path.join(CORE_DIR, name), "utf8");
-      const offender = source.split("\n").find((line) => NODE_BUILTIN_IMPORT.test(line));
+  for (const name of coreModules()) {
+    it(`${name} imports no Node builtin`, () => {
+      const offender = findBuiltinImport(name);
       assert.equal(offender, undefined, `${name} reaches the browser bundle — take the platform piece as an argument instead of importing it`);
     });
   }
+});
 
-  it("the check can actually fail", () => {
-    // The regex is the whole test; pin that it matches what it is meant to.
-    assert.ok(NODE_BUILTIN_IMPORT.test('import nodePath from "node:path";'));
-    assert.ok(NODE_BUILTIN_IMPORT.test('const p = require("node:fs");'));
-    assert.ok(!NODE_BUILTIN_IMPORT.test(" * The slice of `node:path` this rule needs."));
+describe("the guard recognises every spelling of a builtin import", () => {
+  // The detection IS the test, so it is pinned directly — including the bare
+  // form the first version missed.
+  const CAUGHT = [
+    'import nodePath from "node:path";',
+    'import path from "path";',
+    'import { readFileSync } from "node:fs";',
+    'import { readFileSync } from "fs";',
+    'const p = require("path");',
+    'const p = require("node:path");',
+    'export { sep } from "path";',
+    'const mod = await import("node:os");',
+  ];
+  const ALLOWED = [
+    " * The slice of `node:path` this rule needs.",
+    'import { ARTIFACTS_ROOT } from "@mulmoclaude/core/artifacts";',
+    'import { normalizeStoryPath } from "./paths";',
+    'import type { MulmoBeat } from "@mulmocast/types";',
+    // A package whose name merely CONTAINS a builtin's name is not one.
+    'import { join } from "path-browserify";',
+    'import x from "node-fetch";',
+  ];
+
+  for (const line of CAUGHT) {
+    it(`catches ${line}`, () => {
+      assert.ok(importedSpecifiers(line).some(isNodeBuiltin), line);
+    });
+  }
+
+  for (const line of ALLOWED) {
+    it(`allows ${line.trim().slice(0, 48)}`, () => {
+      assert.ok(!importedSpecifiers(line).some(isNodeBuiltin), line);
+    });
+  }
+
+  it("takes its builtin list from Node itself", () => {
+    // Not from a list in this file — that is the shape the first version got
+    // wrong, and the shape that rots as Node adds builtins.
+    assert.ok(BUILTINS.size > 30, `expected Node's builtin list, got ${BUILTINS.size} entries`);
+    for (const expected of ["path", "fs", "os", "url", "crypto"]) {
+      assert.ok(isNodeBuiltin(expected), `${expected} must be recognised as a builtin`);
+    }
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
@@ -52,8 +52,22 @@ function moduleSpecifierOf(node: ts.Node): string | undefined {
   }
   if (ts.isCallExpression(node) && isModuleLoadCall(node.expression)) {
     const [first] = node.arguments;
-    if (first && ts.isStringLiteral(first)) return first.text;
+    if (first) return staticSpecifierText(first);
   }
+  return undefined;
+}
+
+/**
+ * The text of a specifier argument, when it is knowable without running.
+ *
+ * Unlike the syntactic forms above, this set is CLOSED: a call's specifier can
+ * be a string literal or a no-substitution template (`` import(`node:path`) ``
+ * — legal, and missed by a check that asked only `isStringLiteral`; Codex on
+ * #3017). A template WITH substitutions has no static text at all, so there is
+ * nothing for any checker to read and nothing this guard can promise about it.
+ */
+function staticSpecifierText(argument: ts.Expression): string | undefined {
+  if (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument)) return argument.text;
   return undefined;
 }
 
@@ -111,6 +125,10 @@ describe("the guard finds a specifier wherever the grammar allows one", () => {
     ["star re-export", 'export * from "node:path";'],
     ["require", 'const p = require("path");'],
     ["dynamic import", 'const mod = await import("node:os");'],
+    // Backtick specifiers: legal, and missed by a check that asks only
+    // `isStringLiteral`.
+    ["dynamic import with a template literal", "const mod = await import(`node:path`);"],
+    ["require with a template literal", "const p = require(`path`);"],
   ];
 
   for (const [label, source] of CAUGHT) {
@@ -144,6 +162,15 @@ describe("the guard does not flag things that only look like imports", () => {
       assert.deepEqual(found, [], `${label} must not be flagged: ${JSON.stringify(source)}`);
     });
   }
+
+  it("says nothing about a computed specifier, because nothing can", () => {
+    // `import(`node:${name}`)` has no static text — there is no answer to read
+    // without running the code. Pinned so the silence is a decision rather
+    // than an oversight: a core module doing this would not be caught here,
+    // and the reviewer of such a line is the check.
+    const found = importedSpecifiers("const mod = await import(`node:${name}`);").filter(isNodeBuiltin);
+    assert.deepEqual(found, [], "a computed specifier has no static text to judge");
+  });
 
   it("takes its builtin list from Node itself", () => {
     // Not from a list in this file — that is the shape the first version got

--- a/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_browserSafeCore.ts
@@ -22,10 +22,25 @@ import { fileURLToPath } from "node:url";
 const CORE_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src", "core");
 const BUILTINS = new Set(builtinModules);
 
-/** Every module specifier the line imports from, however it spells it. */
+/**
+ * Every module specifier the line imports, however it spells it.
+ *
+ * Two rules rather than a list of syntactic forms. The first version listed
+ * `from` / `require(` / `import(`, and `import "path";` — which has none of
+ * them — walked straight past it, twice (Codex + CodeRabbit on #3017). The
+ * forms are open-ended; what is closed is WHERE a specifier can appear.
+ *
+ * 1. On an `import` / `export` statement, every string literal is a specifier.
+ *    That covers the side-effect form for free, because there is nothing else
+ *    a quoted string can be there.
+ * 2. Anywhere at all, the argument of `require(…)` or a dynamic `import(…)`.
+ */
 function importedSpecifiers(line: string): string[] {
   const specifiers: string[] = [];
-  for (const match of line.matchAll(/(?:from\s*|require\(\s*|import\(\s*)["']([^"']+)["']/g)) {
+  if (/^\s*(?:import|export)\b/.test(line)) {
+    for (const match of line.matchAll(/["']([^"']+)["']/g)) specifiers.push(match[1]!);
+  }
+  for (const match of line.matchAll(/(?:require|import)\(\s*["']([^"']+)["']/g)) {
     specifiers.push(match[1]!);
   }
   return specifiers;
@@ -70,10 +85,17 @@ describe("the guard recognises every spelling of a builtin import", () => {
     'import path from "path";',
     'import { readFileSync } from "node:fs";',
     'import { readFileSync } from "fs";',
+    // Side-effect imports: no `from`, no call — the form that slipped past two
+    // versions of this guard.
+    'import "path";',
+    'import "node:path";',
+    '  import "node:crypto";',
     'const p = require("path");',
     'const p = require("node:path");',
     'export { sep } from "path";',
+    'export * from "node:path";',
     'const mod = await import("node:os");',
+    'import type { Stats } from "node:fs";',
   ];
   const ALLOWED = [
     " * The slice of `node:path` this rule needs.",
@@ -83,6 +105,10 @@ describe("the guard recognises every spelling of a builtin import", () => {
     // A package whose name merely CONTAINS a builtin's name is not one.
     'import { join } from "path-browserify";',
     'import x from "node-fetch";',
+    'import "./styles.css";',
+    // A quoted builtin name OUTSIDE an import statement is not an import.
+    'const which = "path";',
+    'log.info("fs", "wrote the file");',
   ];
 
   for (const line of CAUGHT) {

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "os";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
 import { createMulmoScriptServerOps } from "../src/server/ops";
+import { storyRefWithin } from "../src/core/paths";
 import type { OpResult } from "../src/server/types";
 import type { MulmoScriptGenerationEvent, MulmoScriptChangedEvent } from "../src/core/contract";
 
@@ -579,5 +580,85 @@ describe("one root, one cache entry, whatever the spelling", () => {
     if (!fixture) return t.skip("this platform refuses to create the symlink");
     rmSync(fixture.realTree, { recursive: true, force: true });
     assert.equal(fixture.ops.toStoryRef(path.join(fixture.realStories, "foo.json"), "repoA"), null);
+  });
+});
+
+describe("a path that has no relative route to the root gets no wire ref", () => {
+  // Windows-only in the wild, but pinned so every platform runs it.
+  //
+  // `path.relative` says "not under the base" in two ways, and only one looks
+  // like an escape. `../…` is the familiar one. Across DRIVES there is no
+  // relative path at all, so `path.relative("C:\\base", "D:\\x")` answers
+  // `"D:\\x"` — absolute, with no `..` for the escape check to catch. It
+  // minted `stories/D:/anything`: a wire ref that reads back as a different
+  // file, which is the exact substitution `toStoryRef` exists to refuse. Only
+  // Windows CI caught it; macOS and Linux have one root and always find a
+  // relative route (#3015 post-merge).
+  const workspaces: string[] = [];
+  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+  it("refuses a target with no relative route, whatever the platform calls it", () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-noroute-"));
+    workspaces.push(workspace);
+    const storiesDir = path.join(workspace, "artifacts", "stories");
+    mkdirSync(storiesDir, { recursive: true });
+    const { ops } = { ops: createMulmoScriptServerOps({ storiesDir, artifacts: stubFileOps, writeFileAtomic: async () => {} }) };
+
+    // On Windows the second drive has no relative route; on POSIX the same
+    // string is an ordinary escape. Either way the answer must be null, and
+    // the ref must never carry the target verbatim.
+    for (const outside of ["D:\\anything", "/anything", path.join(workspace, "..", "elsewhere", "deck.json")]) {
+      const ref = ops.toStoryRef(outside, undefined);
+      assert.ok(ref === null || !ref.includes(".."), `${outside} must not mint a traversal ref, got ${ref}`);
+      assert.ok(ref === null || !path.isAbsolute(ref.replace(/^stories\//, "")), `${outside} must not mint an absolute ref, got ${ref}`);
+    }
+  });
+
+  it("still names a file that IS under the root", () => {
+    // Without this the test above passes by refusing everything.
+    const workspace = mkdtempSync(path.join(tmpdir(), "mulmoscript-noroute-ok-"));
+    workspaces.push(workspace);
+    const storiesDir = path.join(workspace, "artifacts", "stories");
+    mkdirSync(storiesDir, { recursive: true });
+    const ops = createMulmoScriptServerOps({ storiesDir, artifacts: stubFileOps, writeFileAtomic: async () => {} });
+    assert.equal(ops.toStoryRef(path.join(realpathSync(storiesDir), "deck.json"), undefined), "stories/deck.json");
+  });
+});
+
+describe("storyRefWithin — the Windows case, driven from any platform", () => {
+  // The bug: `path.relative` says "not under the base" in TWO ways, and only
+  // one looks like an escape. `../…` is familiar. Across Windows DRIVES there
+  // is no relative path at all, so `relative("C:\\base", "D:\\x")` answers
+  // `"D:\\x"` — absolute, no `..` for the escape check to catch. That minted
+  // `stories/D:/anything`: a wire ref reading back as a DIFFERENT file, the
+  // exact substitution this rule exists to refuse. Only Windows CI caught it.
+  //
+  // The rule takes its path module as an argument precisely so the case is
+  // reachable here — on macOS and Linux there is one root and always a
+  // relative route, so a test using the real `path` proves nothing.
+  const WIN_ROOT = "C:\\workspace\\artifacts\\stories";
+
+  it("refuses a target on another drive", () => {
+    assert.equal(storyRefWithin(WIN_ROOT, "D:\\anything", path.win32), null);
+    assert.equal(storyRefWithin(WIN_ROOT, "D:\\repo\\artifacts\\stories\\deck.json", path.win32), null);
+  });
+
+  it("refuses an ordinary escape on the same drive", () => {
+    assert.equal(storyRefWithin(WIN_ROOT, "C:\\elsewhere\\deck.json", path.win32), null);
+  });
+
+  it("still names a file inside the root, with forward slashes on the wire", () => {
+    // The other half: the drive check must not reject legitimate refs, and the
+    // wire form stays POSIX whatever the host separator is.
+    assert.equal(storyRefWithin(WIN_ROOT, "C:\\workspace\\artifacts\\stories\\deck.json", path.win32), "stories/deck.json");
+    assert.equal(storyRefWithin(WIN_ROOT, "C:\\workspace\\artifacts\\stories\\sub\\deck.json", path.win32), "stories/sub/deck.json");
+    assert.equal(storyRefWithin(WIN_ROOT, WIN_ROOT, path.win32), "stories");
+  });
+
+  it("keeps the POSIX rules intact", () => {
+    const root = "/workspace/artifacts/stories";
+    assert.equal(storyRefWithin(root, "/workspace/artifacts/stories/deck.json", path.posix), "stories/deck.json");
+    assert.equal(storyRefWithin(root, "/elsewhere/deck.json", path.posix), null);
+    assert.equal(storyRefWithin(root, root, path.posix), "stories");
   });
 });


### PR DESCRIPTION
## Summary

**main が赤です。** #3015 のマージ後、Windows の `lint_test` が落ちています
（[run](https://github.com/receptron/mulmoclaude/actions/runs/33355132723)）。

`toStoryRef` が `stories/D:/anything` を返していました。

`path.relative` は「base の下にない」を **2 通り**で表現し、**片方しか escape に見えません**:

| | 返り値 | `..` チェック |
|---|---|---|
| 通常の脱出 | `../elsewhere/deck.json` | 捕まる |
| **ドライブ跨ぎ（Windows）** | `D:\anything` | **捕まらない** |

ドライブが違うと**そもそも相対経路が存在しない**ので、`path.relative` は
第 2 引数をそのまま返します。絶対パスなので `..` が無く、ガードの材料がありません。

結果として **読み戻すと別のファイルになる wire ref** が生成されていました。
`toStoryRef` が存在する理由そのものの失敗です。

## Items to Confirm / Review

1. **手元で赤にできる形にしたこと。** macOS / Linux は根が 1 つで常に相対経路が
   あるので、**この分岐に到達しません**。最初に書いた修正（`ops.ts` に
   `path.isAbsolute` を足すだけ）は、ガードを外しても手元では緑のままでした。
   CLAUDE.md の「手元で赤にできない修正は検証されていない」に反します。

   そこで規則を `core/paths.ts` の純関数に切り出し、**path モジュールを引数で
   受ける**ようにしました:

   ```ts
   export function storyRefWithin(base: string, absolutePath: string, rules: PathRules = nodePath): string | null
   ```

   `path.win32` を渡せば POSIX マシンから Windows の規則を駆動できます。
   **ドライブガードを外すと手元でもテストが赤くなることを確認済み**です。

2. **wire 形式は不変。** `stories/<rel>` のまま、区切りも forward slash のままです
   （win32 の中のパスでも）。テストで固定しています。

3. **既存の `..` チェックは残してあります。** ドライブ跨ぎとは別の失敗なので、
   片方で片方を代替しません。

## 検証

- テスト 268 件（+6）。win32 / posix 両方の規則を固定: ドライブ跨ぎ拒否、
  同一ドライブの通常 escape 拒否、根の中のファイルが wire で forward slash になること
- **リバートで赤**: `rules.isAbsolute(relative)` の行を消すと `refuses a target on
  another drive` が落ちる（macOS で確認）
- `prettier --check` / `eslint` / `typecheck`（plugin + root）/ `test` 緑

Windows の実挙動そのものは CI が ground truth です。

## User Prompt

「マージしようか。」

（#3015 をマージした直後、main の Windows CI が赤になったので、その修正です。）

work in mulmoclaude2

## Summary by Sourcery

Harden story reference generation against path escapes across Windows drives while keeping the wire format and browser-safe core intact.

Bug Fixes:
- Prevent story wire references from escaping their root when resolving paths across Windows drive letters.
- Preserve rejection of ordinary relative-path traversal while maintaining forward-slash story references.

Enhancements:
- Extract story reference containment into a platform-agnostic core helper with injectable path rules, allowing Windows behavior to be tested on any platform.
- Add an automated guard ensuring browser-facing core modules do not import Node built-ins.

Tests:
- Add cross-platform tests covering Windows drive-crossing paths, same-drive escapes, valid nested paths, and POSIX behavior.
- Add parser-based tests for detecting Node built-in imports without false positives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected story references generated from file paths.
  * Prevented invalid references for paths outside the stories directory, traversal attempts, and Windows cross-drive paths.
  * Preserved valid nested story references and handled root-level targets correctly.
  * Improved browser compatibility by avoiding Node.js path dependencies.
  * Made browser compatibility checks more accurate across import styles while ignoring comments and ordinary strings.
* **Tests**
  * Added expanded cross-platform path and import-detection coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->