### PR TITLE
refactor(shapescript): move the render TOOL into the plugin as well

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Changed
 
-#### `@mulmoclaude/shapescript-plugin@1.2.0` — the renderer moves into the package
+#### `@mulmoclaude/shapescript-plugin@1.3.0` — the render TOOL moves in too
 
 `renderShapeScriptSheet` — the Puppeteer-driven rasteriser behind the `renderShapeScript` MCP tool
 — moves from this host's `server/utils/render/` into a new server-only `@mulmoclaude/shapescript-plugin/render`
@@ -24,6 +24,12 @@ render page is served three's own build files, and the plugin — which already 
 the geometry — resolves them from its own copy. And Puppeteer is now an OPTIONAL peer of the
 plugin rather than an assumed host dependency, so a host that does not want a browser download is
 not made to take one.
+
+**1.3.0** finishes the move: the tool's schema, defaults, four-view sheet and result sentence go
+with it as `executeRenderShapeScript`, leaving each host only what is genuinely its own — reading a
+`.shape` through its file layer, saving into its image store, and its logger. 1.2.0 shared the
+renderer but left the tool wrapper behind, and porting to MulmoTerminal made that immediately
+visible: the parts a MODEL sees would have been the duplicated ones.
 
 
 ### Added
@@ -110,7 +116,7 @@ the same way.
 An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
 diagnostic `presentShapeScript` returns.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@1.2.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@1.3.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^1.2.0",
+    "@mulmoclaude/shapescript-plugin": "^1.3.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "presentShapeScript \u2014 interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/render/index.ts
+++ b/packages/plugins/shapescript-plugin/src/render/index.ts
@@ -20,5 +20,7 @@ export {
   RENDER_SHAPE_SCRIPT_PROMPT,
   RENDER_SHAPE_SCRIPT_SCHEMA,
   RENDER_TOOL_TIMEOUT_MS,
+  renderOptionsFrom,
+  savedMessage,
 } from "./tool";
-export type { RenderToolDeps } from "./tool";
+export type { RenderToolDeps, RenderToolResult } from "./tool";

