### PR TITLE
ci: Codex レビューを手動実行だけにする（on: から pull_request を外す）

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -1,4 +1,4 @@
-# Auto-review every non-draft PR using OpenAI Codex CLI pointed at
+# Review a PR on request using OpenAI Codex CLI pointed at
 # Azure OpenAI. Runs alongside CodeRabbit + Sourcery; the verdict
 # marker (`CODEX VERDICT: LGTM` / `CHANGES REQUESTED`) matches the
 # `/codex-cross-review` skill so both human-driven and automated
@@ -27,32 +27,23 @@
 #                                  as a model — see the AZURE_MODEL comment below)
 #   - AZURE_OPENAI_API_VERSION    (defaults to `preview`)
 #
-# `workflow_dispatch` is also kept for manual re-runs (e.g.
-# requesting a re-review after argument changes, or running on a
-# closed PR for forensics).
+# MANUAL ONLY. It used to fire on every PR; the `pull_request` trigger
+# was removed deliberately, so nothing here starts on its own. Ask for
+# a review with the PR number:
+#
+#     gh workflow run "Codex auto-review" -f pr_number=<N>
+#
+# The same input serves a re-review after argument changes, or a run
+# against a closed PR for forensics.
 
 name: Codex auto-review
 
 on:
-  # Auto-fire on EVERY PR — including drafts and docs-only diffs.
-  # The user's directive: "極力制限しないでどんどんつかえる". Cost is
-  # bounded anyway by `concurrency.cancel-in-progress` (a push burst
-  # collapses to one review against the final commit) and the Azure
-  # deployment's 5000 TPM ceiling. A docs-only PR review is cheap
-  # and occasionally catches a typo or broken link the bots missed.
-  # `ready_for_review` is intentionally NOT in `types`: `opened` already
-  # fires on draft PRs, so promoting draft → ready would otherwise re-run
-  # Codex on the identical SHA (no new commits to review). If a fresh
-  # take is wanted on draft promotion, use `workflow_dispatch` instead.
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-  # Manual escalation: run on demand against any PR (re-review,
-  # one-off check on a closed PR, etc.).
+  # The only trigger: run on demand against any PR — open, draft or closed.
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to review (required for workflow_dispatch)"
+        description: "PR number to review"
         required: true
         type: string
 
@@ -68,7 +59,7 @@ env:
   CODEX_VERSION: "0.147.0"
 
 concurrency:
-  group: codex-review-pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: codex-review-pr-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -176,7 +167,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
           # `--sandbox danger-full-access` skips bubblewrap entirely.


### PR DESCRIPTION
## Summary

`.github/workflows/codex_review.yaml` の `on:` から `pull_request` を外し、`workflow_dispatch` だけを
残します。PR を開く / push するだけでは Codex レビューが走らなくなり、必要なときだけ回します:

```bash
gh workflow run "Codex auto-review" -f pr_number=<N>
```

mulmoterminal / mulmoclaude / mulmoserver の 3 リポジトリで同じ変更を入れています。

## Items to Confirm / Review

1. **止めてもマージは詰まりません。** このリポジトリの `main` に required status check は無いことを
   確認済みです（`gh api repos/<owner>/<repo>/branches/main/protection`）。
2. **PR 番号の出どころが入力だけになった**ので、`concurrency.group` と `PR_NUMBER` から
   `github.event.pull_request.number ||` を落としました。残すと「常に空になる式」になります。
3. ファイルは**削除していません**。Azure OpenAI の配線（`~/.codex/config.toml` を書く手順、
   `AZURE_OPENAI_*` シークレット、CLI のバージョン固定）とその経緯コメントは、手動実行でそのまま要ります。
4. `actionlint` clean。トリガーが `workflow_dispatch` だけになったことも確認しました。
5. **副作用**: `CODEX VERDICT:` 行を機械信号として使うレビュー運用（`/gh-review-loop`）は、以後この
   ワークフローを手で回さない限り CodeRabbit だけのシグナルになります。

## User Prompt

- 「`.github/workflows/codex_review.yaml` をとめたいんだけど、ci の設定で off にできる？削除必要？」
- 「`on:` から `pull_request:` を外すにしよう」
- 「mulmoclaude と mulmoserver も。」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhpBoaAvZsCqPmkLYFvCyy

## Summary by Sourcery

Make Codex pull request reviews manual-only while preserving on-demand review support.

Enhancements:
- Change the Codex review workflow to run only when manually dispatched with a specified pull request number.

CI:
- Remove automatic pull request triggers so Codex reviews no longer run on pull request activity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - The code review workflow no longer runs automatically for every pull request.
  - Maintainers can now start reviews on demand by providing the relevant pull request number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->