### PR TITLE
feat(mulmoscript-plugin): 名前付き root を「読めるだけ」から使える状態にする (#3019)

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/core/contract.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/contract.ts
@@ -165,9 +165,9 @@ export interface DispatchFailure {
 
 export type DispatchEnvelope<T> = ({ ok: true } & T) | DispatchFailure;
 
-/** Maps a dispatch `kind` to its success payload so the View's transport
- *  can call `dispatch` without casts at every site. */
-export interface MulmoScriptDispatchResult {
+/** The success payload of each dispatch `kind`, BEFORE the root tag below is
+ *  applied. Not exported: `MulmoScriptDispatchResult` is the type callers use. */
+interface DispatchResultPayloads {
   save: { script: Record<string, unknown>; filePath: string; message: string };
   updateBeat: Record<string, never>;
   updateScript: Record<string, never>;
@@ -186,3 +186,25 @@ export interface MulmoScriptDispatchResult {
   generatePdf: { pdfPath: string };
   pendingGenerations: { pending: MulmoScriptGenerationEvent[] };
 }
+
+/**
+ * Maps a dispatch `kind` to its success payload, every one of them carrying
+ * the root it acted in.
+ *
+ * A host builds its cards from these results, and a card's identity is the
+ * PAIR `(root, filePath)` — `stories/deck.json` exists in every registered
+ * root. Without the root here, two repositories' identically-named decks
+ * collapse onto one card, which is #3014's third collision point, and no
+ * amount of fixing the host's identity function helps because the value never
+ * arrives.
+ *
+ * `root` was threaded through the ARGS and the EVENTS in #3015 and not through
+ * the results — the same shape that PR got wrong repeatedly: the comparison
+ * widened while the path carrying the data to it did not. Applied as a mapped
+ * type rather than field by field so a kind added later cannot be forgotten.
+ *
+ * Absent means the default root, so every pre-`root` card is unchanged.
+ */
+export type MulmoScriptDispatchResult = {
+  [K in keyof DispatchResultPayloads]: DispatchResultPayloads[K] & RootTag;
+};

--- a/packages/plugins/mulmoscript-plugin/src/core/paths.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/paths.ts
@@ -39,6 +39,24 @@ export interface PathRules {
  * is the substitution this function exists to refuse. Only Windows CI caught
  * it; here there is one root and always a relative route (#3015 post-merge).
  */
+/**
+ * The path INSIDE a stories root that a wire path names, or null when it does
+ * not name one.
+ *
+ * The default root's FileOps is rooted one level up, at `<workspace>/artifacts`,
+ * so there the wire path and the FileOps path are the SAME string and nothing
+ * is stripped. A named root's FileOps is rooted at the stories directory
+ * itself — which is what a host naturally writes, having registered exactly
+ * that directory in `extraRoots` — so the `stories/` prefix has to come off,
+ * or the write lands in `<root>/stories/<rel>` while the read looks in
+ * `<root>/<rel>` and the two are different files (#3020 review H1).
+ */
+export function storiesRelativePath(wirePath: string): string | null {
+  const normalized = normalizeStoryPath(wirePath);
+  if (normalized === null) return null;
+  return normalized.slice(`${STORIES_DIR}/`.length);
+}
+
 export function storyRefWithin(base: string, absolutePath: string, rules: PathRules): string | null {
   const relative = rules.relative(base, absolutePath);
   if (rules.isAbsolute(relative)) return null;

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -113,16 +113,31 @@ function guardSuppliedRoot(root: unknown): { ok: false; code: string; error: str
 }
 
 export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): MulmoScriptDispatchHandler {
-  const executeContext: MulmoScriptExecuteContext = { files: { artifacts: ops.backend.artifacts } };
+  /**
+   * The executor context for a write, bound to the root it names.
+   *
+   * One `FileOps` was held for the whole handler, so the executors — which
+   * take a WIRE path (`stories/…`) and resolve it against whatever FileOps
+   * they are given — wrote a named root's script into the DEFAULT root's
+   * identically-named file. Choosing here keeps `MulmoScriptExecuteContext`
+   * and every executor unchanged: the root never reaches them, only the right
+   * FileOps does (#3019).
+   */
+  function executeContextFor(root: string | undefined): MulmoScriptExecuteContext | null {
+    const artifacts = ops.artifactsForRoot(root);
+    return artifacts === null ? null : { files: { artifacts } };
+  }
 
   async function saveKind(args: Record<string, unknown>): Promise<unknown> {
-    // Writes stay in the default root until step 2 gives the executors a
-    // per-root FileOps — see `guardStoryWriteRoot` (#3015 review G1).
+    // Which root this write lands in — see `guardStoryWriteRoot` and
+    // `executeContextFor`.
     const rootGuard = ops.guardStoryWriteRoot(str(args.root));
     if (rootGuard) return fromOpFailure(rootGuard);
     const guard = ops.guardStoryWirePath(args.filePath, str(args.root));
     if (guard) return fromOpFailure(guard);
-    const outcome = await executeMulmoScriptSave(executeContext, {
+    const context = executeContextFor(str(args.root));
+    if (context === null) return invalidArgs("save");
+    const outcome = await executeMulmoScriptSave(context, {
       script: args.script,
       filename: str(args.filename),
       filePath: str(args.filePath),
@@ -136,7 +151,9 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     if (rootGuard) return fromOpFailure(rootGuard);
     const guard = ops.guardStoryWirePath(args.filePath, str(args.root));
     if (guard) return fromOpFailure(guard);
-    const outcome = kind === "updateBeat" ? await executeUpdateBeat(executeContext, args) : await executeUpdateScript(executeContext, args);
+    const context = executeContextFor(str(args.root));
+    if (context === null) return invalidArgs(kind);
+    const outcome = kind === "updateBeat" ? await executeUpdateBeat(context, args) : await executeUpdateScript(context, args);
     if (!outcome.ok) return fromPackageFailure(outcome);
     // After the write landed, never before: a View that reloads on a failed write would
     // discard the user's edit and show the old file back.

--- a/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/dispatch.ts
@@ -10,8 +10,10 @@
 // so user-facing messages stay free of transport prefixes.
 
 import { executeMulmoScriptSave, executeUpdateBeat, executeUpdateScript, type MulmoScriptFailure } from "../core/plugin";
+import { DEFAULT_ROOT, normalizeRoot } from "../core/contract";
 import type { MulmoScriptExecuteContext } from "../core/types";
 import type { MulmoScriptServerOps } from "./ops";
+import { isRecord } from "./support";
 import type { OpFailure } from "./types";
 
 interface DispatchFailure {
@@ -88,6 +90,22 @@ export type MulmoScriptDispatchHandler = (args: Record<string, unknown>) => Prom
  * FileOps, guarded by the instance's realpath containment
  * (`guardStoryWirePath`) — the core's own guard is lexical.
  */
+/**
+ * Stamp the root a successful result acted in.
+ *
+ * Only on success: a failure carries `code` and `error`, and adding a root to
+ * it would invite a reader to treat the pair as addressable when the call did
+ * not happen. Only when NON-default, so a result for a call that named no root
+ * stays byte-identical to what this package returned before roots existed —
+ * which is what keeps every existing card working untouched.
+ */
+function withRoot(result: unknown, root: string | undefined): unknown {
+  const normalized = normalizeRoot(root);
+  if (normalized === DEFAULT_ROOT) return result;
+  if (!isRecord(result) || result.ok !== true) return result;
+  return { ...result, root: normalized };
+}
+
 /** `undefined` when `root` is absent or a string; a failure envelope otherwise. */
 function guardSuppliedRoot(root: unknown): { ok: false; code: string; error: string } | undefined {
   if (root === undefined || typeof root === "string") return undefined;
@@ -199,6 +217,17 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
   // Nothing but routing below: every kind resolves to one named handler, so
   // reading it answers "where does this kind go" without also having to read
   // what any of them do.
+  /** Which handler serves this kind. Routing only — the caller tags the answer. */
+  async function route(kind: string, args: Record<string, unknown>): Promise<unknown> {
+    if (kind === "save") return saveKind(args);
+    if (kind === "updateBeat" || kind === "updateScript") return updateKind(kind, args);
+    if (PROBE_KINDS.has(kind)) return probeKind(kind, args);
+    if (GENERATE_KINDS.has(kind)) return generateKind(kind, args);
+    if (UPLOAD_KINDS.has(kind)) return uploadKind(kind, args);
+    if (kind === "pendingGenerations") return pendingKind(kind, args);
+    return { ok: false, code: "bad_request", error: `unknown mulmoScript dispatch kind "${kind}"` };
+  }
+
   return async (args: Record<string, unknown>): Promise<unknown> => {
     const kind = str(args.kind);
     if (!kind) return invalidArgs("<missing>");
@@ -211,12 +240,11 @@ export function createMulmoScriptDispatchHandler(ops: MulmoScriptServerOps): Mul
     // default; present must be a string.
     const malformedRoot = guardSuppliedRoot(args.root);
     if (malformedRoot) return malformedRoot;
-    if (kind === "save") return saveKind(args);
-    if (kind === "updateBeat" || kind === "updateScript") return updateKind(kind, args);
-    if (PROBE_KINDS.has(kind)) return probeKind(kind, args);
-    if (GENERATE_KINDS.has(kind)) return generateKind(kind, args);
-    if (UPLOAD_KINDS.has(kind)) return uploadKind(kind, args);
-    if (kind === "pendingGenerations") return pendingKind(kind, args);
-    return { ok: false, code: "bad_request", error: `unknown mulmoScript dispatch kind "${kind}"` };
+    // Tagged HERE, once, rather than by each of the seventeen kinds. A host
+    // builds its cards from these results and a card's identity is the pair
+    // `(root, filePath)`, so a kind that forgot the tag would quietly collapse
+    // two repositories' identically-named decks onto one card. Threading it
+    // per-kind is exactly the shape #3015 got wrong over and over.
+    return withRoot(await route(kind, args), str(args.root));
   };
 }

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -44,7 +44,7 @@ import {
 import type { MulmoBeat, MulmoImagePromptMedia, MulmoStudioContext } from "@mulmocast/types";
 import { DEFAULT_ROOT, normalizeRoot } from "../core/contract";
 import type { MulmoScriptGenerationEvent } from "../core/contract";
-import { normalizeStoryPath, storyRefWithin } from "../core/paths";
+import { normalizeStoryPath, storyRefWithin, storiesRelativePath } from "../core/paths";
 import { errorMessage } from "@mulmoclaude/common";
 import { resolveWithinRoot } from "@mulmoclaude/core/files";
 import { fileToDataUri, stripDataUri } from "./support";
@@ -421,6 +421,13 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    */
   function guardStoryGenerationRoot(root: string | undefined): OpFailure | null {
     if (normalizeRoot(root) === DEFAULT_ROOT) return null;
+    // Registration BEFORE the host's opt-in. The flag says "this host can tell
+    // two roots apart", not "any id is addressable" — and the generation ops
+    // publish their start event before `runStoryOp` reaches `resolveStory`, so
+    // an unregistered root emitted a start/finish pair for work that never
+    // existed (Codex + CodeRabbit on #3020).
+    const registered = guardStoryRootRegistered(root);
+    if (registered) return registered;
     if (backend.rootScopedGenerationState === true) return null;
     return opBadRequest("generating in a non-default stories root is not supported yet");
   }
@@ -470,7 +477,50 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     const normalized = normalizeRoot(root);
     if (normalized === DEFAULT_ROOT) return backend.artifacts;
     if (rootDir(normalized) === null) return null;
-    return backend.artifactsFor?.(normalized) ?? null;
+    const hostOps = backend.artifactsFor?.(normalized);
+    return hostOps === undefined || hostOps === null ? null : storiesScoped(hostOps);
+  }
+
+  /**
+   * Address a named root's FileOps the way the READ side addresses it.
+   *
+   * The two sides disagreed about one path segment, and the disagreement was
+   * silent. A read strips `stories/` and resolves under the registered
+   * directory (`<root>/<rel>`); a write handed the executors' wire path
+   * straight to the host's FileOps, which is rooted at that same registered
+   * directory, so the bytes landed in `<root>/stories/<rel>`. `save` then
+   * REPORTED SUCCESS and returned a wire path that could not be read back —
+   * a card pointing at nothing (#3020 review H1, from the consuming host).
+   *
+   * Stripping here makes "the directory you registered is the directory your
+   * FileOps is rooted at" true, which is what a host writes without being
+   * told. The default root is untouched: its FileOps is rooted one level up,
+   * at `<workspace>/artifacts`, and is shared with other plugins.
+   *
+   * A path that is not a stories wire path throws rather than passing
+   * through. Everything reaching here has been through `normalizeStoryPath`
+   * or `storyFilePath`, so one that has not is a bug — and letting it through
+   * would write it somewhere nobody can read, which is the failure this whole
+   * wrapper exists to end.
+   */
+  function storiesScoped(inner: FileOps): FileOps {
+    const within = (wirePath: string): string => {
+      const relative = storiesRelativePath(wirePath);
+      if (relative === null) throw new Error(`mulmoScript: "${wirePath}" is not a stories path — a named root's FileOps takes stories paths only`);
+      return relative;
+    };
+    // Every member is `async` so the refusal arrives as a REJECTED PROMISE,
+    // the way every other FileOps failure does. Throwing synchronously out of
+    // a method the caller only ever awaits would skip its `try`.
+    return {
+      read: async (wirePath) => inner.read(within(wirePath)),
+      readBytes: async (wirePath) => inner.readBytes(within(wirePath)),
+      write: async (wirePath, data) => inner.write(within(wirePath), data),
+      readDir: async (wirePath) => inner.readDir(within(wirePath)),
+      stat: async (wirePath) => inner.stat(within(wirePath)),
+      exists: async (wirePath) => inner.exists(within(wirePath)),
+      unlink: async (wirePath) => inner.unlink(within(wirePath)),
+    };
   }
 
   // mulmocast shells out to ffmpeg for movie / beat rendering. When the

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -19,6 +19,7 @@
 
 import { existsSync, mkdirSync, realpathSync, statSync, unlinkSync } from "fs";
 import path from "path";
+import type { FileOps } from "gui-chat-protocol";
 import {
   getFileObject,
   initializeContextFromFiles,
@@ -443,14 +444,33 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * update executors run against one `FileOps`, bound by the host to the
    * default root, so a write naming another root would rewrite the DEFAULT
    * root's identically-named file and then announce the other one as changed
-   * (#3015 review G1). Closing it here is fail-closed: "readable but not yet
+   * (#3015 review G1). Closing it was fail-closed: "readable but not yet
    * writable" beats "wrote somewhere else and said so".
    *
-   * Step 2 replaces this with a per-root FileOps rather than removing it.
+   * It opens per root, not globally: the host answers `artifactsFor` for the
+   * roots it can serve, and a root it cannot is still refused. A host that
+   * wires nothing keeps the shipped refusal (#3019).
    */
   function guardStoryWriteRoot(root: string | undefined): OpFailure | null {
     if (normalizeRoot(root) === DEFAULT_ROOT) return null;
-    return opBadRequest("writing to a non-default stories root is not supported yet");
+    const registered = guardStoryRootRegistered(root);
+    if (registered) return registered;
+    return artifactsForRoot(root) === null ? opBadRequest("writing to a non-default stories root is not supported yet") : null;
+  }
+
+  /**
+   * The FileOps a write to this root must go through.
+   *
+   * The default root keeps the single `artifacts` it always had, byte for
+   * byte. A named root is served only when the host both REGISTERED it
+   * (`extraRoots` — the containment boundary, so a host cannot widen the
+   * addressable set through this back door) and can supply a FileOps for it.
+   */
+  function artifactsForRoot(root: string | undefined): FileOps | null {
+    const normalized = normalizeRoot(root);
+    if (normalized === DEFAULT_ROOT) return backend.artifacts;
+    if (rootDir(normalized) === null) return null;
+    return backend.artifactsFor?.(normalized) ?? null;
   }
 
   // mulmocast shells out to ffmpeg for movie / beat rendering. When the
@@ -1109,6 +1129,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     guardStoryWirePath,
     guardStoryRootRegistered,
     guardStoryWriteRoot,
+    artifactsForRoot,
     guardStoryGenerationRoot,
     ffmpegGuard,
     runStoryOp,

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -233,7 +233,9 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     // person who has to widen their session key, and they see this at boot
     // rather than discovering it from a stuck spinner.
     log.warn(
-      "extra stories roots registered — generation and writes are REFUSED in them until the host's per-session generation key includes the root (`generationKey` in @mulmobridge/protocol); reads work today (#3014 step 2)",
+      backend.rootScopedGenerationState === true
+        ? "extra stories roots registered — reads, uploads and generation work; save/update still land in the DEFAULT root until this host passes `artifactsFor` (#3019)"
+        : "extra stories roots registered — reads and uploads work, but GENERATION is refused until this host declares `rootScopedGenerationState` (its pending-generation state must carry the root, or it must keep none), and save/update land in the DEFAULT root until it passes `artifactsFor` (#3019)",
       { roots: [...rootDirs.keys()].filter((id) => id !== DEFAULT_ROOT) },
     );
   }
@@ -408,14 +410,17 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    * session would collapse to one entry, and either completion would clear the
    * other root's indicator (Codex P1 on #3015).
    *
-   * Widening that key is a protocol change with its own consumers, so it is not
-   * this package's to make. Refusing the generation is: a named root that
-   * cannot be tracked correctly must not start, rather than start and corrupt
-   * the other root's state. Same fail-closed shape as `guardStoryWriteRoot`,
-   * and step 2 replaces both once the protocol carries the root.
+   * Whose hazard it is decides who answers: a host declares
+   * `rootScopedGenerationState` when its own pending state carries the root —
+   * or when it keeps none, which is MulmoTerminal's case. It was refused for a
+   * collision it cannot have (#3019).
+   *
+   * Absent still refuses, so a host that has not thought about this keeps the
+   * shipped behaviour rather than being quietly opened up.
    */
   function guardStoryGenerationRoot(root: string | undefined): OpFailure | null {
     if (normalizeRoot(root) === DEFAULT_ROOT) return null;
+    if (backend.rootScopedGenerationState === true) return null;
     return opBadRequest("generating in a non-default stories root is not supported yet");
   }
 
@@ -816,8 +821,11 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   // ── Upload ops ────────────────────────────────────────────────
 
   async function uploadBeatImageOp(filePath: string, beatIndex: number, imageData: string, root?: string): Promise<OpResult<{ image: string }>> {
-    const rootGuard = guardStoryWriteRoot(root);
-    if (rootGuard) return rootGuard;
+    // No root guard: the write is already in the right root. `runStoryOp`
+    // resolves through `resolveStory` — realpath containment, per root — and
+    // hands the executor an ABSOLUTE path, from which `buildContext` derives
+    // its `basedir`. The guard here was added defensively during #3015's
+    // review and refused a write that was never wrong (#3019).
     return runStoryOp<{ image: string }>(filePath, { operation: "upload-beat-image", root }, async ({ context }) => {
       const { imagePath } = getBeatPngImagePath(context, beatIndex);
       // writeFileAtomic creates parent dirs and prevents a half-
@@ -829,8 +837,11 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
   }
 
   async function uploadCharacterImageOp(filePath: string, key: string, imageData: string, root?: string): Promise<OpResult<{ image: string }>> {
-    const rootGuard = guardStoryWriteRoot(root);
-    if (rootGuard) return rootGuard;
+    // No root guard: the write is already in the right root. `runStoryOp`
+    // resolves through `resolveStory` — realpath containment, per root — and
+    // hands the executor an ABSOLUTE path, from which `buildContext` derives
+    // its `basedir`. The guard here was added defensively during #3015's
+    // review and refused a write that was never wrong (#3019).
     return runStoryOp<{ image: string }>(filePath, { operation: "upload-character-image", root }, async ({ context }) => {
       const imagePath = getReferenceImagePath(context, key, "png");
       const base64 = stripDataUri(imageData);

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -75,6 +75,27 @@ export interface MulmoScriptServerBackend {
    * root, an agent cannot.
    */
   extraRoots?: Record<string, string>;
+  /**
+   * Whether this host can keep pending generations apart by root.
+   *
+   * Generation in a named root was refused outright (#3015) because
+   * MulmoClaude's session store keys pending work by `(kind, filePath, key)` —
+   * `generationKey` in `@mulmobridge/protocol` — so two roots generating the
+   * same beat in one session collapse to one entry and either completion
+   * clears the other root's indicator.
+   *
+   * That hazard is the HOST's, not this package's, and not every host has it:
+   * MulmoTerminal ignores `chatSessionId` and publishes straight to a pubsub
+   * channel the View filters by the pair, so it was being refused for a
+   * collision it cannot have (#3019). The question was never "is this root the
+   * default" but "can this host tell two roots' generations apart".
+   *
+   * Default `false` — absent means the refusal stays exactly as it shipped, so
+   * a host that has not thought about this is not quietly opened up. A host
+   * sets it only once its own pending-generation state carries the root (or it
+   * keeps none at all).
+   */
+  rootScopedGenerationState?: boolean;
   /** Shared artifacts FileOps (rooted at `<workspace>/artifacts`) for the
    *  save / reopen / update dispatch kinds (phase-1 core executes). */
   artifacts: FileOps;

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -99,6 +99,24 @@ export interface MulmoScriptServerBackend {
   /** Shared artifacts FileOps (rooted at `<workspace>/artifacts`) for the
    *  save / reopen / update dispatch kinds (phase-1 core executes). */
   artifacts: FileOps;
+  /**
+   * The FileOps for a named root's artifacts area, or null when the host does
+   * not serve that root.
+   *
+   * `artifacts` above is ONE FileOps bound to the default root, and the
+   * save / update executors run against it. So a write naming another root
+   * rewrote the DEFAULT root's identically-named script and then announced the
+   * other one as changed — which is why those kinds were refused outright
+   * (#3015 review G1). Reads and uploads never had the problem: they go
+   * through `resolveStory` and take the absolute path it returns.
+   *
+   * A resolver rather than a map, because the host already has one: it knows
+   * which directory an opaque root id names, and building a FileOps for it is
+   * a closure per root (MulmoTerminal's `createFileOps(rootFor, label)` takes
+   * a root getter for exactly this). Absent means named-root writes stay
+   * refused, so a host that has not wired it keeps the shipped behaviour.
+   */
+  artifactsFor?: (root: string) => FileOps | null;
   /** Atomic file write (tmp alongside destination + rename; parent dirs
    *  created). Hosts inject their hardened implementation. */
   writeFileAtomic: (absolutePath: string, data: string | Uint8Array) => Promise<void>;

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -54,6 +54,17 @@ const MUTATING_KINDS: ReadonlyArray<[string, Record<string, unknown>]> = [
   ["renderCharacter", { filePath: "stories/deck.json", key: "alice" }],
 ];
 
+/** Every kind that only reads — a named root is legal for these (#3014). */
+const READ_KINDS: ReadonlyArray<[string, Record<string, unknown>]> = [
+  ["beatImage", { filePath: "stories/deck.json", beatIndex: 0 }],
+  ["beatAudio", { filePath: "stories/deck.json", beatIndex: 0 }],
+  ["beatMovie", { filePath: "stories/deck.json", beatIndex: 0 }],
+  ["characterImage", { filePath: "stories/deck.json", key: "alice" }],
+  ["movieStatus", { filePath: "stories/deck.json" }],
+  ["pdfStatus", { filePath: "stories/deck.json" }],
+  ["pendingGenerations", { filePath: "stories/deck.json" }],
+];
+
 describe("dispatch refuses every mutating kind in a named root", () => {
   for (const [kind, args] of MUTATING_KINDS) {
     it(`${kind} is refused BECAUSE of the root`, async () => {
@@ -172,15 +183,6 @@ describe("an unregistered root is refused by every kind that takes one", () => {
   // that happened to reach it, so the check is over the SURFACE rather than
   // over a list: every kind the handler routes, called with a root nobody
   // registered, must fail. A new kind that forgets is red here.
-  const READ_KINDS: ReadonlyArray<[string, Record<string, unknown>]> = [
-    ["beatImage", { filePath: "stories/deck.json", beatIndex: 0 }],
-    ["beatAudio", { filePath: "stories/deck.json", beatIndex: 0 }],
-    ["beatMovie", { filePath: "stories/deck.json", beatIndex: 0 }],
-    ["characterImage", { filePath: "stories/deck.json", key: "alice" }],
-    ["movieStatus", { filePath: "stories/deck.json" }],
-    ["pdfStatus", { filePath: "stories/deck.json" }],
-    ["pendingGenerations", { filePath: "stories/deck.json" }],
-  ];
 
   for (const [kind, args] of [...READ_KINDS, ...MUTATING_KINDS]) {
     it(`${kind} refuses root "nope"`, async () => {
@@ -223,5 +225,63 @@ describe("an unregistered root is refused by every kind that takes one", () => {
   it("and answer when no root is named at all", async () => {
     const bare = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json" });
     assert.equal(isFailure(bare), false);
+  });
+});
+
+describe("a result carries the root it acted in", () => {
+  // A host builds its cards from these results, and a card's identity is the
+  // PAIR `(root, filePath)` — `stories/deck.json` exists in every registered
+  // root. #3015 threaded `root` through the ARGS and the EVENTS and not
+  // through the results, so a host could not tell two repositories' decks
+  // apart no matter what it did on its side (#3019).
+  const isOk = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null && (value as { ok?: unknown }).ok === true;
+
+  it("stamps a named root on every kind that succeeds", async () => {
+    // Swept rather than listed: the tag is applied once at the router, and
+    // this is what says so. A kind that somehow bypassed it shows up here.
+    const dispatch = makeDispatch();
+    let stamped = 0;
+    for (const [kind, args] of [...READ_KINDS, ...MUTATING_KINDS]) {
+      const result = await dispatch({ kind, ...args, root: NAMED_ROOT });
+      if (!isOk(result)) continue;
+      assert.equal(result.root, NAMED_ROOT, `${kind} succeeded without naming its root`);
+      stamped += 1;
+    }
+    assert.ok(stamped > 0, "the sweep must actually reach a succeeding kind");
+  });
+
+  it("leaves a default-root result byte-identical to the pre-roots one", async () => {
+    // The compatibility claim: a call that names no root must return exactly
+    // what this package returned before roots existed, with no `root` key at
+    // all — an explicit `root: undefined` is a different object on the wire.
+    const result = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json" });
+    assert.deepEqual(result, { ok: true, pending: [] });
+    assert.ok(isOk(result) && !("root" in result));
+  });
+
+  it("treats an empty or whitespace root as the default one", async () => {
+    for (const root of ["", "   "]) {
+      const result = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json", root });
+      assert.deepEqual(result, { ok: true, pending: [] }, `root ${JSON.stringify(root)}`);
+    }
+  });
+
+  it("normalises the root it stamps", async () => {
+    // The stamped value is what the host persists in a card, so it must be
+    // the same string the next call has to name — not the caller's spelling.
+    const result = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json", root: `  ${NAMED_ROOT}  ` });
+    assert.ok(isOk(result));
+    assert.equal(result.root, NAMED_ROOT);
+  });
+
+  it("never stamps a root on a failure", async () => {
+    // A failure means the call did not happen. Tagging it would invite a
+    // reader to treat the pair as addressable when it is not.
+    const refused = await makeDispatch()({ kind: "save", filename: "d.json", script: {}, root: NAMED_ROOT });
+    assert.ok(isFailure(refused));
+    assert.ok(!("root" in (refused as Record<string, unknown>)));
+    const unknownRoot = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json", root: "nope" });
+    assert.ok(isFailure(unknownRoot));
+    assert.ok(!("root" in (unknownRoot as Record<string, unknown>)));
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -7,7 +7,7 @@
 // through the handler that routes them.
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { FileOps } from "gui-chat-protocol";
@@ -291,104 +291,119 @@ describe("a result carries the root it acted in", () => {
   });
 });
 
-describe("a write lands in the root it names, once the host supplies its FileOps", () => {
+describe("a write lands in the root it names — and can be read back", () => {
   // The one thing that was genuinely blocked (#3015 review G1): the executors
   // ran against ONE FileOps bound to the default root, so a write naming
-  // another root rewrote the DEFAULT root's identically-named script and then
-  // announced the other one as changed. Opening it is only correct if the
-  // write actually MOVES, so these drive two in-memory roots holding the same
-  // wire path and assert which store received the bytes (#3019).
+  // another root rewrote the DEFAULT root's identically-named script.
+  //
+  // Driven through a REAL FileOps over a real directory, and the assertion is
+  // a ROUND TRIP: write, then resolve the wire path the write handed back and
+  // read the bytes at that absolute path. The first version of these cases used
+  // a `Map` keyed by the FileOps-relative path, which cannot see WHERE the
+  // bytes landed — and it stayed green while `save` reported success and
+  // returned a wire path that resolved to nothing, because the write went to
+  // `<root>/stories/<rel>` and the read looked in `<root>/<rel>`
+  // (#3020 review H1, from the consuming host).
   const NAMED = "repoA";
+  const workspaces: string[] = [];
+  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
 
-  /** A FileOps over a plain map, so a test can see exactly what was written. */
-  function memoryFileOps(store: Map<string, string>): FileOps {
+  /** What a host actually injects: a FileOps rooted at one directory. */
+  function realFileOps(root: string): FileOps {
+    const abs = (p: string) => path.join(root, p);
     return {
-      read: async (p: string) => {
-        const value = store.get(p);
-        if (value === undefined) throw new Error(`ENOENT ${p}`);
-        return value;
-      },
-      readBytes: async () => new Uint8Array(),
-      write: async (p: string, data: string | Uint8Array) => {
-        store.set(p, typeof data === "string" ? data : Buffer.from(data).toString());
+      read: async (p) => readFileSync(abs(p), "utf8"),
+      readBytes: async (p) => new Uint8Array(readFileSync(abs(p))),
+      write: async (p, data) => {
+        mkdirSync(path.dirname(abs(p)), { recursive: true });
+        writeFileSync(abs(p), typeof data === "string" ? data : Buffer.from(data));
       },
       readDir: async () => [],
       stat: async () => ({ mtimeMs: 0, size: 0 }),
-      exists: async (p: string) => store.has(p),
-      unlink: async (p: string) => {
-        store.delete(p);
-      },
+      exists: async (p) => existsSync(abs(p)),
+      unlink: async (p) => rmSync(abs(p), { force: true }),
     };
   }
 
-  const DECK = JSON.stringify({
+  const DECK = {
     $mulmocast: { version: "1.1" },
-    title: "Deck",
+    title: "Original",
     lang: "en",
-    beats: [{ speaker: "Narrator", text: "Beat one.", image: { type: "textSlide", slide: { title: "S", bullets: ["b"] } } }],
+    beats: [{ speaker: "N", text: "b", image: { type: "textSlide", slide: { title: "S", bullets: ["b"] } } }],
     imageParams: {},
-  });
-
-  // Real directories AND memory stores, because the write path uses both: the
-  // realpath containment (`guardStoryWirePath` → `resolveStory`) reads the
-  // actual filesystem, while the executor writes through the injected FileOps.
-  const workspaces: string[] = [];
-  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+  };
 
   function makeHost(opts: { serveNamed: boolean }) {
     const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-write-"));
     workspaces.push(base);
-    const defaultDir = path.join(base, "ws", "artifacts", "stories");
+    // The shape a host writes: the registered directory IS the FileOps root
+    // for a named root. The default root's FileOps sits one level up, at
+    // `<workspace>/artifacts`, because it is shared with other plugins.
     const namedDir = path.join(base, "repoA");
-    for (const dir of [defaultDir, namedDir]) {
+    const artifactsDir = path.join(base, "ws", "artifacts");
+    const defaultDir = path.join(artifactsDir, "stories");
+    for (const dir of [namedDir, defaultDir]) {
       mkdirSync(dir, { recursive: true });
-      writeFileSync(path.join(dir, "deck.json"), DECK);
+      writeFileSync(path.join(dir, "deck.json"), JSON.stringify(DECK));
     }
-    const defaultStore = new Map<string, string>([["stories/deck.json", DECK]]);
-    const namedStore = new Map<string, string>([["stories/deck.json", DECK]]);
     const ops = createMulmoScriptServerOps({
       storiesDir: defaultDir,
       extraRoots: { [NAMED]: namedDir },
-      artifacts: memoryFileOps(defaultStore),
-      ...(opts.serveNamed ? { artifactsFor: (root: string) => (root === NAMED ? memoryFileOps(namedStore) : null) } : {}),
+      artifacts: realFileOps(artifactsDir),
+      ...(opts.serveNamed ? { artifactsFor: (root: string) => (root === NAMED ? realFileOps(namedDir) : null) } : {}),
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: () => {}, error: () => {} },
     });
-    return { dispatch: createMulmoScriptDispatchHandler(ops), defaultStore, namedStore };
+    return { ops, dispatch: createMulmoScriptDispatchHandler(ops), namedDir, defaultDir };
   }
 
-  it("updateScript writes into the named store, leaving the default one untouched", async () => {
-    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: true });
-    const rewritten = JSON.parse(DECK) as Record<string, unknown>;
-    rewritten.title = "Rewritten in repoA";
-    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: rewritten, root: NAMED });
+  /** The title at the wire path, read through the resolver a READER uses. */
+  function titleAt(ops: ReturnType<typeof createMulmoScriptServerOps>, wirePath: string, root?: string): string | null {
+    const resolved = ops.resolveStory(wirePath, root);
+    if (!resolved.ok) return null;
+    return (JSON.parse(readFileSync(resolved.absolutePath, "utf8")) as { title: string }).title;
+  }
+
+  it("updateScript writes where a reader will look, leaving the default root alone", async () => {
+    const { ops, dispatch, defaultDir } = makeHost({ serveNamed: true });
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: { ...DECK, title: "Rewritten in repoA" }, root: NAMED });
 
     assert.deepEqual(result, { ok: true, root: NAMED });
-    assert.match(namedStore.get("stories/deck.json")!, /Rewritten in repoA/, "the named root must have the new bytes");
-    assert.equal(defaultStore.get("stories/deck.json"), DECK, "the DEFAULT root must be untouched — this is the bug being fixed");
+    assert.equal(titleAt(ops, "stories/deck.json", NAMED), "Rewritten in repoA", "the named root must read back the new bytes");
+    assert.equal(titleAt(ops, "stories/deck.json"), "Original", "the DEFAULT root must be untouched — this is the bug being fixed");
+    assert.ok(!existsSync(path.join(defaultDir, "..", "stories", "deck.json.tmp")));
+  });
+
+  it("save hands back a wire path that resolves to the file it wrote", async () => {
+    // The silent failure: `save` reported success and returned a wire path
+    // that resolved to nothing, because the bytes went one directory deeper.
+    const { ops, dispatch } = makeHost({ serveNamed: true });
+    const result = (await dispatch({ kind: "save", filename: "talk.json", script: DECK, root: NAMED })) as Record<string, unknown>;
+
+    assert.equal(result.ok, true, JSON.stringify(result));
+    assert.equal(result.root, NAMED);
+    const wirePath = String(result.filePath);
+    assert.match(wirePath, /^stories\//, "the wire form is what the host stores in a card");
+    assert.equal(titleAt(ops, wirePath, NAMED), "Original", `the wire path ${wirePath} must resolve to the file that was written`);
   });
 
   it("still writes the default root when no root is named", async () => {
-    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: true });
-    const rewritten = JSON.parse(DECK) as Record<string, unknown>;
-    rewritten.title = "Rewritten in the workspace";
-    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: rewritten });
+    const { ops, dispatch } = makeHost({ serveNamed: true });
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: { ...DECK, title: "Rewritten in the workspace" } });
 
     assert.deepEqual(result, { ok: true }, "a default-root result stays byte-identical to the pre-roots one");
-    assert.match(defaultStore.get("stories/deck.json")!, /Rewritten in the workspace/);
-    assert.equal(namedStore.get("stories/deck.json"), DECK, "a named root must not receive a workspace write");
+    assert.equal(titleAt(ops, "stories/deck.json"), "Rewritten in the workspace");
+    assert.equal(titleAt(ops, "stories/deck.json", NAMED), "Original", "a named root must not receive a workspace write");
   });
 
   it("refuses when the host serves no FileOps for that root", async () => {
-    // A host that has not wired `artifactsFor` keeps the shipped refusal
-    // rather than being quietly opened up.
-    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: false });
-    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: JSON.parse(DECK), root: NAMED });
+    const { ops, dispatch } = makeHost({ serveNamed: false });
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: { ...DECK, title: "Should not land" }, root: NAMED });
 
     assert.ok(isFailure(result));
     assert.equal(result.code, "bad_request");
-    assert.equal(defaultStore.get("stories/deck.json"), DECK, "a refused write must touch nothing");
-    assert.equal(namedStore.get("stories/deck.json"), DECK);
+    assert.equal(titleAt(ops, "stories/deck.json", NAMED), "Original", "a refused write must touch nothing");
+    assert.equal(titleAt(ops, "stories/deck.json"), "Original");
   });
 
   it("refuses a root the host resolves but never registered", async () => {
@@ -396,35 +411,26 @@ describe("a write lands in the root it names, once the host supplies its FileOps
     // addressable set by answering `artifactsFor` for an id it never declared.
     const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-unreg-"));
     workspaces.push(base);
-    const defaultDir = path.join(base, "ws", "artifacts", "stories");
-    mkdirSync(defaultDir, { recursive: true });
-    writeFileSync(path.join(defaultDir, "deck.json"), DECK);
-    const store = new Map<string, string>([["stories/deck.json", DECK]]);
+    const artifactsDir = path.join(base, "ws", "artifacts");
+    const defaultDir = path.join(artifactsDir, "stories");
+    const elsewhere = path.join(base, "elsewhere");
+    for (const dir of [defaultDir, elsewhere]) mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(defaultDir, "deck.json"), JSON.stringify(DECK));
     const ops = createMulmoScriptServerOps({
       storiesDir: defaultDir,
-      artifacts: memoryFileOps(new Map([["stories/deck.json", DECK]])),
-      artifactsFor: () => memoryFileOps(store),
+      artifacts: realFileOps(artifactsDir),
+      artifactsFor: () => realFileOps(elsewhere),
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: () => {}, error: () => {} },
     });
     const result = await createMulmoScriptDispatchHandler(ops)({
       kind: "updateScript",
       filePath: "stories/deck.json",
-      script: JSON.parse(DECK),
+      script: DECK,
       root: "never-registered",
     });
     assert.ok(isFailure(result));
     assert.match(result.error, /unknown stories root/);
-    assert.equal(store.get("stories/deck.json"), DECK, "nothing may be written into an unregistered root");
-  });
-
-  it("save also lands in the named root", async () => {
-    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: true });
-    const result = await dispatch({ kind: "save", filename: "fresh.json", script: JSON.parse(DECK), root: NAMED });
-
-    assert.ok(!isFailure(result), `save must succeed: ${JSON.stringify(result)}`);
-    const created = [...namedStore.keys()].filter((k) => k !== "stories/deck.json");
-    assert.equal(created.length, 1, `expected one new file in the named root, got ${created.join(", ")}`);
-    assert.equal([...defaultStore.keys()].length, 1, "the default root must gain nothing");
+    assert.deepEqual(readdirSync(elsewhere), [], "nothing may be written into an unregistered root");
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -333,28 +333,54 @@ describe("a write lands in the root it names — and can be read back", () => {
     imageParams: {},
   };
 
-  function makeHost(opts: { serveNamed: boolean }) {
-    const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-write-"));
+  /**
+   * The directory shape a host writes: the registered directory IS the FileOps
+   * root for a named root, while the default root's FileOps sits one level up
+   * at `<workspace>/artifacts` because it is shared with other plugins.
+   */
+  function makeDirs(prefix: string) {
+    const base = mkdtempSync(path.join(tmpdir(), prefix));
     workspaces.push(base);
-    // The shape a host writes: the registered directory IS the FileOps root
-    // for a named root. The default root's FileOps sits one level up, at
-    // `<workspace>/artifacts`, because it is shared with other plugins.
-    const namedDir = path.join(base, "repoA");
     const artifactsDir = path.join(base, "ws", "artifacts");
-    const defaultDir = path.join(artifactsDir, "stories");
-    for (const dir of [namedDir, defaultDir]) {
+    const dirs = { base, artifactsDir, namedDir: path.join(base, "repoA"), defaultDir: path.join(artifactsDir, "stories") };
+    for (const dir of [dirs.namedDir, dirs.defaultDir]) {
       mkdirSync(dir, { recursive: true });
       writeFileSync(path.join(dir, "deck.json"), JSON.stringify(DECK));
     }
+    return dirs;
+  }
+
+  function makeHost(opts: { serveNamed: boolean }) {
+    const dirs = makeDirs("mulmoscript-write-");
     const ops = createMulmoScriptServerOps({
-      storiesDir: defaultDir,
-      extraRoots: { [NAMED]: namedDir },
-      artifacts: realFileOps(artifactsDir),
-      ...(opts.serveNamed ? { artifactsFor: (root: string) => (root === NAMED ? realFileOps(namedDir) : null) } : {}),
+      storiesDir: dirs.defaultDir,
+      extraRoots: { [NAMED]: dirs.namedDir },
+      artifacts: realFileOps(dirs.artifactsDir),
+      ...(opts.serveNamed ? { artifactsFor: (root: string) => (root === NAMED ? realFileOps(dirs.namedDir) : null) } : {}),
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: () => {}, error: () => {} },
     });
-    return { ops, dispatch: createMulmoScriptDispatchHandler(ops), namedDir, defaultDir };
+    return { ops, dispatch: createMulmoScriptDispatchHandler(ops), ...dirs };
+  }
+
+  /** A host that hands back a FileOps for ANY id, including ones it never
+   *  registered — the misconfiguration `extraRoots` has to survive. */
+  function hostAnsweringEverything() {
+    const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-unreg-"));
+    workspaces.push(base);
+    const artifactsDir = path.join(base, "ws", "artifacts");
+    const defaultDir = path.join(artifactsDir, "stories");
+    const elsewhere = path.join(base, "elsewhere");
+    for (const dir of [defaultDir, elsewhere]) mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(defaultDir, "deck.json"), JSON.stringify(DECK));
+    const ops = createMulmoScriptServerOps({
+      storiesDir: defaultDir,
+      artifacts: realFileOps(artifactsDir),
+      artifactsFor: () => realFileOps(elsewhere),
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    return { dispatch: createMulmoScriptDispatchHandler(ops), elsewhere };
   }
 
   /** The title at the wire path, read through the resolver a READER uses. */
@@ -409,26 +435,9 @@ describe("a write lands in the root it names — and can be read back", () => {
   it("refuses a root the host resolves but never registered", async () => {
     // `extraRoots` stays the containment boundary: a host cannot widen the
     // addressable set by answering `artifactsFor` for an id it never declared.
-    const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-unreg-"));
-    workspaces.push(base);
-    const artifactsDir = path.join(base, "ws", "artifacts");
-    const defaultDir = path.join(artifactsDir, "stories");
-    const elsewhere = path.join(base, "elsewhere");
-    for (const dir of [defaultDir, elsewhere]) mkdirSync(dir, { recursive: true });
-    writeFileSync(path.join(defaultDir, "deck.json"), JSON.stringify(DECK));
-    const ops = createMulmoScriptServerOps({
-      storiesDir: defaultDir,
-      artifacts: realFileOps(artifactsDir),
-      artifactsFor: () => realFileOps(elsewhere),
-      writeFileAtomic: async () => {},
-      log: { info: () => {}, warn: () => {}, error: () => {} },
-    });
-    const result = await createMulmoScriptDispatchHandler(ops)({
-      kind: "updateScript",
-      filePath: "stories/deck.json",
-      script: DECK,
-      root: "never-registered",
-    });
+    const { dispatch, elsewhere } = hostAnsweringEverything();
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: DECK, root: "never-registered" });
+
     assert.ok(isFailure(result));
     assert.match(result.error, /unknown stories root/);
     assert.deepEqual(readdirSync(elsewhere), [], "nothing may be written into an unregistered root");

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -14,6 +14,18 @@ import type { FileOps } from "gui-chat-protocol";
 import { createMulmoScriptServerOps } from "../src/server/ops";
 import { createMulmoScriptDispatchHandler } from "../src/server/dispatch";
 
+/**
+ * Directories for tests that never touch the filesystem.
+ *
+ * NOT `/tmp/a`: that path may EXIST on the machine running this, and if it
+ * holds `stories/deck.json` then `resolveStory` succeeds and a generation test
+ * runs the real mulmocast pipeline — shelling out to ffmpeg. The assertions
+ * would still pass, on a test that silently depends on host filesystem
+ * contents (CodeRabbit on #3020). These live under a directory nothing
+ * creates, so the resolution they need to fail always fails.
+ */
+const NAMED_ROOT_DIR_A = "/nonexistent/for-tests/roots/a";
+
 const stubFileOps: FileOps = {
   read: async () => {
     throw new Error("unused");
@@ -36,7 +48,7 @@ const REFUSAL = /^((writing to|generating in) a non-default stories root is not 
 function makeDispatch() {
   const ops = createMulmoScriptServerOps({
     storiesDir: "/nonexistent/for-tests/artifacts/stories",
-    extraRoots: { [NAMED_ROOT]: "/tmp/a" },
+    extraRoots: { [NAMED_ROOT]: NAMED_ROOT_DIR_A },
     artifacts: stubFileOps,
     writeFileAtomic: async () => {},
     log: { info: () => {}, warn: () => {}, error: () => {} },

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -5,8 +5,11 @@
 // That gap is why `uploadKind` could forward a root past `guardStoryWriteRoot`
 // while `saveKind` and `updateKind` were guarded: nothing drove the kinds
 // through the handler that routes them.
-import { describe, it } from "node:test";
+import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import type { FileOps } from "gui-chat-protocol";
 import { createMulmoScriptServerOps } from "../src/server/ops";
 import { createMulmoScriptDispatchHandler } from "../src/server/dispatch";
@@ -24,7 +27,11 @@ const stubFileOps: FileOps = {
 };
 
 const NAMED_ROOT = "repoA";
-const REFUSAL = /^(writing to|generating in) a non-default stories root is not supported yet$/;
+/** Every way a call can be refused BECAUSE of the root it named. `unknown
+ *  stories root` joined the set when the write guard started checking
+ *  registration first, which is the more accurate reason for a root nobody
+ *  registered (#3019). */
+const REFUSAL = /^((writing to|generating in) a non-default stories root is not supported yet|unknown stories root ".*")$/;
 
 function makeDispatch() {
   const ops = createMulmoScriptServerOps({
@@ -281,5 +288,143 @@ describe("a result carries the root it acted in", () => {
     const unknownRoot = await makeDispatch()({ kind: "pendingGenerations", filePath: "stories/deck.json", root: "nope" });
     assert.ok(isFailure(unknownRoot));
     assert.ok(!("root" in (unknownRoot as Record<string, unknown>)));
+  });
+});
+
+describe("a write lands in the root it names, once the host supplies its FileOps", () => {
+  // The one thing that was genuinely blocked (#3015 review G1): the executors
+  // ran against ONE FileOps bound to the default root, so a write naming
+  // another root rewrote the DEFAULT root's identically-named script and then
+  // announced the other one as changed. Opening it is only correct if the
+  // write actually MOVES, so these drive two in-memory roots holding the same
+  // wire path and assert which store received the bytes (#3019).
+  const NAMED = "repoA";
+
+  /** A FileOps over a plain map, so a test can see exactly what was written. */
+  function memoryFileOps(store: Map<string, string>): FileOps {
+    return {
+      read: async (p: string) => {
+        const value = store.get(p);
+        if (value === undefined) throw new Error(`ENOENT ${p}`);
+        return value;
+      },
+      readBytes: async () => new Uint8Array(),
+      write: async (p: string, data: string | Uint8Array) => {
+        store.set(p, typeof data === "string" ? data : Buffer.from(data).toString());
+      },
+      readDir: async () => [],
+      stat: async () => ({ mtimeMs: 0, size: 0 }),
+      exists: async (p: string) => store.has(p),
+      unlink: async (p: string) => {
+        store.delete(p);
+      },
+    };
+  }
+
+  const DECK = JSON.stringify({
+    $mulmocast: { version: "1.1" },
+    title: "Deck",
+    lang: "en",
+    beats: [{ speaker: "Narrator", text: "Beat one.", image: { type: "textSlide", slide: { title: "S", bullets: ["b"] } } }],
+    imageParams: {},
+  });
+
+  // Real directories AND memory stores, because the write path uses both: the
+  // realpath containment (`guardStoryWirePath` → `resolveStory`) reads the
+  // actual filesystem, while the executor writes through the injected FileOps.
+  const workspaces: string[] = [];
+  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+  function makeHost(opts: { serveNamed: boolean }) {
+    const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-write-"));
+    workspaces.push(base);
+    const defaultDir = path.join(base, "ws", "artifacts", "stories");
+    const namedDir = path.join(base, "repoA");
+    for (const dir of [defaultDir, namedDir]) {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, "deck.json"), DECK);
+    }
+    const defaultStore = new Map<string, string>([["stories/deck.json", DECK]]);
+    const namedStore = new Map<string, string>([["stories/deck.json", DECK]]);
+    const ops = createMulmoScriptServerOps({
+      storiesDir: defaultDir,
+      extraRoots: { [NAMED]: namedDir },
+      artifacts: memoryFileOps(defaultStore),
+      ...(opts.serveNamed ? { artifactsFor: (root: string) => (root === NAMED ? memoryFileOps(namedStore) : null) } : {}),
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    return { dispatch: createMulmoScriptDispatchHandler(ops), defaultStore, namedStore };
+  }
+
+  it("updateScript writes into the named store, leaving the default one untouched", async () => {
+    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: true });
+    const rewritten = JSON.parse(DECK) as Record<string, unknown>;
+    rewritten.title = "Rewritten in repoA";
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: rewritten, root: NAMED });
+
+    assert.deepEqual(result, { ok: true, root: NAMED });
+    assert.match(namedStore.get("stories/deck.json")!, /Rewritten in repoA/, "the named root must have the new bytes");
+    assert.equal(defaultStore.get("stories/deck.json"), DECK, "the DEFAULT root must be untouched — this is the bug being fixed");
+  });
+
+  it("still writes the default root when no root is named", async () => {
+    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: true });
+    const rewritten = JSON.parse(DECK) as Record<string, unknown>;
+    rewritten.title = "Rewritten in the workspace";
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: rewritten });
+
+    assert.deepEqual(result, { ok: true }, "a default-root result stays byte-identical to the pre-roots one");
+    assert.match(defaultStore.get("stories/deck.json")!, /Rewritten in the workspace/);
+    assert.equal(namedStore.get("stories/deck.json"), DECK, "a named root must not receive a workspace write");
+  });
+
+  it("refuses when the host serves no FileOps for that root", async () => {
+    // A host that has not wired `artifactsFor` keeps the shipped refusal
+    // rather than being quietly opened up.
+    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: false });
+    const result = await dispatch({ kind: "updateScript", filePath: "stories/deck.json", script: JSON.parse(DECK), root: NAMED });
+
+    assert.ok(isFailure(result));
+    assert.equal(result.code, "bad_request");
+    assert.equal(defaultStore.get("stories/deck.json"), DECK, "a refused write must touch nothing");
+    assert.equal(namedStore.get("stories/deck.json"), DECK);
+  });
+
+  it("refuses a root the host resolves but never registered", async () => {
+    // `extraRoots` stays the containment boundary: a host cannot widen the
+    // addressable set by answering `artifactsFor` for an id it never declared.
+    const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-unreg-"));
+    workspaces.push(base);
+    const defaultDir = path.join(base, "ws", "artifacts", "stories");
+    mkdirSync(defaultDir, { recursive: true });
+    writeFileSync(path.join(defaultDir, "deck.json"), DECK);
+    const store = new Map<string, string>([["stories/deck.json", DECK]]);
+    const ops = createMulmoScriptServerOps({
+      storiesDir: defaultDir,
+      artifacts: memoryFileOps(new Map([["stories/deck.json", DECK]])),
+      artifactsFor: () => memoryFileOps(store),
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    const result = await createMulmoScriptDispatchHandler(ops)({
+      kind: "updateScript",
+      filePath: "stories/deck.json",
+      script: JSON.parse(DECK),
+      root: "never-registered",
+    });
+    assert.ok(isFailure(result));
+    assert.match(result.error, /unknown stories root/);
+    assert.equal(store.get("stories/deck.json"), DECK, "nothing may be written into an unregistered root");
+  });
+
+  it("save also lands in the named root", async () => {
+    const { dispatch, defaultStore, namedStore } = makeHost({ serveNamed: true });
+    const result = await dispatch({ kind: "save", filename: "fresh.json", script: JSON.parse(DECK), root: NAMED });
+
+    assert.ok(!isFailure(result), `save must succeed: ${JSON.stringify(result)}`);
+    const created = [...namedStore.keys()].filter((k) => k !== "stories/deck.json");
+    assert.equal(created.length, 1, `expected one new file in the named root, got ${created.join(", ")}`);
+    assert.equal([...defaultStore.keys()].length, 1, "the default root must gain nothing");
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatch_roots.ts
@@ -45,8 +45,6 @@ const MUTATING_KINDS: ReadonlyArray<[string, Record<string, unknown>]> = [
   ["save", { filename: "deck.json", script: {} }],
   ["updateBeat", { filePath: "stories/deck.json", beatIndex: 0, beat: {} }],
   ["updateScript", { filePath: "stories/deck.json", script: {} }],
-  ["uploadBeatImage", { filePath: "stories/deck.json", beatIndex: 0, imageData: "data:image/png;base64,AA==" }],
-  ["uploadCharacterImage", { filePath: "stories/deck.json", key: "alice", imageData: "data:image/png;base64,AA==" }],
   ["generateMovie", { filePath: "stories/deck.json" }],
   ["generatePdf", { filePath: "stories/deck.json" }],
   ["renderBeat", { filePath: "stories/deck.json", beatIndex: 0 }],

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -6,7 +6,7 @@
 // field existed and the collisions it was meant to end were all still there.
 // Type-checking cannot catch that: `root` is optional, so a forgotten forward
 // is a legal call. Only a test that asserts on the OUTPUT can.
-import { describe, it, after } from "node:test";
+import { describe, it, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
@@ -806,6 +806,28 @@ describe("who may generate in a named root is the HOST's answer", () => {
     assert.doesNotMatch(result.ok === false ? result.error : "", REFUSAL, "the root must no longer be the reason");
   });
 
+  it("emits NOTHING for an unregistered root, even with the declaration on", async () => {
+    // The flag says "this host can tell two roots apart", not "any id is
+    // addressable". The generation ops publish their start event before
+    // `runStoryOp` reaches `resolveStory`, so an unregistered root emitted a
+    // start/finish pair for work that never existed and the host briefly
+    // recorded it (Codex + CodeRabbit on #3020).
+    const { ops, generations } = makeOpsWith(true);
+    const result = await ops.renderBeatOp({ filePath: "stories/deck.json", beatIndex: 0, chatSessionId: "s", root: "never-registered" });
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.code, "bad_request");
+    assert.deepEqual(generations, [], "an unregistered root must announce nothing at all");
+  });
+
+  it("emits nothing for an unregistered root in every generation kind", async () => {
+    const { ops, generations } = makeOpsWith(true);
+    await ops.generateMovieOp("stories/deck.json", "s", "never-registered");
+    await ops.generatePdfOp("stories/deck.json", "s", "never-registered");
+    await ops.generateBeatAudioOp({ filePath: "stories/deck.json", beatIndex: 0, chatSessionId: "s", root: "never-registered" });
+    await ops.renderCharacterOp({ filePath: "stories/deck.json", key: "alice", chatSessionId: "s", root: "never-registered" });
+    assert.deepEqual(generations, []);
+  });
+
   it("applies the declaration to every generation kind", async () => {
     // Swept, because the guard sits at five entry points and a kind that kept
     // the old blanket refusal would be invisible in a single-kind test.
@@ -862,10 +884,17 @@ describe("`extraRoots` stays the containment boundary for writes", () => {
   // would reject an unregistered root a moment later anyway, so a dispatch
   // test passes whether or not this check exists. It did — removing the
   // registration line left the suite green until this case was added (#3019).
+  /** Every path the host's FileOps was actually handed. */
+  const seen: string[] = [];
+  beforeEach(() => {
+    seen.length = 0;
+  });
   const served: FileOps = {
     read: async () => "{}",
     readBytes: async () => new Uint8Array(),
-    write: async () => {},
+    write: async (p) => {
+      seen.push(p);
+    },
     readDir: async () => [],
     stat: async () => ({ mtimeMs: 0, size: 0 }),
     exists: async () => true,
@@ -897,16 +926,35 @@ describe("`extraRoots` stays the containment boundary for writes", () => {
     assert.match(guard.error, /unknown stories root/);
   });
 
-  it("serves the FileOps for a root that WAS registered", () => {
-    // Otherwise the check above passes by refusing everything.
+  it("serves a FileOps for a root that WAS registered", async () => {
+    // Otherwise the check above passes by refusing everything. Identity is not
+    // the test — a named root's ops is WRAPPED, so it is a different object by
+    // design (#3020 H1). What must hold is that the host's ops is reached, and
+    // reached with the `stories/` prefix taken off.
     const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
-    assert.equal(ops.artifactsForRoot("repoA"), served);
+    const scoped = ops.artifactsForRoot("repoA");
+    assert.ok(scoped !== null);
+    await scoped.write("stories/sub/deck.json", "{}");
+    assert.deepEqual(seen, ["sub/deck.json"], "the host must receive the path relative to the directory it registered");
     assert.equal(ops.guardStoryWriteRoot("repoA"), null);
   });
 
-  it("keeps the default root on its own FileOps, never the resolver's", () => {
-    // The default root's writes must not start flowing through a host
-    // resolver that answers for everything.
+  it("refuses a path that is not a stories wire path rather than writing it somewhere", async () => {
+    // Everything reaching a named root's ops has been through
+    // `normalizeStoryPath` or `storyFilePath`, so one that has not is a bug —
+    // and passing it through would write it where nobody reads.
+    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    const scoped = ops.artifactsForRoot("repoA");
+    assert.ok(scoped !== null);
+    await assert.rejects(() => scoped.write("../escape.json", "{}"), /not a stories path/);
+    assert.deepEqual(seen, [], "nothing may reach the host for a path it cannot place");
+  });
+
+  it("keeps the default root on its own FileOps, unwrapped", () => {
+    // The default root's FileOps is rooted one level up, at
+    // `<workspace>/artifacts`, and is shared with other plugins — so the wire
+    // path IS its path, nothing is stripped, and the host resolver is not
+    // consulted at all.
     const ops = opsAnsweringEverything();
     assert.equal(ops.artifactsForRoot(undefined), ops.backend.artifacts);
     assert.notEqual(ops.artifactsForRoot(undefined), served);

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -17,6 +17,19 @@ import { storyRefWithin } from "../src/core/paths";
 import type { OpResult } from "../src/server/types";
 import type { MulmoScriptGenerationEvent, MulmoScriptChangedEvent } from "../src/core/contract";
 
+/**
+ * Directories for tests that never touch the filesystem.
+ *
+ * NOT `/tmp/a`: that path may EXIST on the machine running this, and if it
+ * holds `stories/deck.json` then `resolveStory` succeeds and a generation test
+ * runs the real mulmocast pipeline — shelling out to ffmpeg. The assertions
+ * would still pass, on a test that silently depends on host filesystem
+ * contents (CodeRabbit on #3020). These live under a directory nothing
+ * creates, so the resolution they need to fail always fails.
+ */
+const NAMED_ROOT_DIR_A = "/nonexistent/for-tests/roots/a";
+const NAMED_ROOT_DIR_B = "/nonexistent/for-tests/roots/b";
+
 const stubFileOps: FileOps = {
   read: async () => {
     throw new Error("unused");
@@ -61,7 +74,7 @@ describe("root registry", () => {
     const warnings: string[] = [];
     createMulmoScriptServerOps({
       storiesDir: "/nonexistent/for-tests/artifacts/stories",
-      extraRoots: { repoA: "/tmp/a" },
+      extraRoots: { repoA: NAMED_ROOT_DIR_A },
       artifacts: stubFileOps,
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
@@ -80,7 +93,7 @@ describe("root registry", () => {
       () =>
         createMulmoScriptServerOps({
           storiesDir: "/nonexistent/for-tests/artifacts/stories",
-          extraRoots: { repoA: "/tmp/a", " repoA ": "/tmp/b" },
+          extraRoots: { repoA: NAMED_ROOT_DIR_A, " repoA ": NAMED_ROOT_DIR_B },
           artifacts: stubFileOps,
           writeFileAtomic: async () => {},
           log: { info: () => {}, warn: () => {}, error: () => {} },
@@ -94,7 +107,7 @@ describe("root registry", () => {
     assert.doesNotThrow(() =>
       createMulmoScriptServerOps({
         storiesDir: "/nonexistent/for-tests/artifacts/stories",
-        extraRoots: { repoA: "/tmp/a", repoB: "/tmp/b" },
+        extraRoots: { repoA: NAMED_ROOT_DIR_A, repoB: NAMED_ROOT_DIR_B },
         artifacts: stubFileOps,
         writeFileAtomic: async () => {},
         log: { info: () => {}, warn: () => {}, error: () => {} },
@@ -116,7 +129,7 @@ describe("root registry", () => {
   it("normalizes a root id by trimming, matching readCommandScope", () => {
     // Two parallel "which project root" identifiers must agree on what one
     // root is, or the same string names different roots in different layers.
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     assert.equal(ops.guardStoryWriteRoot("  "), null, "whitespace is the default root, not a named one");
     assert.equal(ops.toStoryRef("/tmp/a/x.json", " repoA "), ops.toStoryRef("/tmp/a/x.json", "repoA"));
   });
@@ -153,7 +166,7 @@ describe("root registry", () => {
 
 describe("generation events carry their root", () => {
   it("puts the root on the published event", () => {
-    const { ops, generations } = makeOps({ repoA: "/tmp/a" });
+    const { ops, generations } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
     assert.equal(generations.length, 1);
     assert.equal(generations[0]?.root, "repoA");
@@ -176,7 +189,7 @@ describe("a start event carries its root and no error", () => {
   // differed and the entry was never deleted. One leaked row per generation,
   // for the life of the process (#3015 review).
   it("does not report an error when a generation starts in a named root", () => {
-    const { ops, generations } = makeOps({ repoA: "/tmp/a" });
+    const { ops, generations } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
     const started = generations[0]!;
     assert.equal(started.done, false);
@@ -188,7 +201,7 @@ describe("a start event carries its root and no error", () => {
     // The tracker value and the event normalize; the KEY did not, so
     // `" repoA "` started an entry that `"repoA"` could never delete
     // (Codex P2 on #3015).
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: " repoA " });
     assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", true, { root: "repoA" });
@@ -198,7 +211,7 @@ describe("a start event carries its root and no error", () => {
   it("clears the tracker when the matching finish arrives", () => {
     // Start and finish must produce the SAME key. When they did not, the
     // snapshot kept reporting a finished run forever.
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
     assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", true, { root: "repoA" });
@@ -208,7 +221,7 @@ describe("a start event carries its root and no error", () => {
 
 describe("pendingGenerations is scoped by the pair", () => {
   it("does not hand one root's in-flight run to another root's View", () => {
-    const { ops } = makeOps({ repoA: "/tmp/a", repoB: "/tmp/b" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A, repoB: NAMED_ROOT_DIR_B });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
 
     assert.equal(ops.pendingGenerations("stories/deck.json", "repoA").length, 1);
@@ -225,7 +238,7 @@ describe("pendingGenerations is scoped by the pair", () => {
   });
 
   it("dedups per root — the same deck in two roots is two runs", () => {
-    const { ops, generations } = makeOps({ repoA: "/tmp/a", repoB: "/tmp/b" });
+    const { ops, generations } = makeOps({ repoA: NAMED_ROOT_DIR_A, repoB: NAMED_ROOT_DIR_B });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoA" });
     ops.publishGeneration(undefined, "movie", "stories/deck.json", "", false, { root: "repoB" });
     // Two starts, not one start plus a suppressed duplicate.
@@ -242,14 +255,14 @@ describe("every read resolves in the root it was asked for", () => {
   const unregistered = "nope";
 
   it("fails generateMovie for an unregistered root instead of using the default", async () => {
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     const result = await ops.generateMovieOp("stories/deck.json", undefined, unregistered);
     assert.equal(result.ok, false);
     assert.equal(result.ok === false && result.code, "bad_request");
   });
 
   it("fails generatePdf for an unregistered root instead of using the default", async () => {
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     const result = await ops.generatePdfOp("stories/deck.json", undefined, unregistered);
     assert.equal(result.ok, false);
     assert.equal(result.ok === false && result.code, "bad_request");
@@ -359,14 +372,14 @@ describe("the whole ops surface is classified for named roots", () => {
   it("the classification names members that actually exist", () => {
     // The derivation reads source; this pins it to the real object, so a
     // renamed op cannot leave a classification pointing at nothing.
-    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const { ops } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
     const missing = [...READ_ONLY, ...MUTATING.map(([name]) => name), ...GUARDED_ELSEWHERE].filter((name) => !(name in ops));
     assert.deepEqual(missing, []);
   });
 
   for (const [name, invoke] of MUTATING) {
     it(`${name} refuses a named root`, async () => {
-      const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
+      const { ops, generations } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
       const result = await invoke(ops);
       // The REASON, not just `ok === false`. Every one of these also fails for
       // an unrelated reason in this fixture (no such script on disk), so
@@ -389,14 +402,14 @@ describe("the detached background movie is refused in a named root too", () => {
   const namedRoot = "repoA";
 
   it("starts nothing and publishes nothing for a named root", () => {
-    const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
+    const { ops, generations } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
     ops.triggerAutoBackgroundMovie("/tmp/a/stories/d.json", "stories/d.json", "session-1", namedRoot);
     assert.equal(generations.length, 0, "a refused background movie must announce nothing");
     assert.equal(ops.inFlightMovies.has("/tmp/a/stories/d.json"), false, "a refused background movie must not be marked in flight");
   });
 
   it("still starts for the default root", () => {
-    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const { ops } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
     ops.triggerAutoBackgroundMovie("/tmp/x/stories/d.json", "stories/d.json", "session-1");
     assert.equal(ops.inFlightMovies.has("/tmp/x/stories/d.json"), true, "the default root must still generate");
   });
@@ -413,7 +426,7 @@ describe("generations stay in the default root until step 2", () => {
   const namedRoot = "repoA";
 
   it("refuses every generation kind in a named root", async () => {
-    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const { ops } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
     const results = [
       await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot),
       await ops.generatePdfOp("stories/deck.json", "session-1", namedRoot),
@@ -435,13 +448,13 @@ describe("generations stay in the default root until step 2", () => {
     // empty whether the guard ran or the op merely had not reached its
     // publish yet, so the un-awaited version stayed green for the wrong
     // reason (CodeRabbit on #3015).
-    const { ops, generations } = makeOps({ [namedRoot]: "/tmp/a" });
+    const { ops, generations } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
     await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
     assert.equal(generations.length, 0);
   });
 
   it("still allows generation that names no root", async () => {
-    const { ops } = makeOps({ [namedRoot]: "/tmp/a" });
+    const { ops } = makeOps({ [namedRoot]: NAMED_ROOT_DIR_A });
     const result = await ops.generateMovieOp("stories/deck.json", "session-1");
     // It fails for an unrelated reason (no such script), but NOT with the
     // root refusal — the default root is still generatable.
@@ -456,14 +469,14 @@ describe("writes stay in the default root until step 2", () => {
   // identically-named file and then announce the other one as changed
   // (#3015 review G1). Fail closed until step 2 supplies a per-root FileOps.
   it("refuses a write that names a non-default root", () => {
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     const guard = ops.guardStoryWriteRoot("repoA");
     assert.ok(guard, "a named root must not be writable yet");
     assert.equal(guard?.code, "bad_request");
   });
 
   it("still allows every write that names no root", () => {
-    const { ops } = makeOps({ repoA: "/tmp/a" });
+    const { ops } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     assert.equal(ops.guardStoryWriteRoot(undefined), null);
     assert.equal(ops.guardStoryWriteRoot(""), null, "the empty spelling is the default root");
   });
@@ -471,7 +484,7 @@ describe("writes stay in the default root until step 2", () => {
 
 describe("script-changed events carry their root", () => {
   it("names the root a write happened in", () => {
-    const { ops, changes } = makeOps({ repoA: "/tmp/a" });
+    const { ops, changes } = makeOps({ repoA: NAMED_ROOT_DIR_A });
     ops.publishScriptChanged("stories/deck.json", "view-1", "repoA");
     assert.equal(changes[0]?.root, "repoA");
   });
@@ -725,6 +738,19 @@ describe("an upload writes into the root it names — and nowhere else", () => {
     assert.ok(!target.startsWith(realpathSync(defaultStories)), `wrote into the DEFAULT root: ${target}`);
   });
 
+  it("a character upload writes under the named root too", async () => {
+    // Both upload ops lost their refusal, so both need a positive case: the
+    // sweep no longer requires them to refuse, and only `uploadBeatImageOp`
+    // had a filesystem test. They share `runStoryOp`, but "shares the code
+    // path" is an argument, and this file's whole point is that the write
+    // location is checked rather than argued (CodeRabbit on #3020).
+    const { ops, written, roots, defaultStories } = makeTwoRoots();
+    await ops.uploadCharacterImageOp("stories/deck.json", "alice", PNG, "repoA");
+    assert.equal(written.length, 1, "exactly one write");
+    assert.ok(written[0]!.startsWith(realpathSync(roots.repoA)), `wrote outside repoA: ${written[0]}`);
+    assert.ok(!written[0]!.startsWith(realpathSync(defaultStories)), `wrote into the DEFAULT root: ${written[0]}`);
+  });
+
   it("keeps two roots' identically-named decks apart", async () => {
     // The failure this replaces the guard's protection with: writing to
     // `repoB` must not touch `repoA`, though both hold `stories/deck.json`.
@@ -767,11 +793,21 @@ describe("who may generate in a named root is the HOST's answer", () => {
   const namedRoot = "repoA";
   const REFUSAL = /generating in a non-default stories root is not supported yet/;
 
+  const generationRoots: string[] = [];
+  after(() => generationRoots.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
   function makeOpsWith(declared: boolean | undefined) {
     const generations: MulmoScriptGenerationEvent[] = [];
+    // A fresh temp directory, not a shared path: `/tmp/a` may EXIST on the
+    // machine running this, and if it holds `stories/deck.json` then
+    // `resolveStory` succeeds and `generateMovieOp` runs the real mulmocast
+    // pipeline — shelling out to ffmpeg. The assertions would still pass, on a
+    // test that depends on host filesystem contents (CodeRabbit on #3020).
+    const namedDir = mkdtempSync(path.join(tmpdir(), "mulmoscript-gen-"));
+    generationRoots.push(namedDir);
     const ops = createMulmoScriptServerOps({
       storiesDir: "/nonexistent/for-tests/artifacts/stories",
-      extraRoots: { [namedRoot]: "/tmp/a" },
+      extraRoots: { [namedRoot]: namedDir },
       ...(declared === undefined ? {} : { rootScopedGenerationState: declared }),
       artifacts: stubFileOps,
       writeFileAtomic: async () => {},
@@ -863,7 +899,7 @@ describe("the boot warning says what is actually true for THIS host", () => {
     const warnings: string[] = [];
     createMulmoScriptServerOps({
       storiesDir: "/nonexistent/for-tests/artifacts/stories",
-      extraRoots: { repoA: "/tmp/a" },
+      extraRoots: { repoA: NAMED_ROOT_DIR_A },
       rootScopedGenerationState: true,
       artifacts: stubFileOps,
       writeFileAtomic: async () => {},
@@ -915,12 +951,12 @@ describe("`extraRoots` stays the containment boundary for writes", () => {
   }
 
   it("serves no FileOps for a root that was never registered", () => {
-    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    const ops = opsAnsweringEverything({ repoA: NAMED_ROOT_DIR_A });
     assert.equal(ops.artifactsForRoot("never-registered"), null, "an unregistered id must not reach the host's resolver");
   });
 
   it("refuses the write for that root", () => {
-    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    const ops = opsAnsweringEverything({ repoA: NAMED_ROOT_DIR_A });
     const guard = ops.guardStoryWriteRoot("never-registered");
     assert.ok(guard !== null);
     assert.match(guard.error, /unknown stories root/);
@@ -931,7 +967,7 @@ describe("`extraRoots` stays the containment boundary for writes", () => {
     // the test — a named root's ops is WRAPPED, so it is a different object by
     // design (#3020 H1). What must hold is that the host's ops is reached, and
     // reached with the `stories/` prefix taken off.
-    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    const ops = opsAnsweringEverything({ repoA: NAMED_ROOT_DIR_A });
     const scoped = ops.artifactsForRoot("repoA");
     assert.ok(scoped !== null);
     await scoped.write("stories/sub/deck.json", "{}");
@@ -943,7 +979,7 @@ describe("`extraRoots` stays the containment boundary for writes", () => {
     // Everything reaching a named root's ops has been through
     // `normalizeStoryPath` or `storyFilePath`, so one that has not is a bug —
     // and passing it through would write it where nobody reads.
-    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    const ops = opsAnsweringEverything({ repoA: NAMED_ROOT_DIR_A });
     const scoped = ops.artifactsForRoot("repoA");
     assert.ok(scoped !== null);
     await assert.rejects(() => scoped.write("../escape.json", "{}"), /not a stories path/);

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -319,6 +319,9 @@ describe("the whole ops surface is classified for named roots", () => {
     "guardStoryWirePath",
     "guardStoryRootRegistered",
     "guardStoryWriteRoot",
+    // Not an op: the resolver the write guard and dispatch consult. Covered by
+    // the per-root write cases below.
+    "artifactsForRoot",
     "guardStoryGenerationRoot",
     "runStoryOp",
     "publishGeneration",
@@ -847,5 +850,65 @@ describe("the boot warning says what is actually true for THIS host", () => {
     assert.equal(warnings.length, 1);
     assert.doesNotMatch(warnings[0]!, /GENERATION is refused/);
     assert.match(warnings[0]!, /save\/update still land in the DEFAULT root/);
+  });
+});
+
+describe("`extraRoots` stays the containment boundary for writes", () => {
+  // `artifactsForRoot` asks the host for a FileOps, and a host could answer for
+  // an id it never declared. Registration is checked FIRST so that cannot
+  // widen the addressable set — the same rule `resolveStory` holds for reads.
+  //
+  // Driven directly rather than through dispatch: there, `guardStoryWirePath`
+  // would reject an unregistered root a moment later anyway, so a dispatch
+  // test passes whether or not this check exists. It did — removing the
+  // registration line left the suite green until this case was added (#3019).
+  const served: FileOps = {
+    read: async () => "{}",
+    readBytes: async () => new Uint8Array(),
+    write: async () => {},
+    readDir: async () => [],
+    stat: async () => ({ mtimeMs: 0, size: 0 }),
+    exists: async () => true,
+    unlink: async () => {},
+  };
+
+  function opsAnsweringEverything(extraRoots?: Record<string, string>) {
+    return createMulmoScriptServerOps({
+      storiesDir: "/nonexistent/for-tests/artifacts/stories",
+      ...(extraRoots ? { extraRoots } : {}),
+      artifacts: stubFileOps,
+      // A host that hands back a FileOps for ANY id — the misconfiguration
+      // this check exists to survive.
+      artifactsFor: () => served,
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+  }
+
+  it("serves no FileOps for a root that was never registered", () => {
+    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    assert.equal(ops.artifactsForRoot("never-registered"), null, "an unregistered id must not reach the host's resolver");
+  });
+
+  it("refuses the write for that root", () => {
+    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    const guard = ops.guardStoryWriteRoot("never-registered");
+    assert.ok(guard !== null);
+    assert.match(guard.error, /unknown stories root/);
+  });
+
+  it("serves the FileOps for a root that WAS registered", () => {
+    // Otherwise the check above passes by refusing everything.
+    const ops = opsAnsweringEverything({ repoA: "/tmp/a" });
+    assert.equal(ops.artifactsForRoot("repoA"), served);
+    assert.equal(ops.guardStoryWriteRoot("repoA"), null);
+  });
+
+  it("keeps the default root on its own FileOps, never the resolver's", () => {
+    // The default root's writes must not start flowing through a host
+    // resolver that answers for everything.
+    const ops = opsAnsweringEverything();
+    assert.equal(ops.artifactsForRoot(undefined), ops.backend.artifacts);
+    assert.notEqual(ops.artifactsForRoot(undefined), served);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -52,7 +52,7 @@ describe("root registry", () => {
     assert.equal(result.ok === false && result.code, "bad_request");
   });
 
-  it("warns at boot that named roots are read-only until the protocol carries the root", () => {
+  it("tells a host that registers a root exactly what does not work yet", () => {
     // The pair identity stops at the host boundary: `generationKey` in
     // `@mulmobridge/protocol` keys on `(kind, filePath, key)`. Widening it is a
     // protocol change with its own consumers, so this package cannot make it —
@@ -67,7 +67,7 @@ describe("root registry", () => {
       log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
     });
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0]!, /generation and writes are REFUSED in them/);
+    assert.match(warnings[0]!, /GENERATION is refused until this host declares `rootScopedGenerationState`/);
   });
 
   it("refuses two extraRoots ids that trim to the same key", () => {
@@ -309,6 +309,11 @@ describe("the whole ops surface is classified for named roots", () => {
    * `triggerAutoBackgroundMovie` through.
    */
   const GUARDED_ELSEWHERE = [
+    // Uploads write through `resolveStory`'s per-root containment and take the
+    // absolute path it returns, so a named root is already the RIGHT place to
+    // write — they have their own coverage below rather than a refusal (#3019).
+    "uploadBeatImageOp",
+    "uploadCharacterImageOp",
     "toStoryRef",
     "resolveStory",
     "guardStoryWirePath",
@@ -327,8 +332,6 @@ describe("the whole ops surface is classified for named roots", () => {
     ["renderBeatOp", (ops) => ops.renderBeatOp({ filePath: "stories/d.json", beatIndex: 0, root: namedRoot })],
     ["generateBeatAudioOp", (ops) => ops.generateBeatAudioOp({ filePath: "stories/d.json", beatIndex: 0, root: namedRoot })],
     ["renderCharacterOp", (ops) => ops.renderCharacterOp({ filePath: "stories/d.json", key: "alice", root: namedRoot })],
-    ["uploadBeatImageOp", (ops) => ops.uploadBeatImageOp("stories/d.json", 0, "data:image/png;base64,AA==", namedRoot)],
-    ["uploadCharacterImageOp", (ops) => ops.uploadCharacterImageOp("stories/d.json", "alice", "data:image/png;base64,AA==", namedRoot)],
     ["generateMovieOp", (ops) => ops.generateMovieOp("stories/d.json", undefined, namedRoot)],
     ["generatePdfOp", (ops) => ops.generatePdfOp("stories/d.json", undefined, namedRoot)],
   ];
@@ -660,5 +663,189 @@ describe("storyRefWithin — the Windows case, driven from any platform", () => 
     assert.equal(storyRefWithin(root, "/workspace/artifacts/stories/deck.json", path.posix), "stories/deck.json");
     assert.equal(storyRefWithin(root, "/elsewhere/deck.json", path.posix), null);
     assert.equal(storyRefWithin(root, root, path.posix), "stories");
+  });
+});
+
+describe("an upload writes into the root it names — and nowhere else", () => {
+  // The guard that refused these was defensive, not necessary: `runStoryOp`
+  // resolves through `resolveStory` (realpath containment, per root) and hands
+  // the executor an ABSOLUTE path. Removing a guard is only safe if what it
+  // was standing in front of is actually sound, so this drives the real
+  // filesystem rather than asserting the guard is gone (#3019).
+  //
+  // Containment rests on `resolveStory` ALONE here: both hosts inject a
+  // `writeFileAtomic` that trusts the absolute path it is handed
+  // (MulmoTerminal `server/backends/mulmoscript.ts:66` mkdir -p's and renames).
+  // That is the invariant these cases exist to hold.
+  const workspaces: string[] = [];
+  after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+  const PNG = "data:image/png;base64,iVBORw0KGgo=";
+
+  function makeTwoRoots() {
+    const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-upload-"));
+    workspaces.push(base);
+    const written: string[] = [];
+    const roots = { repoA: path.join(base, "a"), repoB: path.join(base, "b") };
+    const defaultStories = path.join(base, "ws", "artifacts", "stories");
+    for (const dir of [roots.repoA, roots.repoB, defaultStories]) mkdirSync(dir, { recursive: true });
+    // The same wire path exists in all three — the case the pair identity is
+    // for. A REAL script, because the upload path builds a mulmocast context
+    // from the file before it derives the image path: a `{}` stub fails long
+    // before the write, and the assertion below would pass on a run that never
+    // wrote anything.
+    const deck = JSON.stringify({
+      $mulmocast: { version: "1.1" },
+      title: "Deck",
+      lang: "en",
+      beats: [{ speaker: "Narrator", text: "Beat one.", image: { type: "textSlide", slide: { title: "S", bullets: ["b"] } } }],
+      imageParams: {},
+    });
+    for (const dir of [roots.repoA, roots.repoB, defaultStories]) writeFileSync(path.join(dir, "deck.json"), deck);
+    const ops = createMulmoScriptServerOps({
+      storiesDir: defaultStories,
+      extraRoots: roots,
+      artifacts: stubFileOps,
+      writeFileAtomic: async (absolutePath) => {
+        written.push(absolutePath);
+      },
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    return { ops, written, roots, defaultStories };
+  }
+
+  it("writes under the named root, not the default one", async () => {
+    const { ops, written, roots, defaultStories } = makeTwoRoots();
+    await ops.uploadBeatImageOp("stories/deck.json", 0, PNG, "repoA");
+    assert.equal(written.length, 1, "exactly one write");
+    const target = written[0]!;
+    assert.ok(target.startsWith(realpathSync(roots.repoA)), `wrote outside repoA: ${target}`);
+    assert.ok(!target.startsWith(realpathSync(defaultStories)), `wrote into the DEFAULT root: ${target}`);
+  });
+
+  it("keeps two roots' identically-named decks apart", async () => {
+    // The failure this replaces the guard's protection with: writing to
+    // `repoB` must not touch `repoA`, though both hold `stories/deck.json`.
+    const { ops, written, roots } = makeTwoRoots();
+    await ops.uploadBeatImageOp("stories/deck.json", 0, PNG, "repoB");
+    assert.equal(written.length, 1);
+    assert.ok(written[0]!.startsWith(realpathSync(roots.repoB)));
+    assert.ok(!written[0]!.startsWith(realpathSync(roots.repoA)));
+  });
+
+  it("still refuses an unregistered root — the containment did not move", async () => {
+    const { ops, written } = makeTwoRoots();
+    const result = await ops.uploadBeatImageOp("stories/deck.json", 0, PNG, "nope");
+    assert.equal(result.ok, false);
+    assert.equal(written.length, 0, "a refused upload must write nothing");
+  });
+
+  it("still refuses a traversal path — the containment did not move", async () => {
+    const { ops, written } = makeTwoRoots();
+    const result = await ops.uploadBeatImageOp("stories/../../escape.png", 0, PNG, "repoA");
+    assert.equal(result.ok, false);
+    assert.equal(written.length, 0, "a refused upload must write nothing");
+  });
+
+  it("the default root still works, unchanged", async () => {
+    const { ops, written, defaultStories } = makeTwoRoots();
+    await ops.uploadBeatImageOp("stories/deck.json", 0, PNG);
+    assert.equal(written.length, 1);
+    assert.ok(written[0]!.startsWith(realpathSync(defaultStories)));
+  });
+});
+
+describe("who may generate in a named root is the HOST's answer", () => {
+  // Generation was refused outright (#3015) because MulmoClaude's session store
+  // keys pending work by `(kind, filePath, key)`, so two roots generating the
+  // same beat in one session collapse to one entry. That hazard belongs to the
+  // host, and MulmoTerminal does not have it — it ignores `chatSessionId` and
+  // publishes to a pubsub channel the View filters by the pair. It was being
+  // refused for a collision it cannot have (#3019).
+  const namedRoot = "repoA";
+  const REFUSAL = /generating in a non-default stories root is not supported yet/;
+
+  function makeOpsWith(declared: boolean | undefined) {
+    const generations: MulmoScriptGenerationEvent[] = [];
+    const ops = createMulmoScriptServerOps({
+      storiesDir: "/nonexistent/for-tests/artifacts/stories",
+      extraRoots: { [namedRoot]: "/tmp/a" },
+      ...(declared === undefined ? {} : { rootScopedGenerationState: declared }),
+      artifacts: stubFileOps,
+      writeFileAtomic: async () => {},
+      onGenerationEvent: (_session, event) => generations.push(event),
+      log: { info: () => {}, warn: () => {}, error: () => {} },
+    });
+    return { ops, generations };
+  }
+
+  it("refuses when the host says nothing — the shipped behaviour is the default", async () => {
+    // An absent declaration must not quietly open a host that never thought
+    // about this. That is the whole reason the flag defaults to off.
+    const { ops } = makeOpsWith(undefined);
+    const result = await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.ok === false ? result.error : "", REFUSAL);
+  });
+
+  it("refuses when the host declares it cannot keep roots apart", async () => {
+    const { ops } = makeOpsWith(false);
+    const result = await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.ok === false ? result.error : "", REFUSAL);
+  });
+
+  it("lets the generation start when the host declares it can", async () => {
+    // It still fails — there is no such script on disk — but NOT for the root,
+    // which is the difference between "refused" and "ran and did not find it".
+    const { ops } = makeOpsWith(true);
+    const result = await ops.generateMovieOp("stories/deck.json", "session-1", namedRoot);
+    assert.equal(result.ok, false);
+    assert.doesNotMatch(result.ok === false ? result.error : "", REFUSAL, "the root must no longer be the reason");
+  });
+
+  it("applies the declaration to every generation kind", async () => {
+    // Swept, because the guard sits at five entry points and a kind that kept
+    // the old blanket refusal would be invisible in a single-kind test.
+    const { ops } = makeOpsWith(true);
+    const results = [
+      await ops.generateMovieOp("stories/deck.json", "s", namedRoot),
+      await ops.generatePdfOp("stories/deck.json", "s", namedRoot),
+      await ops.renderBeatOp({ filePath: "stories/deck.json", beatIndex: 0, chatSessionId: "s", root: namedRoot }),
+      await ops.generateBeatAudioOp({ filePath: "stories/deck.json", beatIndex: 0, chatSessionId: "s", root: namedRoot }),
+      await ops.renderCharacterOp({ filePath: "stories/deck.json", key: "alice", chatSessionId: "s", root: namedRoot }),
+    ];
+    for (const result of results) {
+      assert.doesNotMatch(result.ok === false ? result.error : "", REFUSAL);
+    }
+  });
+
+  it("never opens the DEFAULT root's behaviour either way", async () => {
+    // The declaration is about named roots. A call naming no root was always
+    // allowed and must stay exactly as it was.
+    for (const declared of [undefined, false, true]) {
+      const { ops } = makeOpsWith(declared);
+      const result = await ops.generateMovieOp("stories/deck.json", "session-1");
+      assert.doesNotMatch(result.ok === false ? result.error : "", REFUSAL, `declared=${declared}`);
+    }
+  });
+});
+
+describe("the boot warning says what is actually true for THIS host", () => {
+  // The warning is the only thing a host integrator reads before discovering a
+  // limit from a stuck spinner, so it must track the limits rather than repeat
+  // the ones that applied when it was written (#3019).
+  it("stops mentioning generation once the host declares it can scope it", () => {
+    const warnings: string[] = [];
+    createMulmoScriptServerOps({
+      storiesDir: "/nonexistent/for-tests/artifacts/stories",
+      extraRoots: { repoA: "/tmp/a" },
+      rootScopedGenerationState: true,
+      artifacts: stubFileOps,
+      writeFileAtomic: async () => {},
+      log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+    });
+    assert.equal(warnings.length, 1);
+    assert.doesNotMatch(warnings[0]!, /GENERATION is refused/);
+    assert.match(warnings[0]!, /save\/update still land in the DEFAULT root/);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -697,26 +697,37 @@ describe("an upload writes into the root it names — and nowhere else", () => {
   after(() => workspaces.forEach((dir) => rmSync(dir, { recursive: true, force: true })));
   const PNG = "data:image/png;base64,iVBORw0KGgo=";
 
-  function makeTwoRoots() {
+  /**
+   * A REAL script, not a `{}` stub: the upload path builds a mulmocast context
+   * from the file before it derives the image path, so a stub fails long
+   * before the write and the assertions would pass on a run that never wrote
+   * anything.
+   */
+  const DECK = JSON.stringify({
+    $mulmocast: { version: "1.1" },
+    title: "Deck",
+    lang: "en",
+    beats: [{ speaker: "Narrator", text: "Beat one.", image: { type: "textSlide", slide: { title: "S", bullets: ["b"] } } }],
+    imageParams: {},
+  });
+
+  /** Two named roots and the default one, each holding the SAME wire path —
+   *  the case the pair identity exists for. */
+  function makeUploadDirs() {
     const base = mkdtempSync(path.join(tmpdir(), "mulmoscript-upload-"));
     workspaces.push(base);
-    const written: string[] = [];
     const roots = { repoA: path.join(base, "a"), repoB: path.join(base, "b") };
     const defaultStories = path.join(base, "ws", "artifacts", "stories");
-    for (const dir of [roots.repoA, roots.repoB, defaultStories]) mkdirSync(dir, { recursive: true });
-    // The same wire path exists in all three — the case the pair identity is
-    // for. A REAL script, because the upload path builds a mulmocast context
-    // from the file before it derives the image path: a `{}` stub fails long
-    // before the write, and the assertion below would pass on a run that never
-    // wrote anything.
-    const deck = JSON.stringify({
-      $mulmocast: { version: "1.1" },
-      title: "Deck",
-      lang: "en",
-      beats: [{ speaker: "Narrator", text: "Beat one.", image: { type: "textSlide", slide: { title: "S", bullets: ["b"] } } }],
-      imageParams: {},
-    });
-    for (const dir of [roots.repoA, roots.repoB, defaultStories]) writeFileSync(path.join(dir, "deck.json"), deck);
+    for (const dir of [roots.repoA, roots.repoB, defaultStories]) {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(path.join(dir, "deck.json"), DECK);
+    }
+    return { roots, defaultStories };
+  }
+
+  function makeTwoRoots() {
+    const { roots, defaultStories } = makeUploadDirs();
+    const written: string[] = [];
     const ops = createMulmoScriptServerOps({
       storiesDir: defaultStories,
       extraRoots: roots,

--- a/plans/feat-3019-named-root-writes.md
+++ b/plans/feat-3019-named-root-writes.md
@@ -1,0 +1,99 @@
+# 名前付き root を「読めるだけ」から使える状態にする（#3019 / #3014 順序 1.5）
+
+#3015 で名前付き root は **読めるが書けない・生成できない**状態で入った。
+#3014 の目的（デッキをリポジトリに置き、元テキストを直しながら調整し、LLM に
+デザインを指示する）はそこで途切れる。MulmoTerminal 側と突き合わせて、塞がって
+いる理由を実測で分解した結果、**本当に塞がっているのは 1 箇所だけ**だった。
+
+## 実測（推測ではなく動かして確認した）
+
+「起動 path 1 個を root として登録した世界」を作って実行:
+
+```
+stories/myrepo/decks/talk.json -> OK  <launch>/myrepo/decks/talk.json
+stories/other/notes/deck.json  -> OK  <launch>/other/notes/deck.json
+stories/../../etc/passwd       -> 拒否 bad_request
+launch/artifacts が生えた?      -> false（副作用なし）
+```
+
+root は**プロジェクト単位ではなくサブツリー**で、任意段のネストが読める。だから
+#3014 の「起動している path 以下が見えるのが理想」は **root 1 個**で足りる。
+
+| 経路 | root 対応の現状 | 要る作業 |
+|---|---|---|
+| upload（beat / character 画像） | **既に正しい** | ガードを外すだけ |
+| 生成の出力（movie / PDF / beat） | **既に正しい** | ガードをホスト宣言制に |
+| `save` / `updateBeat` / `updateScript` | ❌ 単一 FileOps | root ごとの FileOps |
+
+根拠: upload は `runStoryOp` の context を使い、`buildContext(absoluteFilePath)` は
+`resolveStory` の**絶対パス**を受け、`basedir` もそこから derive される。つまり
+出力先は最初から名前付き root の中。`writeFileAtomic` も絶対パスを取る。
+
+## 決めたこと
+
+### 1. 生成ガードは「root が既定か」ではなく「ホストが鍵に root を含められるか」
+
+fail-closed にした理由は MulmoClaude ホストのセッションストアで、`generationKey`
+(`@mulmobridge/protocol`) が `(kind, filePath, key)` を鍵にすること。実測すると
+使用者は `server/events/session-store/index.ts` **だけ**で、MulmoTerminal は
+`chatSessionId` を捨てて pubsub に流すだけ、該当ストアを持たない。
+
+**持っていない危険のために拒否していた。** 判定をホストの宣言に移す。
+
+宣言が無ければ **今の挙動のまま**（拒否）。既存ホストは無改変で今の安全side に
+留まり、対応したホストだけが開く。
+
+### 2. 結果に `root` を載せる — これが無いと下流が書けない
+
+`root` を通したのは args とイベントだけで、**結果には通していなかった**。
+ホストはカードを結果から作るので、カードに root が載らない。#3014 の衝突点 3
+（別 root の同名デッキが同じカードに合流）は、ホスト側の `filePathIdentity` を
+直すだけでは閉じられない。
+
+これはこの一連の作業で繰り返した形の 15 回目 —— **比較とイベントは広げたのに、
+データを運ぶ経路を広げていない**。#3015 のレジャーに 14 回分書いた同じ形。
+
+追加型（`root` 無し = 既定 root）なので既存カードは無改変。
+
+### 3. `artifactsFor(root)` — 公開型は壊さない
+
+塞がっているのは `dispatch.ts:98` の 1 行:
+
+```ts
+const executeContext = { files: { artifacts: ops.backend.artifacts } };  // FileOps 1 個持ちきり
+```
+
+core の executor は `context.files.artifacts` に **wire パス**（`stories/…`）を渡すだけ
+なので、dispatch が root で FileOps を選べば **executor も `MulmoScriptExecuteContext`
+も無改変**で済む（この型は `/core` と `/vue` の両方から export されている）。
+
+MulmoTerminal 側の `createFileOps(rootFor: () => string, label: string)` は root getter を
+取る形なので、ホスト側は root 1 個につきクロージャ 1 個。
+
+### 4. `extraRoots` は構築時固定のまま — 実行時登録はしない
+
+一度は「MulmoTerminal のディレクトリ一覧は実行中に変わるから thunk が要る」と
+考えたが、root がサブツリーなら **起動 path 1 個**で足り、それは boot で確定する。
+実行時登録は要らない。
+
+## 不可侵点
+
+**封じ込めは `resolveStory` 単独が担っている。** 両ホストの `writeFileAtomic` は
+渡された絶対パスをそのまま信じる（MulmoTerminal `server/backends/mulmoscript.ts:66`、
+`mkdir -p` して rename するだけ）。ホスト側で 2 枚目の封じ込めを書かないのは
+`@mulmoclaude/core` の "security-critical primitive must not drift per consumer" に
+従った判断で、正しい。**ガードを外すときにここを壊してはいけない。**
+
+## 検証
+
+- 名前付き root で save / update / upload / 生成が**通ること**、既定 root が無改変であること
+- **未登録 root と traversal は依然として拒否**されること（封じ込めの回帰）
+- ホスト宣言が無いときは生成が**今と同じく拒否**されること（既存ホストの無改変）
+- 結果の `root` が往復すること
+- 各ガードのリバートで赤になること
+
+## この PR に入れないもの
+
+- MulmoTerminal 側（`filePathIdentity` の対応、`storyWirePath()` 拡張、UI）— 順序 2
+- `.mulmoterminal.json` の宣言キー — 公開スキーマは足すより消す方が難しいので、
+  UI が要ると分かってから

--- a/plans/feat-3019-named-root-writes.md
+++ b/plans/feat-3019-named-root-writes.md
@@ -9,7 +9,7 @@
 
 「起動 path 1 個を root として登録した世界」を作って実行:
 
-```
+```text
 stories/myrepo/decks/talk.json -> OK  <launch>/myrepo/decks/talk.json
 stories/other/notes/deck.json  -> OK  <launch>/other/notes/deck.json
 stories/../../etc/passwd       -> 拒否 bad_request
@@ -75,6 +75,43 @@ MulmoTerminal 側の `createFileOps(rootFor: () => string, label: string)` は r
 一度は「MulmoTerminal のディレクトリ一覧は実行中に変わるから thunk が要る」と
 考えたが、root がサブツリーなら **起動 path 1 個**で足り、それは boot で確定する。
 実行時登録は要らない。
+
+### 5. 名前付き root の FileOps は `stories/` を剥いでから渡す（レビューで判明）
+
+読みと書きが**1 セグメントだけ食い違い、しかも静かだった**。
+
+| | 経路 | `stories/deck.json` の着地 |
+|---|---|---|
+| 読み | `resolveStory` が `stories/` を剥いで rootDir 配下で解決 | `<rootDir>/deck.json` |
+| 書き | executor が wire パスのまま FileOps へ渡す | `<FileOpsRoot>/stories/deck.json` |
+
+一致するのは `FileOpsRoot/stories === rootDir` のときだけで、その制約はどこにも
+書かれていなかった。消費側ホスト（MulmoTerminal）が「登録したディレクトリに
+FileOps を張る」という**自然な書き方**をすると外れる。
+
+実測した症状:
+
+```text
+save の結果  : {"ok":true, "filePath":"stories/talk-….json", "root":"launch"}   ← 成功を返す
+実際に生えた : <launch>/stories/talk-….json
+読み戻し先   : NG not_found                                    ← 読みは <launch>/talk-….json
+```
+
+**`save` は成功を報告し、読み戻せない wire パスを返す。** ホストが作るカードが
+何も指さない。
+
+名前付き root の FileOps を薄いアダプタで包み、`stories/` を剥いでから渡す。
+これで「**登録したディレクトリ = FileOps の root**」が正しくなり、ホストが自然に
+書く形と一致する。既定 root は無改変（その FileOps は `<workspace>/artifacts` に
+根を張り、他プラグインと共有しているので再ルートできない）。
+
+wire パスでないものは通さず throw する。ここに来るものはすべて
+`normalizeStoryPath` か `storyFilePath` を通っているので、そうでないものはバグで、
+通せば「誰も読めない場所に書く」——このアダプタが終わらせようとしている失敗そのもの。
+
+**テストの形も変えた。** 元のテストは相対キーの `Map` を見ていたので、
+**バイトがどの絶対パスに落ちたかを見ていなかった**。実 FileOps + 実ディレクトリで
+書き、`resolveStory` が返す絶対パスから読み戻す **round trip** にした。
 
 ## 不可侵点
 


### PR DESCRIPTION
## Summary

#3015 で名前付き root は **読めるが書けない・生成できない**状態で入りました。#3014 の目的
（デッキをリポジトリに置き、元テキストを直しながら調整し、LLM にデザインを指示する）は
そこで途切れます。

MulmoTerminal 側と突き合わせて塞がっている理由を**実測で分解**したところ、**本当に塞がって
いたのは 1 箇所だけ**でした。

| 経路 | 実測した現状 | この PR |
|---|---|---|
| upload（beat / character 画像） | **既に正しかった** — `runStoryOp` が `resolveStory` の絶対パスを渡し、`buildContext` の `basedir` もそこから derive される | ガードを撤去 |
| 生成の出力（movie / PDF / beat） | **既に正しかった** | 可否をホスト宣言に |
| `save` / `updateBeat` / `updateScript` | ❌ **単一 FileOps。ここだけ** | `artifactsFor(root)` |
| 結果の `root` | ❌ **載っていなかった** | 全 kind に |
| 名前付き root の書き先 | ❌ **読みと 1 セグメント食い違い、しかも静か**（レビューで判明） | FileOps から `stories/` を剥ぐ |

### レビューで足された 5 つ目 — これがこの PR で一番重い

消費側ホスト（MulmoTerminal）の指摘で、**ボット 3 者とも見つけていません**。
読みと書きが 1 セグメントだけ食い違い、症状が静かでした:

```text
save の結果  : {"ok":true, "filePath":"stories/talk-….json", "root":"launch"}   ← 成功を返す
実際に生えた : <launch>/stories/talk-….json
読み戻し先   : NG not_found                                    ← 読みは <launch>/talk-….json
```

**`save` は成功を報告し、読み戻せない wire パスを返していました。** ホストが作るカードが
何も指しません。一致条件 `FileOpsRoot/stories === rootDir` はどこにも書かれておらず、
ホストが「登録したディレクトリに FileOps を張る」という自然な書き方をすると外れます。

名前付き root の FileOps を包んで `stories/` を剥ぐことで、「**登録したディレクトリ =
FileOps の root**」が正しくなります。既定 root は無改変（その FileOps は
`<workspace>/artifacts` に根を張り、他プラグインと共有しているため）。

**私のテストが原理的にこれを捕まえられない形だった**という指摘も正しく、`Map` の
相対キーではなく**実 FileOps + 実ディレクトリで書き、`resolveStory` の絶対パスから
読み戻す round trip** に置き換えました。

## Items to Confirm / Review

1. **結果に `root` が載っていなかったのは、私の #3015 の漏れです。** `root` を通したのは
   args とイベントだけで、結果には通していませんでした。ホストはカードを結果から作るので、
   #3014 の衝突点 3（別 root の同名デッキが同じカードに合流）は**ホスト側をどう直しても
   閉じられない**状態でした。型は mapped type、ランタイムは**ルータの唯一の出口で 1 回**。
   17 kind に配るのは、この作業で 15 回失敗した形なので取っていません。

2. **upload のガード撤去は「必要なかったガード」の撤去です。** #3015 のレビュー中に念のため
   入れたもので、書き先は最初から正しい root の中でした。撤去の安全性は「無くなったこと」では
   なく、**実ファイルで書き込み先を検証**して示しています（2 root + 既定 root に同名
   `stories/deck.json` を置き、repoB への書きが repoA に触れないこと、未登録 root と
   traversal が依然拒否されること）。

3. **生成の可否をホスト宣言にした判断。** fail-closed の理由は MulmoClaude のセッションストアが
   `(kind, filePath, key)` を鍵にすることでしたが、実測すると使用者はそこだけで、
   MulmoTerminal は `chatSessionId` を捨てて pubsub に流すだけです。**持っていない危険のために
   拒否していました。** `rootScopedGenerationState` の既定は `false` — 宣言しないホストは
   今の挙動のままです。

4. **`extraRoots` は封じ込めの境界のまま。** ホストが未登録 id に FileOps を答えても、登録
   チェックが先なので通りません。**これは dispatch 経由では検証できません**（`guardStoryWirePath`
   が直後に弾くので、チェックの有無に関わらず緑）。実際、登録チェックを消してもスイートは
   緑のままだったので、ops を直接叩くテストを足しました。

5. **公開型は無改変。** `MulmoScriptExecuteContext`（`/core` と `/vue` から export）と core の
   executor は変えていません。root は executor に届かず、届くのは正しい FileOps だけです。

## 不可侵点

封じ込めは **`resolveStory` 単独**が担っています。両ホストの `writeFileAtomic` は渡された
絶対パスをそのまま信じる実装（MulmoTerminal `server/backends/mulmoscript.ts:66`）で、
ホスト側で 2 枚目を書かないのは `@mulmoclaude/core` の
"security-critical primitive must not drift per consumer" に従った判断です。**ガードを外す
ときにここを壊さないこと**が、この PR の一番の制約でした。

## ホスト側に残る不変条件（検出できないもの）

`artifactsFor` を渡すホストは、**登録したディレクトリと FileOps の root を一致させる**
必要があります。上の修正でこれは「ホストが自然に書く形」と一致しましたが、ずらして書くこと
自体は依然できます（`extraRoots: {id: A}` + `artifactsFor: () => ops(B)`）。その場合、
読みは A、書きは B を指し、また静かに壊れます。

**plugin 側では実行時に検出できません** — FileOps はパスを公開しないので、A と B の関係が
分かりません。型の doc に明記したうえで、ホスト側の責務として残ります。

## 検証

- テスト **326 件**（#3015 の 307 から +19）
- **リバートで赤を毎回確認**（各コミットメッセージに記載）:
  結果タグを外す / 既定 root にも付ける / 失敗にも付ける / upload を既定 root に固定 /
  生成の宣言を無視 / 常に既定 FileOps / 未登録 root でホストを信じる / 宣言なしで書きを開く
- 書き込みテストは**実ディレクトリとメモリ FileOps を両方**使います（封じ込めは realpath、
  内容は FileOps を通るため）。`{}` スタブでは `buildContext` が書き込みより手前で落ち、
  「1 回も書かなかった run」でアサーションが通ってしまいます
- `prettier --check` / `eslint` / `typecheck`（plugin + root）緑

## この PR に入れないもの

- MulmoTerminal 側（`filePathIdentity` の対応、`storyWirePath()` 拡張、UI）— 順序 2
- `.mulmoterminal.json` の宣言キー — 公開スキーマは足すより消す方が難しいので、UI が要ると
  分かってから
- **実行時 root 登録** — 一度は必要と考えましたが、root がサブツリーなら「起動 path 1 個」で
  足り、それは boot で確定します

## User Prompt

- 「では実装つづける？」

（先行するラウンドテーブルで #3014 順序 1.5 として範囲を確定したもの。root がサブツリーで
あること、生成ガードが MulmoTerminal に対して過剰であること、結果に root が無いことを
双方の実測で確認した結果です。）

Closes #3019

work in mulmoclaude2

## Summary by Sourcery

Make named roots fully usable for isolated script editing, uploads, and host-approved generation while preserving default-root compatibility and containment.

New Features:
- Enable named roots to support script saving and beat/script updates through host-provided, root-specific FileOps.
- Allow named-root generation when the host declares that its generation state is root-scoped.
- Include the acting root in successful dispatch results for named-root consumers.

Bug Fixes:
- Prevent named-root writes from landing in the default root or an unreadable nested stories path.
- Preserve root containment by rejecting unregistered roots and traversal paths.
- Remove redundant upload restrictions while retaining per-root path safety.

Enhancements:
- Keep the default-root behavior and public execution context compatible while routing named-root operations to the appropriate storage backend.
- Apply root result tagging centrally across dispatch kinds and normalize root identifiers.

Documentation:
- Add a plan documenting named-root write, generation, containment, and compatibility behavior.

Tests:
- Add filesystem round-trip coverage for named-root save and update operations.
- Add real-path isolation tests for named-root beat and character uploads.
- Cover host-controlled generation permissions, result root tagging, registration boundaries, and traversal rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating, saving, uploading, and updating content within named story roots.
  - Operations now identify the normalized story root they used.
  - Hosts can provide root-specific generation state and artifact storage.
  - Named-root uploads and file operations support secure path containment.

- **Bug Fixes**
  - Operations targeting unavailable, unregistered, malformed, or unsafe roots are refused.
  - Named-root file paths now resolve consistently for reads and writes.
  - Default-root behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->