### PR TITLE
chore: @mulmoclaude/mulmoscript-plugin のレンジを ^4.5.2 に追随させる

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -126,7 +126,7 @@ the baseline" where it now means "as well as". Both consumers here pass two argu
 unaffected, but the rename is a source break for anyone who read the published type. **2.1.0**
 follows with the narrowed inline-`$` rule described above.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.5.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.5.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.2`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
-    "@mulmoclaude/mulmoscript-plugin": "^4.5.1",
+    "@mulmoclaude/mulmoscript-plugin": "^4.5.2",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",


### PR DESCRIPTION
## Summary

`@mulmoclaude/mulmoscript-plugin@4.5.2` を publish したので（#3024 / #3028）、
ランチャーの宣言レンジを追随させます。差分は 2 行です。

## Items to Confirm / Review

1. **`Ships` 行を同じコミットに入れています。** #3021 でレンジだけ上げて置き去りにし、
   `lint_test` を 4 本落としました。この行は「このランチャーはどのバージョンを pull in
   するか」を答えるので、レンジと一緒に動きます。
2. **`[1.14.0]` の同じ文字列は触っていません** — 過去のリリースが実際に ship した
   バージョンで、書き換えると履歴が嘘になります。
3. **ランチャー自身の `version` は無変更**（`/publish-mulmoclaude` の持ち物）。

## 検証

- `check:changelog-ships` → `OK — [1.15.0] lists all 13 @mulmoclaude/* dependencies.`
- `check:launcher-sync` → `OK — root ↔ launcher deps in sync, no peer-dep violations.`
- `test_changelogShips.ts` 緑

work in mulmoclaude2

## Summary by Sourcery

Enhancements:
- Synchronize the launcher dependency range and changelog Ships entry with @mulmoclaude/mulmoscript-plugin 4.5.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled MulmoScript plugin to version 4.5.2.
  * Updated the changelog to reflect the new plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->