### PR TITLE
chore: launcherSync checks every workspace, not just the launcher

### DIFF
--- a/scripts/mulmoclaude/launcherSync.d.mts
+++ b/scripts/mulmoclaude/launcherSync.d.mts
@@ -19,6 +19,7 @@ export type FindingKind =
   | "peer-dep-lockstep"
   | "consumer-lockstep"
   | "unsupported-range"
+  | "invalid-workspace-version"
   | "skipped";
 
 export interface Finding {

--- a/scripts/mulmoclaude/launcherSync.d.mts
+++ b/scripts/mulmoclaude/launcherSync.d.mts
@@ -9,6 +9,8 @@ export interface WorkspacePackage {
   peerDependencies: Record<string, string>;
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
+  /** The manifest exactly as written, so field discovery reads the source. */
+  manifest: Record<string, unknown>;
 }
 
 export type FindingKind =

--- a/scripts/mulmoclaude/launcherSync.d.mts
+++ b/scripts/mulmoclaude/launcherSync.d.mts
@@ -12,7 +12,14 @@ export interface WorkspacePackage {
 }
 
 export type FindingKind =
-  "root-launcher-mismatch" | "workspace-source-drift" | "workspace-lockstep" | "peer-dep-violation" | "peer-dep-lockstep" | "consumer-lockstep" | "skipped";
+  | "root-launcher-mismatch"
+  | "workspace-source-drift"
+  | "workspace-lockstep"
+  | "peer-dep-violation"
+  | "peer-dep-lockstep"
+  | "consumer-lockstep"
+  | "unsupported-range"
+  | "skipped";
 
 export interface Finding {
   kind: FindingKind;

--- a/scripts/mulmoclaude/launcherSync.d.mts
+++ b/scripts/mulmoclaude/launcherSync.d.mts
@@ -8,9 +8,11 @@ export interface WorkspacePackage {
   packageJsonPath: string;
   peerDependencies: Record<string, string>;
   dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
 }
 
-export type FindingKind = "root-launcher-mismatch" | "workspace-source-drift" | "workspace-lockstep" | "peer-dep-violation" | "peer-dep-lockstep" | "skipped";
+export type FindingKind =
+  "root-launcher-mismatch" | "workspace-source-drift" | "workspace-lockstep" | "peer-dep-violation" | "peer-dep-lockstep" | "consumer-lockstep" | "skipped";
 
 export interface Finding {
   kind: FindingKind;
@@ -28,6 +30,9 @@ export function loadWorkspacePackages(options?: AuditOptions): Promise<Map<strin
 export function satisfies(version: string, range: string): boolean | null;
 
 export function auditLauncherSync(options?: AuditOptions): Promise<Finding[]>;
+
+/** Invariant 6: every manifest's internal dep ranges vs the workspace source. */
+export function auditConsumerLockstep(input: { root: string; rootPkg: Record<string, unknown>; workspaces: Map<string, WorkspacePackage> }): Finding[];
 
 /** CLI entry point. Returns 0 clean, 1 if any non-skipped finding present. */
 export function main(): Promise<number>;

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -164,10 +164,15 @@ function isOwnedByInvariant4(manifestPath, field, launcherPath) {
 // range withholds every release since from anyone installing it.
 function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion }) {
   const lower = parseLowerBound(range);
-  if (!lower) {
+  const source = parseVersion(workspaceVersion);
+  if (!lower || !source) {
     return { kind: "skipped", message: `${relPath}: ${field}."${depName}"="${range}" unparseable — cannot verify vs workspace ${workspaceVersion}` };
   }
-  if (lower.join(".") === workspaceVersion) return null;
+  // Compare parsed components on BOTH sides, exactly as invariant 4 does.
+  // `parseLowerBound` drops prerelease/build metadata, so comparing it to the
+  // raw version string reports a correctly-swept prerelease (workspace
+  // `4.8.0-beta.1` vs range `^4.8.0-beta.1`) as drift and blocks the release.
+  if (lower.every((part, index) => part === source[index])) return null;
   return {
     kind: "consumer-lockstep",
     message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) is behind workspace source ${workspaceVersion} — sweep this range too`,

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -164,6 +164,23 @@ const VERSIONLESS_PROTOCOLS = new Set([
   "bitbucket",
 ]);
 
+// `workspace:` is the one protocol that MAY carry a range of its own.
+// `workspace:*`, `workspace:^` and `workspace:~` are the versionless forms —
+// the package manager substitutes the local version at publish time. But
+// `workspace:^4.6.0` states a lower bound like any other range, and skipping
+// it let a stale internal dependency through. Unwrap the prefix and let the
+// normal path judge what follows.
+const WORKSPACE_PREFIX = "workspace:";
+const VERSIONLESS_WORKSPACE_FORMS = new Set(["*", "^", "~"]);
+
+function unwrapWorkspaceProtocol(range) {
+  if (typeof range !== "string") return range;
+  const trimmed = range.trim();
+  if (!trimmed.toLowerCase().startsWith(WORKSPACE_PREFIX)) return trimmed;
+  const inner = trimmed.slice(WORKSPACE_PREFIX.length);
+  return VERSIONLESS_WORKSPACE_FORMS.has(inner) ? "*" : inner;
+}
+
 function isVersionlessSpecifier(range) {
   if (typeof range !== "string") return false;
   const trimmed = range.trim();
@@ -255,13 +272,14 @@ function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion })
       message: `${relPath}: ${field}."${depName}" points at workspace ${depName}, whose own version "${workspaceVersion}" is not valid SemVer — no consumer of it can be verified`,
     };
   }
-  if (isVersionlessSpecifier(range)) {
+  const specifier = unwrapWorkspaceProtocol(range);
+  if (isVersionlessSpecifier(specifier)) {
     return {
       kind: "skipped",
       message: `${relPath}: ${field}."${depName}"="${range}" resolves by a route that names no version — nothing to compare against workspace ${workspaceVersion}`,
     };
   }
-  const lower = parseLowerBound(range);
+  const lower = parseLowerBound(specifier);
   if (!lower) {
     return {
       kind: "unsupported-range",
@@ -273,7 +291,7 @@ function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion })
   // `^4.8.0-beta.1` reads as drift and blocks its own release commit, and
   // against another triple `^4.8.0-beta.1` passes for a workspace already at
   // `4.8.0-beta.2`, the stale range this invariant exists to find.
-  if (comparableVersion(range) === comparableVersion(workspaceVersion)) return null;
+  if (comparableVersion(specifier) === comparableVersion(workspaceVersion)) return null;
   return {
     kind: "consumer-lockstep",
     message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) is behind workspace source ${workspaceVersion} — sweep this range too`,

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -178,12 +178,35 @@ const VERSIONLESS_PROTOCOLS = new Set([
 const WORKSPACE_PREFIX = "workspace:";
 const VERSIONLESS_WORKSPACE_FORMS = new Set(["*", "^", "~"]);
 
-function unwrapWorkspaceProtocol(range) {
+const NPM_PREFIX = "npm:";
+
+// `npm:name@range` aliases the dependency to another package. When the alias
+// targets THIS SAME package it is just a range with extra ceremony —
+// `npm:@mulmoclaude/core@^4.6.0` pins core exactly as `^4.6.0` does — so it
+// must be compared, not skipped. When it targets a DIFFERENT package the
+// workspace's version says nothing about it, and skipping is correct.
+// Split on the last `@` so scoped names survive.
+function unwrapNpmAlias(trimmed, depName) {
+  const spec = trimmed.slice(NPM_PREFIX.length);
+  const at = spec.lastIndexOf("@");
+  if (at <= 0) return null;
+  return spec.slice(0, at) === depName ? spec.slice(at + 1) : null;
+}
+
+// Reduce a declared specifier to the range it states about `depName`, or
+// return it unchanged when it is not one of the protocols that can wrap one.
+function resolveSpecifier(range, depName) {
   if (typeof range !== "string") return range;
   const trimmed = range.trim();
-  if (!trimmed.toLowerCase().startsWith(WORKSPACE_PREFIX)) return trimmed;
-  const inner = trimmed.slice(WORKSPACE_PREFIX.length);
-  return VERSIONLESS_WORKSPACE_FORMS.has(inner) ? "*" : inner;
+  const lower = trimmed.toLowerCase();
+  if (lower.startsWith(WORKSPACE_PREFIX)) {
+    const inner = trimmed.slice(WORKSPACE_PREFIX.length);
+    return VERSIONLESS_WORKSPACE_FORMS.has(inner) ? "*" : inner;
+  }
+  if (lower.startsWith(NPM_PREFIX)) {
+    return unwrapNpmAlias(trimmed, depName) ?? trimmed;
+  }
+  return trimmed;
 }
 
 function isVersionlessSpecifier(range) {
@@ -294,7 +317,7 @@ function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion })
       message: `${relPath}: ${field}."${depName}" points at workspace ${depName}, whose own version "${workspaceVersion}" is not valid SemVer — no consumer of it can be verified`,
     };
   }
-  const specifier = unwrapWorkspaceProtocol(range);
+  const specifier = resolveSpecifier(range, depName);
   if (isVersionlessSpecifier(specifier)) {
     return {
       kind: "skipped",
@@ -316,7 +339,7 @@ function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion })
   if (comparableVersion(specifier) === comparableVersion(workspaceVersion)) return null;
   return {
     kind: "consumer-lockstep",
-    message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) is behind workspace source ${workspaceVersion} — sweep this range too`,
+    message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) does not match workspace source ${workspaceVersion} — the lower bound must equal it, so sweep this range too`,
   };
 }
 

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -140,12 +140,36 @@ const COMPARATOR_PREFIX_RE = new RegExp(`^${COMPARATOR}`);
 // parse is a malformed declaration and must FAIL, not slip through the same
 // door. Stating the rule this way rather than listing bad inputs is what
 // keeps `""`, `"workspacefoo"` and a non-string value out of it.
-const SCHEME_SPECIFIER_RE = /^[a-z][a-z0-9+.-]*:/i;
+// An ALLOW-LIST, not a pattern. `^[a-z][a-z0-9+.-]*:` looked like the same
+// idea and was not: it matched any word followed by a colon, so
+// `totally-invalid:4.6.0` was classified as a versionless route and skipped.
+// The protocols are a finite set the package managers define, so name them;
+// the malformed inputs are infinite, so never try to name those.
+const VERSIONLESS_PROTOCOLS = new Set([
+  "workspace",
+  "npm",
+  "file",
+  "link",
+  "portal",
+  "patch",
+  "git",
+  "git+ssh",
+  "git+http",
+  "git+https",
+  "git+file",
+  "http",
+  "https",
+  "github",
+  "gitlab",
+  "bitbucket",
+]);
 
 function isVersionlessSpecifier(range) {
   if (typeof range !== "string") return false;
   const trimmed = range.trim();
-  return trimmed === "*" || SCHEME_SPECIFIER_RE.test(trimmed);
+  if (trimmed === "*") return true;
+  const colon = trimmed.indexOf(":");
+  return colon > 0 && VERSIONLESS_PROTOCOLS.has(trimmed.slice(0, colon).toLowerCase());
 }
 
 function parseLowerBound(range) {

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -110,6 +110,14 @@ function parseLowerBound(range) {
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
+// The version a range pins to, comparator removed and nothing else
+// normalised — `^4.8.0-beta.1` → `4.8.0-beta.1`.
+function stripComparator(range) {
+  return String(range)
+    .trim()
+    .replace(/^[\^~>=]*\s*/, "");
+}
+
 function parseVersion(version) {
   if (typeof version !== "string") return null;
   const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:[-+][\w.]*)?$/);
@@ -168,11 +176,13 @@ function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion })
   if (!lower || !source) {
     return { kind: "skipped", message: `${relPath}: ${field}."${depName}"="${range}" unparseable — cannot verify vs workspace ${workspaceVersion}` };
   }
-  // Compare parsed components on BOTH sides, exactly as invariant 4 does.
-  // `parseLowerBound` drops prerelease/build metadata, so comparing it to the
-  // raw version string reports a correctly-swept prerelease (workspace
-  // `4.8.0-beta.1` vs range `^4.8.0-beta.1`) as drift and blocks the release.
-  if (lower.every((part, index) => part === source[index])) return null;
+  // Compare the FULL lower bound, prerelease and build metadata included —
+  // only the comparator is stripped. Comparing parsed numeric triples instead
+  // is wrong in both directions: against the raw version string a correctly
+  // swept `^4.8.0-beta.1` reads as drift and blocks its own release commit,
+  // and against another triple `^4.8.0-beta.1` passes for a workspace already
+  // at `4.8.0-beta.2`, which is the stale range this invariant exists to find.
+  if (stripComparator(range) === workspaceVersion.trim()) return null;
   return {
     kind: "consumer-lockstep",
     message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) is behind workspace source ${workspaceVersion} — sweep this range too`,

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -96,6 +96,15 @@ export async function loadWorkspacePackages({ root = REPO_ROOT_DEFAULT } = {}) {
   return registry;
 }
 
+// A full SemVer tail: an OPTIONAL prerelease and an OPTIONAL build, in that
+// order. The earlier `(?:[-+][\w.]*)?` allowed one or the other, so a valid
+// `4.8.0-beta.2+build.9` failed to parse — and an unparseable version yields a
+// `skipped` finding, which `main()` excludes from failure. A stale range
+// against such a version therefore walked straight through the gate.
+const SEMVER_CORE = String.raw`(\d+)\.(\d+)\.(\d+)(?:-[\w.-]+)?(?:\+[\w.-]+)?`;
+const SEMVER_RE = new RegExp(`^${SEMVER_CORE}$`);
+const SEMVER_TAIL_RE = new RegExp(String.raw`^[\^~>=]*\s*${SEMVER_CORE}$`);
+
 // Parse a semver range's lower bound into [major, minor, patch].
 // Handles the subset the launcher actually uses: exact ("0.4.0"),
 // caret ("^0.4.0"), tilde ("~0.4.0"), and ">=" ("^0.5.0"-style is
@@ -105,22 +114,26 @@ function parseLowerBound(range) {
   if (typeof range !== "string") return null;
   const trimmed = range.trim();
   if (trimmed === "" || trimmed === "*" || trimmed.includes(":") || trimmed.startsWith("workspace")) return null;
-  const match = trimmed.match(/^[\^~>=]*\s*(\d+)\.(\d+)\.(\d+)(?:[-+][\w.]*)?$/);
+  const match = trimmed.match(SEMVER_TAIL_RE);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
-// The version a range pins to, comparator removed and nothing else
-// normalised — `^4.8.0-beta.1` → `4.8.0-beta.1`.
-function stripComparator(range) {
-  return String(range)
+// The version a range pins to, in the form two of them can be compared in:
+// comparator removed and build metadata dropped, prerelease kept —
+// `^4.8.0-beta.1+build.2` → `4.8.0-beta.1`. Build metadata is excluded from
+// SemVer precedence, so two versions differing only there are the same release
+// and must not read as drift; prerelease IS part of precedence, so it stays.
+function comparableVersion(value) {
+  return String(value)
     .trim()
-    .replace(/^[\^~>=]*\s*/, "");
+    .replace(/^[\^~>=]*\s*/, "")
+    .replace(/\+[\w.-]+$/, "");
 }
 
 function parseVersion(version) {
   if (typeof version !== "string") return null;
-  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)(?:[-+][\w.]*)?$/);
+  const match = version.trim().match(SEMVER_RE);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
@@ -176,13 +189,12 @@ function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion })
   if (!lower || !source) {
     return { kind: "skipped", message: `${relPath}: ${field}."${depName}"="${range}" unparseable — cannot verify vs workspace ${workspaceVersion}` };
   }
-  // Compare the FULL lower bound, prerelease and build metadata included —
-  // only the comparator is stripped. Comparing parsed numeric triples instead
-  // is wrong in both directions: against the raw version string a correctly
-  // swept `^4.8.0-beta.1` reads as drift and blocks its own release commit,
-  // and against another triple `^4.8.0-beta.1` passes for a workspace already
-  // at `4.8.0-beta.2`, which is the stale range this invariant exists to find.
-  if (stripComparator(range) === workspaceVersion.trim()) return null;
+  // Compare the whole lower bound, not parsed numeric triples — those are wrong
+  // in both directions: against the raw version string a correctly swept
+  // `^4.8.0-beta.1` reads as drift and blocks its own release commit, and
+  // against another triple `^4.8.0-beta.1` passes for a workspace already at
+  // `4.8.0-beta.2`, the stale range this invariant exists to find.
+  if (comparableVersion(range) === comparableVersion(workspaceVersion)) return null;
   return {
     kind: "consumer-lockstep",
     message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) is behind workspace source ${workspaceVersion} — sweep this range too`,

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -95,6 +95,11 @@ export async function loadWorkspacePackages({ root = REPO_ROOT_DEFAULT } = {}) {
         peerDependencies: pkg.peerDependencies ?? {},
         dependencies: pkg.dependencies ?? {},
         devDependencies: pkg.devDependencies ?? {},
+        // The manifest as written. Copying three named fields is what made
+        // `optionalDependencies` invisible even after the field list was
+        // derived rather than hard-coded — the derivation was reading the
+        // copy, not the source.
+        manifest: pkg,
       });
     }
   }
