### PR TITLE
chore: sweep @mulmoclaude/core ranges to ^4.6.0 (unblocks main)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -169,7 +169,7 @@ the baseline" where it now means "as well as". Both consumers here pass two argu
 unaffected, but the rename is a source break for anyone who read the published type. **2.1.0**
 follows with the narrowed inline-`$` rule described above.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.5.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.2`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.6.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.2`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.6.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -40,7 +40,7 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "express": "^5.2.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/express": "^5.0.6",
     "@types/node": "^26.4.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,14 +35,14 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,12 +31,12 @@
     "lint": "eslint src test"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "gui-chat-protocol": "^2.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@types/node": "^26.4.1",
     "tsx": "^4.23.13",
     "typescript": "^6.0.3",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -38,14 +38,14 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -44,13 +44,13 @@
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "mulmocast": "^2.9.0",
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.5.0",
+    "@mulmoclaude/core": "^4.6.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",


### PR DESCRIPTION
## Summary

**`main` is currently red, and it blocks every open PR.** `9700bf13b` (`@mulmoclaude/core@4.6.0`) bumped `packages/core/package.json` and nothing else, so every consumer still declares `^4.5.0`:

```
✗ [workspace-lockstep] @mulmoclaude/core: workspace source 4.6.0 is ahead of
  launcher range "^4.5.0" (lower bound 4.5.0) — bump the launcher range to match
```

The Node.js CI run on `9700bf13b` failed on this, and because CI builds each PR *merged into* `main`, unrelated PRs inherit it (that is how I hit it, on #3036).

This sweeps all **15 declarations across 8 `package.json` files** — `dependencies`, `devDependencies` and `peerDependencies` alike — to `^4.6.0`.

| file | occurrences |
|---|---|
| `packages/mulmoclaude/package.json` | 1 |
| `packages/plugins/{accounting,chart,collection,google,html,markdown,mulmoscript}-plugin/package.json` | 2 each |

## Items to Confirm / Review

- **The gate only checks the launcher**, so the seven plugin peer/dev ranges would have stayed stale silently. Per CLAUDE.md an internal range MUST equal `^<latest published>` in *every* manifest that declares it — and a stale caret on a `0.x`/`4.x` peer isn't cosmetic, it pins consumers to the old line. `4.6.0` is confirmed live on npm.
- **No `yarn.lock` change** — these are workspace-internal ranges, resolved by the workspace symlink. `yarn install` produced no lockfile diff, which is the expected outcome and worth confirming in review.
- I swept **only** `@mulmoclaude/core`. I scripted a scan of every workspace-internal dep against its workspace version and found no other stale ranges, so this should be the complete set.
- Deliberately separate from #3036 (the #3018 fix) — that PR is a behaviour change on the MCP shim, this is a release-hygiene sweep. They are independently revertable.

## Testing

`check:launcher-sync` (the failing gate) → OK, plus `yarn install`, `yarn typecheck`, `yarn build` locally green.

## Follow-up

The release flow skipped the consumer sweep that CLAUDE.md requires of a `chore(release)` commit. Worth considering extending `launcherSync.mjs` to check **all** workspace manifests rather than only the launcher, so the next release can't half-land the same way.

## User Prompt

- 「fix https://github.com/receptron/mulmoclaude/pull/3030」 — 別PRのCI修正（マージ済み）。
- 「https://github.com/receptron/mulmoclaude/issues/3018 原因わかる？」 — 原因調査。
- 「あれ、これってユーザの勘違い？こっちのバグ？」 — こちらのバグと判定。
- 「ok　では修正して。」 — 修正実施（#3036）。その CI で main 側のこの破損に当たったため、本PRで切り出して修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsP85JQHVTN9gY63Z2VMKi

work in mulmoclaude2

## Summary by Sourcery

Update every `@mulmoclaude/core` dependency declaration to `^4.6.0` across the workspace.

Bug Fixes:
- Align all workspace consumers with the released `@mulmoclaude/core` 4.6.0 version so launcher synchronization checks pass and dependent PRs are no longer blocked.

Documentation:
- Update the changelog to record `@mulmoclaude/core@4.6.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the core package compatibility requirement to version 4.6.0 across the main package and supported plugins.
  * Maintained alignment between plugin development and peer dependency requirements.
  * Updated the release documentation to reflect the 4.6.0 package version.

* **Compatibility**
  * Ensured supported plugins remain aligned with the latest core package release for consistent installation and development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->