--- a/packages/plugins/shapescript-plugin/src/render/index.ts
+++ b/packages/plugins/shapescript-plugin/src/render/index.ts
@@ -12,3 +12,13 @@ export { renderShapeScriptSheet, RenderUnavailableError, CHROMIUM_HINT, RENDER_T
 export type { RenderShapeScriptOptions } from "./renderer";
 export { buildRenderPage, gridFor } from "./page";
 export type { ViewAngle, RenderPageOptions } from "./page";
+export {
+  executeRenderShapeScript,
+  viewAngles,
+  RENDER_SHAPE_SCRIPT_TOOL_NAME,
+  RENDER_SHAPE_SCRIPT_DESCRIPTION,
+  RENDER_SHAPE_SCRIPT_PROMPT,
+  RENDER_SHAPE_SCRIPT_SCHEMA,
+  RENDER_TOOL_TIMEOUT_MS,
+} from "./tool";
+export type { RenderToolDeps } from "./tool";

--- a/packages/plugins/shapescript-plugin/src/render/renderer.ts
+++ b/packages/plugins/shapescript-plugin/src/render/renderer.ts
@@ -74,13 +74,19 @@ export interface RenderShapeScriptOptions {
  *  the script is at fault. */
 export class RenderUnavailableError extends Error {}
 
-/** Report a fault that did not fail the render, without letting the report
- *  become one. The callback is the HOST's code: it runs inside the `finally`
- *  that releases the browser, so a synchronous throw from it would reject that
- *  block and replace a finished PNG with a logging error (CodeRabbit on #3059). */
-function warn(options: RenderShapeScriptOptions, message: string): void {
+/** Report something the host should record, without letting the report become
+ *  the outcome. The callback is the HOST's code, and it is called from paths
+ *  whose whole purpose is to answer gracefully — the `finally` that releases the
+ *  browser after a finished render (CodeRabbit on #3059), and the
+ *  browser-unavailable branch that returns install guidance (codex on #3060). A
+ *  synchronous throw from a logger must not turn either into a rejection.
+ *
+ *  Exported because both callers need the same guarantee and one of them lives
+ *  in `./tool`; two copies of "wrap the host's logger" is exactly the kind of
+ *  thing that ends up guarded in one place and not the other. */
+export function safeWarn(onWarning: ((message: string) => void) | undefined, message: string): void {
   try {
-    options.onWarning?.(message);
+    onWarning?.(message);
   } catch {
     // A logger that throws is the host's problem, not this render's.
   }
@@ -285,6 +291,6 @@ export async function renderShapeScriptSheet(options: RenderShapeScriptOptions):
     // that just succeeded, so it must not replace the result with an error. The
     // host has the logger; this package reports it through `onWarning` when one
     // was supplied.
-    await browser.close().catch((err: unknown) => warn(options, `chromium close failed: ${errorMessage(err)}`));
+    await browser.close().catch((err: unknown) => safeWarn(options.onWarning, `chromium close failed: ${errorMessage(err)}`));
   }
 }

--- a/packages/plugins/shapescript-plugin/src/render/tool.ts
+++ b/packages/plugins/shapescript-plugin/src/render/tool.ts
@@ -8,7 +8,7 @@
 // host-side is genuinely host-shaped: reading a `.shape` through that host's file
 // capability, and saving an image where that host keeps images.
 
-import { renderShapeScriptSheet, RenderUnavailableError, RENDER_BUDGET_MS } from "./renderer";
+import { renderShapeScriptSheet, RenderUnavailableError, RENDER_BUDGET_MS, safeWarn } from "./renderer";
 import type { ViewAngle } from "./page";
 
 const DEFAULT_AZIMUTH = 30;
@@ -201,7 +201,9 @@ export async function executeRenderShapeScript(deps: RenderToolDeps, args: Recor
     if (err instanceof RenderUnavailableError) {
       // Told to the host as well as the model: to the operator this is a
       // degraded service, not a normal completion.
-      deps.onWarning?.(`renderShapeScript: unavailable — ${err.message}`);
+      // Guarded: this branch exists to answer gracefully, and a host logger that
+      // throws must not turn the install guidance into a rejection (codex on #3060).
+      safeWarn(deps.onWarning, `renderShapeScript: unavailable — ${err.message}`);
       return { message: err.message, rendered: false };
     }
     throw err;

--- a/packages/plugins/shapescript-plugin/src/render/tool.ts
+++ b/packages/plugins/shapescript-plugin/src/render/tool.ts
@@ -1,0 +1,175 @@
+// The `renderShapeScript` TOOL: its schema, its defaults, and what it does with
+// them — everything about the tool except where the PNG goes and who logs.
+//
+// It lives in the package for the same reason the renderer does. Two hosts offer
+// this tool, and the parts a model actually sees — the argument descriptions, the
+// four-view default, the clamps, the sentence naming the saved file — are exactly
+// the parts that would drift silently if each host kept its own copy. What stays
+// host-side is genuinely host-shaped: reading a `.shape` through that host's file
+// capability, and saving an image where that host keeps images.
+
+import { renderShapeScriptSheet, RenderUnavailableError, RENDER_BUDGET_MS } from "./renderer";
+import type { ViewAngle } from "./page";
+
+const DEFAULT_AZIMUTH = 30;
+const DEFAULT_ELEVATION = 25;
+const DEFAULT_ZOOM = 1;
+const DEFAULT_TILE = 480;
+// A tile bigger than this buys the model nothing and costs render time; the
+// sheet is up to 2x2 of these.
+const MAX_TILE = 900;
+const MIN_TILE = 160;
+// Not a true 90: a hair off vertical keeps a little of the sides visible, which
+// is what tells the reader how tall the model is.
+const TOP_ELEVATION = 85;
+
+/** Milliseconds a host must allow this tool before its own transport gives up.
+ *  Covers launch plus render, plus room for the work either side — serialising
+ *  the scene and writing the PNG. A transport sized to the render alone aborts a
+ *  call that was about to succeed. */
+export const RENDER_TOOL_TIMEOUT_MS = RENDER_BUDGET_MS + 30_000;
+
+export const RENDER_SHAPE_SCRIPT_TOOL_NAME = "renderShapeScript";
+
+export const RENDER_SHAPE_SCRIPT_DESCRIPTION =
+  "Render a ShapeScript model to a PNG image and save it, so you can LOOK at the model you wrote and check it before showing it to the user. Returns the image path — read that file to see the result. By default it renders four camera angles onto one sheet, because a single view cannot settle what is in front of what. Takes the same source as presentShapeScript: inline `script`, or `path` to a saved .shape file.";
+
+export const RENDER_SHAPE_SCRIPT_PROMPT =
+  "Use renderShapeScript to CHECK a 3D model you wrote before presenting it — it saves a PNG and returns the path, which you then read to see what the model actually looks like. Fix what you see and re-render. Rendering needs a local headless browser; if it reports one is missing, say so and continue with presentShapeScript rather than retrying.";
+
+/** The tool's JSON schema, in the shape both a gui-chat-protocol `ToolDefinition`
+ *  (`parameters`) and an MCP tool (`inputSchema`) take. */
+export const RENDER_SHAPE_SCRIPT_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    script: {
+      type: "string",
+      description: "ShapeScript source to render. Provide either this or `path`, not both.",
+    },
+    path: {
+      type: "string",
+      description: "Path to an existing .shape file to render (e.g. one presentShapeScript saved under artifacts/shapes/).",
+    },
+    azimuth: {
+      type: "number",
+      description: `Camera rotation around the model in degrees, 0 = looking from +Z. Default ${DEFAULT_AZIMUTH}. In the default four-view sheet this is the FIRST view's angle; the others are offset from it.`,
+    },
+    elevation: {
+      type: "number",
+      description: `Camera height in degrees above the horizon, 90 = straight down. Default ${DEFAULT_ELEVATION}. Avoid 0 and 90 for the main view — an axis-aligned shot flattens depth.`,
+    },
+    zoom: {
+      type: "number",
+      description: `Multiplier on the automatic framing, which fits the whole model. 1 = fit (default), 2 = twice as close, 0.5 = further out. Prefer this over guessing a camera distance: it means the same thing at any model scale.`,
+    },
+    views: {
+      type: "string",
+      enum: ["quad", "single"],
+      description:
+        "`quad` (default) renders four angles on one sheet — use it to judge shape and layout. `single` renders only `azimuth`/`elevation`, for a close look at one detail.",
+    },
+    projection: {
+      type: "string",
+      enum: ["perspective", "orthographic"],
+      description: "`perspective` (default) looks natural; `orthographic` keeps parallel edges parallel, which is better for comparing proportions.",
+    },
+    width: {
+      type: "number",
+      description: `Pixel width of ONE view. Default ${DEFAULT_TILE}, clamped to ${MIN_TILE}–${MAX_TILE}.`,
+    },
+    height: {
+      type: "number",
+      description: `Pixel height of ONE view. Default ${DEFAULT_TILE}, clamped to ${MIN_TILE}–${MAX_TILE}.`,
+    },
+  },
+  required: [] as string[],
+};
+
+function clampTile(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(MAX_TILE, Math.max(MIN_TILE, Math.round(value)));
+}
+
+function num(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+/** Round for a caption — an azimuth of `30.000000000000004` helps nobody. */
+const deg = (value: number): string => `${Math.round(value)}°`;
+
+/**
+ * The angles one call renders.
+ *
+ * The default is FOUR views, not one, and that is the point of the tool: a
+ * single projection is ambiguous about depth and occlusion, and a model asked
+ * to judge one confidently gets "which of these is in front" wrong. Three
+ * quarters around the model plus a top-down resolves it.
+ */
+export function viewAngles(azimuth: number, elevation: number, single: boolean): ViewAngle[] {
+  const view = (turn: number, rise: number, name: string): ViewAngle => ({
+    azimuth: turn,
+    elevation: rise,
+    label: `${name} — az ${deg(turn)}, el ${deg(rise)}`,
+  });
+  if (single) return [view(azimuth, elevation, "view")];
+  return [
+    view(azimuth, elevation, "front-right"),
+    view(azimuth + 90, elevation, "back-right"),
+    view(azimuth + 180, elevation, "back-left"),
+    view(azimuth, TOP_ELEVATION, "top"),
+  ];
+}
+
+/** What a host has to supply: the two things that are actually its own. */
+export interface RenderToolDeps {
+  /** Read the `.shape` a `path` argument names, through this host's file layer.
+   *  Throws — with a message the agent can act on — when the path is not one it
+   *  will open. */
+  readShape: (path: string) => Promise<string>;
+  /** Persist the PNG (base64) and answer with the path the AGENT should read.
+   *  Absolute or relative is the host's call: it depends on where its sessions
+   *  run, and only the host knows that. */
+  saveImage: (base64: string) => Promise<string>;
+  /** Optional host logger for a fault that did not fail the render. */
+  onWarning?: (message: string) => void;
+}
+
+async function resolveScript(deps: RenderToolDeps, args: Record<string, unknown>): Promise<string> {
+  const script = typeof args.script === "string" && args.script.trim() !== "" ? args.script : undefined;
+  const filePath = typeof args.path === "string" && args.path.trim() !== "" ? args.path : undefined;
+  if (script && filePath) throw new Error("Provide either `script` or `path`, not both");
+  if (script) return script;
+  if (filePath) return deps.readShape(filePath);
+  throw new Error("Provide either `script` (inline source) or `path` (an existing .shape file)");
+}
+
+/**
+ * Run one `renderShapeScript` call and answer with the sentence the agent reads.
+ *
+ * A missing browser comes back as that sentence rather than a throw: the model
+ * can do nothing about it, and the useful response is the install hint plus
+ * "carry on without me". Everything else throws, so a host's own error path
+ * reports it.
+ */
+export async function executeRenderShapeScript(deps: RenderToolDeps, args: Record<string, unknown>): Promise<string> {
+  const script = await resolveScript(deps, args);
+  const views = viewAngles(num(args.azimuth, DEFAULT_AZIMUTH), num(args.elevation, DEFAULT_ELEVATION), args.views === "single");
+  try {
+    const base64 = await renderShapeScriptSheet({
+      script,
+      views,
+      width: clampTile(args.width, DEFAULT_TILE),
+      height: clampTile(args.height, DEFAULT_TILE),
+      zoom: Math.max(num(args.zoom, DEFAULT_ZOOM), 0.01),
+      projection: args.projection === "orthographic" ? "orthographic" : "perspective",
+      ...(deps.onWarning ? { onWarning: deps.onWarning } : {}),
+    });
+    const imagePath = await deps.saveImage(base64);
+    const captions = views.map((angle) => angle.label).join("; ");
+    const count = views.length === 1 ? "1 view" : `${views.length} views`;
+    return `Saved render to ${imagePath} (${count}: ${captions}). Read that file to see the model.`;
+  } catch (err) {
+    if (err instanceof RenderUnavailableError) return err.message;
+    throw err;
+  }
+}

--- a/packages/plugins/shapescript-plugin/src/render/tool.ts
+++ b/packages/plugins/shapescript-plugin/src/render/tool.ts
@@ -130,7 +130,9 @@ export interface RenderToolDeps {
    *  Absolute or relative is the host's call: it depends on where its sessions
    *  run, and only the host knows that. */
   saveImage: (base64: string) => Promise<string>;
-  /** Optional host logger for a fault that did not fail the render. */
+  /** Optional host logger for anything the host should record but the model does
+   *  not need as an error — a browser that would not close, and the unavailable
+   *  browser below. */
   onWarning?: (message: string) => void;
 }
 
@@ -143,33 +145,65 @@ async function resolveScript(deps: RenderToolDeps, args: Record<string, unknown>
   throw new Error("Provide either `script` (inline source) or `path` (an existing .shape file)");
 }
 
-/**
- * Run one `renderShapeScript` call and answer with the sentence the agent reads.
+/** What one call did. `rendered: false` means the tool answered without an image
+ *  — today only a host with no usable browser.
  *
- * A missing browser comes back as that sentence rather than a throw: the model
- * can do nothing about it, and the useful response is the install hint plus
- * "carry on without me". Everything else throws, so a host's own error path
- * reports it.
+ *  The flag exists because the two outcomes look identical from the outside: both
+ *  return a sentence for the model. Before the extraction the host logged
+ *  `unavailable` on this path and `ok` on the other; collapsing them to a string
+ *  made a missing Chromium invisible to host monitoring while the host went on
+ *  logging success (codex on #3060). A host that ignores the flag still behaves
+ *  correctly — it just cannot tell the two apart, which is the caller's choice
+ *  to make rather than this function's. */
+export interface RenderToolResult {
+  /** The sentence the agent reads — the saved path, or why there is none. */
+  message: string;
+  rendered: boolean;
+}
+
+/**
+ * Run one `renderShapeScript` call.
+ *
+ * A missing browser comes back as a message rather than a throw: the model can
+ * do nothing about it, and the useful response is the install hint plus "carry
+ * on without me". Everything else throws, so a host's own error path reports it.
  */
-export async function executeRenderShapeScript(deps: RenderToolDeps, args: Record<string, unknown>): Promise<string> {
+/** The renderer's options for one call: every model-supplied number defaulted and
+ *  clamped, so nothing downstream has to wonder whether it was checked. */
+export function renderOptionsFrom(args: Record<string, unknown>, script: string, views: readonly ViewAngle[], onWarning?: (message: string) => void) {
+  return {
+    script,
+    views,
+    width: clampTile(args.width, DEFAULT_TILE),
+    height: clampTile(args.height, DEFAULT_TILE),
+    zoom: Math.max(num(args.zoom, DEFAULT_ZOOM), 0.01),
+    projection: args.projection === "orthographic" ? ("orthographic" as const) : ("perspective" as const),
+    ...(onWarning ? { onWarning } : {}),
+  };
+}
+
+/** What the model is told about a sheet that WAS produced. The captions are
+ *  repeated here rather than left to the image alone: a model that has not opened
+ *  the file yet still knows which angles it is about to see. */
+export function savedMessage(imagePath: string, views: readonly ViewAngle[]): string {
+  const captions = views.map((angle) => angle.label).join("; ");
+  const count = views.length === 1 ? "1 view" : `${views.length} views`;
+  return `Saved render to ${imagePath} (${count}: ${captions}). Read that file to see the model.`;
+}
+
+export async function executeRenderShapeScript(deps: RenderToolDeps, args: Record<string, unknown>): Promise<RenderToolResult> {
   const script = await resolveScript(deps, args);
   const views = viewAngles(num(args.azimuth, DEFAULT_AZIMUTH), num(args.elevation, DEFAULT_ELEVATION), args.views === "single");
   try {
-    const base64 = await renderShapeScriptSheet({
-      script,
-      views,
-      width: clampTile(args.width, DEFAULT_TILE),
-      height: clampTile(args.height, DEFAULT_TILE),
-      zoom: Math.max(num(args.zoom, DEFAULT_ZOOM), 0.01),
-      projection: args.projection === "orthographic" ? "orthographic" : "perspective",
-      ...(deps.onWarning ? { onWarning: deps.onWarning } : {}),
-    });
-    const imagePath = await deps.saveImage(base64);
-    const captions = views.map((angle) => angle.label).join("; ");
-    const count = views.length === 1 ? "1 view" : `${views.length} views`;
-    return `Saved render to ${imagePath} (${count}: ${captions}). Read that file to see the model.`;
+    const base64 = await renderShapeScriptSheet(renderOptionsFrom(args, script, views, deps.onWarning));
+    return { message: savedMessage(await deps.saveImage(base64), views), rendered: true };
   } catch (err) {
-    if (err instanceof RenderUnavailableError) return err.message;
+    if (err instanceof RenderUnavailableError) {
+      // Told to the host as well as the model: to the operator this is a
+      // degraded service, not a normal completion.
+      deps.onWarning?.(`renderShapeScript: unavailable — ${err.message}`);
+      return { message: err.message, rendered: false };
+    }
     throw err;
   }
 }

--- a/server/agent/mcp-tools/renderShapeScript.ts
+++ b/server/agent/mcp-tools/renderShapeScript.ts
@@ -5,68 +5,30 @@
 // pushed to the chat canvas, and the answer is a file path — the same contract
 // `generateImage` uses, which is what makes the result readable (the image
 // lands under `artifacts/images/` and the agent opens it with Read).
+//
+// The tool itself — schema, defaults, the four-view sheet, the sentence naming
+// the saved file — lives in `@mulmoclaude/shapescript-plugin/render`, because
+// MulmoTerminal offers the same tool and those are precisely the parts that
+// would drift if each host kept a copy. What is left here is what is actually
+// this host's: reading a `.shape` through its file layer, saving into its image
+// store, and its logger.
 
-import { isShapeArtifactPath, isPresentableShapePath, toArtifactsRelative } from "@mulmoclaude/shapescript-plugin";
+import {
+  executeRenderShapeScript,
+  RENDER_SHAPE_SCRIPT_DESCRIPTION,
+  RENDER_SHAPE_SCRIPT_PROMPT,
+  RENDER_SHAPE_SCRIPT_SCHEMA,
+  RENDER_SHAPE_SCRIPT_TOOL_NAME,
+  RENDER_TOOL_TIMEOUT_MS,
+} from "@mulmoclaude/shapescript-plugin/render";
+import { isShapeArtifactPath, isPresentableShapePath, toArtifactsRelative, SHAPE_EXTENSIONS } from "@mulmoclaude/shapescript-plugin";
 import { readFile } from "fs/promises";
 import path from "node:path";
 import { saveImage } from "../../utils/files/image-store.js";
 import { resolveByPath } from "../../utils/files/by-path.js";
 import { workspacePath } from "../../workspace/workspace.js";
-import { renderShapeScriptSheet, RenderUnavailableError, RENDER_BUDGET_MS } from "@mulmoclaude/shapescript-plugin/render";
-import type { ViewAngle } from "@mulmoclaude/shapescript-plugin/render";
-import { errorMessage } from "../../utils/errors.js";
 import { log } from "../../system/logger/index.js";
-import { ONE_SECOND_MS } from "../../utils/time.js";
 import type { McpTool } from "./index.js";
-
-const DEFAULT_AZIMUTH = 30;
-const DEFAULT_ELEVATION = 25;
-const DEFAULT_ZOOM = 1;
-const DEFAULT_TILE = 480;
-// A tile bigger than this buys the model nothing and costs render time; the
-// sheet is up to 2x2 of these.
-const MAX_TILE = 900;
-const MIN_TILE = 160;
-// Not a true 90: a hair off vertical keeps a little of the sides visible, which
-// is what tells the reader how tall the model is.
-const TOP_ELEVATION = 85;
-
-const SHAPE_EXTENSIONS = [".shape"] as const;
-
-function clampTile(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
-  return Math.min(MAX_TILE, Math.max(MIN_TILE, Math.round(value)));
-}
-
-function num(value: unknown, fallback: number): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
-}
-
-/** Round for a caption — an azimuth of `30.000000000000004` helps nobody. */
-const deg = (value: number): string => `${Math.round(value)}°`;
-
-/**
- * The angles one call renders.
- *
- * The default is FOUR views, not one, and that is the point of the tool: a
- * single projection is ambiguous about depth and occlusion, and a model asked
- * to judge one confidently gets "which of these is in front" wrong. Three
- * quarters around the model plus a top-down resolves it.
- */
-export function viewAngles(azimuth: number, elevation: number, single: boolean): ViewAngle[] {
-  const view = (turn: number, rise: number, name: string): ViewAngle => ({
-    azimuth: turn,
-    elevation: rise,
-    label: `${name} — az ${deg(turn)}, el ${deg(rise)}`,
-  });
-  if (single) return [view(azimuth, elevation, "view")];
-  return [
-    view(azimuth, elevation, "front-right"),
-    view(azimuth + 90, elevation, "back-right"),
-    view(azimuth + 180, elevation, "back-left"),
-    view(azimuth, TOP_ELEVATION, "top"),
-  ];
-}
 
 /** Read the source a `path` argument names — an `artifacts/shapes/**` file this
  *  tool saved, or any other `.shape` on disk. Mirrors the plugin's own routing
@@ -81,101 +43,28 @@ async function readShapeFile(filePath: string): Promise<string> {
   return readFile(resolved, "utf-8");
 }
 
-async function resolveScript(args: Record<string, unknown>): Promise<string> {
-  const script = typeof args.script === "string" && args.script.trim() !== "" ? args.script : undefined;
-  const filePath = typeof args.path === "string" && args.path.trim() !== "" ? args.path : undefined;
-  if (script && filePath) throw new Error("Provide either `script` or `path`, not both");
-  if (script) return script;
-  if (filePath) return readShapeFile(filePath);
-  throw new Error("Provide either `script` (inline source) or `path` (an existing .shape file)");
-}
-
 export const renderShapeScript: McpTool = {
   definition: {
-    name: "renderShapeScript",
-    description:
-      "Render a ShapeScript model to a PNG image and save it, so you can LOOK at the model you wrote and check it before showing it to the user. Returns the image path — read that file to see the result. By default it renders four camera angles onto one sheet, because a single view cannot settle what is in front of what. Takes the same source as presentShapeScript: inline `script`, or `path` to a saved .shape file.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        script: {
-          type: "string",
-          description: "ShapeScript source to render. Provide either this or `path`, not both.",
-        },
-        path: {
-          type: "string",
-          description: "Path to an existing .shape file to render (e.g. one presentShapeScript saved under artifacts/shapes/).",
-        },
-        azimuth: {
-          type: "number",
-          description: `Camera rotation around the model in degrees, 0 = looking from +Z. Default ${DEFAULT_AZIMUTH}. In the default four-view sheet this is the FIRST view's angle; the others are offset from it.`,
-        },
-        elevation: {
-          type: "number",
-          description: `Camera height in degrees above the horizon, 90 = straight down. Default ${DEFAULT_ELEVATION}. Avoid 0 and 90 for the main view — an axis-aligned shot flattens depth.`,
-        },
-        zoom: {
-          type: "number",
-          description: `Multiplier on the automatic framing, which fits the whole model. 1 = fit (default), 2 = twice as close, 0.5 = further out. Prefer this over guessing a camera distance: it means the same thing at any model scale.`,
-        },
-        views: {
-          type: "string",
-          enum: ["quad", "single"],
-          description:
-            "`quad` (default) renders four angles on one sheet — use it to judge shape and layout. `single` renders only `azimuth`/`elevation`, for a close look at one detail.",
-        },
-        projection: {
-          type: "string",
-          enum: ["perspective", "orthographic"],
-          description: "`perspective` (default) looks natural; `orthographic` keeps parallel edges parallel, which is better for comparing proportions.",
-        },
-        width: {
-          type: "number",
-          description: `Pixel width of ONE view. Default ${DEFAULT_TILE}, clamped to ${MIN_TILE}–${MAX_TILE}.`,
-        },
-        height: {
-          type: "number",
-          description: `Pixel height of ONE view. Default ${DEFAULT_TILE}, clamped to ${MIN_TILE}–${MAX_TILE}.`,
-        },
-      },
-      required: [],
-    },
+    name: RENDER_SHAPE_SCRIPT_TOOL_NAME,
+    description: RENDER_SHAPE_SCRIPT_DESCRIPTION,
+    inputSchema: RENDER_SHAPE_SCRIPT_SCHEMA,
   },
   // Launching a browser and rasterising several views outlasts the bridge's
   // 30 s default for external-API tools; without the headroom a render that was
-  // about to succeed is aborted in transit. `RENDER_BUDGET_MS` already covers
-  // launch + render, so this margin is for the work either side of it —
-  // serialising the scene and writing the PNG.
-  bridgeTimeoutMs: RENDER_BUDGET_MS + 30 * ONE_SECOND_MS,
-  prompt:
-    "Use renderShapeScript to CHECK a 3D model you wrote before presenting it — it saves a PNG and returns the path, which you then read to see what the model actually looks like. Fix what you see and re-render. Rendering needs a local headless browser; if it reports one is missing, say so and continue with presentShapeScript rather than retrying.",
+  // about to succeed is aborted in transit.
+  bridgeTimeoutMs: RENDER_TOOL_TIMEOUT_MS,
+  prompt: RENDER_SHAPE_SCRIPT_PROMPT,
   handler: async (args: Record<string, unknown>): Promise<string> => {
-    const script = await resolveScript(args);
-    const azimuth = num(args.azimuth, DEFAULT_AZIMUTH);
-    const elevation = num(args.elevation, DEFAULT_ELEVATION);
-    const views = viewAngles(azimuth, elevation, args.views === "single");
-    log.info("render", "renderShapeScript: start", { views: views.length, bytes: script.length });
-    try {
-      const base64 = await renderShapeScriptSheet({
-        script,
-        onWarning: (message) => log.warn("render", message),
-        views,
-        width: clampTile(args.width, DEFAULT_TILE),
-        height: clampTile(args.height, DEFAULT_TILE),
-        zoom: Math.max(num(args.zoom, DEFAULT_ZOOM), 0.01),
-        projection: args.projection === "orthographic" ? "orthographic" : "perspective",
-      });
-      const imagePath = await saveImage(base64);
-      log.info("render", "renderShapeScript: ok", { imagePath });
-      const captions = views.map((angle) => angle.label).join("; ");
-      const count = views.length === 1 ? "1 view" : `${views.length} views`;
-      return `Saved render to ${imagePath} (${count}: ${captions}). Read that file to see the model.`;
-    } catch (err) {
-      if (err instanceof RenderUnavailableError) {
-        log.warn("render", "renderShapeScript: unavailable", { error: errorMessage(err) });
-        return err.message;
-      }
-      throw err;
-    }
+    log.info("render", "renderShapeScript: start", { args: Object.keys(args).join(",") });
+    const message = await executeRenderShapeScript(
+      {
+        readShape: readShapeFile,
+        saveImage,
+        onWarning: (warning) => log.warn("render", warning),
+      },
+      args,
+    );
+    log.info("render", "renderShapeScript: done");
+    return message;
   },
 };

--- a/server/agent/mcp-tools/renderShapeScript.ts
+++ b/server/agent/mcp-tools/renderShapeScript.ts
@@ -56,7 +56,7 @@ export const renderShapeScript: McpTool = {
   prompt: RENDER_SHAPE_SCRIPT_PROMPT,
   handler: async (args: Record<string, unknown>): Promise<string> => {
     log.info("render", "renderShapeScript: start", { args: Object.keys(args).join(",") });
-    const message = await executeRenderShapeScript(
+    const { message, rendered } = await executeRenderShapeScript(
       {
         readShape: readShapeFile,
         saveImage,
@@ -64,7 +64,10 @@ export const renderShapeScript: McpTool = {
       },
       args,
     );
-    log.info("render", "renderShapeScript: done");
+    // `rendered` is the difference between a saved image and a host with no
+    // usable browser. Both answer the model with a sentence, so without the flag
+    // a degraded service logs exactly like a working one.
+    log.info("render", rendered ? "renderShapeScript: ok" : "renderShapeScript: answered without an image", { message });
     return message;
   },
 };

--- a/test/agent/test_renderShapeScript.ts
+++ b/test/agent/test_renderShapeScript.ts
@@ -6,8 +6,8 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { renderShapeScript, viewAngles } from "../../server/agent/mcp-tools/renderShapeScript.js";
-import { gridFor } from "@mulmoclaude/shapescript-plugin/render";
+import { renderShapeScript } from "../../server/agent/mcp-tools/renderShapeScript.js";
+import { gridFor, viewAngles } from "@mulmoclaude/shapescript-plugin/render";
 
 describe("renderShapeScript view angles", () => {
   // The default is four views, and that IS the feature: one projection is


### PR DESCRIPTION
## Why now

#3059 moved the *renderer* into `@mulmoclaude/shapescript-plugin/render` so both hosts could share it. Starting the MulmoTerminal port showed that was half the job: what the second host still had to copy was the tool's **schema, defaults, four-view logic and result sentence** — every part a model actually sees. Those are the worst candidates for duplication, because drift there is invisible until the same agent behaves differently in the two apps. (We already have a live example: MulmoTerminal's `toolGroups.ts` still describes `presentShapeScript` as a tool that saves nothing, which stopped being true at 1.1.0.)

## What

`executeRenderShapeScript(deps, args)` moves into the package beside the renderer. A host supplies only what is genuinely its own:

| dep | why it can't be shared |
|---|---|
| `readShape(path)` | each host has its own file capability and its own idea of which paths it will open |
| `saveImage(base64)` → path | MulmoClaude saves under `artifacts/images/` and can answer relatively; MulmoTerminal runs sessions in per-project directories, where only an absolute path resolves |
| `onWarning?` | the package has no logger |

`saveImage` **returns** the path rather than taking one, which is the load-bearing bit of the interface: the host decides what the agent should read, because only the host knows where its sessions run.

`server/agent/mcp-tools/renderShapeScript.ts` goes from 180 lines to a definition plus two callbacks. **No behaviour changes** — same schema, same defaults, same clamps, same timeout budget, same messages.

## Verification

`yarn format` / `lint` / `typecheck` / `build` / `test` clean, plus `check:launcher-sync`, the changelog Ships check and the launcher dep audit.

Exercised the shared contract directly with stub deps: a real render round-trips to `Saved render to … (1 view: view — az 30°, el 25°). Read that file to see the model.`, and calling it with neither `script` nor `path` refuses with the expected message.

Before this, I also verified the **published** 1.2.0 tarball in a clean `npm install` outside the repo — `./render` resolves and renders — so the subpath and the three-resolution anchoring hold as shipped, not just in the workspace.

## Sequencing

Publishes as `1.3.0`. The MulmoTerminal port imports `executeRenderShapeScript` from it, so that PR follows the publish. Its `renderShapeScript` will be a host tool in the `render` group, and the same PR fixes the stale `AUTO_ALLOWED_TOOLS` comment.

work in mulmoclaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvsMjzTPP41UUAKS1R3Saa

## Summary by Sourcery

Centralize the renderShapeScript tool contract and execution in the Shapescript plugin while leaving only host-specific file and image capabilities in MulmoClaude.

New Features:
- Move the complete `renderShapeScript` tool contract into the Shapescript plugin for reuse by multiple hosts.

Bug Fixes:
- Prevent host implementations from drifting in tool schema, defaults, rendering views, result messaging, and unavailable-browser handling.

Enhancements:
- Reduce the MulmoClaude tool wrapper to host-specific file reading, image storage, logging, and delegation to the shared execution API.
- Expose shared render-tool constants, helpers, dependency types, and rendered-status results from the plugin.
- Make warning reporting resilient to logger failures and distinguish successful renders from responses without an image.

Build:
- Release `@mulmoclaude/shapescript-plugin` as version 1.3.0 and update the MulmoClaude dependency.

Documentation:
- Update the changelog to document the shared render-tool extraction and 1.3.0 release.

Tests:
- Update render tool tests to use the shared plugin view-angle implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared ShapeScript rendering support across supported hosts.
  - Rendering supports inline scripts or file paths, configurable views, camera settings, dimensions, and projections.
  - Improved render results with contact-sheet output and clearer saved-file messages.
  - Missing browser availability is reported gracefully.

- **Chores**
  - Updated the ShapeScript plugin and dependency to version 1.3.0.
  - Updated the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->