### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.15.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+---
+
+## [1.15.1] - 2026-09-03
+
+**A stdio MCP server run on the host from inside the Docker sandbox now actually reaches the agent.**
+
 ### Fixed
 
 #### A stdio MCP server opted into `hostExecInDocker` never reached the agent (#3018, PR #3036)
@@ -96,6 +102,8 @@ minors, so they resolve 4.6.0 on their own; nothing in this tree imports `staged
 published package, so the sweep would be tidiness rather than delivery (the same reasoning as
 4.1.1 / 4.3.0). Also refreshed in this window: `zod` `^4.5.2` → `^4.5.4`, plus `@types/node` and
 `tsx` on the dev side (PR #3030).
+
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.7.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.5.2`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.15.1",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoclaude",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {

--- a/scripts/mulmoclaude/tarball.d.mts
+++ b/scripts/mulmoclaude/tarball.d.mts
@@ -79,6 +79,11 @@ export function computeFirstPartyClosure(packages: { name: string; deps: string[
  *  to exercise the Windows shape from a POSIX host. */
 export function toFileSpecifier(tarballPath: string, sep?: string): string;
 
+/** The tarball filename out of `npm pack --json` stdout, across every output
+ *  shape npm emits (array, flat object, object keyed by package name), or
+ *  `null` when the payload carries none. */
+export function packFilenameFrom(stdout: string): string | null;
+
 export interface PackWorkspaceOverridesOptions {
   root: string;
   packDir: string;

--- a/scripts/mulmoclaude/tarball.mjs
+++ b/scripts/mulmoclaude/tarball.mjs
@@ -190,6 +190,28 @@ export function computeFirstPartyClosure(packages, rootName) {
   return closure;
 }
 
+// `npm pack --json` does not have one output shape. npm 11 and earlier emit an
+// ARRAY of results; npm 12 emits an OBJECT KEYED BY PACKAGE NAME, and a flat
+// `{ filename }` also turns up. Reading only the first two forms made npm 12
+// fail with "produced no filename" on a pack that had in fact succeeded — and
+// since this stage is the documented go/no-go for every launcher release, the
+// gate would have broken for everyone the moment CI's runners moved to npm 12.
+// Take the first entry that carries a filename, whichever shape it arrives in.
+export function packFilenameFrom(stdout) {
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  const candidates = Array.isArray(parsed) ? parsed : [parsed, ...Object.values(parsed ?? {})];
+  for (const entry of candidates) {
+    const filename = entry?.filename;
+    if (typeof filename === "string" && filename.length > 0) return filename;
+  }
+  return null;
+}
+
 // `npm pack` one workspace package into `destDir` with --ignore-scripts (dist is
 // already built by the CI build step, so we archive it as-is rather than paying a
 // prepack rebuild per package). Returns the absolute tarball path.
@@ -200,8 +222,7 @@ async function packOneWorkspacePackage({ packageDir, destDir, runCommandImpl = r
   if (result.code !== 0 || result.timedOut) {
     throw new Error(`npm pack failed for ${packageDir} (code=${result.code}, timedOut=${result.timedOut})\n${result.stderr}`);
   }
-  const parsed = JSON.parse(result.stdout);
-  const filename = Array.isArray(parsed) ? parsed[0]?.filename : parsed?.filename;
+  const filename = packFilenameFrom(result.stdout);
   if (!filename) throw new Error(`npm pack produced no filename for ${packageDir}`);
   return path.join(destDir, filename);
 }

--- a/test/scripts/mulmoclaude/test_tarball.ts
+++ b/test/scripts/mulmoclaude/test_tarball.ts
@@ -611,3 +611,30 @@ describe("makeDevPluginFixture", () => {
     }
   });
 });
+
+describe("packFilenameFrom", () => {
+  // `npm pack --json` has no single output shape, and this stage is the
+  // documented go/no-go for every launcher release — reading only the shapes
+  // one npm version happens to emit breaks the gate for everyone the moment
+  // CI's runners move.
+  it("reads the array form npm 11 and earlier emit", () => {
+    assert.equal(tarball.packFilenameFrom(JSON.stringify([{ filename: "a.tgz" }])), "a.tgz");
+  });
+
+  it("reads the object-keyed-by-package-name form npm 12 emits", () => {
+    // The shape that made a successful pack report "produced no filename".
+    assert.equal(tarball.packFilenameFrom(JSON.stringify({ "@mulmobridge/chat-service": { filename: "c.tgz" } })), "c.tgz");
+  });
+
+  it("reads a flat object", () => {
+    assert.equal(tarball.packFilenameFrom(JSON.stringify({ filename: "b.tgz" })), "b.tgz");
+  });
+
+  it("returns null for an error payload rather than inventing a name", () => {
+    assert.equal(tarball.packFilenameFrom(JSON.stringify({ error: { code: "EALLOWGIT" } })), null);
+  });
+
+  it("returns null for output that is not JSON at all", () => {
+    assert.equal(tarball.packFilenameFrom("boom"), null);
+  });
+});


### PR DESCRIPTION
## Summary

`mulmoclaude@1.15.1` is **already published** (`latest` on npm). This is the §8 follow-up PR carrying the version bumps and the CHANGELOG, plus one fix found while running the release gate.

**Why this release exists:** the #3018 fix lives under `server/`, and the launcher's `files` include `server/` and `src/` — so that fix reached npm users only through this publish. It had been sitting unshipped since #3036 merged.

Two commits, deliberately separate:

| commit | what |
|---|---|
| `5be38cec` | `fix(release)`: the publish smoke could not read `npm pack --json` on npm 12 |
| `cc893b7d` | `chore`: root + launcher → 1.15.1, CHANGELOG `[1.15.1]` |

## The smoke fix is not incidental — it is the release gate

Running §4 locally failed with **`npm pack produced no filename`** on a pack that had succeeded. npm 11 and earlier emit an **array** of results; **npm 12 emits an object keyed by package name**. The parser read only the array and flat-object forms.

`node scripts/mulmoclaude/smoke.mjs` is the documented go/no-go for every launcher release, so this **breaks the gate for everyone the moment CI's runners move to npm 12**. CI is green today only because `actions/setup-node@v7` with `node-version: 24.x` still bundles npm 11.

Extracted as `packFilenameFrom` so the shapes are testable without spawning npm; five tests, and the npm 12 case goes red on the old parser.

## Items to Confirm / Review

- **The `Ships` line was generated from the launcher's own `dependencies`, not retyped.** `yarn check:changelog-ships` → `OK — [1.15.1] lists all 13 @mulmoclaude/* dependencies`. §9a warns specifically about this line being thirteen hand-typed strings.
- **CHANGELOG section shape**: §9a describes `### Highlights`, but the released `[1.15.0]` section above it uses `### Fixed` / `### Added`. I followed the file rather than the skill text — worth a call on which is canonical.
- **`[Unreleased]` is left empty**, matching the state the file was in right after the 1.15.0 release.
- Root and launcher are in lockstep (§5.5), so `v1.15.1` will correspond to `mulmoclaude@1.15.1`.

## ⚠️ Blocker found for npm 12 users — needs a decision, not part of this PR

The smoke's **install** stage then failed on this machine:

```
npm error code EALLOWREMOTE
npm error Refusing to fetch "xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
```

`xlsx` is declared as an https tarball rather than a registry version, and **npm 12 defaults to `allow-remote=none`** (verified: no local `.npmrc` sets it; `npm config list -l` shows the default). So a clean install of the launcher tarball fails under npm 12 — which is the same path `npx mulmoclaude` takes.

I could not complete the local tarball boot test for that reason. The release proceeded on the documented go/no-go instead: the `MulmoClaude publish smoke` run on `main` (`9f0a9573`) is green, and it runs npm 11.

**This is worth its own issue**: moving `xlsx` to a registry version would make the package installable on npm 12. I have not opened one yet — say the word and I will.

## Testing

`format`, `lint` (0 errors), `typecheck`, `test`, `build` + bundle integrity, `check:changelog-ships`, `check:launcher-sync` — all green. Smoke stages: deps ✓, drift ✓ (4 packages), tarball pack ✓ (after this PR's fix), tarball install ✗ (npm 12 / `xlsx`, above).

## User Prompt

- 「リリースしようか」→「tagつけて。そしてすすめよう」→「publishだけこっちでやるのでほかやって」→「npm publish --access public だけこっちでやる。そこまでやっている？」→「done」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsP85JQHVTN9gY63Z2VMKi

work in mulmoclaude2

## Summary by Sourcery

Prepare the monorepo and launcher for the 1.15.1 release while keeping the publish smoke gate compatible with npm 12.

Bug Fixes:
- Fix release smoke tests to correctly identify packed tarballs across npm output formats, including npm 12.

Enhancements:
- Release the root project and mulmoclaude launcher as version 1.15.1.
- Document the shipped MCP server fix and record the launcher dependency versions in the changelog.

Documentation:
- Add the 1.15.1 changelog entry describing the stdio MCP server connectivity fix and shipped package versions.

Tests:
- Add coverage for npm pack filename parsing across array, flat-object, npm 12 keyed-object, invalid, and error payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing host-run stdio MCP servers from working inside Docker environments.
  * Improved package creation compatibility across supported npm versions, helping ensure release artifacts are generated reliably.

* **Release**
  * Updated the application and package versions to 1.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->