### PR TITLE
docs(changelog): record the #3018 host-exec stdio MCP fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 
+#### A stdio MCP server opted into `hostExecInDocker` never reached the agent (#3018, PR #3036)
+
+The documented opt-in that runs a stdio MCP server on the host while the Docker sandbox is on has
+never worked, for any server, since it shipped in #1421 Phase B (2026-05-18). The shim logged
+`stdio→http shim ready`, `/api/diagnostics/report` listed the server, and the agent got zero
+tools. Two independent defects, either one enough on its own.
+
+**The spec named the wrong transport.** `prepareUserServers` wrote `{ type: "http", url: "…/sse" }`,
+but `supergateway` defaults `--outputTransport` to `sse` for `--stdio` and serves a GET stream at
+`/sse` with POSTed messages at `/message` — there is no `POST /sse`. The CLI treats `type: "http"`
+as Streamable HTTP, so it POSTed `initialize` to the stream path, took a 404, and registered the
+server with no tools.
+
+**The readiness probe consumed the gateway's only session.** `supergateway` keeps a single MCP
+`Server` and calls `server.connect()` on every `GET /sse`; the second connect throws
+`Already connected to a transport` inside an Express handler, which is unhandled and takes the
+gateway down with its stdio child. `probeOnce` opened that stream and never released it, so the
+agent's connect was always the fatal second one. Closing the probe's stream does not help — the
+gateway never calls `server.close()`. Readiness is now proven by `POST /message` without a
+`sessionId`, which answers 400 from a route that never touches the `Server`.
+
+**Why both signals looked healthy.** The `shim ready` log came from a probe that validated the
+**SSE** endpoint while the caller labelled the spec `http` — the probe was quietly proving the
+mismatch. And "MCP servers" in `/api/diagnostics/report` is `Object.keys(loadMcpConfig().mcpServers)`,
+read from `config/mcp.json`: it reports what is **configured**, never what is **connected**. The
+CLI does report `status: "failed"` for the server, but nothing on the host side reads it, so no
+error surfaced.
+
+**Nothing to change in your config.** A `config/mcp.json` entry that was correct before is correct
+now. User config still accepts only `http` and `stdio`; the `sse` spec is produced internally by
+the shim and `isMcpServerSpec` continues to reject it, so the Settings UI gains no new option.
+
+Verified end to end through the real `prepareUserServers` + `startStdioHttpShim` + `claude` CLI
+against `@modelcontextprotocol/server-memory`: `status: "connected"` with all nine tools.
+
 #### `@mulmoclaude/core@4.7.0` — a version-only republish of 4.6.0, no code change
 
 Released 2026-09-03. The 4.6.0 publish had already landed when the release was re-run, and npm


### PR DESCRIPTION
## Summary

`[Unreleased]` documented the `@mulmoclaude/core` 4.6.0 / 4.7.0 publishes but not PR #3036. That fix lives under `server/`, so it reaches npm users **only** through the next `mulmoclaude` launcher publish — writing the entry now means it exists before that release is cut rather than being backfilled after.

Docs only. No code, no dependency, no version change.

## Items to Confirm / Review

- **Placement**: filed under `[Unreleased] → Fixed`, alongside the core entries, since the launcher release is what will carry it. Heading follows the house style for host-side fixes (descriptive, no package prefix) rather than the `@scope/pkg@x.y.z` form the core entries use.
- **The claim "never worked for any server since #1421 Phase B (2026-05-18)"** is from `git log -L` on the line that set `type: "http"` — it was introduced in `06d73a766` and never changed. Worth a second look since it is a strong statement to put in a changelog.
- I did **not** pin a version in the heading. The launcher version is chosen inside the `/publish-mulmoclaude` flow; whoever cuts the release can move this block under that heading.

## Release context (not part of this PR)

`yarn audit:releases --code-only` now reports the launcher as `code drift — 5 shipped file(s)`, which it could not measure before: `mulmoclaude@1.15.0` had never been tagged. I created that tag retroactively on `b03c80f8e`, the commit that bumped the version, per the "tag every publish" rule.

The five unshipped files are the four from #3036 plus `server/api/routes/mulmo-script.ts` (a `publishGeneration` signature follow-up). `packages/core/` has no changes since `@mulmoclaude/core@4.7.0`, so core does not need republishing.

## User Prompt

- 「リリースしようか」 — リリース対象の調査。
- 「tagつけて。そしてすすめよう」 — 欠けていた `mulmoclaude@1.15.0` タグの作成と、リリース準備の続行。
- 「publishだけこっちでやるのでほかやって」 — publish はユーザーが実施、それ以外を担当。本PRはその準備。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsP85JQHVTN9gY63Z2VMKi

work in mulmoclaude2

## Summary by Sourcery

Documentation:
- Document the host-exec stdio MCP fix, including the transport and readiness issues that prevented configured servers from connecting and the successful end-to-end verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing certain stdio MCP servers configured with Docker host execution from reaching the agent.
  * Corrected transport handling and readiness checks so server connectivity is detected reliably.
  * No configuration changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->