### PR TITLE
fix(shapescript): a stray `}` hung the parser, and with it the whole host

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,7 +74,25 @@ diagnostic (`PARSE_ERROR` / `EVALUATION_ERROR` / `LIMIT_EXCEEDED`, with the line
 where it can be known) instead of opening an empty viewport. `rnd` / `rand()` draw from a
 seeded generator so the server's validation and the browser's render cannot disagree.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@1.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+### Fixed
+
+#### `@mulmoclaude/shapescript-plugin@1.1.1` — a stray `}` in a model hung the parser, and with it the whole host (PR #3058)
+
+`parseShapeScript("cube { size 1 }\n}")` never returned. `parseNode()` answers `null` at a
+`}` — that is how a BLOCK's loop stops, leaving the block itself to consume the brace. At the
+TOP level there is no block to close: nothing consumed the token, the position did not move,
+and the top-level loop spun on that same `}` forever.
+
+The parse is synchronous and runs in-process, so this was not one stuck request. It pinned the
+host: a 4394-character agent-written model with one extra `}` on its last line (41 to 40) left
+MulmoTerminal's server still LISTENing on its port at 100% CPU, accepting nothing, with every
+`/api/*` call and websocket timing out until it was restarted. MulmoClaude runs the same plugin
+the same way.
+
+An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
+diagnostic `presentShapeScript` returns.
+
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@1.1.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^1.1.0",
+    "@mulmoclaude/shapescript-plugin": "^1.1.1",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "presentShapeScript — interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1640,11 +1640,24 @@ export class Parser {
     const nodes: SceneNode[] = [];
 
     while (this.current().type !== TokenType.EOF) {
+      const before = this.pos;
       const node = this.parseNode();
       if (node) {
         nodes.push(node);
       }
       this.skipNewlines();
+      // `parseNode()` answers `null` at a `}` so that a BLOCK's loop stops there
+      // and the block itself consumes the brace. At the TOP level there is no
+      // block to close: nothing consumes the token, `this.pos` does not move, and
+      // this loop spins on the same `}` forever. That is not a hang in a worker —
+      // the parse is synchronous, so it pins the whole host process (one stray
+      // trailing `}` in an agent-written model stopped MulmoTerminal's server from
+      // answering any request at all). An unmatched brace is a parse error; report
+      // it as one.
+      if (node === null && this.pos === before) {
+        const token = this.current();
+        throw new ParseError(`Unexpected token: ${token.type}`, token.line, token.column);
+      }
     }
 
     return nodes;

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1636,28 +1636,30 @@ export class Parser {
     }
   }
 
