### PR TITLE
chore: sweep @mulmoclaude/core ranges + Ships line to ^4.7.0 (unblocks main again)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -180,7 +180,7 @@ the baseline" where it now means "as well as". Both consumers here pass two argu
 unaffected, but the rename is a source break for anyone who read the published type. **2.1.0**
 follows with the narrowed inline-`$` rule described above.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.6.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.2`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.7.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.2`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -39,7 +39,7 @@
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.6.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -40,7 +40,7 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "express": "^5.2.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/express": "^5.0.6",
     "@types/node": "^26.4.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,14 +35,14 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.5.4"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,12 +31,12 @@
     "lint": "eslint src test"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "gui-chat-protocol": "^2.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@types/node": "^26.4.1",
     "tsx": "^4.23.13",
     "typescript": "^6.0.3",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -38,14 +38,14 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -44,13 +44,13 @@
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "mulmocast": "^2.9.0",
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.6.0",
+    "@mulmoclaude/core": "^4.7.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.69.0",


### PR DESCRIPTION
## Summary

**`main` is red again, the same way as #3037 — one release later.** While #3037 was in CI, `d36fc4f78` published `@mulmoclaude/core@4.7.0` changing only `packages/core/package.json`:

```
✗ [workspace-lockstep] @mulmoclaude/core: workspace source 4.7.0 is ahead of
  launcher range "^4.6.0" (lower bound 4.6.0) — bump the launcher range to match
```

`^4.6.0` is the value #3037 had *just* set, so this is the third occurrence of the same miss (4.6.0 broke it, #3037 fixed it, 4.7.0 broke it again).

This sweeps the same **15 declarations across 8 manifests** to `^4.7.0`, **and** the `[1.15.0]` `Ships` line in the same commit. #3037 needed a follow-up commit for that line because the two gates fail in sequence — `check:launcher-sync` runs first, so the `Ships` failure is invisible until the ranges are fixed. Doing both up front saves a CI round-trip.

`4.7.0` is confirmed live on npm.

## Items to Confirm / Review

- **The `#### @mulmoclaude/core@4.6.0` release-note heading at line 24 is deliberately untouched.** Only the `Ships` line tracks what the launcher currently pulls in; the heading is history. A blind find-and-replace would have rewritten both — worth checking I picked the right one.
- **No `yarn.lock` change** — workspace-internal ranges only.
- Only `@mulmoclaude/core` is swept; nothing else was stale.

## This keeps happening — the gate is in the wrong place

Three releases, three breakages, each blocking **every open PR** (CI builds each PR merged into `main`). The release step keeps the package's own `version` in step and nothing else, while two other places must move with it:

| what must move | enforced by |
|---|---|
| `packages/core/package.json` `version` | the release step |
| 15 consumer ranges across 8 manifests | `launcherSync.mjs`, **launcher only** — the 7 plugin peer/dev ranges are unchecked |
| the `[1.15.0]` `Ships` line | `check-changelog-ships.mjs`, and only *after* the gate above passes |

Two concrete fixes worth doing:

1. Extend `launcherSync.mjs` to check **all** workspace manifests, not just the launcher. Today a stale plugin peer range ships silently.
2. Have the release script sweep consumers + the `Ships` line, so a `chore(release)` commit lands complete — which is what CLAUDE.md already requires of it.

Happy to implement either.

## Testing

`check:launcher-sync` → OK, `check:doc-links` → OK, `check-changelog-ships.mjs` → `OK — [1.15.0] lists all 13 @mulmoclaude/* dependencies`, plus `yarn typecheck`, `yarn build`, `yarn test:coverage` green locally.

## User Prompt

- 「fix https://github.com/receptron/mulmoclaude/pull/3030」 — 別PRのCI修正（マージ済み）。
- 「https://github.com/receptron/mulmoclaude/issues/3018 原因わかる？」 / 「あれ、これってユーザの勘違い？こっちのバグ？」 — 原因調査、こちらのバグと判定。
- 「ok　では修正して。」 — #3036 で修正。
- 「両方 green になったらマージして」 — #3037 をマージ済み。その直後に本件で main が再度赤くなったため、#3036 を通すために切り出し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsP85JQHVTN9gY63Z2VMKi

work in mulmoclaude2

## Summary by Sourcery

Synchronize workspace consumers and release notes with @mulmoclaude/core 4.7.0 to restore passing main-branch checks.

Bug Fixes:
- Update all stale @mulmoclaude/core consumer ranges to ^4.7.0 so workspace synchronization checks pass after the core 4.7.0 release.

Documentation:
- Update the [1.15.0] changelog Ships entry to reference @mulmoclaude/core@4.7.0 while preserving the historical release heading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core package version to 4.7.0 across the main package and plugins.
  * Synchronized peer and development dependency requirements for all affected plugins.

* **Documentation**
  * Updated the 1.15.0 package roster to reflect the core package version 4.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->