### PR TITLE
feat(collection-plugin): チャット開始モーダルに、ホストが差し込める options slot を開ける (#3026)

### DIFF
--- a/e2e/tests/collection-chat-button.spec.ts
+++ b/e2e/tests/collection-chat-button.spec.ts
@@ -60,6 +60,11 @@ test.describe("collection + Chat button", () => {
     await expect(send).toBeDisabled();
     await page.getByTestId("collections-chat-input").fill("make a new entry");
     await expect(send).toBeEnabled();
+
+    // The footer's `options` slot is for HOSTS that need one (MulmoTerminal names the agent the
+    // chat will start as). MulmoClaude passes nothing, so the footer stays the two buttons it
+    // always was — that the slot is invisible here is the whole reason it could be added.
+    await expect(modal.locator("footer button")).toHaveCount(2);
   });
 
   test("submitting seeds a general-role chat with `/<slug> <message>`", async ({ page }) => {

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionChatModal.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionChatModal.vue
@@ -44,6 +44,17 @@
       </div>
 
       <footer class="px-6 py-3.5 border-t border-slate-100 flex items-center justify-end gap-2 bg-slate-50/50">
+        <!-- Host controls for the chat that is about to start. Empty in every host that passes
+             nothing, and the wrapper is then zero-width — `mr-auto` absorbs the free space the
+             footer's `justify-end` was absorbing anyway, so the buttons do not move.
+
+             The plugin knows nothing about what a host puts here. MulmoTerminal starts these
+             chats as one of several agents and needs to say which; MulmoClaude has one and does
+             not. Whether the slot is filled at all is the parent's call — see CollectionView,
+             which withholds it on the embedded path where no new chat is started. -->
+        <div class="mr-auto flex items-center gap-2">
+          <slot name="options" />
+        </div>
         <button
           type="button"
           class="h-8 px-2.5 rounded text-xs font-bold text-slate-500 hover:bg-slate-200/50 transition-colors"

--- a/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
+++ b/packages/plugins/collection-plugin/src/vue/components/CollectionView.vue
@@ -334,7 +334,13 @@
       @close="configOpen = false"
     />
 
-    <CollectionChatModal v-if="chatOpen && collection" :collection-title="collection.title" @close="closeChat" @submit="submitChat" />
+    <!-- `chat-modal-options` reaches the modal's footer, and ONLY on the standalone path. With
+         `sendTextMessage` set we are inside a chat card and `submitChat` sends into the session
+         already running (useCollectionChat's `dispatchSeed`), so a host control over "which chat
+         gets started" would change nothing — an option that does not apply is worse than none. -->
+    <CollectionChatModal v-if="chatOpen && collection" :collection-title="collection.title" @close="closeChat" @submit="submitChat">
+      <template v-if="!sendTextMessage" #options><slot name="chat-modal-options" /></template>
+    </CollectionChatModal>
   </div>
 </template>
 

--- a/plans/feat-3026-chat-modal-options-slot.md
+++ b/plans/feat-3026-chat-modal-options-slot.md
@@ -23,7 +23,7 @@ plugin はホストが何を置くかを知らない。エージェントの語�
 
 ### 2. `CollectionView.vue` — `chat-modal-options` を、標準経路でだけ転送
 
-```
+```vue
 <template v-if="!sendTextMessage" #options><slot name="chat-modal-options" /></template>
 ```
 

--- a/plans/feat-3026-chat-modal-options-slot.md
+++ b/plans/feat-3026-chat-modal-options-slot.md
@@ -1,0 +1,57 @@
+# CollectionChatModal に、ホストが差し込める `options` slot を開ける (#3026)
+
+## 問題
+
+`CollectionChatModal` は `fixed inset-0` + `backdrop-blur-sm` で画面全体を覆う。ホストが
+「このチャットは何で立ち上がるか」をどこか別の場所に描いていても、**押すまさにその瞬間だけ
+ぼかされて見えない**。
+
+MulmoTerminal はコレクション発のチャットを 5 種のエージェント（Claude / Codex / Antigravity /
+Grok / Muse）のいずれかで起こす。グローバルに永続化された 1 つの値が効くので、「コレクション
+から始めたら Claude ではなく Muse が立ち上がった。なぜ？」という報告が実際に出た
+（receptron/mulmoterminal#1938）。ホスト側はオーバーレイとペインのヘッダに選択 UI を出したが
+（receptron/mulmoterminal#1940）、この modal が開いている間はそれが覆われる。
+
+## 変更
+
+### 1. `CollectionChatModal.vue` — フッターに `options` slot
+
+キャンセル / 開始 の左。`mr-auto` を持つラッパで包む。slot が空ならラッパは幅 0 になり、
+`mr-auto` はフッターの `justify-end` が既に吸っていた余白を吸うだけなので、**ボタンは動かない**。
+
+plugin はホストが何を置くかを知らない。エージェントの語彙は持ち込まない。
+
+### 2. `CollectionView.vue` — `chat-modal-options` を、標準経路でだけ転送
+
+```
+<template v-if="!sendTextMessage" #options><slot name="chat-modal-options" /></template>
+```
+
+`sendTextMessage` があるときは chat カードの中で、`submitChat` は**今動いているセッション**へ
+送る（`useCollectionChat` の `dispatchSeed`）。新しいチャットは起きないので、「どのチャットが
+始まるか」を選ばせるコントロールは何も変えない。**効かないオプションは、無いより悪い。**
+
+`sendTextMessage` の存在を「chat の中にいる」シグナルとして使うのは既存の約束
+（`CollectionView.vue` の props コメント）で、新しい規則ではない。
+
+## slot 名
+
+issue では `chat-modal-lead` を仮に置いたが `chat-modal-options` にした。「どこに座るか」では
+なく「そこに何が属するか」を言う名前のほうが、API として長持ちする。
+
+## 検証
+
+- `test/components/test_collection_chat_modal_slot.ts`（新規）— このリポジトリに Vue の
+  component unit test の基盤は無いので、`test_stackview_googlemap_wiring.ts` と同じ
+  ソース解析型の guard。slot の存在・転送・gate が同じ template 要素に載っていることを固定する。
+- `e2e/tests/collection-chat-button.spec.ts` に 1 行追加 — MulmoClaude では
+  フッターのボタンが 2 つのままであること。**この変更が MulmoClaude から見えない**ことが、
+  そもそも足せた理由なので、それを固定する。
+- `yarn format` → `lint` → `typecheck` → `build`
+
+## この PR に含めないもの
+
+- **バージョン bump と ChangeLog** — このリポジトリでは `chore(release):` が別コミットで行う
+  （`e00a578cf` 等）。publish 後に MulmoTerminal 側が上げる。
+- **`CollectionRecordModal` 側の record チャット** — 同じ判断が当てはまるが、まずは要求のある
+  ほうだけ。

--- a/test/components/test_collection_chat_modal_slot.ts
+++ b/test/components/test_collection_chat_modal_slot.ts
@@ -1,0 +1,52 @@
+// The chat modal's `options` slot, and the one rule that makes it correct: it is forwarded on the
+// STANDALONE path only.
+//
+// A host that starts these chats as one of several agents (MulmoTerminal) needs to say which one
+// is about to start, at the moment the button is pressed — the modal covers the whole page, so
+// anything the host draws behind it is not on screen. But with `sendTextMessage` set the modal is
+// inside a chat card and `submitChat` sends into the session already running, so no new chat is
+// started and such a control would change nothing.
+//
+// The repo has no Vue component unit-test infrastructure (e2e/ covers that surface), so this
+// parses the sources — the same lightweight guard test_stackview_googlemap_wiring.ts uses. A
+// restructure that drops the slot, or drops the gate, trips here ahead of the e2e run.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const PLUGIN = "packages/plugins/collection-plugin/src/vue/components";
+
+const readSource = (rel: string): string => readFileSync(path.join(REPO_ROOT, rel), "utf-8");
+
+test("CollectionChatModal exposes an `options` slot in its footer", () => {
+  const src = readSource(`${PLUGIN}/CollectionChatModal.vue`);
+  assert.match(src, /<slot\s+name="options"\s*\/>/, 'CollectionChatModal must render `<slot name="options" />` for host controls');
+  const footer = src.slice(src.indexOf("<footer"), src.indexOf("</footer>"));
+  assert.ok(footer.includes('<slot name="options" />'), "the slot belongs in the FOOTER, beside the buttons it qualifies — not in the header or the body");
+});
+
+test("CollectionView forwards `chat-modal-options` into the modal", () => {
+  const src = readSource(`${PLUGIN}/CollectionView.vue`);
+  assert.match(
+    src,
+    /#options><slot name="chat-modal-options" \/><\/template>/,
+    "CollectionView must pass its own `chat-modal-options` slot through to the modal's `options` slot",
+  );
+});
+
+test("CollectionView withholds the slot on the embedded path", () => {
+  const src = readSource(`${PLUGIN}/CollectionView.vue`);
+  // The gate and the slot must be on the SAME template element: a `v-if` that drifted onto
+  // another node would leave the control showing inside a chat card, where pressing it changes
+  // nothing (useCollectionChat's dispatchSeed takes the `sendTextMessage` branch).
+  assert.match(
+    src,
+    /<template\s+v-if="!sendTextMessage"\s+#options>/,
+    'the `#options` template must carry v-if="!sendTextMessage" — embedded chats send into the current session, so a "which chat starts" control does not apply there',
+  );
+});


### PR DESCRIPTION
## Summary

`CollectionChatModal` は `fixed inset-0` + `backdrop-blur-sm` で画面全体を覆う。ホストが「このチャットは何で立ち上がるか」をどこか別の場所に描いていても、**押すまさにその瞬間だけ**ぼかされて見えない。MulmoTerminal はコレクション発のチャットを 5 種のエージェント（Claude / Codex / Antigravity / Grok / Muse）のいずれかで起こすので、「コレクションから始めたら Claude ではなく Muse が立ち上がった。なぜ？」という報告が実際に出た（receptron/mulmoterminal#1938）。

modal のフッターに **ホストが差し込める slot** を 1 つ開ける。

Closes #3026

| ファイル | 変更 |
|---|---|
| `CollectionChatModal.vue` | フッターのキャンセル / 開始の左に `<slot name="options" />`。`mr-auto` を持つラッパで包む |
| `CollectionView.vue` | `chat-modal-options` を modal の `options` へ転送。**`sendTextMessage` が無いときだけ** |
| `test/components/test_collection_chat_modal_slot.ts` | **新規**。slot・転送・gate が同じ template 要素に載っていることを固定するソース解析型 guard |
| `e2e/tests/collection-chat-button.spec.ts` | 1 行追加。MulmoClaude ではフッターのボタンが 2 つのままであること |
| `plans/feat-3026-chat-modal-options-slot.md` | 設計メモ |

## Items to Confirm / Review

- **slot 名**。issue では `chat-modal-lead` を仮に置いたが `chat-modal-options` にした。「どこに座るか」ではなく「そこに何が属するか」を言う名前のほうが API として長持ちすると考えたため。異論があれば変えます（まだ publish 前なので今なら自由）
- **gate を plugin 側に置いた判断**。`sendTextMessage` があるときは chat カードの中で、`submitChat` は**今動いているセッション**へ送る（`useCollectionChat` の `dispatchSeed`）。新しいチャットは起きないので、「どのチャットが始まるか」を選ばせるコントロールは何も変えない。**効かないオプションは、無いより悪い。** ホストに任せる案もあったが、`CollectionView` を描く場所と modal が出る場所が離れていて、ホストからは判断しづらい
- **`mr-auto` ラッパがレイアウトを動かさないこと**。slot が空ならラッパは幅 0 で、`mr-auto` はフッターの `justify-end` が既に吸っていた余白を吸うだけ。実機で確認済み（下記）だが、目視でも見てほしい
- **`CollectionRecordModal` 側の record チャット**（`onItemChat`）にも同じ判断が当てはまるが、今回は要求のあるほうだけにした
- **バージョン bump と ChangeLog はこの PR に含めていない**。このリポジトリでは `chore(release):` が別コミットで行う慣習（`e00a578cf` など）なので、それに従った

## 検証

`yarn format` → `lint`（0 errors、41 warnings はすべて既存で変更ファイル外）→ `typecheck` → `build` → `test` すべて緑。

> `typecheck` は最初 `server/api/routes/mulmo-script.ts` で 2 件落ちたが、これは変更とは無関係で、checkout の workspace package の型が未ビルドだったため。`yarn build:packages` 後に解消。

**slot が実際に描かれることを実機で確認した**（compile が通る ≠ 動く）。`src/App.vue` の `CollectionView` に一時的に probe を差し込み、Playwright で `/collections/reading-list` の「Chat」→ modal のフッターを実測。確認後、一時変更はすべて revert 済み。

- **標準経路**（`sendTextMessage` 無し）— ホストの中身がフッター左に出て、既存ボタンは動かない:
  ```html
  <footer …><div class="mr-auto flex items-center gap-2"><button data-testid="slot-probe">probe</button></div>
    <button …data-testid="collections-chat-cancel">Cancel</button>
    <button …data-testid="collections-chat-send">Start chat</button></footer>
  ```
- **埋め込み経路**（`:send-text-message` を渡す）— slot は出ない。ラッパだけが残り、フッターは元のまま:
  ```html
  <footer …><div class="mr-auto flex items-center gap-2"></div>
    <button …>Cancel</button><button …>Start chat</button></footer>
  ```

この過程で、e2e が動かしているのは `packages/mulmoclaude/src/App.vue` ではなく**リポジトリルートの `src/App.vue`** であることも確認した（最初そちらを patch して probe が出ず、原因を追って判明）。今回の変更はどちらの App.vue にも触れていない。

## この先

publish 後、MulmoTerminal 側が `@mulmoclaude/collection-plugin` を上げ、この slot に自前の `LaunchAgentPicker` を差し込む（receptron/mulmoterminal#1938 / #1940 の続き）。

## User Prompt

- MulmoTerminal のコレクションからチャットを始めると Claude ではなく Meta Muse が立ち上がる、という報告の原因を調べてほしい。
- ドロップダウンの見えない画面でも分かるようにしたい。あわせて、そこで変更もできるようにしておくと良い。
- （MulmoTerminal 側の実装後、plugin の「チャットを開始」ダイアログを指して）ここでは選べないのか。
- receptron/mulmoclaude 側の issue を立てて、その実装をしてほしい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxdCdUWcAikvCU6fkhMP7p

## Summary by Sourcery

Expose a host-controlled options area in the collection chat start modal while preserving the existing embedded chat behavior.

New Features:
- Add an `options` slot to the collection chat modal footer for host-provided controls.
- Forward host chat-modal options to standalone collection chat flows.

Enhancements:
- Restrict option controls to flows that start a new chat, keeping embedded chat cards unchanged.

Documentation:
- Document the chat modal options slot design and usage.

Tests:
- Add source-level guards for slot placement, forwarding, and standalone-flow gating.
- Verify the default chat modal continues to display only its Cancel and Start chat buttons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional chat modal footer area for host-provided controls, such as agent selection.
  - Custom options appear on the left while Cancel and Start remain right-aligned.
  - Custom options are available for standalone chats and omitted for embedded chats.

- **Tests**
  - Added coverage verifying footer layout and conditional option forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->