+  // `parseNode()` answers `null` at a `}` so that a BLOCK's loop stops there and the
+  // block itself consumes the brace. At the TOP level there is no block to close: if
+  // nothing consumed the token, `this.pos` has not moved and `parse()` would spin on
+  // that same `}` forever. That is not one hung request — the parse is synchronous, so
+  // it pins the whole host process (one stray trailing `}` in an agent-written model
+  // stopped MulmoTerminal's server from answering anything at all). An unmatched brace
+  // is a parse error; report it as one, at its own line and column.
+  private refuseStalledToken(posBefore: number): void {
+    if (this.pos !== posBefore) return;
+    const token = this.current();
+    throw new ParseError(`Unexpected token: ${token.type}`, token.line, token.column);
+  }
+
   parse(): SceneNode[] {
     const nodes: SceneNode[] = [];
 
     while (this.current().type !== TokenType.EOF) {
-      const before = this.pos;
+      const posBefore = this.pos;
       const node = this.parseNode();
       if (node) {
         nodes.push(node);
       }
       this.skipNewlines();
-      // `parseNode()` answers `null` at a `}` so that a BLOCK's loop stops there
-      // and the block itself consumes the brace. At the TOP level there is no
-      // block to close: nothing consumes the token, `this.pos` does not move, and
-      // this loop spins on the same `}` forever. That is not a hang in a worker —
-      // the parse is synchronous, so it pins the whole host process (one stray
-      // trailing `}` in an agent-written model stopped MulmoTerminal's server from
-      // answering any request at all). An unmatched brace is a parse error; report
-      // it as one.
-      if (node === null && this.pos === before) {
-        const token = this.current();
-        throw new ParseError(`Unexpected token: ${token.type}`, token.line, token.column);
-      }
+      if (node === null) this.refuseStalledToken(posBefore);
     }
 
     return nodes;

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -43,6 +43,10 @@ describe("validation before presentation", () => {
     ["cube { size 1.2.3 }", "PARSE_ERROR", /Invalid number/],
     ["cube { size 1e999 }", "PARSE_ERROR", /Invalid number/],
     ["cube { size }", "PARSE_ERROR", /Unexpected token/],
+    // A `}` with no block open. `parseNode()` answers null there (that is how a
+    // block's loop stops) so nothing consumed it, and the top-level loop used to
+    // spin on it forever — synchronously, taking the whole host process with it.
+    ["cube { size 1 }\n}", "PARSE_ERROR", /Unexpected token/],
   ] as const) {
     it(`returns a diagnostic for ${script}`, async () => {
       const result = await executePresentShapeScript(context, { title: "Invalid", script });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -46,7 +46,7 @@ describe("validation before presentation", () => {
     // A `}` with no block open. `parseNode()` answers null there (that is how a
     // block's loop stops) so nothing consumed it, and the top-level loop used to
     // spin on it forever — synchronously, taking the whole host process with it.
-    ["cube { size 1 }\n}", "PARSE_ERROR", /Unexpected token/],
+    ["cube { size 1 }\n}", "PARSE_ERROR", /line 2, column 1: Unexpected token: RBRACE/],
   ] as const) {
     it(`returns a diagnostic for ${script}`, async () => {
       const result = await executePresentShapeScript(context, { title: "Invalid", script });


### PR DESCRIPTION
## What happened

MulmoTerminal's server stopped answering anything — every `/api/*` call and every websocket through the Vite proxy timed out with `AggregateError [ETIMEDOUT]`. `ETIMEDOUT` rather than `ECONNREFUSED` was the tell: the process was alive and still `LISTEN`ing on its port, at 100% CPU, accepting no connections.

Pausing the wedged process over the inspector put the top JS frame in this parser:

```
parse @ shapescript-plugin/dist/…:1109   for (; this.current().type !== S.EOF;)
E     @ …:1118                           new T(new w(e).tokenize()).parse()
om/dm @ …:12452                          n = "EVALUATION_ERROR", om(r.script)   ← executePresentShapeScript
```

The frozen call's own arguments, read off the stack frame: `presentShapeScript({ title: "Empire State Building", script: <4394 chars> })`. That script has **41 `}` to 40 `{`** — one stray closing brace on its last line, written by an agent.

## Why it loops

`parseNode()` answers `null` at a `}`. That is deliberate: it is how a BLOCK's loop stops, leaving the block itself to consume the brace. At the TOP level there is no block to close — nothing consumes the token, `pos` does not move, and `parse()`'s `while (current().type !== EOF)` spins on that same `}` forever.

The parse is synchronous and runs in-process, so this is not one stuck request. It pins the host: one unbalanced brace in one model takes the whole server down until it is restarted. MulmoClaude runs the same plugin the same way.

Minimal repro, no host needed:

```js
parseShapeScript("cube { size 1 }\n}"); // never returns
```

## The fix

Guard the top-level loop on **progress** rather than on the token: if `parseNode()` returned `null` and did not advance `pos`, nothing can consume the token and the brace is unmatched — which is a parse error, reported with its line and column like every other one. Block loops are untouched and still rely on the `null`.

The real script now returns `Parse error at line 131, column 1: Unexpected token: RBRACE` instead of hanging.

## Tests

A new case in `test_language.ts`'s existing diagnostic table — `["cube { size 1 }\n}", "PARSE_ERROR", /Unexpected token/]` — which hung the suite before the fix. `yarn test` 93/93, `yarn typecheck` and `yarn lint` clean.

Bumped to **1.1.1** here, with the host's range pinned to it in the same commit — the convention #3054 and #3056 followed. The publish still has to happen before MulmoTerminal picks it up (its own range is `^1.1.0`, so it takes 1.1.1 without a change there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tVmyinjLa4mFiR5tyL4fg

## Summary by Sourcery

Prevent unmatched top-level braces from blocking the host process by converting stalled ShapeScript parses into diagnostics.

Bug Fixes:
- Prevent ShapeScript parsing from hanging indefinitely on unmatched top-level closing braces by reporting a location-aware parse error instead.
- Update the host package to consume the fixed ShapeScript plugin release.

Documentation:
- Document the ShapeScript parser hang fix and release ShapeScript plugin version 1.1.1 in the changelog.

Tests:
- Add coverage ensuring an unmatched closing brace returns a parse diagnostic with the expected line and column.

Chores:
- Bump the ShapeScript plugin version to 1.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid ShapeScript containing an unmatched closing brace now reports a parse error instead of becoming unresponsive.
  - Diagnostics identify the unexpected closing brace at its precise line and column, making the issue easier to locate.
  - Added validation coverage to ensure unexpected top-level closing braces consistently produce the expected parse error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->