### PR TITLE
fix(mulmoscript-plugin): 起動警告が「足りないもの」を見ずに毎起動で嘘をつく (#3022)

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -220,25 +220,46 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
     }
     rootDirs.set(trimmed, path.resolve(dir));
   }
-  if (rootDirs.size > 1) {
-    // The pair identity is complete INSIDE this package, and stops at the host
-    // boundary. A host's per-session generation store keys on
-    // `(kind, filePath, key)` — `generationKey` in `@mulmobridge/protocol`,
-    // which bridges also consume — so two roots running the same generation in
-    // one session collapse to one entry and either finish clears the other's
-    // pending state (Codex P1 on #3015).
-    //
-    // Widening that key is a protocol change with its own consumers, so it is
-    // not this package's to make. Unreachable until a host registers a root,
-    // which is exactly the moment this fires: whoever first does it is the
-    // person who has to widen their session key, and they see this at boot
-    // rather than discovering it from a stuck spinner.
-    log.warn(
-      backend.rootScopedGenerationState === true
-        ? "extra stories roots registered — reads, uploads and generation work; save/update still land in the DEFAULT root until this host passes `artifactsFor` (#3019)"
-        : "extra stories roots registered — reads and uploads work, but GENERATION is refused until this host declares `rootScopedGenerationState` (its pending-generation state must carry the root, or it must keep none), and save/update land in the DEFAULT root until it passes `artifactsFor` (#3019)",
-      { roots: [...rootDirs.keys()].filter((id) => id !== DEFAULT_ROOT) },
-    );
+  warnAboutUnwiredRoots();
+
+  /**
+   * Tell a host which named-root capabilities it has not wired — and nothing
+   * when it has wired them all.
+   *
+   * The condition used to be the root COUNT alone, so a host that had passed
+   * `artifactsFor` was still told, at every boot, that its writes land in the
+   * default root. That is not a stale wording: it is the opposite of what the
+   * code then does, read by the hosts that got the wiring RIGHT (#3022, from
+   * the consuming host).
+   *
+   * Silence when nothing is missing, because a warning that always fires is
+   * one people learn to skip — and then the host that really did forget
+   * `artifactsFor` cannot tell either. Each clause is emitted only when that
+   * capability is actually absent, so the message says what is true for THIS
+   * host rather than what was true when it was written.
+   */
+  function warnAboutUnwiredRoots(): void {
+    if (rootDirs.size <= 1) return;
+    const missing: string[] = [];
+    // The pair identity is complete INSIDE this package and stops at the host
+    // boundary: a host's per-session store keys pending work on
+    // `(kind, filePath, key)` — `generationKey` in `@mulmobridge/protocol` —
+    // so two roots generating the same beat in one session collapse to one
+    // entry (Codex P1 on #3015). A host that keeps no such store declares it.
+    if (backend.rootScopedGenerationState !== true) {
+      missing.push(
+        "GENERATION is refused until this host declares `rootScopedGenerationState` (its pending-generation state must carry the root, or it must keep none)",
+      );
+    }
+    // The save/update executors run against one FileOps; without a per-root
+    // one they would rewrite the DEFAULT root's identically-named script.
+    if (backend.artifactsFor === undefined) {
+      missing.push("save/update land in the DEFAULT root until this host passes `artifactsFor`");
+    }
+    if (missing.length === 0) return;
+    log.warn(`extra stories roots registered — reads and uploads work, but ${missing.join(", and ")} (#3019)`, {
+      roots: [...rootDirs.keys()].filter((id) => id !== DEFAULT_ROOT),
+    });
   }
 
   /** The registered directory for a wire `root`, or null when the host never

--- a/packages/plugins/mulmoscript-plugin/src/server/ops.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/ops.ts
@@ -48,6 +48,7 @@ import { normalizeStoryPath, storyRefWithin, storiesRelativePath } from "../core
 import { errorMessage } from "@mulmoclaude/common";
 import { resolveWithinRoot } from "@mulmoclaude/core/files";
 import { fileToDataUri, stripDataUri } from "./support";
+import { missingRootCapabilities } from "./types";
 import { enableGraphAIErrorCapture, setMulmoErrorCaptureLogger, withMulmoErrorCapture } from "./mulmoErrorCapture";
 import type {
   GenerateOpArgsWith,
@@ -240,22 +241,7 @@ export function createMulmoScriptServerOps(backend: MulmoScriptServerBackend) {
    */
   function warnAboutUnwiredRoots(): void {
     if (rootDirs.size <= 1) return;
-    const missing: string[] = [];
-    // The pair identity is complete INSIDE this package and stops at the host
-    // boundary: a host's per-session store keys pending work on
-    // `(kind, filePath, key)` — `generationKey` in `@mulmobridge/protocol` —
-    // so two roots generating the same beat in one session collapse to one
-    // entry (Codex P1 on #3015). A host that keeps no such store declares it.
-    if (backend.rootScopedGenerationState !== true) {
-      missing.push(
-        "GENERATION is refused until this host declares `rootScopedGenerationState` (its pending-generation state must carry the root, or it must keep none)",
-      );
-    }
-    // The save/update executors run against one FileOps; without a per-root
-    // one they would rewrite the DEFAULT root's identically-named script.
-    if (backend.artifactsFor === undefined) {
-      missing.push("save/update land in the DEFAULT root until this host passes `artifactsFor`");
-    }
+    const missing = missingRootCapabilities(backend);
     if (missing.length === 0) return;
     log.warn(`extra stories roots registered — reads and uploads work, but ${missing.join(", and ")} (#3019)`, {
       roots: [...rootDirs.keys()].filter((id) => id !== DEFAULT_ROOT),

--- a/packages/plugins/mulmoscript-plugin/src/server/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/server/types.ts
@@ -51,6 +51,36 @@ export type MulmoScriptServerLog = MinimalLogger;
  * host-specific transport lives here — the mulmocast orchestration, path
  * containment, and generation-state tracking are all in-package.
  */
+/**
+ * Which named-root capabilities a host has NOT wired.
+ *
+ * Pure and exported so the rule can be tested without building a server: the
+ * condition used to key on the root COUNT alone, so a host that HAD passed
+ * `artifactsFor` was told at every boot that its writes land in the default
+ * root — the opposite of what the code then did (#3022).
+ *
+ * Reads and uploads need nothing from the host, so they never appear here.
+ */
+export function missingRootCapabilities(backend: Pick<MulmoScriptServerBackend, "rootScopedGenerationState" | "artifactsFor">): string[] {
+  const missing: string[] = [];
+  // The pair identity is complete INSIDE this package and stops at the host
+  // boundary: a host's per-session store keys pending work on
+  // `(kind, filePath, key)` — `generationKey` in `@mulmobridge/protocol` — so
+  // two roots generating the same beat in one session collapse to one entry
+  // (Codex P1 on #3015). A host that keeps no such store declares it.
+  if (backend.rootScopedGenerationState !== true) {
+    missing.push(
+      "GENERATION is refused until this host declares `rootScopedGenerationState` (its pending-generation state must carry the root, or it must keep none)",
+    );
+  }
+  // The save/update executors run against one FileOps; without a per-root one
+  // they would rewrite the DEFAULT root's identically-named script.
+  if (backend.artifactsFor === undefined) {
+    missing.push("save/update land in the DEFAULT root until this host passes `artifactsFor`");
+  }
+  return missing;
+}
+
 export interface MulmoScriptServerBackend {
   /** Absolute path of the DEFAULT stories directory
    *  (`<workspace>/artifacts/stories`). May not exist yet — the ops lazily

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -14,6 +14,7 @@ import path from "path";
 import type { FileOps } from "gui-chat-protocol";
 import { createMulmoScriptServerOps } from "../src/server/ops";
 import { storyRefWithin } from "../src/core/paths";
+import { missingRootCapabilities } from "../src/server/types";
 import type { OpResult } from "../src/server/types";
 import type { MulmoScriptGenerationEvent, MulmoScriptChangedEvent } from "../src/core/contract";
 
@@ -1057,5 +1058,41 @@ describe("`extraRoots` stays the containment boundary for writes", () => {
     const ops = opsAnsweringEverything();
     assert.equal(ops.artifactsForRoot(undefined), ops.backend.artifacts);
     assert.notEqual(ops.artifactsForRoot(undefined), served);
+  });
+});
+
+describe("missingRootCapabilities — the rule, without building a server", () => {
+  // Extracted so it can be driven directly (CodeRabbit on #3023). The rule is
+  // what went wrong in #3022: the warning keyed on the root COUNT and never
+  // looked at `artifactsFor`, so a correctly-wired host was told at every boot
+  // that its writes land in the default root.
+  const someOps = (): FileOps => stubFileOps;
+
+  it("names nothing when both capabilities are wired", () => {
+    assert.deepEqual(missingRootCapabilities({ rootScopedGenerationState: true, artifactsFor: someOps }), []);
+  });
+
+  it("names only generation when only that is missing", () => {
+    const missing = missingRootCapabilities({ artifactsFor: someOps });
+    assert.equal(missing.length, 1);
+    assert.match(missing[0]!, /rootScopedGenerationState/);
+  });
+
+  it("names only writes when only those are missing", () => {
+    const missing = missingRootCapabilities({ rootScopedGenerationState: true });
+    assert.equal(missing.length, 1);
+    assert.match(missing[0]!, /artifactsFor/);
+  });
+
+  it("names both when neither is wired", () => {
+    assert.equal(missingRootCapabilities({}).length, 2);
+  });
+
+  it("treats an explicitly false declaration as unwired", () => {
+    // `false` is a host saying "I cannot scope generation state", which is the
+    // same answer as saying nothing — and must read that way here.
+    const missing = missingRootCapabilities({ rootScopedGenerationState: false, artifactsFor: someOps });
+    assert.equal(missing.length, 1);
+    assert.match(missing[0]!, /rootScopedGenerationState/);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_server_roots.ts
@@ -904,21 +904,73 @@ describe("who may generate in a named root is the HOST's answer", () => {
 
 describe("the boot warning says what is actually true for THIS host", () => {
   // The warning is the only thing a host integrator reads before discovering a
-  // limit from a stuck spinner, so it must track the limits rather than repeat
-  // the ones that applied when it was written (#3019).
-  it("stops mentioning generation once the host declares it can scope it", () => {
+  // limit from a stuck spinner, so it must track what THIS host is missing.
+  //
+  // It used to key on the root COUNT alone, so a host that HAD passed
+  // `artifactsFor` was told at every boot that its writes land in the default
+  // root — the opposite of what the code then did, read by the hosts that got
+  // the wiring right (#3022, reported by the consuming host).
+  const CAPABILITIES = {
+    none: {},
+    generationOnly: { rootScopedGenerationState: true },
+    writesOnly: { artifactsFor: () => stubFileOps },
+    both: { rootScopedGenerationState: true, artifactsFor: () => stubFileOps },
+  } as const;
+
+  function warningsFor(capabilities: Record<string, unknown>): string[] {
     const warnings: string[] = [];
     createMulmoScriptServerOps({
       storiesDir: "/nonexistent/for-tests/artifacts/stories",
       extraRoots: { repoA: NAMED_ROOT_DIR_A },
-      rootScopedGenerationState: true,
+      ...capabilities,
       artifacts: stubFileOps,
       writeFileAtomic: async () => {},
       log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
     });
-    assert.equal(warnings.length, 1);
-    assert.doesNotMatch(warnings[0]!, /GENERATION is refused/);
-    assert.match(warnings[0]!, /save\/update still land in the DEFAULT root/);
+    return warnings;
+  }
+
+  it("says nothing at all when the host wired everything", () => {
+    // The bug this replaces: a correctly-wired host was told, every boot, that
+    // a feature it had enabled did not work.
+    assert.deepEqual(warningsFor(CAPABILITIES.both), []);
+  });
+
+  it("names only the missing generation capability", () => {
+    const [warning] = warningsFor(CAPABILITIES.writesOnly);
+    assert.ok(warning);
+    assert.match(warning, /rootScopedGenerationState/);
+    assert.doesNotMatch(warning, /artifactsFor/, "a host that passed it must not be told it did not");
+  });
+
+  it("names only the missing write capability", () => {
+    const [warning] = warningsFor(CAPABILITIES.generationOnly);
+    assert.ok(warning);
+    assert.match(warning, /artifactsFor/);
+    assert.doesNotMatch(warning, /rootScopedGenerationState/, "a host that declared it must not be told it did not");
+  });
+
+  it("names both when the host wired neither", () => {
+    const [warning] = warningsFor(CAPABILITIES.none);
+    assert.ok(warning);
+    assert.match(warning, /rootScopedGenerationState/);
+    assert.match(warning, /artifactsFor/);
+  });
+
+  it("still says nothing when only the default root exists, whatever the host wired", () => {
+    // The warning is about named roots. A single-root host must stay silent
+    // even if it passes nothing.
+    for (const capabilities of Object.values(CAPABILITIES)) {
+      const warnings: string[] = [];
+      createMulmoScriptServerOps({
+        storiesDir: "/nonexistent/for-tests/artifacts/stories",
+        ...capabilities,
+        artifacts: stubFileOps,
+        writeFileAtomic: async () => {},
+        log: { info: () => {}, warn: (message) => warnings.push(message), error: () => {} },
+      });
+      assert.deepEqual(warnings, [], JSON.stringify(Object.keys(capabilities)));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

条件が root の**数**だけを見ており、`backend.artifactsFor` を一度も判定していませんでした。
`rootScopedGenerationState` は分岐に使われているのに、`artifactsFor` は文面に出てくるだけです。
#3020 で `artifactsFor` を足したとき、この警告の条件が追随していませんでした。

**文言が古いのではなく、コードの逆を言っています。** しかもそれを読まされるのは
**配線を正しくやったホスト**です。

再現（修正前は 4 通りすべてで同じ嘘）:

| ホストの配線 | 修正前 | 修正後 |
|---|---|---|
| 何も渡さない | 「`artifactsFor` を渡していない」 | 両方を名指し |
| generation だけ宣言 | 「`artifactsFor` を渡していない」 | **`artifactsFor` だけ**を名指し |
| `artifactsFor` だけ渡す | 「`artifactsFor` を渡していない」← **渡している** | `rootScopedGenerationState` だけを名指し |
| 両方（MulmoTerminal #1934） | 「`artifactsFor` を渡していない」← **渡している** | **黙る** |

## Items to Confirm / Review

1. **「両方揃っていれば完全に黙る」を選びました**（issue の決めること 1）。常に出る警告は
   無視されるようになり、そうなると**本当に配線を忘れたホストも気づけません** — issue の
   2 番目の理由をそのまま設計理由にしています。

2. **`log.info` を 1 行残す案は採りませんでした。** ホストは自分が何を登録したか知っています
   （`extraRoots` を渡したのは自分自身）ので、毎起動 1 行の価値がノイズを上回らないと
   判断しました。診断が要る場面が出たら足す方が安いです。

3. **文面は「足りないものだけ」を並べる形にしました**（issue の決めること 2）。1 本にまとめる
   より、読んだホストが「自分は何をすればいいか」だけを受け取れます。

## 検証

- テスト **334 件**（+4）。4 通りの配線すべてと、**単一 root では何を渡しても黙る**ことを検証
- **リバートで赤**: `artifactsFor` の判定を外す（2 件赤）/ 足りなくても警告を出す（1 件赤）
- 既存テストが**古い文面を固定していた**ので、そちらも 4 状態を網羅する形に置き換えました
- `prettier --check` / `eslint` / `typecheck`（plugin + root）緑

## User Prompt

- `receptron/mulmoclaude#3022`

Closes #3022

work in mulmoclaude2

## Summary by Sourcery

Make named-root startup warnings accurately reflect the host capabilities that are not wired.

Bug Fixes:
- Correct boot warnings for hosts using named story roots so they report only the capabilities that are actually missing.
- Stop warning on every startup when both named-root capabilities are configured, preventing false alarms for correctly wired hosts.

Enhancements:
- Extract the named-root capability check into a reusable pure helper for clearer behavior and direct testing.

Tests:
- Expand root warning coverage across all capability combinations and single-root configurations.
- Add direct tests for missing capability detection, including explicitly disabled generation-state scoping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-root startup warnings to report only capabilities that are actually missing.
  * Suppressed unnecessary warnings when all required capabilities are configured.
  * Single-root setups no longer produce capability warnings, regardless of configuration.
  * Warning messages now clearly identify affected generation and save/update functionality.
* **Tests**
  * Added coverage for all capability combinations, including explicitly disabled capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->