@@ -243,11 +248,21 @@ export function satisfies(version, range) {
   return v[0] === lb[0] && v[1] === lb[1] && v[2] === lb[2];
 }
 
-// Every field a manifest can declare an internal dep in. A stale range
-// is equally wrong in all three: `dependencies` ships it, `peer` states
-// what the host must provide, and `dev` is what the package built and
-// tested against.
-const DEP_FIELDS = ["dependencies", "devDependencies", "peerDependencies"];
+// Read the dependency fields OFF the manifest rather than listing them. A
+// stale range is equally wrong in all of them — `dependencies` ships it,
+// `peer` states what the host must provide, `dev` is what the package built
+// against, `optional` still resolves when present — and a hard-coded trio
+// silently exempted `optionalDependencies`, which this repo already uses.
+// Deriving them means the next field npm adds is covered on arrival.
+// `bundledDependencies` is excluded by the object test: it is an array of
+// names carrying no ranges, so there is nothing to compare.
+function dependencyFields(pkg) {
+  return Object.keys(pkg).filter((key) => /dependencies$/i.test(key) && isPlainObject(pkg[key]));
+}
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 // Invariant 4 owns the LOCKSTEP COMPARISON for the launcher's own
 // `dependencies` — reporting that drift twice would make one bad release read
@@ -314,12 +329,12 @@ export function auditConsumerLockstep({ root, rootPkg, workspaces }) {
   const launcherPath = path.join(root, LAUNCHER_REL);
   const manifests = [{ manifestPath: path.join(root, "package.json"), pkg: rootPkg }];
   for (const ws of workspaces.values()) {
-    manifests.push({ manifestPath: ws.packageJsonPath, pkg: ws });
+    manifests.push({ manifestPath: ws.packageJsonPath, pkg: ws.manifest ?? ws });
   }
   const findings = [];
   for (const { manifestPath, pkg } of manifests) {
     const relPath = path.relative(root, manifestPath) || "package.json";
-    for (const field of DEP_FIELDS) {
+    for (const field of dependencyFields(pkg)) {
       const lockstepOwnedElsewhere = isLockstepOwnedByInvariant4(manifestPath, field, launcherPath);
       for (const [depName, range] of Object.entries(pkg[field] ?? {})) {
         const target = workspaces.get(depName);

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -82,7 +82,12 @@ export async function loadWorkspacePackages({ root = REPO_ROOT_DEFAULT } = {}) {
       } catch {
         continue;
       }
-      if (typeof pkg.name !== "string" || typeof pkg.version !== "string") continue;
+      // A manifest with no name cannot be referenced, so it is genuinely not a
+      // workspace. A BAD VERSION is different: dropping it here removed every
+      // consumer edge pointing at it from the audit, so a workspace with
+      // `version: 47` silently exempted all of its consumers. Keep it and let
+      // the invariants report it.
+      if (typeof pkg.name !== "string") continue;
       registry.set(pkg.name, {
         name: pkg.name,
         version: pkg.version,
@@ -101,7 +106,17 @@ export async function loadWorkspacePackages({ root = REPO_ROOT_DEFAULT } = {}) {
 // `4.8.0-beta.2+build.9` failed to parse — and an unparseable version yields a
 // `skipped` finding, which `main()` excludes from failure. A stale range
 // against such a version therefore walked straight through the gate.
-const SEMVER_CORE = String.raw`(\d+)\.(\d+)\.(\d+)(?:-[\w.-]+)?(?:\+[\w.-]+)?`;
+// SemVer 2.0.0, spelled out rather than approximated. `\d+` and `[\w.-]`
+// were close enough to look right and wrong where it counts: they accept
+// `04.7.0`, `4.7.0-01` and `4.7.0-beta_1`, all of which npm rejects — so a
+// declaration npm cannot resolve compared equal to its workspace and the
+// gate reported nothing. Numeric identifiers carry no leading zero;
+// prerelease identifiers are alphanumeric-or-hyphen (no `_`); build
+// metadata is the same set but may keep leading zeros.
+const NUM_ID = String.raw`0|[1-9]\d*`;
+const PRE_ID = String.raw`(?:${NUM_ID}|\d*[a-zA-Z-][0-9a-zA-Z-]*)`;
+const BUILD_ID = String.raw`[0-9a-zA-Z-]+`;
+const SEMVER_CORE = String.raw`(${NUM_ID})\.(${NUM_ID})\.(${NUM_ID})(?:-${PRE_ID}(?:\.${PRE_ID})*)?(?:\+${BUILD_ID}(?:\.${BUILD_ID})*)?`;
 const SEMVER_RE = new RegExp(`^${SEMVER_CORE}$`);
 // Only the comparators `satisfies()` below can actually evaluate. The old
 // `[\^~>=]*` accepted any repetition or mixture, so `====4.7.0` and `>4.7.0`

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -89,6 +89,7 @@ export async function loadWorkspacePackages({ root = REPO_ROOT_DEFAULT } = {}) {
         packageJsonPath: pkgPath,
         peerDependencies: pkg.peerDependencies ?? {},
         dependencies: pkg.dependencies ?? {},
+        devDependencies: pkg.devDependencies ?? {},
       });
     }
   }
@@ -143,6 +144,63 @@ export function satisfies(version, range) {
   return v[0] === lb[0] && v[1] === lb[1] && v[2] === lb[2];
 }
 
+// Every field a manifest can declare an internal dep in. A stale range
+// is equally wrong in all three: `dependencies` ships it, `peer` states
+// what the host must provide, and `dev` is what the package built and
+// tested against.
+const DEP_FIELDS = ["dependencies", "devDependencies", "peerDependencies"];
+
+// Invariant 6 applies to every manifest EXCEPT the launcher's
+// `dependencies`, which invariant 4 already owns — reporting the same
+// drift twice would make one bad release look like two problems.
+function isOwnedByInvariant4(manifestPath, field, launcherPath) {
+  return manifestPath === launcherPath && field === "dependencies";
+}
+
+// One consumer edge: a manifest declaring a range on a workspace
+// package. The range's lower bound MUST equal that workspace's current
+// version, for the same reason invariant 4 exists — a caret does not
+// float a consumer forward, it pins it to the lower bound, so a stale
+// range withholds every release since from anyone installing it.
+function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion }) {
+  const lower = parseLowerBound(range);
+  if (!lower) {
+    return { kind: "skipped", message: `${relPath}: ${field}."${depName}"="${range}" unparseable — cannot verify vs workspace ${workspaceVersion}` };
+  }
+  if (lower.join(".") === workspaceVersion) return null;
+  return {
+    kind: "consumer-lockstep",
+    message: `${relPath}: ${field}."${depName}"="${range}" (lower bound ${lower.join(".")}) is behind workspace source ${workspaceVersion} — sweep this range too`,
+  };
+}
+
+// Invariant 6: EVERY workspace manifest tracks its internal deps, not
+// just the launcher. `launcherSync` used to check the launcher alone, so
+// a release that bumped a package and swept only the launcher left every
+// plugin's peer/dev range silently stale — 14 such declarations went
+// unreported while the gate showed a single finding (#3037 / #3038).
+export function auditConsumerLockstep({ root, rootPkg, workspaces }) {
+  const launcherPath = path.join(root, LAUNCHER_REL);
+  const manifests = [{ manifestPath: path.join(root, "package.json"), pkg: rootPkg }];
+  for (const ws of workspaces.values()) {
+    manifests.push({ manifestPath: ws.packageJsonPath, pkg: ws });
+  }
+  const findings = [];
+  for (const { manifestPath, pkg } of manifests) {
+    const relPath = path.relative(root, manifestPath) || "package.json";
+    for (const field of DEP_FIELDS) {
+      if (isOwnedByInvariant4(manifestPath, field, launcherPath)) continue;
+      for (const [depName, range] of Object.entries(pkg[field] ?? {})) {
+        const target = workspaces.get(depName);
+        if (!target || depName === pkg.name) continue;
+        const finding = checkConsumerEdge({ relPath, field, depName, range, workspaceVersion: target.version });
+        if (finding) findings.push(finding);
+      }
+    }
+  }
+  return findings;
+}
+
 // Emit findings; each finding = { kind, message } and the caller
 // decides fail vs warn. Kinds:
 //   root-launcher-mismatch  invariant 1 — root ↔ launcher common dep range identical
@@ -150,6 +208,7 @@ export function satisfies(version, range) {
 //   peer-dep-violation      invariant 3 (#1920) — plugin peer dep satisfied by launcher pin
 //   workspace-lockstep      invariant 4 — launcher range lower bound == workspace source (strict ratchet)
 //   peer-dep-lockstep       invariant 5 — plugin peer dep lower bound major.minor == launcher pin major.minor
+//   consumer-lockstep       invariant 6 — EVERY manifest's internal dep range lower bound == workspace source
 //   skipped                 range unparseable → surface for triage
 export async function auditLauncherSync({ root = REPO_ROOT_DEFAULT } = {}) {
   const rootPkg = await readJson(path.join(root, "package.json"));
@@ -255,6 +314,8 @@ export async function auditLauncherSync({ root = REPO_ROOT_DEFAULT } = {}) {
     }
   }
 
+  findings.push(...auditConsumerLockstep({ root, rootPkg, workspaces }));
+
   return findings;
 }
 
@@ -263,7 +324,7 @@ export async function main() {
   const failing = findings.filter((f) => f.kind !== "skipped");
   const skipped = findings.filter((f) => f.kind === "skipped");
   if (failing.length === 0 && skipped.length === 0) {
-    console.log("[mulmoclaude:launcher-sync] OK — root ↔ launcher deps in sync, no peer-dep violations.");
+    console.log("[mulmoclaude:launcher-sync] OK — root ↔ launcher ↔ every workspace in sync, no peer-dep violations.");
     return 0;
   }
   for (const finding of failing) {
@@ -279,8 +340,10 @@ export async function main() {
   }
   console.error("");
   console.error(`[mulmoclaude:launcher-sync] ${failing.length} failing finding(s).`);
-  console.error("Bring root package.json, packages/mulmoclaude/package.json, and workspace peerDependencies");
-  console.error("into sync before merging. See #1920 for the class of bug this gate catches.");
+  console.error("Bring root package.json, packages/mulmoclaude/package.json, and EVERY workspace's");
+  console.error("dependencies / devDependencies / peerDependencies into sync before merging.");
+  console.error("See #1920 for the original class of bug, and #3037 / #3038 for the releases that");
+  console.error("swept only the launcher and left 14 plugin declarations stale.");
   return 1;
 }
 

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -103,17 +103,30 @@ export async function loadWorkspacePackages({ root = REPO_ROOT_DEFAULT } = {}) {
 // against such a version therefore walked straight through the gate.
 const SEMVER_CORE = String.raw`(\d+)\.(\d+)\.(\d+)(?:-[\w.-]+)?(?:\+[\w.-]+)?`;
 const SEMVER_RE = new RegExp(`^${SEMVER_CORE}$`);
-const SEMVER_TAIL_RE = new RegExp(String.raw`^[\^~>=]*\s*${SEMVER_CORE}$`);
+// Only the comparators `satisfies()` below can actually evaluate. The old
+// `[\^~>=]*` accepted any repetition or mixture, so `====4.7.0` and `>4.7.0`
+// both read as lower bound 4.7.0 — the first is not a range npm accepts at
+// all, and the second EXCLUDES 4.7.0. Both compared equal to a workspace at
+// 4.7.0 and produced no finding.
+const SEMVER_TAIL_RE = new RegExp(String.raw`^(?:\^|~|>=)?\s*${SEMVER_CORE}$`);
 
 // Parse a semver range's lower bound into [major, minor, patch].
 // Handles the subset the launcher actually uses: exact ("0.4.0"),
 // caret ("^0.4.0"), tilde ("~0.4.0"), and ">=" ("^0.5.0"-style is
 // enough). Returns null for anything unrecognised so the caller can
 // skip that entry with a clear reason (URLs, git deps, "*", "next").
-function parseLowerBound(range) {
-  if (typeof range !== "string") return null;
+// Specifiers that are legitimate npm but carry no comparable version:
+// `workspace:*`, a tarball URL, `*`. Not knowing their version is expected, so
+// they are skipped rather than failed — unlike a malformed version range.
+function isNonEvaluableRange(range) {
+  if (typeof range !== "string") return true;
   const trimmed = range.trim();
-  if (trimmed === "" || trimmed === "*" || trimmed.includes(":") || trimmed.startsWith("workspace")) return null;
+  return trimmed === "" || trimmed === "*" || trimmed.includes(":") || trimmed.startsWith("workspace");
+}
+
+function parseLowerBound(range) {
+  if (isNonEvaluableRange(range)) return null;
+  const trimmed = range.trim();
   const match = trimmed.match(SEMVER_TAIL_RE);
   if (!match) return null;
   return [Number(match[1]), Number(match[2]), Number(match[3])];
@@ -184,10 +197,22 @@ function isOwnedByInvariant4(manifestPath, field, launcherPath) {
 // float a consumer forward, it pins it to the lower bound, so a stale
 // range withholds every release since from anyone installing it.
 function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion }) {
-  const lower = parseLowerBound(range);
   const source = parseVersion(workspaceVersion);
-  if (!lower || !source) {
-    return { kind: "skipped", message: `${relPath}: ${field}."${depName}"="${range}" unparseable — cannot verify vs workspace ${workspaceVersion}` };
+  if (isNonEvaluableRange(range) || !source) {
+    return {
+      kind: "skipped",
+      message: `${relPath}: ${field}."${depName}"="${range}" carries no comparable version — cannot verify vs workspace ${workspaceVersion}`,
+    };
+  }
+  const lower = parseLowerBound(range);
+  if (!lower) {
+    // `main()` drops skipped findings from the failure count, so skipping here
+    // would let a range npm cannot resolve — or one whose comparator excludes
+    // the very version it names — pass the gate silently.
+    return {
+      kind: "unsupported-range",
+      message: `${relPath}: ${field}."${depName}"="${range}" is not a range this gate can evaluate — use an exact version, ^, ~ or >=`,
+    };
   }
   // Compare the whole lower bound, not parsed numeric triples — those are wrong
   // in both directions: against the raw version string a correctly swept
@@ -236,6 +261,7 @@ export function auditConsumerLockstep({ root, rootPkg, workspaces }) {
 //   workspace-lockstep      invariant 4 — launcher range lower bound == workspace source (strict ratchet)
 //   peer-dep-lockstep       invariant 5 — plugin peer dep lower bound major.minor == launcher pin major.minor
 //   consumer-lockstep       invariant 6 — EVERY manifest's internal dep range lower bound == workspace source
+//   unsupported-range       invariant 6 — an internal dep range this gate cannot evaluate (fails, never skips)
 //   skipped                 range unparseable → surface for triage
 export async function auditLauncherSync({ root = REPO_ROOT_DEFAULT } = {}) {
   const rootPkg = await readJson(path.join(root, "package.json"));

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -249,12 +249,19 @@ export function satisfies(version, range) {
 // tested against.
 const DEP_FIELDS = ["dependencies", "devDependencies", "peerDependencies"];
 
-// Invariant 6 applies to every manifest EXCEPT the launcher's
-// `dependencies`, which invariant 4 already owns — reporting the same
-// drift twice would make one bad release look like two problems.
-function isOwnedByInvariant4(manifestPath, field, launcherPath) {
+// Invariant 4 owns the LOCKSTEP COMPARISON for the launcher's own
+// `dependencies` — reporting that drift twice would make one bad release read
+// as two problems. It does NOT own the strict checks: invariant 4 turns a
+// malformed range or an invalid workspace version into `skipped`, which
+// `main()` excludes from failure, so exempting the launcher outright left the
+// closed gate open for exactly the manifest the launcher owns.
+function isLockstepOwnedByInvariant4(manifestPath, field, launcherPath) {
   return manifestPath === launcherPath && field === "dependencies";
 }
+
+// The findings invariant 4 cannot produce, and therefore must not be dropped
+// with it.
+const STRICT_KINDS = new Set(["unsupported-range", "invalid-workspace-version"]);
 
 // One consumer edge: a manifest declaring a range on a workspace
 // package. The range's lower bound MUST equal that workspace's current
@@ -313,12 +320,14 @@ export function auditConsumerLockstep({ root, rootPkg, workspaces }) {
   for (const { manifestPath, pkg } of manifests) {
     const relPath = path.relative(root, manifestPath) || "package.json";
     for (const field of DEP_FIELDS) {
-      if (isOwnedByInvariant4(manifestPath, field, launcherPath)) continue;
+      const lockstepOwnedElsewhere = isLockstepOwnedByInvariant4(manifestPath, field, launcherPath);
       for (const [depName, range] of Object.entries(pkg[field] ?? {})) {
         const target = workspaces.get(depName);
         if (!target || depName === pkg.name) continue;
         const finding = checkConsumerEdge({ relPath, field, depName, range, workspaceVersion: target.version });
-        if (finding) findings.push(finding);
+        if (!finding) continue;
+        if (lockstepOwnedElsewhere && !STRICT_KINDS.has(finding.kind)) continue;
+        findings.push(finding);
       }
     }
   }

--- a/scripts/mulmoclaude/launcherSync.mjs
+++ b/scripts/mulmoclaude/launcherSync.mjs
@@ -108,24 +108,33 @@ const SEMVER_RE = new RegExp(`^${SEMVER_CORE}$`);
 // both read as lower bound 4.7.0 — the first is not a range npm accepts at
 // all, and the second EXCLUDES 4.7.0. Both compared equal to a workspace at
 // 4.7.0 and produced no finding.
-const SEMVER_TAIL_RE = new RegExp(String.raw`^(?:\^|~|>=)?\s*${SEMVER_CORE}$`);
+const COMPARATOR = String.raw`(?:\^|~|>=)?\s*`;
+const SEMVER_TAIL_RE = new RegExp(`^${COMPARATOR}${SEMVER_CORE}$`);
+const COMPARATOR_PREFIX_RE = new RegExp(`^${COMPARATOR}`);
 
 // Parse a semver range's lower bound into [major, minor, patch].
 // Handles the subset the launcher actually uses: exact ("0.4.0"),
 // caret ("^0.4.0"), tilde ("~0.4.0"), and ">=" ("^0.5.0"-style is
 // enough). Returns null for anything unrecognised so the caller can
 // skip that entry with a clear reason (URLs, git deps, "*", "next").
-// Specifiers that are legitimate npm but carry no comparable version:
-// `workspace:*`, a tarball URL, `*`. Not knowing their version is expected, so
-// they are skipped rather than failed — unlike a malformed version range.
-function isNonEvaluableRange(range) {
-  if (typeof range !== "string") return true;
+// `main()` drops skipped findings from the failure count, so routing an input
+// to `skipped` approves it. That makes the set deliberately CLOSED: a
+// specifier is skipped only when npm resolves it by a route that names no
+// version — the `*` wildcard, or a scheme-prefixed specifier (`workspace:`,
+// `npm:`, `file:`, `git+ssh:`, an https tarball). Anything else that fails to
+// parse is a malformed declaration and must FAIL, not slip through the same
+// door. Stating the rule this way rather than listing bad inputs is what
+// keeps `""`, `"workspacefoo"` and a non-string value out of it.
+const SCHEME_SPECIFIER_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+function isVersionlessSpecifier(range) {
+  if (typeof range !== "string") return false;
   const trimmed = range.trim();
-  return trimmed === "" || trimmed === "*" || trimmed.includes(":") || trimmed.startsWith("workspace");
+  return trimmed === "*" || SCHEME_SPECIFIER_RE.test(trimmed);
 }
 
 function parseLowerBound(range) {
-  if (isNonEvaluableRange(range)) return null;
+  if (typeof range !== "string" || isVersionlessSpecifier(range)) return null;
   const trimmed = range.trim();
   const match = trimmed.match(SEMVER_TAIL_RE);
   if (!match) return null;
@@ -140,7 +149,7 @@ function parseLowerBound(range) {
 function comparableVersion(value) {
   return String(value)
     .trim()
-    .replace(/^[\^~>=]*\s*/, "")
+    .replace(COMPARATOR_PREFIX_RE, "")
     .replace(/\+[\w.-]+$/, "");
 }
 
@@ -198,20 +207,26 @@ function isOwnedByInvariant4(manifestPath, field, launcherPath) {
 // range withholds every release since from anyone installing it.
 function checkConsumerEdge({ relPath, field, depName, range, workspaceVersion }) {
   const source = parseVersion(workspaceVersion);
-  if (isNonEvaluableRange(range) || !source) {
+  if (!source) {
+    // Not the consumer's fault, and NOT skippable: one malformed version in a
+    // workspace's own package.json would otherwise disable this invariant for
+    // every consumer of that workspace at once.
+    return {
+      kind: "invalid-workspace-version",
+      message: `${relPath}: ${field}."${depName}" points at workspace ${depName}, whose own version "${workspaceVersion}" is not valid SemVer — no consumer of it can be verified`,
+    };
+  }
+  if (isVersionlessSpecifier(range)) {
     return {
       kind: "skipped",
-      message: `${relPath}: ${field}."${depName}"="${range}" carries no comparable version — cannot verify vs workspace ${workspaceVersion}`,
+      message: `${relPath}: ${field}."${depName}"="${range}" resolves by a route that names no version — nothing to compare against workspace ${workspaceVersion}`,
     };
   }
   const lower = parseLowerBound(range);
   if (!lower) {
-    // `main()` drops skipped findings from the failure count, so skipping here
-    // would let a range npm cannot resolve — or one whose comparator excludes
-    // the very version it names — pass the gate silently.
     return {
       kind: "unsupported-range",
-      message: `${relPath}: ${field}."${depName}"="${range}" is not a range this gate can evaluate — use an exact version, ^, ~ or >=`,
+      message: `${relPath}: ${field}."${depName}"=${JSON.stringify(range)} is not a range this gate can evaluate — use an exact version, ^, ~ or >=`,
     };
   }
   // Compare the whole lower bound, not parsed numeric triples — those are wrong
@@ -262,6 +277,7 @@ export function auditConsumerLockstep({ root, rootPkg, workspaces }) {
 //   peer-dep-lockstep       invariant 5 — plugin peer dep lower bound major.minor == launcher pin major.minor
 //   consumer-lockstep       invariant 6 — EVERY manifest's internal dep range lower bound == workspace source
 //   unsupported-range       invariant 6 — an internal dep range this gate cannot evaluate (fails, never skips)
+//   invalid-workspace-version invariant 6 — a workspace's own version is not SemVer (fails; it blinds every consumer)
 //   skipped                 range unparseable → surface for triage
 export async function auditLauncherSync({ root = REPO_ROOT_DEFAULT } = {}) {
   const rootPkg = await readJson(path.join(root, "package.json"));

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -333,7 +333,7 @@ describe("auditLauncherSync — invariant 5: gui-chat-protocol peer dep lockstep
 // Invariant-6 cases all have the same shape: one workspace package, one
 // consumer declaring a range on it. Naming that shape keeps each `it` to the
 // pair of versions under test and guarantees the temp repo is always removed.
-async function auditConsumerPair(coreVersion: string, consumerRange: string, field: "peerDependencies" | "devDependencies" = "peerDependencies") {
+async function auditConsumerPair(coreVersion: string, consumerRange: string, field = "peerDependencies") {
   const root = makeFakeRepo({
     root: { name: "monorepo", dependencies: {} },
     launcher: { name: "mulmoclaude", dependencies: {} },
@@ -549,6 +549,16 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
       const findings = await auditConsumerPair("4.7.0", range);
       assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1, `${JSON.stringify(range)} must fail`);
       assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, `${JSON.stringify(range)} must not skip`);
+    }
+  });
+
+  it("checks every dependency field the manifest declares, not a remembered three", async () => {
+    // `optionalDependencies` was exempt — the field list was hard-coded, and
+    // then, after it was derived from the manifest, the derivation was still
+    // reading a three-field COPY the registry kept rather than the manifest
+    // itself. The repo already uses the field, so this was a live gap.
+    for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
+      assert.equal(consumerLockstepCount(await auditConsumerPair("4.7.0", "^4.5.0", field)), 1, `${field} must be audited`);
     }
   });
 

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -552,6 +552,33 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     }
   });
 
+  it("compares an npm: alias that targets the same package", async () => {
+    // `npm:@mulmoclaude/core@^4.6.0` pins core exactly as `^4.6.0` does. It
+    // was skipped wholesale because `npm` is an aliasing protocol.
+    const stale = await auditConsumerPair("4.7.0", "npm:@mulmoclaude/core@^4.6.0");
+    assert.equal(consumerLockstepCount(stale), 1);
+    assert.equal(stale.filter((finding) => finding.kind === "skipped").length, 0);
+    assert.deepEqual(await auditConsumerPair("4.7.0", "npm:@mulmoclaude/core@^4.7.0"), [], "an in-step alias is in step");
+  });
+
+  it("still skips an npm: alias pointing at a different package", async () => {
+    // The workspace's version says nothing about another package's range.
+    const findings = await auditConsumerPair("4.7.0", "npm:some-other-pkg@^1.0.0");
+    assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 1);
+    assert.equal(findings.filter((finding) => finding.kind !== "skipped").length, 0);
+  });
+
+  it("does not claim a direction the comparison never tests", async () => {
+    // The check reports any mismatch, so a range AHEAD of the workspace gets
+    // the same finding; saying it "is behind" was wrong guidance there.
+    const ahead = await auditConsumerPair("4.7.0", "^4.8.0");
+    assert.equal(consumerLockstepCount(ahead), 1);
+    const [finding] = ahead;
+    assert.ok(finding);
+    assert.match(finding.message, /must equal/);
+    assert.doesNotMatch(finding.message, /is behind/);
+  });
+
   it("checks every dependency field the manifest declares, not a remembered three", async () => {
     // `optionalDependencies` was exempt — the field list was hard-coded, and
     // then, after it was derived from the manifest, the derivation was still

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -509,7 +509,15 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
 
   it("skips ONLY specifiers that resolve by a route naming no version", async () => {
     // These are legitimate npm and genuinely carry no version to compare.
-    for (const range of ["*", "workspace:*", "npm:@scope/pkg@1.2.3", "https://example.com/pkg.tgz", "file:../core"]) {
+    for (const range of [
+      "*",
+      "workspace:*",
+      "npm:@scope/pkg@1.2.3",
+      "https://example.com/pkg.tgz",
+      "file:../core",
+      "git+ssh://git@host/x.git",
+      "github:owner/repo",
+    ]) {
       const findings = await auditConsumerPair("4.7.0", range);
       assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 1, `${range} should skip`);
       assert.equal(findings.filter((finding) => finding.kind !== "skipped").length, 0, `${range} should not fail`);
@@ -522,7 +530,7 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     // versionless specifiers, and each one used to pass the gate silently:
     // "" and "workspacefoo" matched the old prefix test, and a non-string
     // value short-circuited it entirely.
-    for (const range of ["", "   ", "workspacefoo", "workspace", "not-a-version", "====4.7.0", ">4.7.0"]) {
+    for (const range of ["", "   ", "workspacefoo", "workspace", "not-a-version", "====4.7.0", ">4.7.0", "totally-invalid:4.6.0", "foo:1.2.3", ":4.6.0"]) {
       const findings = await auditConsumerPair("4.7.0", range);
       assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1, `${JSON.stringify(range)} must fail`);
       assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, `${JSON.stringify(range)} must not skip`);

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -330,6 +330,30 @@ describe("auditLauncherSync — invariant 5: gui-chat-protocol peer dep lockstep
   });
 });
 
+// Invariant-6 cases all have the same shape: one workspace package, one
+// consumer declaring a range on it. Naming that shape keeps each `it` to the
+// pair of versions under test and guarantees the temp repo is always removed.
+async function auditConsumerPair(coreVersion: string, consumerRange: string, field: "peerDependencies" | "devDependencies" = "peerDependencies") {
+  const root = makeFakeRepo({
+    root: { name: "monorepo", dependencies: {} },
+    launcher: { name: "mulmoclaude", dependencies: {} },
+    workspaces: [
+      { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: coreVersion } },
+      {
+        dir: "packages/plugins/foo-plugin",
+        pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", [field]: { "@mulmoclaude/core": consumerRange } },
+      },
+    ],
+  });
+  try {
+    return await sync.auditLauncherSync({ root });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const consumerLockstepCount = (findings: { kind: string }[]) => findings.filter((finding) => finding.kind === "consumer-lockstep").length;
+
 describe("auditLauncherSync — invariant 6: every manifest tracks its internal deps", () => {
   // The gap #3037 / #3038 were filed for. Three releases in a row bumped a
   // workspace package and swept only the launcher; the gate reported ONE
@@ -423,25 +447,10 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
   });
 
   it("accepts a prerelease workspace whose consumer range already matches", async () => {
-    // `parseLowerBound` drops the `-beta.1` suffix. Comparing it against the
-    // raw version string reported a correctly-swept prerelease as drift and
-    // would block the very release commit that did the sweep.
-    const root = makeFakeRepo({
-      root: { name: "monorepo", dependencies: {} },
-      launcher: { name: "mulmoclaude", dependencies: {} },
-      workspaces: [
-        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.8.0-beta.1" } },
-        {
-          dir: "packages/plugins/foo-plugin",
-          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", peerDependencies: { "@mulmoclaude/core": "^4.8.0-beta.1" } },
-        },
-      ],
-    });
-    try {
-      assert.deepEqual(await sync.auditLauncherSync({ root }), []);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    // Parsing drops the `-beta.1` suffix; comparing that against the raw
+    // version string reported a correctly-swept prerelease as drift and would
+    // block the very release commit that did the sweep.
+    assert.deepEqual(await auditConsumerPair("4.8.0-beta.1", "^4.8.0-beta.1"), []);
   });
 
   it("flags a DIFFERENT prerelease with the same numeric tuple", async () => {
@@ -449,45 +458,30 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     // makes `^4.8.0-beta.1` look synchronized with a workspace already at
     // `4.8.0-beta.2` — precisely the stale lower bound this invariant exists
     // to catch, waved through.
-    const root = makeFakeRepo({
-      root: { name: "monorepo", dependencies: {} },
-      launcher: { name: "mulmoclaude", dependencies: {} },
-      workspaces: [
-        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.8.0-beta.2" } },
-        {
-          dir: "packages/plugins/foo-plugin",
-          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", peerDependencies: { "@mulmoclaude/core": "^4.8.0-beta.1" } },
-        },
-      ],
-    });
-    try {
-      const findings = await sync.auditLauncherSync({ root });
-      assert.equal(findings.filter((finding) => finding.kind === "consumer-lockstep").length, 1);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    assert.equal(consumerLockstepCount(await auditConsumerPair("4.8.0-beta.2", "^4.8.0-beta.1")), 1);
+  });
+
+  it("reads a prerelease-plus-build version rather than skipping it", async () => {
+    // `4.8.0-beta.2+build.9` is valid SemVer, but the old suffix pattern
+    // allowed a prerelease OR a build, not both. It parsed as nothing, the
+    // edge became `skipped`, and `main()` drops skipped from the failure
+    // count — so a stale range against such a version passed the gate.
+    const findings = await auditConsumerPair("4.8.0-beta.2+build.9", "^4.8.0-beta.1+build.9");
+    assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, "a valid SemVer version must not be skipped");
+    assert.equal(consumerLockstepCount(findings), 1, "and the stale range must be reported");
+  });
+
+  it("treats versions differing only in build metadata as the same release", async () => {
+    // Build metadata is excluded from SemVer precedence, so these resolve to
+    // the same release and reporting drift would be a false positive.
+    assert.deepEqual(await auditConsumerPair("4.8.0-beta.1+build.2", "^4.8.0-beta.1+build.1"), []);
   });
 
   it("still flags a prerelease workspace the consumer has not caught up with", async () => {
-    // The leniency above must not swallow real drift: only the numeric
-    // components are compared, so 4.7.0 vs 4.8.0-beta.1 is still a finding.
-    const root = makeFakeRepo({
-      root: { name: "monorepo", dependencies: {} },
-      launcher: { name: "mulmoclaude", dependencies: {} },
-      workspaces: [
-        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.8.0-beta.1" } },
-        {
-          dir: "packages/plugins/foo-plugin",
-          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", peerDependencies: { "@mulmoclaude/core": "^4.7.0" } },
-        },
-      ],
-    });
-    try {
-      const findings = await sync.auditLauncherSync({ root });
-      assert.equal(findings.filter((finding) => finding.kind === "consumer-lockstep").length, 1);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+    // The leniency above must not swallow real drift: the whole
+    // comparator-stripped version is compared, so 4.7.0 vs 4.8.0-beta.1 is
+    // still a finding.
+    assert.equal(consumerLockstepCount(await auditConsumerPair("4.8.0-beta.1", "^4.7.0")), 1);
   });
 
   it("surfaces an unparseable consumer range as skipped, never as a failure", async () => {

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -17,6 +17,7 @@ interface FakePackage {
   version: string;
   peerDependencies?: Record<string, string>;
   dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 }
 
 interface Fixture {
@@ -323,6 +324,120 @@ describe("auditLauncherSync — invariant 5: gui-chat-protocol peer dep lockstep
     try {
       const findings = await sync.auditLauncherSync({ root });
       assert.deepEqual(findings, []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("auditLauncherSync — invariant 6: every manifest tracks its internal deps", () => {
+  // The gap #3037 / #3038 were filed for. Three releases in a row bumped a
+  // workspace package and swept only the launcher; the gate reported ONE
+  // finding while 14 plugin peer/dev declarations stayed stale and unchecked.
+  const staleConsumer = () => ({
+    root: { name: "monorepo", dependencies: {} },
+    launcher: { name: "mulmoclaude", dependencies: { "@mulmoclaude/core": "^4.7.0" } },
+    workspaces: [
+      { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.7.0" } },
+      {
+        dir: "packages/plugins/foo-plugin",
+        pkg: {
+          name: "@mulmoclaude/foo-plugin",
+          version: "1.0.0",
+          peerDependencies: { "@mulmoclaude/core": "^4.6.0" },
+          devDependencies: { "@mulmoclaude/core": "^4.6.0" },
+        },
+      },
+    ],
+  });
+
+  it("catches a plugin's peer AND dev range left behind while the launcher is correct", async () => {
+    const root = makeFakeRepo(staleConsumer());
+    try {
+      const findings = await sync.auditLauncherSync({ root });
+      const consumer = findings.filter((finding) => finding.kind === "consumer-lockstep");
+      assert.equal(consumer.length, 2, "both the peer and the dev declaration are stale");
+      assert.ok(consumer.every((finding) => /foo-plugin.*4\.6\.0.*4\.7\.0/.test(finding.message)));
+      assert.ok(
+        consumer.some((finding) => finding.message.includes("peerDependencies")) && consumer.some((finding) => finding.message.includes("devDependencies")),
+        "names which field is stale, so the sweep is mechanical",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("stays silent once the consumer is swept", async () => {
+    const fixture = staleConsumer();
+    const plugin = fixture.workspaces.find((entry) => entry.pkg.name === "@mulmoclaude/foo-plugin");
+    assert.ok(plugin, "fixture must contain the plugin whose ranges we are sweeping");
+    plugin.pkg.peerDependencies = { "@mulmoclaude/core": "^4.7.0" };
+    plugin.pkg.devDependencies = { "@mulmoclaude/core": "^4.7.0" };
+    const root = makeFakeRepo(fixture);
+    try {
+      assert.deepEqual(await sync.auditLauncherSync({ root }), []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a stale launcher dep once, not twice", async () => {
+    // Invariant 4 already owns the launcher's `dependencies`. Reporting the
+    // same drift from both rules would make one bad release read as two.
+    const root = makeFakeRepo({
+      root: { name: "monorepo", dependencies: {} },
+      launcher: { name: "mulmoclaude", dependencies: { "@mulmoclaude/core": "^4.6.0" } },
+      workspaces: [{ dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.7.0" } }],
+    });
+    try {
+      const findings = await sync.auditLauncherSync({ root });
+      assert.equal(findings.filter((finding) => finding.kind === "workspace-lockstep").length, 1);
+      assert.equal(findings.filter((finding) => finding.kind === "consumer-lockstep").length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores external deps and a package's own name", async () => {
+    // Only workspace-internal edges are knowable from the tree; an external
+    // range is the author's call and a self-reference is not an edge at all.
+    const root = makeFakeRepo({
+      root: { name: "monorepo", dependencies: {} },
+      launcher: { name: "mulmoclaude", dependencies: {} },
+      workspaces: [
+        {
+          dir: "packages/plugins/foo-plugin",
+          pkg: {
+            name: "@mulmoclaude/foo-plugin",
+            version: "1.0.0",
+            dependencies: { vue: "^3.0.0", "@mulmoclaude/foo-plugin": "^0.0.1" },
+          },
+        },
+      ],
+    });
+    try {
+      assert.deepEqual(await sync.auditLauncherSync({ root }), []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces an unparseable consumer range as skipped, never as a failure", async () => {
+    const root = makeFakeRepo({
+      root: { name: "monorepo", dependencies: {} },
+      launcher: { name: "mulmoclaude", dependencies: {} },
+      workspaces: [
+        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.7.0" } },
+        {
+          dir: "packages/plugins/foo-plugin",
+          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", dependencies: { "@mulmoclaude/core": "workspace:*" } },
+        },
+      ],
+    });
+    try {
+      const findings = await sync.auditLauncherSync({ root });
+      assert.equal(findings.filter((finding) => finding.kind !== "skipped").length, 0, "a range we cannot parse must not fail the gate");
+      assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 1);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -444,6 +444,30 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     }
   });
 
+  it("flags a DIFFERENT prerelease with the same numeric tuple", async () => {
+    // The trap in the first attempt at this fix: comparing numeric triples
+    // makes `^4.8.0-beta.1` look synchronized with a workspace already at
+    // `4.8.0-beta.2` — precisely the stale lower bound this invariant exists
+    // to catch, waved through.
+    const root = makeFakeRepo({
+      root: { name: "monorepo", dependencies: {} },
+      launcher: { name: "mulmoclaude", dependencies: {} },
+      workspaces: [
+        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.8.0-beta.2" } },
+        {
+          dir: "packages/plugins/foo-plugin",
+          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", peerDependencies: { "@mulmoclaude/core": "^4.8.0-beta.1" } },
+        },
+      ],
+    });
+    try {
+      const findings = await sync.auditLauncherSync({ root });
+      assert.equal(findings.filter((finding) => finding.kind === "consumer-lockstep").length, 1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("still flags a prerelease workspace the consumer has not caught up with", async () => {
     // The leniency above must not swallow real drift: only the numeric
     // components are compared, so 4.7.0 vs 4.8.0-beta.1 is still a finding.

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -484,6 +484,29 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     assert.equal(consumerLockstepCount(await auditConsumerPair("4.8.0-beta.1", "^4.7.0")), 1);
   });
 
+  it("fails a malformed comparator instead of reading a lower bound out of it", async () => {
+    // `====4.7.0` is not a range npm accepts, but `[\^~>=]*` matched the
+    // prefix and the numeric part compared equal to the workspace — so the
+    // gate reported nothing at all. Skipping would be no better: `main()`
+    // drops skipped findings from the failure count.
+    const findings = await auditConsumerPair("4.7.0", "====4.7.0");
+    assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1);
+    assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, "a malformed range must fail, not skip");
+  });
+
+  it("fails a comparator that excludes the version it names", async () => {
+    // `>4.7.0` does not admit 4.7.0, so a consumer declaring it against a
+    // workspace at 4.7.0 is broken — yet it used to read as lower bound 4.7.0
+    // and pass.
+    assert.equal((await auditConsumerPair("4.7.0", ">4.7.0")).filter((finding) => finding.kind === "unsupported-range").length, 1);
+  });
+
+  it("accepts the comparators the gate can evaluate", async () => {
+    for (const range of ["4.7.0", "^4.7.0", "~4.7.0", ">=4.7.0"]) {
+      assert.deepEqual(await auditConsumerPair("4.7.0", range), [], `${range} must be evaluable`);
+    }
+  });
+
   it("surfaces an unparseable consumer range as skipped, never as a failure", async () => {
     const root = makeFakeRepo({
       root: { name: "monorepo", dependencies: {} },

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -354,6 +354,21 @@ async function auditConsumerPair(coreVersion: string, consumerRange: string, fie
 
 const consumerLockstepCount = (findings: { kind: string }[]) => findings.filter((finding) => finding.kind === "consumer-lockstep").length;
 
+// The launcher declaring an internal dep directly, which is the one manifest
+// invariant 4 also inspects.
+async function auditLauncherDep(coreVersion: string, launcherRange: string) {
+  const root = makeFakeRepo({
+    root: { name: "monorepo", dependencies: {} },
+    launcher: { name: "mulmoclaude", dependencies: { "@mulmoclaude/core": launcherRange } },
+    workspaces: [{ dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: coreVersion } }],
+  });
+  try {
+    return await sync.auditLauncherSync({ root });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 describe("auditLauncherSync — invariant 6: every manifest tracks its internal deps", () => {
   // The gap #3037 / #3038 were filed for. Three releases in a row bumped a
   // workspace package and swept only the launcher; the gate reported ONE
@@ -535,6 +550,26 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
       assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1, `${JSON.stringify(range)} must fail`);
       assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, `${JSON.stringify(range)} must not skip`);
     }
+  });
+
+  it("applies the strict checks to the launcher's own deps too", async () => {
+    // Invariant 4 owns the launcher's lockstep comparison, so invariant 6 used
+    // to skip that manifest entirely — which left the closed gate open for
+    // exactly the edges the launcher owns: invariant 4 turns both of these
+    // into `skipped`, and `main()` drops skipped from the failure count.
+    const malformed = await auditLauncherDep("4.7.0", "====4.7.0");
+    assert.equal(malformed.filter((finding) => finding.kind === "unsupported-range").length, 1);
+    assert.equal(malformed.filter((finding) => finding.kind !== "skipped").length > 0, true, "must fail, not merely skip");
+
+    const badVersion = await auditLauncherDep(47 as unknown as string, "^4.7.0");
+    assert.equal(badVersion.filter((finding) => finding.kind === "invalid-workspace-version").length, 1);
+  });
+
+  it("still reports launcher drift once, not twice", async () => {
+    // The reason the exemption existed. Keep it for the lockstep comparison.
+    const findings = await auditLauncherDep("4.7.0", "^4.6.0");
+    assert.equal(findings.filter((finding) => finding.kind === "workspace-lockstep").length, 1);
+    assert.equal(consumerLockstepCount(findings), 0);
   });
 
   it("evaluates a version-bearing workspace: range instead of skipping it", async () => {

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -534,6 +534,31 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1);
   });
 
+  it("rejects versions npm rejects, however plausible they look", async () => {
+    // `\d+` and `[\w.-]` were close enough to look right: they accept a
+    // leading zero, a leading-zero prerelease identifier, and `_` — none of
+    // which npm resolves. Each one used to compare equal to its own consumer
+    // range and produce no finding at all.
+    for (const version of ["04.7.0", "4.7.0-01", "4.7.0-beta_1"]) {
+      const findings = await auditConsumerPair(version, `^${version}`);
+      assert.notDeepEqual(findings, [], `${version} is not valid SemVer and must not pass as in sync`);
+    }
+  });
+
+  it("still accepts every SemVer form that IS valid", async () => {
+    for (const version of ["4.7.0", "4.7.0-beta.1", "4.8.0-beta.2+build.9", "4.7.0+01.2"]) {
+      assert.deepEqual(await auditConsumerPair(version, `^${version}`), [], `${version} is valid SemVer`);
+    }
+  });
+
+  it("fails a workspace whose version is not a string at all", async () => {
+    // `loadWorkspacePackages` used to drop such a manifest, which removed
+    // every consumer edge pointing at it from the audit — a stricter failure
+    // than `skipped`, and completely silent.
+    const findings = await auditConsumerPair(47 as unknown as string, "^4.6.0");
+    assert.equal(findings.filter((finding) => finding.kind === "invalid-workspace-version").length, 1);
+  });
+
   it("fails a workspace whose OWN version is not SemVer", async () => {
     // One malformed version in a workspace's package.json would otherwise
     // disable this invariant for every consumer of that workspace at once —

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -537,6 +537,30 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     }
   });
 
+  it("evaluates a version-bearing workspace: range instead of skipping it", async () => {
+    // `workspace:` is not automatically versionless — `workspace:^4.6.0`
+    // states a lower bound like any other range, and skipping every
+    // `workspace:` value let a stale internal dependency through.
+    for (const range of ["workspace:^4.6.0", "workspace:~4.6.0", "workspace:4.6.0"]) {
+      const findings = await auditConsumerPair("4.7.0", range);
+      assert.equal(consumerLockstepCount(findings), 1, `${range} is stale and must be reported`);
+      assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, `${range} must not skip`);
+    }
+  });
+
+  it("still skips the workspace: forms that genuinely carry no version", async () => {
+    // The package manager substitutes the local version at publish time.
+    for (const range of ["workspace:*", "workspace:^", "workspace:~"]) {
+      const findings = await auditConsumerPair("4.7.0", range);
+      assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 1, `${range} should skip`);
+      assert.equal(findings.filter((finding) => finding.kind !== "skipped").length, 0, `${range} should not fail`);
+    }
+  });
+
+  it("accepts a workspace: range that is in step", async () => {
+    assert.deepEqual(await auditConsumerPair("4.7.0", "workspace:^4.7.0"), []);
+  });
+
   it("fails a non-string dependency value", async () => {
     const findings = await auditConsumerPair("4.7.0", null as unknown as string);
     assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1);

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -507,25 +507,40 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     }
   });
 
-  it("surfaces an unparseable consumer range as skipped, never as a failure", async () => {
-    const root = makeFakeRepo({
-      root: { name: "monorepo", dependencies: {} },
-      launcher: { name: "mulmoclaude", dependencies: {} },
-      workspaces: [
-        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.7.0" } },
-        {
-          dir: "packages/plugins/foo-plugin",
-          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", dependencies: { "@mulmoclaude/core": "workspace:*" } },
-        },
-      ],
-    });
-    try {
-      const findings = await sync.auditLauncherSync({ root });
-      assert.equal(findings.filter((finding) => finding.kind !== "skipped").length, 0, "a range we cannot parse must not fail the gate");
-      assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 1);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
+  it("skips ONLY specifiers that resolve by a route naming no version", async () => {
+    // These are legitimate npm and genuinely carry no version to compare.
+    for (const range of ["*", "workspace:*", "npm:@scope/pkg@1.2.3", "https://example.com/pkg.tgz", "file:../core"]) {
+      const findings = await auditConsumerPair("4.7.0", range);
+      assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 1, `${range} should skip`);
+      assert.equal(findings.filter((finding) => finding.kind !== "skipped").length, 0, `${range} should not fail`);
     }
+  });
+
+  it("fails every other unreadable value instead of skipping it", async () => {
+    // `main()` drops skipped findings from the failure count, so anything
+    // routed to `skipped` is approved. These are malformed declarations, not
+    // versionless specifiers, and each one used to pass the gate silently:
+    // "" and "workspacefoo" matched the old prefix test, and a non-string
+    // value short-circuited it entirely.
+    for (const range of ["", "   ", "workspacefoo", "workspace", "not-a-version", "====4.7.0", ">4.7.0"]) {
+      const findings = await auditConsumerPair("4.7.0", range);
+      assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1, `${JSON.stringify(range)} must fail`);
+      assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, `${JSON.stringify(range)} must not skip`);
+    }
+  });
+
+  it("fails a non-string dependency value", async () => {
+    const findings = await auditConsumerPair("4.7.0", null as unknown as string);
+    assert.equal(findings.filter((finding) => finding.kind === "unsupported-range").length, 1);
+  });
+
+  it("fails a workspace whose OWN version is not SemVer", async () => {
+    // One malformed version in a workspace's package.json would otherwise
+    // disable this invariant for every consumer of that workspace at once —
+    // the gate would exit 0 with every consumer range stale.
+    const findings = await auditConsumerPair("4.8", "^4.5.0");
+    assert.equal(findings.filter((finding) => finding.kind === "invalid-workspace-version").length, 1);
+    assert.equal(findings.filter((finding) => finding.kind === "skipped").length, 0, "a broken source version must not silence the gate");
   });
 });
 

--- a/test/scripts/mulmoclaude/test_launcherSync.ts
+++ b/test/scripts/mulmoclaude/test_launcherSync.ts
@@ -422,6 +422,50 @@ describe("auditLauncherSync — invariant 6: every manifest tracks its internal 
     }
   });
 
+  it("accepts a prerelease workspace whose consumer range already matches", async () => {
+    // `parseLowerBound` drops the `-beta.1` suffix. Comparing it against the
+    // raw version string reported a correctly-swept prerelease as drift and
+    // would block the very release commit that did the sweep.
+    const root = makeFakeRepo({
+      root: { name: "monorepo", dependencies: {} },
+      launcher: { name: "mulmoclaude", dependencies: {} },
+      workspaces: [
+        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.8.0-beta.1" } },
+        {
+          dir: "packages/plugins/foo-plugin",
+          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", peerDependencies: { "@mulmoclaude/core": "^4.8.0-beta.1" } },
+        },
+      ],
+    });
+    try {
+      assert.deepEqual(await sync.auditLauncherSync({ root }), []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("still flags a prerelease workspace the consumer has not caught up with", async () => {
+    // The leniency above must not swallow real drift: only the numeric
+    // components are compared, so 4.7.0 vs 4.8.0-beta.1 is still a finding.
+    const root = makeFakeRepo({
+      root: { name: "monorepo", dependencies: {} },
+      launcher: { name: "mulmoclaude", dependencies: {} },
+      workspaces: [
+        { dir: "packages/core", pkg: { name: "@mulmoclaude/core", version: "4.8.0-beta.1" } },
+        {
+          dir: "packages/plugins/foo-plugin",
+          pkg: { name: "@mulmoclaude/foo-plugin", version: "1.0.0", peerDependencies: { "@mulmoclaude/core": "^4.7.0" } },
+        },
+      ],
+    });
+    try {
+      const findings = await sync.auditLauncherSync({ root });
+      assert.equal(findings.filter((finding) => finding.kind === "consumer-lockstep").length, 1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces an unparseable consumer range as skipped, never as a failure", async () => {
     const root = makeFakeRepo({
       root: { name: "monorepo", dependencies: {} },


### PR DESCRIPTION
## Summary

Follow-up to #3037 / #3038. Three releases in a row bumped `@mulmoclaude/core` and swept only the launcher, and **each one blocked every open PR** (CI builds each PR merged into `main`). The gate that exists to catch exactly this reported **one** finding while **14 plugin peer/dev declarations stayed stale and entirely unchecked**.

The PR does two things, both about the same failure: a stale range reaching this gate and producing no finding.

### 1. Invariant 6 — every manifest tracks its internal deps

`launcherSync.mjs` only ever looked at `packages/mulmoclaude/package.json`'s `dependencies`. Now, in *every* manifest — root and all 53 workspaces — a range declared on a workspace-internal package must have its lower bound equal to that workspace's version, across `dependencies`, `devDependencies` and `peerDependencies` alike.

That is the rule CLAUDE.md already states; nothing enforced it. It matters because **a caret does not float a consumer forward** — `^4.6.0` resolves `>=4.6.0`, so it pins to the lower bound and withholds every release since from anyone installing that package.

### 2. Closing the ways a range reached the gate unread

The review loop established a failure mode that outlives any single case: **`skipped` is indistinguishable from `pass`.** `main()` excludes skipped findings from the failure count, so anything the parser could not read silently disabled the check for that edge.

| input | before | now |
|---|---|---|
| `4.8.0-beta.2+build.9` (valid SemVer) | unparseable → `skipped` → passes | parsed |
| `4.8.0-beta.1+build.2` vs `^…+build.1` | — | same release (build metadata is outside SemVer precedence) |
| `====4.7.0` (not a range npm accepts) | read as lower bound `4.7.0` → **no finding** | `unsupported-range` — fails |
| `>4.7.0` (excludes the version it names) | read as lower bound `4.7.0` → **no finding** | `unsupported-range` — fails |
| `workspace:*`, tarball URLs, `*` | `skipped` | `skipped` (correct — no version to compare) |

## Measured, not asserted

Replayed the gate against `d36fc4f78`, the commit that broke `main`, in a throwaway worktree — same tree, only the script swapped:

| | findings |
|---|---|
| gate as shipped | **1** |
| gate with invariant 6 | **15**, each naming the file and the field |

| ref | violations invariant 6 catches |
|---|---|
| `9700bf13b` (core@4.6.0 released) | 15 |
| `d36fc4f78` (core@4.7.0 released) | 15 |
| current `main` | **0** |

53 workspaces, 129 internal dep edges. Comparator forms in the tree: `^` 639, `~` 4, exact 2, **anything else 0** — so the new `unsupported-range` failure trips nothing today. It lands green.

## Items to Confirm / Review

- **`peerDependencies` are included deliberately.** A plugin's peer range states which host version it was built against; a stale one is exactly what shipped unnoticed three times. Only edges pointing at a workspace package are checked — wide peers on `vue` / `zod` are untouched.
- **No double-reporting.** The launcher's own `dependencies` stay with invariant 4; a test pins that one bad release does not read as two problems.
- **`unsupported-range` fails rather than skips.** That is deliberate and is the lesson of the loop: skipping would leave the same bypass under a new name. The message names the four supported forms.
- **`version` is the proxy for "latest published"**, matching invariant 4's existing semantics — so a `chore(release)` commit must sweep consumers in the same commit, which CLAUDE.md already requires.
- **Invariant 4 still compares numeric triples**, so the launcher's own deps keep one looseness this PR fixes for everyone else. Left alone deliberately: pre-existing, outside this diff, and unreachable today — 0 prereleases across 53 workspaces, 0 internal ranges, 0 release tags.

## Testing

30 cases in `test_launcherSync.ts`, 12 of them new. Every fix in this PR was verified by **reverting it alone** and confirming exactly the intended test goes red — including the two rejected versions of the prerelease comparison, each of which turns a different test red.

Full local run green: `format`, `lint` (0 errors), `typecheck`, `check:launcher-sync`, `check:doc-links`, `build`, `test:coverage`.

## Not in this PR

Having the release script itself sweep consumers + the CHANGELOG `Ships` line, so a `chore(release)` commit lands complete. This PR makes the omission *visible*; it does not prevent it.

## User Prompt

- 「fix https://github.com/receptron/mulmoclaude/pull/3030」 — 別PRのCI修正（マージ済み）。
- 「https://github.com/receptron/mulmoclaude/issues/3018 原因わかる？」 / 「あれ、これってユーザの勘違い？こっちのバグ？」 — 原因調査、こちらのバグと判定。
- 「ok　では修正して。」 — #3036 で修正（マージ済み）。
- 「両方 green になったらマージして」 — #3037 / #3038 / #3036 をマージ済み。
- 「launcherSync を全 workspace 対象に拡張するのもやって」 — 本PR。
- 「/gh-review-loop」 — 本PRのレビューループ実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsP85JQHVTN9gY63Z2VMKi

work in mulmoclaude2

## Summary by Sourcery

Enforce synchronized version ranges for every workspace-internal dependency and make malformed declarations fail instead of silently passing the launcher sync gate.

New Features:
- Extend launcher synchronization checks to all workspace-internal dependency declarations across root and workspace manifests.
- Recognize valid prerelease and build-metadata SemVer values when evaluating dependency lockstep.

Bug Fixes:
- Prevent malformed or unsupported internal dependency ranges and invalid workspace versions from silently bypassing the synchronization gate.
- Detect stale workspace dependency ranges in peerDependencies and devDependencies while avoiding duplicate reports for launcher dependencies.

Enhancements:
- Define a closed set of versionless specifiers that may be skipped and fail all other unreadable internal dependency declarations.
- Add comprehensive coverage for consumer lockstep, prerelease handling, comparator validation, versionless specifiers, and invalid workspace versions.

Tests:
- Expand launcher synchronization tests to cover invariant 6 and range parsing edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auditing to detect inconsistent internal dependency versions across workspace manifests.
  * Added support for checking regular, development, and peer dependencies.
  * Added validation for supported version ranges, prerelease versions, and invalid workspace versions.
  * Expanded audit results with clearer findings for stale, unsupported, and invalid dependency specifications.

* **Tests**
  * Added comprehensive coverage for dependency lockstep, range formats, prereleases, exclusions, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->