### PR TITLE
feat(shapescript): adopt upstream ShapeScript units and path semantics

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,9 @@ follows upstream:
   point** with implicit midpoints between consecutive controls (was an end point with an
   optional 4-argument control offset, a syntax that no longer parses).
 - New `seed N` command, scoped to its block, and `rnd` uses upstream's generator with seed 0.
+- Call arguments are a value list, so upstream's `max(0 (j - 1))` parses alongside our
+  `max(0, j - 1)`; a script written the upstream way now opens in both. Ordinal members
+  `.first` … `.tenth`, `.last`, `.allButFirst`, `.allButLast` are accepted.
 
 **Breaking for saved `.shape` files** written against the old conventions — hence the major.
 The remaining gaps are tracked in `plans/feat-shapescript-upstream-parity.md`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Changed
+
+#### `@mulmoclaude/shapescript-plugin@2.0.0` — upstream ShapeScript units and path semantics
+
+The plugin inherited unit conventions from present3D that upstream
+[ShapeScript](https://shapescript.info/mac/) does not use, so a script written against the
+upstream docs (which is what the agent has read) rendered wrong without any error. It now
+follows upstream:
+
+- `size` is the **diameter** of `sphere` / `cylinder` / `cone` / `circle` / `polygon` / `torus`
+  (was the radius, so every curved shape drew twice as large).
+- `orientation` (alias `rotation`) and `rotate` are **half-turns** as `roll yaw pitch`, applied
+  Z → Y → X, positive clockwise (were radians in XYZ order for the property, full turns for the
+  command). A lone value is a roll; `angle x y z` is accepted too.
+- Path `point` / `curve` coordinates are **absolute** in the path's frame, which `rotate` /
+  `translate` / `scale` move (were relative steps). `curve` is a quadratic Bézier **control
+  point** with implicit midpoints between consecutive controls (was an end point with an
+  optional 4-argument control offset, a syntax that no longer parses).
+- New `seed N` command, scoped to its block, and `rnd` uses upstream's generator with seed 0.
+
+**Breaking for saved `.shape` files** written against the old conventions — hence the major.
+The remaining gaps are tracked in `plans/feat-shapescript-upstream-parity.md`.
+
 ### Added
 
 #### `@mulmoclaude/shapescript-plugin@1.4.0` — USDZ export, for the agent and for the user
@@ -136,7 +159,7 @@ the same way.
 An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
 diagnostic `presentShapeScript` returns.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@1.4.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^1.4.0",
+    "@mulmoclaude/shapescript-plugin": "^2.0.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -67,7 +67,9 @@ USDZ units are metres, so `size 1` is one metre in AR.
 - **Variables & expressions**: `define`, arithmetic / comparison / boolean operators, parentheses
 - **Control flow**: `for … in … to … step`, `if` / `else`, `switch` / `case`
 - **Built-ins**: `round floor ceil abs sign sqrt pow min max`, `sin cos tan asin acos atan atan2`
-  (radians), `dot cross length normalize sum`, `rnd`, `seed N`
+  (radians), `dot cross length normalize sum`, `rnd`
+- **Commands**: `detail N`, `seed N` (both scoped to the enclosing block), `color`, and the relative
+  `rotate` / `translate` / `scale`
 
 A function call takes **no space** before its parenthesis: `sin(x)` is a call, `sin (x)` is not.
 

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -74,7 +74,8 @@ USDZ units are metres, so `size 1` is one metre in AR.
 A function call takes **no space** before its parenthesis: `sin(x)` is a call, `sin (x)` is not.
 Arguments are a value list, so upstream's `max(0 (j - 1))` and `max(0, j - 1)` both work; write the
 space-separated form when a script also has to open in the upstream app. Upstream's bare
-`max 0 (j - 1)` (no parentheses) is not supported.
+`max 0 (j - 1)` (no parentheses) is not supported. This parser also accepts several statements on
+one line (`define a 1 define b 2`); upstream requires one per line, so portable scripts keep to that.
 
 ## Storage
 

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -131,16 +131,36 @@ hull {
 }
 extrude { polygon { sides 5 } }
 fill { square }
-lathe path { point 0 0 point 1 0 curve 1.5 1 point 1 2 point 0 2 }
+lathe path {
+    point 0 0
+    point 1 0
+    curve 1.5 1
+    point 1 2
+    point 0 2
+}
 
 // Paths: absolute points, Bézier control points, a frame moved by rotate/translate/scale.
-extrude path { point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }
-fill path { for 0 to 8 { curve 0 1 rotate 1 / 8 } }
+extrude path {
+    point 0 0
+    point 1 0
+    point 1 1
+    point 0 1
+    point 0 0
+}
+fill path {
+    for 0 to 8 {
+        curve 0 1
+        rotate 1 / 8
+    }
+}
 
 // Stencil changes surface material without cutting away the first shape.
 stencil {
     cube { color 1 0 0 }
-    cube { position 0.5 0 0 color 0 1 0 }
+    cube {
+        position 0.5 0 0
+        color 0 1 0
+    }
 }
 
 define offsets ((1 2 3), (4 5 6))

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -188,7 +188,9 @@ conventions, so a script written against the upstream docs renders the same here
 - Path `point` / `curve` coordinates are **absolute** in the path's frame; `rotate`, `translate`
   and `scale` inside a path move that frame for later points. `curve` is a quadratic Bézier
   **control point** — the outline passes through the neighbouring `point`s, and two `curve`s in
-  a row get an implicit on-curve midpoint (eight in an octagon draw a circle).
+  a row get an implicit on-curve midpoint (eight in an octagon draw a circle). A path block may
+  carry `position` / `orientation` / `size` of its own, which is how a `loft` section is placed in
+  3D; `lathe` refuses a placed profile.
 - `rnd` uses upstream's generator (`x = x · 1664525 + 1013904223 mod 2³²`, seed 0) and `seed N`
   reseeds it for the enclosing block only.
 

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -167,7 +167,7 @@ define offsets ((1 2 3), (4 5 6))
 cube { position offsets[0].x offsets[1].y offsets.count }
 ```
 
-Also supported: `pi`, `tau`, `true`, `false`, scientific notation, unary `+`,
+Also supported: `pi`, `tau` (plugin-only; upstream has no `tau`, so portable scripts write `2 * pi`), `true`, `false`, scientific notation, unary `+`,
 short-circuit `and`/`or`, string literals, `join`/`trim`, tuple arguments to `min`/`max`,
 zero-based tuple/string subscripts, `.count`, ordinal members `.first` … `.tenth`, `.last`,
 `.allButFirst`, `.allButLast`, vector `.x/.y/.z/.w`, color

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -61,13 +61,13 @@ USDZ units are metres, so `size 1` is one metre in AR.
 ## ShapeScript language
 
 - **Primitives**: `cube`, `sphere`, `cylinder`, `cone`, `torus`, `circle`, `square`, `polygon`
-- **Properties**: `position X Y Z`, `rotation X Y Z`, `size X Y Z`, `color R G B` (0–1), `opacity`
+- **Properties**: `position X Y Z`, `orientation ROLL YAW PITCH` (alias `rotation`), `size X Y Z`, `color R G B` (0–1), `opacity`
 - **CSG**: `union`, `difference`, `intersection`, `xor`, `stencil`
 - **Builders**: `extrude`, `loft`, `lathe`, `fill`, `hull`
 - **Variables & expressions**: `define`, arithmetic / comparison / boolean operators, parentheses
 - **Control flow**: `for … in … to … step`, `if` / `else`, `switch` / `case`
 - **Built-ins**: `round floor ceil abs sign sqrt pow min max`, `sin cos tan asin acos atan atan2`
-  (radians), `dot cross length normalize sum`
+  (radians), `dot cross length normalize sum`, `rnd`, `seed N`
 
 A function call takes **no space** before its parenthesis: `sin(x)` is a call, `sin (x)` is not.
 
@@ -125,7 +125,11 @@ hull {
 }
 extrude { polygon { sides 5 } }
 fill { square }
-lathe path { point 1 0 curve 0 2 1 -1 }
+lathe path { point 0 0 point 1 0 curve 1.5 1 point 1 2 point 0 2 }
+
+// Paths: absolute points, Bézier control points, a frame moved by rotate/translate/scale.
+extrude path { point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }
+fill path { for 0 to 8 { curve 0 1 rotate 1 / 8 } }
 
 // Stencil changes surface material without cutting away the first shape.
 stencil {
@@ -144,14 +148,31 @@ zero-based tuple/string subscripts, `.count`, vector `.x/.y/.z/.w`, color
 and `polygon { sides N }` (integer 3–256). Lathe samples curved profiles, and inline
 builder paths use the same parser as nested paths, including loops and definitions.
 
+## Units and path semantics — same as upstream
+
+Since 2.0.0 the plugin follows the [upstream ShapeScript](https://shapescript.info/mac/)
+conventions, so a script written against the upstream docs renders the same here:
+
+- `size` is the **diameter** of `sphere`, `cylinder`, `cone`, `circle`, `polygon` and `torus`
+  (a bare `sphere` fits the unit cube) and the edge length of `cube` / `square`.
+- `orientation` (alias `rotation`) and `rotate` take **half-turns** as `roll yaw pitch` —
+  rotations about Z, Y and X applied in that order, `0.5` = 90°, positive clockwise (Euclid's
+  sign). A lone value is a roll; four values are `angle x y z`. Trig *functions* still use radians.
+- Path `point` / `curve` coordinates are **absolute** in the path's frame; `rotate`, `translate`
+  and `scale` inside a path move that frame for later points. `curve` is a quadratic Bézier
+  **control point** — the outline passes through the neighbouring `point`s, and two `curve`s in
+  a row get an implicit on-curve midpoint (eight in an octagon draw a circle).
+- `rnd` uses upstream's generator (`x = x · 1664525 + 1013904223 mod 2³²`, seed 0) and `seed N`
+  reseeds it for the enclosing block only.
+
+Deviations that remain: an *open* path whose first or last point is a `curve` treats it as a
+corner (upstream extrapolates a tangent), and path points are 2D. The gap list lives in
+[`plans/feat-shapescript-upstream-parity.md`](../../../plans/feat-shapescript-upstream-parity.md).
+
 ## Compatibility and limits
 
 This is the plugin's documented modeling subset, **not complete compatibility with
-[upstream ShapeScript](https://shapescript.info/mac/)**. It preserves existing plugin
-conventions: primitive sphere/circle sizes specify radii; rotation/orientation properties
-and trig functions use radians; relative rotate/orientation commands and path rotation
-use turns (`1 = 360°`). Path point/curve coordinates are relative steps, and curve
-control coordinates are offsets from the endpoint. Upstream uses different conventions.
+upstream ShapeScript**.
 
 Loft accepts ordered, closed planar sections with one perimeter each, resamples differing
 vertex counts, interpolates linearly, and triangulates the end caps. Sections must enclose
@@ -164,9 +185,10 @@ substituting different geometry. As with other polygonal CSG engines, degenerate
 self-intersecting inputs may fail.
 
 `rnd` and `rand()` draw from a seeded generator (`randomSeed`, default
-`DEFAULT_RANDOM_SEED`) rather than `Math.random()`: one script is evaluated twice — once
-on the server, which validates it, and again in the browser, which renders it — and an
-unseeded generator lets those two runs take different branches.
+`DEFAULT_RANDOM_SEED` = 0, overridable in-script with `seed`) rather than `Math.random()`:
+one script is evaluated twice — once on the server, which validates it, and again in the
+browser, which renders it — and an unseeded generator lets those two runs take different
+branches.
 
 Conversion limits cover nodes (100,000), loop/path work (100,000 iterations), detail (3–256),
 aggregate vertices (5,000,000, including CSG intermediates), and a coarse 30-second wall-clock

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -72,6 +72,9 @@ USDZ units are metres, so `size 1` is one metre in AR.
   `rotate` / `translate` / `scale`
 
 A function call takes **no space** before its parenthesis: `sin(x)` is a call, `sin (x)` is not.
+Arguments are a value list, so upstream's `max(0 (j - 1))` and `max(0, j - 1)` both work; write the
+space-separated form when a script also has to open in the upstream app. Upstream's bare
+`max 0 (j - 1)` (no parentheses) is not supported.
 
 ## Storage
 
@@ -145,7 +148,8 @@ cube { position offsets[0].x offsets[1].y offsets.count }
 
 Also supported: `pi`, `tau`, `true`, `false`, scientific notation, unary `+`,
 short-circuit `and`/`or`, string literals, `join`/`trim`, tuple arguments to `min`/`max`,
-zero-based tuple/string subscripts, `.count`, vector `.x/.y/.z/.w`, color
+zero-based tuple/string subscripts, `.count`, ordinal members `.first` … `.tenth`, `.last`,
+`.allButFirst`, `.allButLast`, vector `.x/.y/.z/.w`, color
 `.red/.green/.blue/.alpha` (or `.r/.g/.b/.a`), custom shape definitions with options,
 and `polygon { sides N }` (integer 3–256). Lathe samples curved profiles, and inline
 builder paths use the same parser as nested paths, including loops and definitions.

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "presentShapeScript \u2014 interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -79,8 +79,14 @@ for i in 1 to 8 {
 ### Primitives & Properties:
 
 Shapes: cube, sphere, cylinder, cone, torus, circle, square, polygon (sides 3–256)
-Properties: position X Y Z, rotation X Y Z, size X Y Z
+Properties: position X Y Z, orientation ROLL YAW PITCH (alias: rotation), size X Y Z
 Materials: color R G B (0-1), opacity (0-1)
+
+UNITS (same as upstream ShapeScript — https://shapescript.info/mac/):
+- size is the DIAMETER of sphere/cylinder/cone/circle/polygon/torus (a bare sphere fits the unit cube); for cube/square it is the edge length.
+- orientation / rotate use HALF-TURNS in roll (Z), yaw (Y), pitch (X) order: 0.5 = 90°, 1 = 180°. Positive is clockwise. A lone value is a roll: orientation 0.25 = 45° about Z. Angle-axis also works: orientation 0.5 0 1 0.
+- rotate / translate / scale as commands are relative and accumulate; orientation as a command is absolute.
+- Trig FUNCTIONS (sin, cos, …) still take radians. Convert with pi: a half-turn value h is h * pi radians.
 
 ### CSG Operations:
 union, difference, intersection, xor, stencil
@@ -91,10 +97,16 @@ difference {
     cube { size 1.5 }
 }
 
+### Paths:
+path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a path by repeating the first point.
+- curve X Y is a quadratic Bézier CONTROL point: the outline passes through the point commands on either side, not through it. Two curves in a row get an implicit on-curve midpoint, so eight curves in an octagon draw a circle.
+- rotate (half-turns) / translate / scale inside a path move the frame for later points:
+  path { for 0 to 8 { curve 0 1 rotate 1 / 8 } }  // semicircle
+
 ### Builders:
-- extrude: extrude { polygon { sides 3 } } or extrude path { point 0 0 point 1 0 point 0 1 }
+- extrude: extrude { polygon { sides 3 } } or extrude path { point 0 0 point 1 0 point 0 1 point 0 0 } (size Z = depth, default 1)
 - fill: fill { square } or fill path { ... }
-- lathe: lathe path { point 1 0 curve 0 2 1 -1 } (revolves about Y)
+- lathe: lathe path { point 0 0 point 1 0 curve 1.5 1 point 1 2 point 0 2 } (revolves the XY profile about Y)
 - loft: loft { square translate 0 0 2 circle } (closed planar sections joined with caps)
 - hull: hull { cube { position -1 0 0 } cube { position 1 0 0 } } (convex envelope)
 - stencil preserves the first shape and paints its surface with later shapes' materials.
@@ -109,13 +121,13 @@ Loft sections must each have one perimeter and enclose an area; extrude/fill pri
 - Custom shapes with options:
 define post { option height 2 cylinder { size 0.2 height } }
 post { height 3 }
+- Random numbers: rnd (0–1) and seed N (scoped to the enclosing block, same generator as upstream)
 
 ### Compatibility:
-This plugin implements the documented modeling subset, not all upstream ShapeScript syntax.
-Function calls use name(...); trig functions and rotation/orientation properties use radians.
-Relative rotate/orientation commands and path rotate use turns (1 = 360 degrees).
-Path point/curve coordinates are relative steps. Curves accept optional control-point offsets.
-Imports, textures, text/fonts, arbitrary objects, and general user-defined functions are not supported.
+This plugin implements the documented modeling subset, not all upstream ShapeScript syntax; units and
+path semantics follow upstream, so a script written against the upstream docs renders the same here.
+Function calls use name(...). Imports, textures, text/fonts, lights/cameras, arbitrary objects,
+hex/named colours, and general user-defined functions are not supported.
 
 ### Comments:
 // Single-line comment

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -114,6 +114,7 @@ difference {
 ### Paths:
 path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a path by repeating the first point.
 - curve X Y is a quadratic Bézier CONTROL point: the outline passes through the point commands on either side, not through it. Two curves in a row get an implicit on-curve midpoint, so eight curves in an octagon draw a circle.
+- A path may carry position / orientation / size of its own (path { position 0 0 2 orientation 0 0.5 0 point … }); that is how a loft section is placed in 3D. Give loft and extrude PATH children, not fill{} meshes — the upstream app rejects a mesh there.
 - rotate (half-turns) / translate / scale inside a path move the frame for later points:
   path {
       for 0 to 8 {

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -69,6 +69,9 @@ Vector: dot, cross, length, normalize, sum
 IMPORTANT: Function calls require NO space between name and parenthesis:
 - sin(x) ✓ function call
 - sin (x) ✗ NOT a function call (identifier + parenthesized expression)
+Separate arguments with spaces, as upstream does: max(0 (j - 1)), pow(2.718 (0 - x)). Commas also work
+here (max(0, j - 1)) but NOT in the upstream ShapeScript app, so prefer spaces. Bare max 0 1 without
+parentheses is not supported.
 
 Examples:
 for i in 1 to 8 {
@@ -116,7 +119,7 @@ Loft sections must each have one perimeter and enclose an area; extrude/fill pri
 - Constants: pi, tau, true, false
 - Scientific notation and unary plus: 1e-3, +2
 - Tuple/vector members: vector.x, vector.y, vector.z; color.red/green/blue/alpha
-- Tuple/string length: value.count; zero-based indexing: values[0]
+- Tuple/string length: value.count; zero-based indexing: values[0]; ordinals: v.first v.second … v.last, v.allButFirst, v.allButLast
 - String literals, join(...), trim(...); min/max also accept tuples
 - Custom shapes with options:
 define post { option height 2 cylinder { size 0.2 height } }

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -72,6 +72,8 @@ IMPORTANT: Function calls require NO space between name and parenthesis:
 Separate arguments with spaces, as upstream does: max(0 (j - 1)), pow(2.718 (0 - x)). Commas also work
 here (max(0, j - 1)) but NOT in the upstream ShapeScript app, so prefer spaces. Bare max 0 1 without
 parentheses is not supported.
+Write ONE statement per line. This parser accepts "define a 1 define b 2" on one line; the upstream app
+rejects it, and a script that keeps to one statement per line opens in both.
 
 Examples:
 for i in 1 to 8 {

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -27,13 +27,19 @@ export const TOOL_DEFINITION = {
 ### Variables:
 define radius 2
 define red (1 0 0)
-sphere { size radius color red }
+sphere {
+    size radius
+    color red
+}
 
 ### Control Flow:
 
 For loops with variables:
 for i in 1 to 5 {
-    cube { position (i * 2) 0 0 size 1 }
+    cube {
+        position (i * 2) 0 0
+        size 1
+    }
 }
 
 For loops with step:
@@ -98,7 +104,10 @@ union, difference, intersection, xor, stencil
 
 Example:
 difference {
-    sphere { size 2 color (1 0.5 0) }
+    sphere {
+        size 2
+        color (1 0.5 0)
+    }
     cube { size 1.5 }
 }
 
@@ -106,14 +115,41 @@ difference {
 path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a path by repeating the first point.
 - curve X Y is a quadratic Bézier CONTROL point: the outline passes through the point commands on either side, not through it. Two curves in a row get an implicit on-curve midpoint, so eight curves in an octagon draw a circle.
 - rotate (half-turns) / translate / scale inside a path move the frame for later points:
-  path { for 0 to 8 { curve 0 1 rotate 1 / 8 } }  // semicircle
+  path {
+      for 0 to 8 {
+          curve 0 1
+          rotate 1 / 8
+      }
+  }  // semicircle
 
 ### Builders:
-- extrude: extrude { polygon { sides 3 } } or extrude path { point 0 0 point 1 0 point 0 1 point 0 0 } (size Z = depth, default 1)
+- extrude: extrude { polygon { sides 3 } } or an inline path (size Z = depth, default 1):
+  extrude path {
+      point 0 0
+      point 1 0
+      point 0 1
+      point 0 0
+  }
 - fill: fill { square } or fill path { ... }
-- lathe: lathe path { point 0 0 point 1 0 curve 1.5 1 point 1 2 point 0 2 } (revolves the XY profile about Y)
-- loft: loft { square translate 0 0 2 circle } (closed planar sections joined with caps)
-- hull: hull { cube { position -1 0 0 } cube { position 1 0 0 } } (convex envelope)
+- lathe (revolves the XY profile about Y):
+  lathe path {
+      point 0 0
+      point 1 0
+      curve 1.5 1
+      point 1 2
+      point 0 2
+  }
+- loft (closed planar sections joined with caps):
+  loft {
+      square
+      translate 0 0 2
+      circle
+  }
+- hull (convex envelope):
+  hull {
+      cube { position -1 0 0 }
+      cube { position 1 0 0 }
+  }
 - stencil preserves the first shape and paints its surface with later shapes' materials.
 Loft sections must each have one perimeter and enclose an area; extrude/fill primitive profiles must lie in XY.
 
@@ -124,7 +160,10 @@ Loft sections must each have one perimeter and enclose an area; extrude/fill pri
 - Tuple/string length: value.count; zero-based indexing: values[0]; ordinals: v.first v.second … v.last, v.allButFirst, v.allButLast
 - String literals, join(...), trim(...); min/max also accept tuples
 - Custom shapes with options:
-define post { option height 2 cylinder { size 0.2 height } }
+define post {
+    option height 2
+    cylinder { size 0.2 height }
+}
 post { height 3 }
 - Random numbers: rnd (0–1) and seed N (scoped to the enclosing block, same generator as upstream)
 
@@ -144,7 +183,10 @@ hex/named colours, and general user-defined functions are not supported.
 Linear arrangement with expressions:
 define spacing 1.5
 for i in 1 to 4 {
-    cylinder { position ((i - 2.5) * spacing) 0 0 size 0.4 1 }
+    cylinder {
+        position ((i - 2.5) * spacing) 0 0
+        size 0.4 1
+    }
 }
 
 Circular pattern:
@@ -162,11 +204,17 @@ Conditional geometry:
 define makeHollow 1
 if makeHollow {
     difference {
-        sphere { size 2 color (1 0 0) }
+        sphere {
+            size 2
+            color (1 0 0)
+        }
         sphere { size 1.7 }
     }
 } else {
-    sphere { size 2 color (1 0 0) }
+    sphere {
+        size 2
+        color (1 0 0)
+    }
 }
 
 Mathematical visualization:

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -154,7 +154,7 @@ path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a
 Loft sections must each have one perimeter and enclose an area; extrude/fill primitive profiles must lie in XY.
 
 ### Additional Expressions:
-- Constants: pi, tau, true, false
+- Constants: pi, true, false (tau exists here but NOT in the upstream app; write 2 * pi)
 - Scientific notation and unary plus: 1e-3, +2
 - Tuple/vector members: vector.x, vector.y, vector.z; color.red/green/blue/alpha
 - Tuple/string length: value.count; zero-based indexing: values[0]; ordinals: v.first v.second … v.last, v.allButFirst, v.allButLast

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -2,16 +2,53 @@ import { Expression, Vector3, Color } from "./types";
 
 export type Value = number | boolean | string | Value[];
 
-export class SymbolTable {
-  private scopes: Map<string, Value>[] = [];
+/** Upstream's `rnd` generator, bit for bit: a 32-bit LCG kept in a double,
+ *  `x = (x * 1664525 + 1013904223) mod 2^32`, returning `x / 2^32`. Matching
+ *  it means `seed 57` scatters shapes exactly as it does in the upstream app.
+ *  A class, not a closure, because scopes SHARE it: a nested block advances
+ *  its parent's sequence, but `seed` inside the block replaces only the
+ *  block's own reference (see `SymbolTable.reseed`). */
+export class RandomSequence {
+  private static readonly MODULUS = 4294967296;
+  private state: number;
 
-  constructor() {
-    this.pushScope();
+  constructor(seed: number) {
+    this.state = RandomSequence.wrap(seed);
+  }
+
+  private static wrap(value: number): number {
+    const wrapped = value % RandomSequence.MODULUS;
+    return Number.isFinite(wrapped) ? (wrapped < 0 ? wrapped + RandomSequence.MODULUS : wrapped) : 0;
+  }
+
+  next(): number {
+    this.state = RandomSequence.wrap(this.state * 1664525 + 1013904223);
+    return this.state / RandomSequence.MODULUS;
+  }
+}
+
+interface Scope {
+  values: Map<string, Value>;
+  random: RandomSequence;
+}
+
+export class SymbolTable {
+  private scopes: Scope[] = [];
+
+  constructor(seed: number = DEFAULT_RANDOM_SEED) {
+    this.scopes.push({ values: new Map(), random: new RandomSequence(seed) });
     for (const [name, value] of Object.entries({ pi: Math.PI, tau: 2 * Math.PI, true: true, false: false })) this.set(name, value);
   }
 
+  private innermost(): Scope {
+    const scope = this.scopes[this.scopes.length - 1];
+    if (scope === undefined) throw new Error("SymbolTable has no active scope");
+    return scope;
+  }
+
   pushScope(): void {
-    this.scopes.push(new Map());
+    // The child shares its parent's sequence, as upstream's child context does.
+    this.scopes.push({ values: new Map(), random: this.innermost().random });
   }
 
   popScope(): void {
@@ -20,18 +57,26 @@ export class SymbolTable {
     }
   }
 
+  /** `seed N`: a fresh sequence for THIS scope only. The parent keeps the
+   *  sequence it had, so `rnd` after the closing brace carries on from there. */
+  reseed(seed: number): void {
+    this.innermost().random = new RandomSequence(seed);
+  }
+
+  nextRandom(): number {
+    return this.innermost().random.next();
+  }
+
   set(name: string, value: Value): void {
-    const scope = this.scopes[this.scopes.length - 1];
-    if (scope === undefined) throw new Error("SymbolTable has no active scope");
-    scope.set(name, value);
+    this.innermost().values.set(name, value);
   }
 
   get(name: string): Value | undefined {
     // Search from innermost to outermost scope
     for (let i = this.scopes.length - 1; i >= 0; i--) {
       const scope = this.scopes[i];
-      if (scope?.has(name)) {
-        return scope.get(name);
+      if (scope?.values.has(name)) {
+        return scope.values.get(name);
       }
     }
     return undefined;
@@ -168,28 +213,28 @@ function toBoolean(value: Value): boolean {
  *  can take different branches, so `if rnd < .5 { cube } else { … }` could
  *  validate clean and then fail in the viewport, which is exactly the failure
  *  the validation exists to prevent. A seeded generator makes both runs agree,
- *  and re-rendering a model on every keystroke stops reshuffling it. */
-export const DEFAULT_RANDOM_SEED = 0x9e3779b9;
-
-/** mulberry32 — small, fast, and good enough for scattering shapes. */
-function seededRandom(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = (state + 0x6d2b79f5) >>> 0;
-    let t = state;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
-    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+ *  and re-rendering a model on every keystroke stops reshuffling it.
+ *
+ *  Zero, like upstream, so a script's `rnd` values here are the ones the
+ *  upstream app shows for it. */
+export const DEFAULT_RANDOM_SEED = 0;
 
 export class Evaluator {
   private symbols: SymbolTable;
-  private readonly random: () => number;
 
-  constructor(symbols?: SymbolTable, seed: number = DEFAULT_RANDOM_SEED) {
-    this.symbols = symbols || new SymbolTable();
-    this.random = seededRandom(seed);
+  constructor(symbols?: SymbolTable, seed?: number) {
+    this.symbols = symbols || new SymbolTable(seed);
+    if (seed !== undefined) this.symbols.reseed(seed);
+  }
+
+  private random(): number {
+    return this.symbols.nextRandom();
+  }
+
+  /** The `seed` command. Scoped: see `SymbolTable.reseed`. */
+  reseed(seed: number): void {
+    if (!Number.isFinite(seed)) throw new Error("`seed` needs a finite number");
+    this.symbols.reseed(seed);
   }
 
   getSymbols(): SymbolTable {

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -101,6 +101,18 @@ function vectorLength(v: Value): number {
 
 // Built-in functions
 const memberIndices: Record<string, number> = { x: 0, y: 1, z: 2, w: 3, r: 0, g: 1, b: 2, a: 3, red: 0, green: 1, blue: 2, alpha: 3 };
+/** Upstream's ordinal members, `vector.first` … `vector.tenth`. `last`,
+ *  `allButFirst` and `allButLast` depend on the length and are handled inline. */
+const ordinalIndices: Record<string, number> = { first: 0, second: 1, third: 2, fourth: 3, fifth: 4, sixth: 5, seventh: 6, eighth: 7, ninth: 8, tenth: 9 };
+
+function sequenceMember(value: Value[] | string, member: string): Value | undefined {
+  if (member === "count") return value.length;
+  if (member === "last") return value.length > 0 ? value[value.length - 1] : undefined;
+  if (member === "allButFirst") return typeof value === "string" ? value.slice(1) : value.slice(1);
+  if (member === "allButLast") return typeof value === "string" ? value.slice(0, -1) : value.slice(0, -1);
+  const index = ordinalIndices[member] ?? (Array.isArray(value) ? memberIndices[member] : undefined);
+  return index !== undefined && index < value.length ? value[index] : undefined;
+}
 const builtInFunctions: Record<string, (...args: Value[]) => Value> = {
   // Arithmetic
   round: (x: Value) => Math.round(toNumber(x)),
@@ -428,10 +440,9 @@ export class Evaluator {
 
       case "member": {
         const value = this.evaluate(expr.object);
-        if (expr.member === "count" && (Array.isArray(value) || typeof value === "string")) return value.length;
-        const index = memberIndices[expr.member];
-        if (Object.hasOwn(memberIndices, expr.member) && index !== undefined && Array.isArray(value) && index < value.length) return value[index]!;
-        throw new Error(`Unknown member: ${expr.member}`);
+        const result = Array.isArray(value) || typeof value === "string" ? sequenceMember(value, expr.member) : undefined;
+        if (result === undefined) throw new Error(`Unknown member: ${expr.member}`);
+        return result;
       }
       case "subscript": {
         const value = this.evaluate(expr.object);

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1355,13 +1355,14 @@ export class Parser {
     return { type, x, y };
   }
 
-  /** `translate x [y]` / `scale x [y]` inside a path. A lone `scale s` is
-   *  uniform; a lone `translate x` moves along X only. */
+  /** `translate x [y]` / `scale x [y]` inside a path. A lone `translate x`
+   *  moves along X only; a lone `scale s` is uniform, recorded by leaving `y`
+   *  out rather than by copying the expression (which would evaluate it twice). */
   private parsePathVector(type: "translate" | "scale"): TranslateCommand | ScaleCommand {
     this.advance();
     const x = this.parsePathValue();
-    const fallback: Expression = type === "scale" ? x : { type: "number", value: 0 };
-    const y: Expression = this.startsValue() ? this.parsePathValue() : fallback;
+    if (type === "scale") return this.startsValue() ? { type, x, y: this.parsePathValue() } : { type, x };
+    const y: Expression = this.startsValue() ? this.parsePathValue() : { type: "number", value: 0 };
     return { type, x, y };
   }
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -704,15 +704,17 @@ export class Parser {
         this.advance();
         const args: Expression[] = [];
 
-        this.withValueList(false, () => {
-          if (this.current().type !== TokenType.RPAREN) {
-            args.push(this.parseExpression());
-
-            while (this.current().type === TokenType.COMMA) {
-              this.advance();
-              if (this.current().type === TokenType.RPAREN) break;
-              args.push(this.parseExpression());
-            }
+        // The arguments are a VALUE LIST, exactly as the body of `( … )` is:
+        // `max(0 (j - 1))` is upstream's C-like spelling and `max(0, j - 1)`
+        // the one this plugin always took. Reading both through the tuple
+        // rules means a script can be written once for either parser.
+        this.withValueList(true, () => {
+          if (this.current().type === TokenType.RPAREN) return;
+          args.push(this.parseExpression());
+          if (this.current().type === TokenType.COMMA) {
+            this.parseCommaSeparated(args);
+          } else {
+            this.parseSpaceSeparated(args);
           }
         });
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -15,6 +15,12 @@ import {
   TextureNode,
   PathNode,
   PathCommand,
+  PointCommand,
+  CurveCommand,
+  TranslateCommand,
+  ScaleCommand,
+  ForLoopPathCommand,
+  SeedNode,
   Expression,
   ParseError,
   GroupNode,
@@ -137,6 +143,7 @@ class Lexer {
       point: TokenType.POINT,
       curve: TokenType.CURVE,
       detail: TokenType.DETAIL,
+      seed: TokenType.SEED,
       background: TokenType.BACKGROUND,
       texture: TokenType.TEXTURE,
       union: TokenType.UNION,
@@ -1188,6 +1195,11 @@ export class Parser {
     };
   }
 
+  private parseSeed(): SeedNode {
+    this.advance(); // consume 'seed'
+    return { type: "seed", value: this.parseExpression() };
+  }
+
   private parseBackground(): BackgroundNode {
     this.advance(); // consume 'background'
 
@@ -1290,195 +1302,87 @@ export class Parser {
 
   private parsePath(): PathNode {
     this.advance(); // consume 'path'
+    const commands = this.parsePathBody("path");
+    return { type: "path", commands };
+  }
 
+  /** `{ … }` of a path or of a `for` inside one. Both accept the same
+   *  commands, so one reader serves both instead of two drifting copies. */
+  private parsePathBody(where: string): PathCommand[] {
     this.expect(TokenType.LBRACE);
     this.skipNewlines();
-
     const commands: PathCommand[] = [];
-
     while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-      const token = this.current();
-
-      switch (token.type) {
-        case TokenType.DEFINE: {
-          // Handle define statements inside path blocks
-          // These don't produce path commands, just variable definitions
-          commands.push(this.parseDefine());
-          break;
-        }
-
-        case TokenType.DETAIL: {
-          this.advance();
-          const value = this.parseExpression();
-          commands.push({ type: "detail", value });
-          break;
-        }
-
-        case TokenType.POINT: {
-          this.advance();
-          const x = this.parsePathValue();
-          // Y is optional - defaults to 0 if not provided
-          let y: Expression = { type: "number", value: 0 };
-          if (this.startsValue()) {
-            y = this.parsePathValue();
-          }
-          commands.push({ type: "point", x, y });
-          break;
-        }
-
-        case TokenType.CURVE: {
-          this.advance();
-          const x = this.parsePathValue();
-          const y = this.parsePathValue();
-          // Optional control points
-          let controlX: Expression | undefined;
-          let controlY: Expression | undefined;
-
-          // Check if there's a potential third value (control point x)
-          if (this.startsValue()) {
-            controlX = this.parsePathValue();
-
-            // Try to parse fourth value (control point y)
-            if (this.startsValue()) {
-              controlY = this.parsePathValue();
-            }
-          }
-
-          commands.push({
-            type: "curve",
-            x,
-            y,
-            ...(controlX === undefined ? {} : { controlX }),
-            ...(controlY === undefined ? {} : { controlY }),
-          });
-          break;
-        }
-
-        case TokenType.ROTATE: {
-          this.advance();
-          const angle = this.parseExpression();
-          commands.push({ type: "rotate", angle });
-          break;
-        }
-
-        case TokenType.TRANSLATE: {
-          this.advance();
-          const x = this.parsePathValue();
-          const y = this.parsePathValue();
-          commands.push({ type: "translate", x, y });
-          break;
-        }
-
-        case TokenType.FOR: {
-          // Handle for loops inside path - expand them inline
-          this.advance(); // consume 'for'
-
-          // Check if there's a variable name (for i in 1 to 5) or direct range (for 1 to 5)
-          let variable = "_i"; // Default variable name
-          if (this.current().type === TokenType.IDENTIFIER && this.peek(1).type === TokenType.IN) {
-            variable = this.current().value as string;
-            this.advance(); // consume variable
-            this.expect(TokenType.IN); // consume 'in'
-          }
-
-          const from = this.parseExpression();
-          this.expect(TokenType.TO);
-          const to = this.parseExpression();
-
-          const step = this.current().type === TokenType.STEP ? (this.advance(), this.parseExpression()) : { type: "number" as const, value: 1 };
-
-          // Parse the body commands
-          this.expect(TokenType.LBRACE);
-          this.skipNewlines();
-
-          const bodyCommands: PathCommand[] = [];
-          while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-            const cmd = this.current();
-            switch (cmd.type) {
-              case TokenType.POINT: {
-                this.advance();
-                const x = this.parsePathValue();
-                // Y is optional - defaults to 0 if not provided
-                let y: Expression = { type: "number", value: 0 };
-                if (this.startsValue()) {
-                  y = this.parsePathValue();
-                }
-                bodyCommands.push({ type: "point", x, y });
-                break;
-              }
-              case TokenType.CURVE: {
-                this.advance();
-                const x = this.parsePathValue();
-                const y = this.parsePathValue();
-                // Optional control points
-                let controlX: Expression | undefined;
-                let controlY: Expression | undefined;
-
-                // Check if there's a potential third value (control point x)
-                if (this.startsValue()) {
-                  controlX = this.parsePathValue();
-
-                  // Try to parse fourth value (control point y)
-                  if (this.startsValue()) {
-                    controlY = this.parsePathValue();
-                  }
-                }
-
-                bodyCommands.push({
-                  type: "curve",
-                  x,
-                  y,
-                  ...(controlX === undefined ? {} : { controlX }),
-                  ...(controlY === undefined ? {} : { controlY }),
-                });
-                break;
-              }
-              case TokenType.ROTATE: {
-                this.advance();
-                const angle = this.parseExpression();
-                bodyCommands.push({ type: "rotate", angle });
-                break;
-              }
-              case TokenType.TRANSLATE: {
-                this.advance();
-                const x = this.parsePathValue();
-                const y = this.parsePathValue();
-                bodyCommands.push({ type: "translate", x, y });
-                break;
-              }
-              default:
-                throw new ParseError(`Unexpected token in path for loop: ${cmd.type}`, cmd.line, cmd.column);
-            }
-            this.skipNewlines();
-          }
-
-          this.expect(TokenType.RBRACE);
-
-          // Add the for loop command - it will be expanded during rendering
-          commands.push({
-            type: "for",
-            variable,
-            from,
-            to,
-            step,
-            commands: bodyCommands,
-          });
-          break;
-        }
-
-        default:
-          throw new ParseError(`Unexpected token in path: ${token.type}`, token.line, token.column);
-      }
-
+      commands.push(this.parsePathCommand(where));
       this.skipNewlines();
     }
-
     this.expect(TokenType.RBRACE);
+    return commands;
+  }
 
-    return {
-      type: "path",
-      commands,
-    };
+  private parsePathCommand(where: string): PathCommand {
+    const token = this.current();
+    switch (token.type) {
+      case TokenType.DEFINE:
+        return this.parseDefine();
+      case TokenType.DETAIL: {
+        this.advance();
+        return { type: "detail", value: this.parseExpression() };
+      }
+      case TokenType.POINT:
+      case TokenType.CURVE:
+        return this.parsePathPoint(token.type === TokenType.POINT ? "point" : "curve");
+      case TokenType.ROTATE: {
+        this.advance();
+        return { type: "rotate", angle: this.parseExpression() };
+      }
+      case TokenType.TRANSLATE:
+      case TokenType.SCALE:
+        return this.parsePathVector(token.type === TokenType.TRANSLATE ? "translate" : "scale");
+      case TokenType.FOR:
+        return this.parsePathFor();
+      default:
+        throw new ParseError(`Unexpected token in ${where}: ${token.type}`, token.line, token.column);
+    }
+  }
+
+  /** `point x [y]` / `curve x [y]` — absolute coordinates in the path's local
+   *  frame, as upstream. Y defaults to 0. */
+  private parsePathPoint(type: "point" | "curve"): PointCommand | CurveCommand {
+    this.advance();
+    const x = this.parsePathValue();
+    const y: Expression = this.startsValue() ? this.parsePathValue() : { type: "number", value: 0 };
+    return { type, x, y };
+  }
+
+  /** `translate x [y]` / `scale x [y]` inside a path. A lone `scale s` is
+   *  uniform; a lone `translate x` moves along X only. */
+  private parsePathVector(type: "translate" | "scale"): TranslateCommand | ScaleCommand {
+    this.advance();
+    const x = this.parsePathValue();
+    const fallback: Expression = type === "scale" ? x : { type: "number", value: 0 };
+    const y: Expression = this.startsValue() ? this.parsePathValue() : fallback;
+    return { type, x, y };
+  }
+
+  private parsePathFor(): ForLoopPathCommand {
+    this.advance(); // consume 'for'
+
+    // Check if there's a variable name (for i in 1 to 5) or direct range (for 1 to 5)
+    let variable = "_i"; // Default variable name
+    if (this.current().type === TokenType.IDENTIFIER && this.peek(1).type === TokenType.IN) {
+      variable = this.current().value as string;
+      this.advance(); // consume variable
+      this.expect(TokenType.IN); // consume 'in'
+    }
+
+    const from = this.parseExpression();
+    this.expect(TokenType.TO);
+    const to = this.parseExpression();
+    const step = this.current().type === TokenType.STEP ? (this.advance(), this.parseExpression()) : { type: "number" as const, value: 1 };
+
+    // The loop is expanded during rendering.
+    return { type: "for", variable, from, to, step, commands: this.parsePathBody("path for loop") };
   }
 
   private parseNode(): SceneNode | null {
@@ -1571,6 +1475,9 @@ export class Parser {
 
       case TokenType.DETAIL:
         return this.parseDetail();
+
+      case TokenType.SEED:
+        return this.parseSeed();
 
       case TokenType.BACKGROUND:
         return this.parseBackground();

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1304,22 +1304,47 @@ export class Parser {
 
   private parsePath(): PathNode {
     this.advance(); // consume 'path'
-    const commands = this.parsePathBody("path");
-    return { type: "path", commands };
+    const properties: ShapeProperties = {};
+    const commands = this.parsePathBody("path", properties);
+    return Object.keys(properties).length === 0 ? { type: "path", commands } : { type: "path", commands, properties };
   }
 
   /** `{ … }` of a path or of a `for` inside one. Both accept the same
-   *  commands, so one reader serves both instead of two drifting copies. */
-  private parsePathBody(where: string): PathCommand[] {
+   *  commands, so one reader serves both instead of two drifting copies.
+   *  Only the path itself (not a loop inside it) may carry the transform
+   *  options, which land in `properties`. */
+  private parsePathBody(where: string, properties?: ShapeProperties): PathCommand[] {
     this.expect(TokenType.LBRACE);
     this.skipNewlines();
     const commands: PathCommand[] = [];
     while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+      if (properties !== undefined && this.parsePathProperty(properties)) {
+        this.skipNewlines();
+        continue;
+      }
       commands.push(this.parsePathCommand(where));
       this.skipNewlines();
     }
     this.expect(TokenType.RBRACE);
     return commands;
+  }
+
+  /** `position` / `orientation` (alias `rotation`) / `size` inside a path
+   *  block, as upstream allows on any shape. Returns false for anything else. */
+  private parsePathProperty(properties: ShapeProperties): boolean {
+    const type = this.current().type;
+    const key =
+      type === TokenType.POSITION
+        ? "position"
+        : type === TokenType.SIZE
+          ? "size"
+          : type === TokenType.ORIENTATION || type === TokenType.ROTATION
+            ? "orientation"
+            : undefined;
+    if (key === undefined) return false;
+    this.advance();
+    properties[key] = this.parseVectorOrExpression();
+    return true;
   }
 
   private parsePathCommand(where: string): PathCommand {

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -463,14 +463,8 @@ export class Converter {
         return new THREE.ConeGeometry(radius, height, this.detailLevel);
       }
 
-      case "torus": {
-        // A plugin extension (upstream has no torus); `size` is the outer
-        // diameter so it follows the same rule as the primitives above.
-        const outerRadius = node.properties.outerRadius ? this.evaluateNumber(node.properties.outerRadius) : size[0] / 2;
-        const innerRadius = node.properties.innerRadius ? this.evaluateNumber(node.properties.innerRadius) : outerRadius * 0.4;
-        this.requireExtent("torus", [outerRadius, innerRadius]);
-        return new THREE.TorusGeometry(outerRadius, innerRadius, Math.max(3, Math.floor(this.detailLevel / 2)), this.detailLevel);
-      }
+      case "torus":
+        return this.createTorus(node, size);
 
       case "circle": {
         const radius = (size[0] || 1) / 2;
@@ -492,6 +486,22 @@ export class Converter {
       default:
         throw new Error(`Unknown primitive: ${node.primitive}`);
     }
+  }
+
+  /** A plugin extension (upstream has no torus). `size` is the OVERALL
+   *  diameter, tube included, so it follows the same rule as the other curved
+   *  primitives: the ring radius is what is left once the tube is subtracted.
+   *  `outerRadius` (ring) and `innerRadius` (tube) override the derivation. */
+  private createTorus(node: ShapeNode, size: Vector3): THREE.BufferGeometry {
+    const TUBE_TO_RING = 0.4;
+    const overall = size[0] / 2;
+    const explicitTube = node.properties.innerRadius ? this.evaluateNumber(node.properties.innerRadius) : undefined;
+    const explicitRing = node.properties.outerRadius ? this.evaluateNumber(node.properties.outerRadius) : undefined;
+    const ringRadius = explicitRing ?? (explicitTube === undefined ? overall / (1 + TUBE_TO_RING) : overall - explicitTube);
+    const tubeRadius = explicitTube ?? ringRadius * TUBE_TO_RING;
+    if (ringRadius <= 0) throw new Error("`torus` tube is as wide as the whole shape — its ring has no radius left");
+    this.requireExtent("torus", [ringRadius, tubeRadius]);
+    return new THREE.TorusGeometry(ringRadius, tubeRadius, Math.max(3, Math.floor(this.detailLevel / 2)), this.detailLevel);
   }
 
   private materialColor(property: ShapeProperties["color"]): THREE.Color {
@@ -869,9 +879,12 @@ export class Converter {
     const components = this.rotationComponents(value);
     if (components.length === 4) {
       const [angle = 0, x = 0, y = 0, z = 0] = components;
-      const axis = new THREE.Vector3(x, y, z);
-      if (axis.lengthSq() === 0) throw new Error("Rotation axis must not be zero");
-      return new THREE.Quaternion().setFromAxisAngle(axis.normalize(), -angle * Math.PI);
+      // Scale by the largest component first: `lengthSq` of `1e200` overflows
+      // to infinity and `normalize` would collapse a valid axis to zero.
+      const largest = Math.max(Math.abs(x), Math.abs(y), Math.abs(z));
+      if (largest === 0) throw new Error("Rotation axis must not be zero");
+      const axis = new THREE.Vector3(x / largest, y / largest, z / largest).normalize();
+      return new THREE.Quaternion().setFromAxisAngle(axis, -angle * Math.PI);
     }
     const [roll = 0, yaw = 0, pitch = 0] = components;
     return new THREE.Quaternion().setFromEuler(new THREE.Euler(-pitch * Math.PI, -yaw * Math.PI, -roll * Math.PI, "ZYX"));
@@ -1043,9 +1056,11 @@ export class Converter {
         case "translate":
           move(new THREE.Matrix4().makeTranslation(this.evaluateNumber(command.x), this.evaluateNumber(command.y), 0));
           break;
-        case "scale":
-          move(new THREE.Matrix4().makeScale(this.evaluateNumber(command.x), this.evaluateNumber(command.y), 1));
+        case "scale": {
+          const x = this.evaluateNumber(command.x);
+          move(new THREE.Matrix4().makeScale(x, command.y === undefined ? x : this.evaluateNumber(command.y), 1));
           break;
+        }
         case "for":
           this.runPathLoop(command, processCommand);
           break;

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -331,7 +331,7 @@ export class Converter {
         const shape = this.buildPath(node);
         this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
         this.requireEnclosedArea(shape, "path");
-        const mesh = this.makeMesh(new THREE.ShapeGeometry(shape), this.createMaterial({ properties: {} }));
+        const mesh = this.makeMesh(this.placePath(new THREE.ShapeGeometry(shape), node), this.createMaterial({ properties: {} }));
         this.applyCurrentTransform(mesh);
         return mesh;
       }
@@ -991,11 +991,14 @@ export class Converter {
     const curveSegments = Math.max(1, Math.floor(this.detailLevel / 4));
     this.chargePathEstimate(shape, curveSegments, EXTRUDE_VERTICES_PER_POINT);
 
-    const geometry = new THREE.ExtrudeGeometry(shape, {
-      depth,
-      bevelEnabled: false,
-      curveSegments,
-    });
+    const geometry = this.placePath(
+      new THREE.ExtrudeGeometry(shape, {
+        depth,
+        bevelEnabled: false,
+        curveSegments,
+      }),
+      node.path,
+    );
 
     // Create material
     const material = this.createMaterial(node);
@@ -1010,6 +1013,20 @@ export class Converter {
 
   private buildPath(pathNode: PathNode): THREE.Shape {
     return this.shapeFromPathPoints(this.collectPathPoints(pathNode));
+  }
+
+  /** Bake the path's own `position` / `orientation` / `size` into geometry
+   *  built from it. Baked rather than set on the mesh so the consuming
+   *  builder's own options (an `extrude { position … }`) still apply on top,
+   *  the way they do upstream where the path is a placed shape. */
+  private placePath<T extends THREE.BufferGeometry>(geometry: T, pathNode: PathNode): T {
+    const properties = pathNode.properties;
+    if (!properties) return geometry;
+    const position = new THREE.Vector3(...this.evaluateVector3(properties.position));
+    const rotation = properties.orientation ?? properties.rotation;
+    const quaternion = rotation ? this.rotationOf(rotation) : new THREE.Quaternion();
+    const scale = new THREE.Vector3(...(properties.size ? this.evaluateVector3(properties.size) : [1, 1, 1]));
+    return geometry.applyMatrix4(new THREE.Matrix4().compose(position, quaternion, scale));
   }
 
   /** Run the path's commands and return its points in path space.
@@ -1177,6 +1194,9 @@ export class Converter {
       // No path found, return empty group
       throw new Error("Lathe requires a path child");
     }
+    // Upstream transforms the profile before revolving it; a 3D orientation
+    // on a profile has no 2D equivalent here, so refuse rather than guess.
+    if (pathNode.properties) throw new Error("`lathe` does not support position/orientation/size on its profile path — place the lathe itself instead");
 
     const shape = this.buildPath(pathNode);
     this.chargePathEstimate(shape, this.detailLevel, this.detailLevel + 1);
@@ -1275,7 +1295,7 @@ export class Converter {
       const shape = this.buildPath(pathNode);
       this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
       this.requireEnclosedArea(shape, "fill");
-      const geometry = new THREE.ShapeGeometry(shape);
+      const geometry = this.placePath(new THREE.ShapeGeometry(shape), pathNode);
       const mesh = this.makeMesh(geometry, this.createMaterial(node));
 
       this.applyExplicitTransforms(mesh, node.properties);

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -19,6 +19,9 @@ import {
   DetailNode,
   PathNode,
   PathCommand,
+  PointCommand,
+  CurveCommand,
+  ForLoopPathCommand,
   CustomShapeNode,
   ColorNode,
   RotateNode,
@@ -32,6 +35,23 @@ import {
 } from "./types";
 import { Evaluator, SymbolTable, Value } from "./evaluator";
 import { disposeObject3D, disposeScratch } from "./dispose";
+
+/** A path point in path space, after the path's local transform. */
+interface PathPoint {
+  x: number;
+  y: number;
+  curved: boolean;
+}
+
+const PATH_POINT_EPSILON = 1e-9;
+
+function samePathPoint(a: PathPoint, b: PathPoint): boolean {
+  return Math.abs(a.x - b.x) < PATH_POINT_EPSILON && Math.abs(a.y - b.y) < PATH_POINT_EPSILON;
+}
+
+function midPathPoint(a: PathPoint, b: PathPoint): PathPoint {
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2, curved: false };
+}
 
 export interface ConversionOptions {
   wireframe?: boolean;
@@ -47,8 +67,9 @@ export interface ConversionOptions {
   /** Hard ceiling on the wall-clock time one conversion may spend. See
    *  `DEFAULT_MAX_DURATION_MS`. */
   maxDurationMs?: number;
-  /** Seed for `rnd` / `rand()`. Defaults to `DEFAULT_RANDOM_SEED`, which is
-   *  what keeps server validation and browser rendering on the same branch. */
+  /** Starting seed for `rnd` / `rand()`, which a `seed` command in the script
+   *  overrides. Defaults to `DEFAULT_RANDOM_SEED`, which is what keeps server
+   *  validation and browser rendering on the same branch. */
   randomSeed?: number;
 }
 
@@ -286,6 +307,9 @@ export class Converter {
       case "detail":
         this.handleDetail(node);
         return null; // Detail doesn't create geometry
+      case "seed":
+        this.evaluator.reseed(this.evaluateNumber(node.value));
+        return null;
       case "color":
         this.handleColorCommand(node);
         return null;
@@ -417,13 +441,15 @@ export class Converter {
         this.requireExtent("cube", size);
         return new THREE.BoxGeometry(size[0], size[1], size[2]);
 
+      // `size` is the DIAMETER of every curved primitive, as upstream: a
+      // `sphere` with no size fits the unit cube, not a 2-unit one.
       case "sphere":
         this.requireExtent("sphere", size);
-        return new THREE.SphereGeometry(1, this.detailLevel, this.detailLevel).scale(...size);
+        return new THREE.SphereGeometry(0.5, this.detailLevel, this.detailLevel).scale(...size);
 
       case "cylinder": {
-        const radiusTop = node.properties.radiusTop ? this.evaluateNumber(node.properties.radiusTop) : size[0];
-        const radiusBottom = node.properties.radiusBottom ? this.evaluateNumber(node.properties.radiusBottom) : size[0];
+        const radiusTop = node.properties.radiusTop ? this.evaluateNumber(node.properties.radiusTop) : size[0] / 2;
+        const radiusBottom = node.properties.radiusBottom ? this.evaluateNumber(node.properties.radiusBottom) : size[0] / 2;
         const height = node.properties.height ? this.evaluateNumber(node.properties.height) : size[1];
         // One radius may be zero — that is a cone, not a degenerate cylinder.
         this.requireExtent("cylinder", [radiusTop || radiusBottom, height]);
@@ -431,21 +457,23 @@ export class Converter {
       }
 
       case "cone": {
-        const radius = size[0];
+        const radius = size[0] / 2;
         const height = node.properties.height ? this.evaluateNumber(node.properties.height) : size[1];
         this.requireExtent("cone", [radius, height]);
         return new THREE.ConeGeometry(radius, height, this.detailLevel);
       }
 
       case "torus": {
-        const outerRadius = node.properties.outerRadius ? this.evaluateNumber(node.properties.outerRadius) : size[0];
-        const innerRadius = node.properties.innerRadius ? this.evaluateNumber(node.properties.innerRadius) : 0.4;
+        // A plugin extension (upstream has no torus); `size` is the outer
+        // diameter so it follows the same rule as the primitives above.
+        const outerRadius = node.properties.outerRadius ? this.evaluateNumber(node.properties.outerRadius) : size[0] / 2;
+        const innerRadius = node.properties.innerRadius ? this.evaluateNumber(node.properties.innerRadius) : outerRadius * 0.4;
         this.requireExtent("torus", [outerRadius, innerRadius]);
         return new THREE.TorusGeometry(outerRadius, innerRadius, Math.max(3, Math.floor(this.detailLevel / 2)), this.detailLevel);
       }
 
       case "circle": {
-        const radius = size[0] || 1;
+        const radius = (size[0] || 1) / 2;
         return new THREE.CircleGeometry(radius, this.detailLevel);
       }
 
@@ -455,7 +483,7 @@ export class Converter {
       }
 
       case "polygon": {
-        const radius = size[0] || 1;
+        const radius = (size[0] || 1) / 2;
         const sides = node.properties.sides === undefined ? 6 : this.evaluateNumber(node.properties.sides);
         if (!Number.isInteger(sides) || sides < 3 || sides > MAX_DETAIL) throw new Error(`Polygon sides must be an integer from 3 to ${MAX_DETAIL}`);
         return new THREE.CircleGeometry(radius, sides);
@@ -823,16 +851,39 @@ export class Converter {
       object.position.set(...pos);
     }
 
-    if (properties.rotation) {
-      const rot = this.evaluateVector3(properties.rotation);
-      object.rotation.set(...rot);
+    // `orientation` is upstream's name; `rotation` is kept as an alias.
+    const orientation = properties.orientation ?? properties.rotation;
+    if (orientation) {
+      object.quaternion.copy(this.rotationOf(orientation));
     }
+  }
 
-    // orientation is an alias for rotation
-    if (properties.orientation) {
-      const rot = this.evaluateVector3(properties.orientation);
-      object.rotation.set(...rot);
+  /** An upstream rotation value as a quaternion.
+   *
+   *  `roll yaw pitch` are HALF-TURNS (0.5 = 90°) about Z, Y and X, applied in
+   *  that order, and positive is clockwise looking down each axis toward the
+   *  origin — Euclid stores the negated angle, so the sign is flipped here to
+   *  match. A lone number is a roll (`orientation 0.25` = 45° about Z, not a
+   *  uniform tuple like `size`), and four numbers are `angle x y z`. */
+  private rotationOf(value: Expression | Vector3): THREE.Quaternion {
+    const components = this.rotationComponents(value);
+    if (components.length === 4) {
+      const [angle = 0, x = 0, y = 0, z = 0] = components;
+      const axis = new THREE.Vector3(x, y, z);
+      if (axis.lengthSq() === 0) throw new Error("Rotation axis must not be zero");
+      return new THREE.Quaternion().setFromAxisAngle(axis.normalize(), -angle * Math.PI);
     }
+    const [roll = 0, yaw = 0, pitch = 0] = components;
+    return new THREE.Quaternion().setFromEuler(new THREE.Euler(-pitch * Math.PI, -yaw * Math.PI, -roll * Math.PI, "ZYX"));
+  }
+
+  private rotationComponents(value: Expression | Vector3): number[] {
+    const raw: Value = Array.isArray(value) && typeof value[0] === "number" ? (value as number[]) : this.evaluator.evaluate(value as Expression);
+    const components = (Array.isArray(raw) ? raw : [raw]).map((component) => (typeof component === "number" ? component : Number.NaN));
+    if (components.length === 0 || components.length > 4 || !components.every(Number.isFinite)) {
+      throw new Error("Expected a rotation of 1 to 3 half-turn components (roll yaw pitch) or an angle and an axis (angle x y z)");
+    }
+    return components;
   }
 
   private handleDetail(node: DetailNode): void {
@@ -853,18 +904,13 @@ export class Converter {
   }
 
   private handleRotateCommand(node: RotateNode): void {
-    const rotation = this.evaluateVector3(node.value);
     const transform = this.currentTransform();
-    const rotationMatrix = new THREE.Matrix4();
-
-    const euler = new THREE.Euler(rotation[0] * Math.PI * 2, rotation[1] * Math.PI * 2, rotation[2] * Math.PI * 2, "XYZ");
-
-    rotationMatrix.makeRotationFromEuler(euler);
-    transform.matrix.multiply(rotationMatrix);
+    // Post-multiplied, so the rotation is in the current local frame — the
+    // same composition as upstream's `Transform.rotated(by:)`.
+    transform.matrix.multiply(new THREE.Matrix4().makeRotationFromQuaternion(this.rotationOf(node.value)));
   }
 
   private handleOrientationCommand(node: OrientationNode): void {
-    const orientation = this.evaluateVector3(node.value);
     const transform = this.currentTransform();
 
     // Orientation sets absolute rotation, not cumulative like rotate
@@ -873,10 +919,8 @@ export class Converter {
     const scale = new THREE.Vector3();
     transform.matrix.decompose(position, new THREE.Quaternion(), scale);
 
-    const euler = new THREE.Euler(orientation[0] * Math.PI * 2, orientation[1] * Math.PI * 2, orientation[2] * Math.PI * 2, "XYZ");
-
     // Rebuild matrix with new orientation but preserve position and scale
-    transform.matrix.compose(position, new THREE.Quaternion().setFromEuler(euler), scale);
+    transform.matrix.compose(position, this.rotationOf(node.value), scale);
   }
 
   private handleTranslateCommand(node: TranslateNode): void {
@@ -952,26 +996,30 @@ export class Converter {
   }
 
   private buildPath(pathNode: PathNode): THREE.Shape {
-    const shape = new THREE.Shape();
-    let currentX = 0;
-    let currentY = 0;
-    let currentAngle = 0; // In radians
-    // `moveTo` sets the pen without adding a curve, so `curves.length` stays 0
-    // after the first point — which made the ORIGINAL check below `moveTo`
-    // every point and never `lineTo` any of them. The shape came out empty, so
-    // `extrude` and `fill` rendered nothing at all. Track the pen explicitly.
-    let penDown = false;
+    return this.shapeFromPathPoints(this.collectPathPoints(pathNode));
+  }
 
-    // Path coordinates ACCUMULATE — each command is relative to the last — so
-    // operands that are individually finite can still overflow the pen to
-    // infinity. `LatheGeometry` and friends then build with `NaN` positions,
-    // which no later check catches: a comparison against a `NaN` area is simply
-    // false, and validation would report success over invisible geometry.
-    const movePen = (dx: number, dy: number) => {
-      currentX += dx;
-      currentY += dy;
-      if (!Number.isFinite(currentX) || !Number.isFinite(currentY)) {
-        throw new Error("Path coordinates overflowed to a non-finite value — they accumulate, so each command adds to the previous one");
+  /** Run the path's commands and return its points in path space.
+   *
+   *  Coordinates are ABSOLUTE, as upstream: `point 1 0` is at x=1 however many
+   *  points came before it. What `translate`, `rotate` and `scale` move is the
+   *  path's local frame, which every later point is placed through — so
+   *  `for 0 to 8 { curve 0 1 rotate 1 / 8 }` walks a semicircle. The frame is
+   *  post-multiplied like the shape transform, and checked after every command
+   *  because individually finite operands can still overflow it. */
+  private collectPathPoints(pathNode: PathNode): PathPoint[] {
+    const frame = new THREE.Matrix4();
+    const points: PathPoint[] = [];
+
+    const place = (command: PointCommand | CurveCommand) => {
+      const position = new THREE.Vector3(this.evaluateNumber(command.x), this.evaluateNumber(command.y), 0).applyMatrix4(frame);
+      if (!Number.isFinite(position.x) || !Number.isFinite(position.y)) throw new Error("Path coordinates overflowed to a non-finite value");
+      points.push({ x: position.x, y: position.y, curved: command.type === "curve" });
+    };
+    const move = (step: THREE.Matrix4) => {
+      frame.multiply(step);
+      if (!frame.elements.every(Number.isFinite)) {
+        throw new Error("Path transform overflowed to a non-finite value — `translate`, `rotate` and `scale` accumulate inside a path");
       }
     };
 
@@ -984,104 +1032,93 @@ export class Converter {
         case "detail":
           this.handleDetail(command);
           break;
-        case "point": {
-          const x = this.evaluateNumber(command.x);
-          const y = this.evaluateNumber(command.y);
-
-          // Apply current rotation
-          const cos = Math.cos(currentAngle);
-          const sin = Math.sin(currentAngle);
-          const rotatedX = x * cos - y * sin;
-          const rotatedY = x * sin + y * cos;
-
-          movePen(rotatedX, rotatedY);
-
-          if (penDown) {
-            shape.lineTo(currentX, currentY);
-          } else {
-            shape.moveTo(currentX, currentY);
-            penDown = true;
-          }
+        case "point":
+        case "curve":
+          place(command);
           break;
-        }
-
-        case "curve": {
-          const x = this.evaluateNumber(command.x);
-          const y = this.evaluateNumber(command.y);
-
-          // Apply current rotation
-          const cos = Math.cos(currentAngle);
-          const sin = Math.sin(currentAngle);
-          const rotatedX = x * cos - y * sin;
-          const rotatedY = x * sin + y * cos;
-
-          movePen(rotatedX, rotatedY);
-
-          // A curve needs a starting point like any other segment.
-          if (!penDown) {
-            shape.moveTo(currentX, currentY);
-            penDown = true;
-            break;
-          }
-          if (command.controlX !== undefined && command.controlY !== undefined) {
-            const cx = this.evaluateNumber(command.controlX);
-            const cy = this.evaluateNumber(command.controlY);
-            const rotatedCX = cx * cos - cy * sin;
-            const rotatedCY = cx * sin + cy * cos;
-            // The pen itself can stay finite while the control point does not,
-            // and a curve sampled from one returns `NaN` coordinates.
-            if (!Number.isFinite(currentX + rotatedCX) || !Number.isFinite(currentY + rotatedCY)) {
-              throw new Error("Curve control point overflowed to a non-finite value");
-            }
-            shape.quadraticCurveTo(currentX + rotatedCX, currentY + rotatedCY, currentX, currentY);
-          } else {
-            shape.lineTo(currentX, currentY);
-          }
+        case "rotate":
+          // Half-turns, clockwise positive — the same convention as `rotate` on a shape.
+          move(new THREE.Matrix4().makeRotationZ(-this.evaluateNumber(command.angle) * Math.PI));
           break;
-        }
-
-        case "rotate": {
-          // In ShapeScript, 1 = 360 degrees = 2π radians
-          const angle = this.evaluateNumber(command.angle);
-          currentAngle += angle * Math.PI * 2;
-          if (!Number.isFinite(currentAngle)) throw new Error("Path rotation overflowed to a non-finite angle");
+        case "translate":
+          move(new THREE.Matrix4().makeTranslation(this.evaluateNumber(command.x), this.evaluateNumber(command.y), 0));
           break;
-        }
-
-        case "translate": {
-          movePen(this.evaluateNumber(command.x), this.evaluateNumber(command.y));
+        case "scale":
+          move(new THREE.Matrix4().makeScale(this.evaluateNumber(command.x), this.evaluateNumber(command.y), 1));
           break;
-        }
-
-        case "for": {
-          // Expand for loop
-          this.symbols.pushScope();
-
-          const from = this.evaluateNumber(command.from);
-          const to = this.evaluateNumber(command.to);
-          const step = command.step ? this.evaluateNumber(command.step) : 1;
-
-          // Path commands never reach `convertNode`, so `maxNodes` cannot stop
-          // this one — the shared bounded iterator is the only ceiling here.
-          const iterations = this.rangeIterations(from, to, step);
-
-          for (const i of iterations) {
-            this.symbols.set(command.variable, i);
-            for (const bodyCmd of command.commands) {
-              processCommand(bodyCmd);
-            }
-          }
-
-          this.symbols.popScope();
+        case "for":
+          this.runPathLoop(command, processCommand);
           break;
-        }
       }
     };
 
     for (const command of pathNode.commands) {
       processCommand(command);
     }
+    return points;
+  }
 
+  private runPathLoop(command: ForLoopPathCommand, processCommand: (command: PathCommand) => void): void {
+    this.symbols.pushScope();
+    try {
+      const from = this.evaluateNumber(command.from);
+      const to = this.evaluateNumber(command.to);
+      const step = command.step ? this.evaluateNumber(command.step) : 1;
+
+      // Path commands never reach `convertNode`, so `maxNodes` cannot stop
+      // this one — the shared bounded iterator is the only ceiling here.
+      for (const i of this.rangeIterations(from, to, step)) {
+        this.symbols.set(command.variable, i);
+        for (const bodyCmd of command.commands) {
+          processCommand(bodyCmd);
+        }
+      }
+    } finally {
+      this.symbols.popScope();
+    }
+  }
+
+  /** Join path points into an outline, treating `curve` points as upstream does.
+   *
+   *  A `curve` is the CONTROL point of a quadratic Bézier; the outline passes
+   *  through the `point`s on either side of it, not through the control point
+   *  itself. Two `curve`s in a row get an implicit on-curve point halfway
+   *  between them, which is how eight controls in an octagon draw a circle.
+   *  A closed path (first and last point equal) may start on a control point.
+   *  An OPEN path's first and last points are taken as corners even when they
+   *  are `curve`s — upstream extrapolates a tangent there; this does not. */
+  private shapeFromPathPoints(points: readonly PathPoint[]): THREE.Shape {
+    const shape = new THREE.Shape();
+    const first = points[0];
+    if (first === undefined) return shape;
+
+    const last = points[points.length - 1] as PathPoint;
+    const closed = points.length > 2 && samePathPoint(first, last);
+    const ring = closed ? points.slice(0, -1) : points;
+    const at = (index: number): PathPoint => ring[(index + ring.length) % ring.length] as PathPoint;
+
+    // Where a curve through `control` begins: the previous corner, or halfway
+    // from the previous control point.
+    const curveStart = (previous: PathPoint, control: PathPoint): PathPoint => (previous.curved ? midPathPoint(previous, control) : previous);
+    const start = closed && first.curved ? curveStart(at(-1), first) : first;
+    shape.moveTo(start.x, start.y);
+    // A curve ends ON the next corner, so that corner must not be drawn again
+    // as a zero-length line; a corner the script repeats deliberately still is.
+    let cornerDrawn = false;
+
+    for (let index = closed ? 0 : 1; index < ring.length; index++) {
+      const point = at(index);
+      const next = closed || index < ring.length - 1 ? at(index + 1) : undefined;
+      if (!point.curved || next === undefined) {
+        if (!cornerDrawn) shape.lineTo(point.x, point.y);
+        cornerDrawn = false;
+        continue;
+      }
+      const end = next.curved ? midPathPoint(point, next) : next;
+      shape.quadraticCurveTo(point.x, point.y, end.x, end.y);
+      cornerDrawn = !next.curved;
+    }
+    if (closed && !cornerDrawn && !samePathPoint(at(-1), start)) shape.lineTo(start.x, start.y);
     return shape;
   }
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/types.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/types.ts
@@ -72,6 +72,7 @@ export type SceneNode =
   | HullNode
   | GroupNode
   | DetailNode
+  | SeedNode
   | PathNode
   | BackgroundNode
   | TextureNode
@@ -169,6 +170,12 @@ export interface DetailNode {
   value: number | Expression;
 }
 
+/** `seed N` — reseeds the `rnd` sequence for the rest of the enclosing block. */
+export interface SeedNode {
+  type: "seed";
+  value: Expression;
+}
+
 export interface BackgroundNode {
   type: "background";
   value: Expression; // Usually a string (filename)
@@ -186,7 +193,7 @@ export interface ColorNode {
 
 export interface RotateNode {
   type: "rotate";
-  value: Expression; // Rotation value (half-turns) or tuple - relative/cumulative
+  value: Expression; // `roll yaw pitch` in half-turns, or `angle x y z` — relative/cumulative
 }
 
 export interface OrientationNode {
@@ -251,7 +258,7 @@ export interface PathNode {
   commands: PathCommand[];
 }
 
-export type PathCommand = DefineNode | PointCommand | CurveCommand | RotateCommand | TranslateCommand | DetailPathCommand | ForLoopPathCommand;
+export type PathCommand = DefineNode | PointCommand | CurveCommand | RotateCommand | TranslateCommand | ScaleCommand | DetailPathCommand | ForLoopPathCommand;
 
 export interface PointCommand {
   type: "point";
@@ -259,21 +266,28 @@ export interface PointCommand {
   y: number | Expression;
 }
 
+/** A quadratic Bézier CONTROL point. The curve passes through the neighbouring
+ *  `point`s, not through this one; two `curve`s in a row get an implicit
+ *  on-curve midpoint between them, as upstream does. */
 export interface CurveCommand {
   type: "curve";
   x: number | Expression;
   y: number | Expression;
-  controlX?: number | Expression;
-  controlY?: number | Expression;
 }
 
 export interface RotateCommand {
   type: "rotate";
-  angle: number | Expression; // In ShapeScript, 1 = 360 degrees
+  angle: number | Expression; // half-turns: 0.5 = 90°, positive = clockwise
 }
 
 export interface TranslateCommand {
   type: "translate";
+  x: number | Expression;
+  y: number | Expression;
+}
+
+export interface ScaleCommand {
+  type: "scale";
   x: number | Expression;
   y: number | Expression;
 }
@@ -315,6 +329,7 @@ export enum TokenType {
   POINT = "POINT",
   CURVE = "CURVE",
   DETAIL = "DETAIL",
+  SEED = "SEED",
   BACKGROUND = "BACKGROUND",
   TEXTURE = "TEXTURE",
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/types.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/types.ts
@@ -286,10 +286,12 @@ export interface TranslateCommand {
   y: number | Expression;
 }
 
+/** `scale x [y]` inside a path. `y` absent means uniform: the one expression
+ *  is evaluated once and reused, so `scale rnd` cannot draw two values. */
 export interface ScaleCommand {
   type: "scale";
   x: number | Expression;
-  y: number | Expression;
+  y?: number | Expression;
 }
 
 export interface DetailPathCommand {

--- a/packages/plugins/shapescript-plugin/src/shapescript/types.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/types.ts
@@ -256,6 +256,10 @@ export interface GroupNode {
 export interface PathNode {
   type: "path";
   commands: PathCommand[];
+  /** `position` / `orientation` / `size` given inside the path block — the
+   *  standard transform options upstream allows on a path, which is how a
+   *  `loft` section is placed in 3D without a wrapping `fill`. */
+  properties?: ShapeProperties;
 }
 
 export type PathCommand = DefineNode | PointCommand | CurveCommand | RotateCommand | TranslateCommand | ScaleCommand | DetailPathCommand | ForLoopPathCommand;

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -109,7 +109,7 @@ loft {
     circle
 }
 Stencil preserves the first shape's volume and paints the intersecting surface.
-Constants: pi, tau, true, false. Tuple/string access: values[0], vector.x, value.count.
+Constants: pi, true, false (avoid tau, upstream lacks it; write 2 * pi). Tuple/string access: values[0], vector.x, value.count.
 Polygon supports sides (3–256). String literals and join/trim are supported.
 Use the tool schema for exact syntax and builder limits. This is a modeling subset of upstream ShapeScript;
 imports, textures, text/fonts and general user-defined functions are not supported.

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -54,6 +54,7 @@ Switch statements for multiple cases
 CRITICAL: Function calls require NO space between name and (
 - sin(x) ✓ correct
 - sin (x) ✗ wrong - this is NOT a function call!
+Separate arguments with spaces, upstream style: max(0 (j - 1)). Commas work here but not in the upstream app.
 
 ### Best Practices:
 1. Use variables for repeated values

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -101,6 +101,7 @@ Properties: position, orientation (alias rotation), size, color, opacity
 - size = DIAMETER for sphere/cylinder/cone/circle/polygon/torus, edge length for cube/square. A bare sphere fits the unit cube.
 - orientation / rotate = HALF-TURNS as roll yaw pitch (Z, Y, X): 0.5 = 90°. A lone value is a roll. Trig functions still use radians.
 - Path point/curve coordinates are absolute; curve is a Bézier control point; rotate/translate/scale inside a path move the frame.
+- A path can carry its own position/orientation/size; give loft/extrude path children (not fill{}), as the upstream app requires.
 
 Builders: extrude, fill, lathe, loft, hull. Example:
 loft {

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -55,6 +55,7 @@ CRITICAL: Function calls require NO space between name and (
 - sin(x) ✓ correct
 - sin (x) ✗ wrong - this is NOT a function call!
 Separate arguments with spaces, upstream style: max(0 (j - 1)). Commas work here but not in the upstream app.
+One statement per line; the upstream app rejects two statements on one line.
 
 ### Best Practices:
 1. Use variables for repeated values

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -29,7 +29,10 @@ export const SYSTEM_PROMPT = `Use the ${TOOL_NAME} tool to create interactive 3D
 
 For loops with variables (use loop variable in calculations):
 for i in 1 to 5 {
-    cube { position (i * 2 - 6) 0 0 size 1 }
+    cube {
+        position (i * 2 - 6) 0 0
+        size 1
+    }
 }
 
 For loops with step:
@@ -82,7 +85,10 @@ Parametric surface:
 for x in -5 to 5 {
     for z in -5 to 5 {
         define y (sin(x * 0.5) * cos(z * 0.5))
-        cube { position (x * 0.3) y (z * 0.3) size 0.2 }
+        cube {
+            position (x * 0.3) y (z * 0.3)
+            size 0.2
+        }
     }
 }
 
@@ -96,7 +102,12 @@ Properties: position, orientation (alias rotation), size, color, opacity
 - orientation / rotate = HALF-TURNS as roll yaw pitch (Z, Y, X): 0.5 = 90°. A lone value is a roll. Trig functions still use radians.
 - Path point/curve coordinates are absolute; curve is a Bézier control point; rotate/translate/scale inside a path move the frame.
 
-Builders: extrude, fill, lathe, loft, hull. Example: loft { square translate 0 0 2 circle }.
+Builders: extrude, fill, lathe, loft, hull. Example:
+loft {
+    square
+    translate 0 0 2
+    circle
+}
 Stencil preserves the first shape's volume and paints the intersecting surface.
 Constants: pi, tau, true, false. Tuple/string access: values[0], vector.x, value.count.
 Polygon supports sides (3–256). String literals and join/trim are supported.

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -87,7 +87,12 @@ for x in -5 to 5 {
 ### Primitives & CSG:
 Shapes: cube, sphere, cylinder, cone, torus
 CSG: union, difference, intersection, xor, stencil
-Properties: position, rotation, size, color, opacity
+Properties: position, orientation (alias rotation), size, color, opacity
+
+### Units (upstream ShapeScript conventions):
+- size = DIAMETER for sphere/cylinder/cone/circle/polygon/torus, edge length for cube/square. A bare sphere fits the unit cube.
+- orientation / rotate = HALF-TURNS as roll yaw pitch (Z, Y, X): 0.5 = 90°. A lone value is a roll. Trig functions still use radians.
+- Path point/curve coordinates are absolute; curve is a Bézier control point; rotate/translate/scale inside a path move the frame.
 
 Builders: extrude, fill, lathe, loft, hull. Example: loft { square translate 0 0 2 circle }.
 Stencil preserves the first shape's volume and paints the intersecting surface.

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -261,6 +261,28 @@ describe("expressions", () => {
       assert.ok(Math.abs(volume(mesh) - 2) < 1e-5);
     });
   });
+  it("reads call arguments as a value list, so upstream's `max(0 (j - 1))` and our `max(0, j - 1)` both work", () => {
+    for (const call of ["max(0 (j - 1))", "max(0, j - 1)", "max(0,(j - 1))", "(max(0 (j-1)))"]) {
+      withMesh(`define j 3\ncube { size ${call} }`, (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    }
+    withMesh("cube { size pow(2 3) pow(2, 2) pow(2 -1) }", (mesh) => near(extent(mesh).toArray(), [8, 4, 0.5]));
+    withMesh("cube { size min(1, max(0, (1 - 0.5) / 2)) }", (mesh) => near(extent(mesh).toArray(), [0.25, 0.25, 0.25]));
+    withMesh('cube { size join(("a", "b"), "-").count }', (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
+  });
+  it("supports upstream's ordinal members", () => {
+    withMesh("define v (1 2 3 4)\ncube { position v.first v.second v.last size v.fourth }", (mesh) => {
+      near(mesh.position.toArray(), [1, 2, 4]);
+      near(extent(mesh).toArray(), [4, 4, 4]);
+    });
+    withMesh("define rows ((1 2 3) (4 5 6))\ncube { position rows.last size rows.first.third }", (mesh) => near(mesh.position.toArray(), [4, 5, 6]));
+    withMesh('define v (1 2 3)\ncube { position v.allButFirst.first v.allButLast.count 0 size "abc".allButFirst.count }', (mesh) => {
+      near(mesh.position.toArray(), [2, 2, 0]);
+      near(extent(mesh).toArray(), [2, 2, 2]);
+    });
+    for (const expression of ["(1 2).third", "(1 2).fifth", "().last", "5.first"]) {
+      assert.throws(() => astToThreeJS(parseShapeScript(`cube { size ${expression} }`)), /Unknown member|Unexpected|Undefined variable/);
+    }
+  });
   it("distinguishes signed tuple components from binary arithmetic", () => {
     for (const vector of ["1 +2 3", "+1 +2 +3", "(1 +2 +3)", "1 (1 + 1) (1+2)"]) {
       withMesh(`cube { position ${vector} }`, (mesh) => assert.deepEqual(mesh.position.toArray(), [1, 2, 3]));

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -140,13 +140,13 @@ describe("geometry builders", () => {
   });
   it("refuses a lathe profile that samples to nothing", () => {
     for (const script of [
-      "lathe path { point 1e308 0 curve 0 1 1e308 0 }",
+      "lathe path { translate 1e308 0 translate 1e308 0 point 1 0 point 1 1 }",
       "lathe path { point 0 0 point 0 1 point 0 2 }",
       "lathe path { point 1 0 point 1 0 }",
     ]) {
-      assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(script))), /overflow|axis of rotation/, script);
+      assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(script))), /overflow|axis of rotation|at least 2 points/, script);
     }
-    withMesh("lathe path { point 0.5 0 curve 1 1 1 0 point 0 2 }", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count > 0));
+    withMesh("lathe path { point 0.5 0 curve 1.5 1 point 0.5 2 point 0 2 }", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count > 0));
   });
   it("refuses a solid whose extent is zero in some dimension", () => {
     for (const script of [
@@ -174,14 +174,15 @@ describe("geometry builders", () => {
     }
     withMesh("color 0.5 cube", (mesh) => assert.ok((mesh.material as THREE.MeshStandardMaterial).color.equals(new THREE.Color(0.5, 0.5, 0.5))));
   });
-  it("refuses a path whose accumulated coordinates overflow", () => {
-    // Individually finite operands, but the pen is relative: `NaN` positions
-    // reach the geometry and every later comparison against them is false.
+  it("refuses a path whose accumulated transform overflows", () => {
+    // Individually finite operands, but the path's frame accumulates: `NaN`
+    // positions reach the geometry and every later comparison against them is false.
     for (const script of [
-      "lathe path { point 1e308 0 point 1e308 1 }",
-      "fill path { point 1e308 0 point 1e308 1e308 point 0 1e308 }",
-      "extrude path { for i in 1 to 10 { point 1e307 1e307 } }",
+      "lathe path { translate 1e308 0 translate 1e308 0 point 1 0 point 1 1 }",
+      "fill path { scale 1e308 1e308 scale 1e308 1e308 point 1 0 point 1 1 point 0 1 }",
+      "extrude path { for i in 1 to 10 { translate 1e307 1e307 point 0 0 point 1 0 point 0 1 } }",
       "lathe path { rotate 1e308 rotate 1e308 point 1 0 point 1 1 }",
+      "extrude path { point 1e308 0 point 1e308 1e308 point (0 - 1e308) 1e308 }",
     ]) {
       assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(script))), /overflow/, script);
     }
@@ -214,8 +215,10 @@ describe("geometry builders", () => {
     });
   });
   it("extrudes a regular polygon", () => {
+    // `size` is a diameter: a unit triangle has circumradius 0.5, so its area
+    // is 3·√3/4 · 0.5² and the default extrusion depth is 1.
     withMesh("extrude { polygon { sides 3 } }", (mesh) => {
-      assert.ok(volume(mesh) > 1);
+      assert.ok(Math.abs(volume(mesh) - (3 * Math.sqrt(3)) / 16) < 1e-6);
     });
   });
   it("fills a planar primitive", () => {
@@ -224,7 +227,8 @@ describe("geometry builders", () => {
     });
   });
   it("samples curved lathe profiles", () => {
-    withMesh("lathe path { point 1 0 curve 0 2 1 -1 }", (mesh) => {
+    // The control point at x=2 bows the profile out past the end points at x=1.
+    withMesh("lathe path { point 1 0 curve 2 1 point 1 2 point 0 2 }", (mesh) => {
       mesh.geometry.computeBoundingBox();
       assert.ok((mesh.geometry.boundingBox?.max.x ?? 0) > 1.1);
     });
@@ -251,8 +255,10 @@ describe("expressions", () => {
     });
   });
   it("uses inline path definitions and loops in builders", () => {
-    withMesh("extrude path { define edge 1 point 0 0 for i in 1 to 4 { point edge 0 rotate 0.25 } }", (mesh) => {
-      assert.ok(Math.abs(volume(mesh) - 1) < 1e-5);
+    // `rotate 0.5` is a quarter turn of the path's frame, so the four points
+    // land on the axes at radius `edge`: a diamond of area 2.
+    withMesh("extrude path { define edge 1 for i in 1 to 4 { point edge 0 rotate 0.5 } point edge 0 }", (mesh) => {
+      assert.ok(Math.abs(volume(mesh) - 2) < 1e-5);
     });
   });
   it("distinguishes signed tuple components from binary arithmetic", () => {
@@ -282,5 +288,117 @@ describe("expressions", () => {
   it("short circuits boolean expressions", () => {
     withMesh("if 1 or missing { cube }", () => {});
     withMesh("if 0 and missing { sphere } else { cube }", () => {});
+  });
+});
+
+// Upstream ShapeScript conventions (https://shapescript.info/mac/): half-turn
+// rotations in roll/yaw/pitch order, diameters for curved primitives, absolute
+// path coordinates with Bézier control points, and a scoped `seed` command.
+// Every case here is a script that renders WRONG without any error if one of
+// those slips back to the old present3D conventions.
+function meshesOf(script: string): { group: THREE.Group; meshes: THREE.Mesh[] } {
+  const group = astToThreeJS(parseShapeScript(script));
+  const meshes: THREE.Mesh[] = [];
+  group.traverse((object) => {
+    if ((object as THREE.Mesh).isMesh) meshes.push(object as THREE.Mesh);
+  });
+  return { group, meshes };
+}
+function extent(mesh: THREE.Mesh): THREE.Vector3 {
+  mesh.updateMatrixWorld(true);
+  return new THREE.Box3().setFromObject(mesh).getSize(new THREE.Vector3());
+}
+function near(actual: readonly number[], expected: readonly number[], tolerance = 1e-6): void {
+  assert.equal(actual.length, expected.length);
+  actual.forEach((value, index) => assert.ok(Math.abs(value - (expected[index] ?? Number.NaN)) < tolerance, `${actual} ≠ ${expected}`));
+}
+function upstreamRnd(seed: number): number {
+  return ((seed * 1664525 + 1013904223) % 2 ** 32) / 2 ** 32;
+}
+
+describe("upstream conventions", () => {
+  it("treats size as a DIAMETER for curved primitives, so a bare sphere fits the unit cube", () => {
+    withMesh("sphere", (mesh) => near(extent(mesh).toArray(), [1, 1, 1], 1e-3));
+    withMesh("sphere { size 2 1 1 }", (mesh) => near(extent(mesh).toArray(), [2, 1, 1], 1e-3));
+    withMesh("cylinder { size 1 3 }", (mesh) => near(extent(mesh).toArray(), [1, 3, 1], 1e-3));
+    withMesh("cone { size 2 1 }", (mesh) => near(extent(mesh).toArray(), [2, 1, 2], 1e-3));
+    withMesh("circle", (mesh) => near(extent(mesh).toArray(), [1, 1, 0], 1e-3));
+    withMesh("torus", (mesh) => near(extent(mesh).toArray().slice(0, 2), [1.4, 1.4], 1e-3));
+  });
+  it("reads orientation as roll yaw pitch in half-turns, applied Z then Y then X", () => {
+    // 0.5 half-turns = 90°: the 2-long side swings from X onto Z.
+    withMesh("cube { orientation 0 0.5 0 size 2 1 1 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 2], 1e-6));
+    withMesh("cube { rotation 0.5 size 2 1 1 }", (mesh) => near(extent(mesh).toArray(), [1, 2, 1], 1e-6));
+    // A lone value is a roll, not a uniform tuple like `size`.
+    withMesh("cube { orientation 0.25 }", (mesh) => {
+      const roll = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, 0, -Math.PI / 4));
+      assert.ok(Math.abs(mesh.quaternion.dot(roll)) > 1 - 1e-9);
+    });
+    // Angle-axis form: 0.5 about Y is the same rotation as yaw 0.5.
+    const { group, meshes } = meshesOf("cube { orientation 0.5 0 1 0 }\ncube { orientation 0 0.5 0 }");
+    try {
+      assert.ok(Math.abs(meshes[0]!.quaternion.dot(meshes[1]!.quaternion)) > 1 - 1e-9);
+    } finally {
+      disposeObject3D(group);
+    }
+    assert.throws(() => astToThreeJS(parseShapeScript("cube { orientation 0.5 0 0 0 }")), /axis/);
+    assert.throws(() => astToThreeJS(parseShapeScript("cube { orientation 1 2 3 4 5 }")), /rotation/);
+  });
+  it("rotates clockwise for positive angles, like Euclid, and `rotate` is relative in half-turns", () => {
+    // A quarter roll takes +X to -Y when viewed from the front; a quarter yaw takes +X to +Z.
+    withMesh("rotate 0.5\ncube { position 1 0 0 }", (mesh) => near(mesh.position.toArray(), [0, -1, 0]));
+    withMesh("rotate 0 0.5 0\ncube { position 1 0 0 }", (mesh) => near(mesh.position.toArray(), [0, 0, 1]));
+    withMesh("rotate 0 0 0.5\ncube { position 0 1 0 }", (mesh) => near(mesh.position.toArray(), [0, 0, -1]));
+    // Two quarter turns compose into a half turn.
+    withMesh("rotate 0.5\nrotate 0.5\ncube { position 1 0 0 }", (mesh) => near(mesh.position.toArray(), [-1, 0, 0]));
+    // `orientation` as a command is absolute: the second one replaces the first.
+    withMesh("orientation 0.5\norientation 1\ncube { position 1 0 0 }", (mesh) => near(mesh.position.toArray(), [-1, 0, 0]));
+  });
+  it("places path points at absolute coordinates in the path's frame", () => {
+    // A unit square, spelled the way the upstream docs do.
+    withMesh("extrude path { point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 1) < 1e-6));
+    // `translate` moves the frame, so the same square lands 5 units over.
+    withMesh("fill path { translate 5 0 point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }", (mesh) => {
+      mesh.geometry.computeBoundingBox();
+      near([mesh.geometry.boundingBox!.min.x, mesh.geometry.boundingBox!.max.x], [5, 6]);
+    });
+    // `scale` scales the frame.
+    withMesh("extrude path { scale 2 point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 4) < 1e-6));
+  });
+  it("treats `curve` as a Bézier control point, with implicit midpoints between consecutive controls", () => {
+    // The octagon-of-controls idiom from the upstream docs draws a unit circle.
+    const circle =
+      "extrude path { curve -0.414 1 curve 0.414 1 curve 1 0.414 curve 1 -0.414 curve 0.414 -1 curve -0.414 -1 curve -1 -0.414 curve -1 0.414 curve -0.414 1 }";
+    withMesh(circle, (mesh) => assert.ok(Math.abs(volume(mesh) - Math.PI) / Math.PI < 0.03, `${volume(mesh)}`));
+    // The procedural semicircle from the upstream docs: half a unit disc once
+    // filled, give or take the 4% that on-curve midpoints at cos(11.25°) cost.
+    withMesh("extrude path { for 0 to 8 { curve 0 1 rotate 1 / 8 } }", (mesh) =>
+      assert.ok(Math.abs(volume(mesh) - Math.PI / 2) / (Math.PI / 2) < 0.05, `${volume(mesh)}`),
+    );
+    // One control between two corners bows the edge out without passing through the control.
+    withMesh("fill path { point -1 -1 curve 0 1 point 1 -1 point -1 -1 }", (mesh) => {
+      mesh.geometry.computeBoundingBox();
+      const top = mesh.geometry.boundingBox!.max.y;
+      assert.ok(top > -0.5 && top < 0.5, `${top}`);
+    });
+  });
+  it("seeds `rnd` with upstream's generator, scoped to the enclosing block", () => {
+    withMesh("cube { position rnd 0 0 }", (mesh) => near([mesh.position.x], [upstreamRnd(0)]));
+    withMesh("seed 57\ncube { position rnd 0 0 }", (mesh) => near([mesh.position.x], [upstreamRnd(57)]));
+    // The group reseeds itself only; the outer `rnd` is still the first draw of the default sequence.
+    const { group, meshes } = meshesOf("group { seed 57 cube { position rnd 0 0 } }\ncube { position rnd 0 0 }");
+    try {
+      near([meshes[0]!.position.x, meshes[1]!.position.x], [upstreamRnd(57), upstreamRnd(0)]);
+    } finally {
+      disposeObject3D(group);
+    }
+    // Without a reseed, a block advances the sequence it shares with its parent.
+    const shared = meshesOf("group { cube { position rnd 0 0 } }\ncube { position rand() 0 0 }");
+    try {
+      near([shared.meshes[0]!.position.x, shared.meshes[1]!.position.x], [upstreamRnd(0), upstreamRnd(upstreamRnd(0) * 2 ** 32)]);
+    } finally {
+      disposeObject3D(shared.group);
+    }
+    assert.throws(() => astToThreeJS(parseShapeScript("seed (1e308 * 1e308)")), /finite/);
   });
 });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -436,3 +436,24 @@ describe("upstream conventions", () => {
     assert.throws(() => astToThreeJS(parseShapeScript("seed (1e308 * 1e308)")), /finite/);
   });
 });
+
+describe("path transform options", () => {
+  it("places a path with its own position/orientation/size, as upstream does for loft sections", () => {
+    // Two placed unit squares, 2 apart along Z, loft into a 1×1×2 slab.
+    const loft =
+      "loft {\npath {\n position 0 0 -1\n point -0.5 -0.5\n point 0.5 -0.5\n point 0.5 0.5\n point -0.5 0.5\n point -0.5 -0.5\n}\npath {\n position 0 0 1\n point -0.5 -0.5\n point 0.5 -0.5\n point 0.5 0.5\n point -0.5 0.5\n point -0.5 -0.5\n}\n}";
+    withMesh(loft, (mesh) => near(extent(mesh).toArray(), [1, 1, 2], 1e-6));
+    // A yaw of a quarter turn stands the path's plane on the X axis instead of Z.
+    withMesh("fill path {\n orientation 0 0.5 0\n point 0 0\n point 2 0\n point 2 1\n point 0 1\n point 0 0\n}", (mesh) =>
+      near(extent(mesh).toArray(), [0, 1, 2], 1e-6),
+    );
+    withMesh("extrude path {\n position 5 0 0\n size 2\n point 0 0\n point 1 0\n point 1 1\n point 0 1\n point 0 0\n}", (mesh) => {
+      mesh.geometry.computeBoundingBox();
+      near([mesh.geometry.boundingBox!.min.x, mesh.geometry.boundingBox!.max.x], [5, 7]);
+    });
+  });
+  it("refuses a placed profile on a lathe and a placement inside a path loop", () => {
+    assert.throws(() => astToThreeJS(parseShapeScript("lathe path {\n position 1 0 0\n point 0 0\n point 1 0\n point 1 1\n point 0 1\n}")), /place the lathe/);
+    assert.throws(() => parseShapeScript("fill path { for i in 1 to 3 { position 1 0 0 point i 0 } }"), /Unexpected token/);
+  });
+});

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -323,7 +323,9 @@ describe("upstream conventions", () => {
     withMesh("cylinder { size 1 3 }", (mesh) => near(extent(mesh).toArray(), [1, 3, 1], 1e-3));
     withMesh("cone { size 2 1 }", (mesh) => near(extent(mesh).toArray(), [2, 1, 2], 1e-3));
     withMesh("circle", (mesh) => near(extent(mesh).toArray(), [1, 1, 0], 1e-3));
-    withMesh("torus", (mesh) => near(extent(mesh).toArray().slice(0, 2), [1.4, 1.4], 1e-3));
+    withMesh("torus", (mesh) => near(extent(mesh).toArray().slice(0, 2), [1, 1], 1e-3));
+    withMesh("torus {\n size 2\n innerRadius 0.25\n}", (mesh) => near(extent(mesh).toArray(), [2, 2, 0.5], 1e-3));
+    assert.throws(() => astToThreeJS(parseShapeScript("torus {\n size 1\n innerRadius 0.5\n}")), /no radius left/);
   });
   it("reads orientation as roll yaw pitch in half-turns, applied Z then Y then X", () => {
     // 0.5 half-turns = 90°: the 2-long side swings from X onto Z.
@@ -342,6 +344,10 @@ describe("upstream conventions", () => {
       disposeObject3D(group);
     }
     assert.throws(() => astToThreeJS(parseShapeScript("cube { orientation 0.5 0 0 0 }")), /axis/);
+    // An axis is a direction: huge or tiny components must not overflow or underflow it away.
+    for (const magnitude of ["1e200", "1e-200"]) {
+      withMesh(`cube { orientation 0.5 0 ${magnitude} 0 size 2 1 1 }`, (mesh) => near(extent(mesh).toArray(), [1, 1, 2], 1e-6));
+    }
     assert.throws(() => astToThreeJS(parseShapeScript("cube { orientation 1 2 3 4 5 }")), /rotation/);
   });
   it("rotates clockwise for positive angles, like Euclid, and `rotate` is relative in half-turns", () => {
@@ -362,8 +368,14 @@ describe("upstream conventions", () => {
       mesh.geometry.computeBoundingBox();
       near([mesh.geometry.boundingBox!.min.x, mesh.geometry.boundingBox!.max.x], [5, 6]);
     });
-    // `scale` scales the frame.
+    // `scale` scales the frame; a lone value is uniform and evaluated ONCE,
+    // so `scale rnd` draws one number, not one per axis.
     withMesh("extrude path { scale 2 point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 4) < 1e-6));
+    withMesh("extrude path { scale rnd point 0 0 point 1 0 point 1 1 point 0 1 point 0 0 }", (mesh) => {
+      mesh.geometry.computeBoundingBox();
+      const box = mesh.geometry.boundingBox!;
+      near([box.max.x, box.max.y], [upstreamRnd(0), upstreamRnd(0)]);
+    });
   });
   it("treats `curve` as a Bézier control point, with implicit midpoints between consecutive controls", () => {
     // The octagon-of-controls idiom from the upstream docs draws a unit circle.

--- a/packages/plugins/shapescript-plugin/test/test_presentShapeScript.ts
+++ b/packages/plugins/shapescript-plugin/test/test_presentShapeScript.ts
@@ -202,7 +202,7 @@ describe("ShapeScript robustness", () => {
       return original.apply(this, args);
     };
     try {
-      const script = `detail ${MAX_DETAIL}\nextrude {\n  path {\n    for i in 1 to 60000 {\n      point i 1\n    }\n  }\n}`;
+      const script = `detail ${MAX_DETAIL}\nextrude {\n  path {\n    for i in 1 to 60000 {\n      point i sqrt(i)\n    }\n  }\n}`;
       assert.throws(() => astToThreeJS(parseShapeScript(script)), ShapeScriptLimitError);
     } finally {
       THREE.BufferGeometry.prototype.setAttribute = original;

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -26,6 +26,7 @@ These are the highest-value fixes: valid upstream scripts render, but incorrectl
 | 8 | angle-axis rotation `orientation 0.5 0 1 0` | supported (1.11.0) | not supported | fixed in this PR |
 | 9 | call arguments `max(0 (j - 1))` | space-separated (C-like parens) or bare `max 0 (j - 1)` | comma-separated only, so no script with a 2-arg call could open in both | parenthesised form fixed in this PR; bare form still unsupported |
 | 10 | ordinal members `.first` … `.last`, `.allButFirst`, `.allButLast` | supported | only `[i]` and `.x/.y/.z` | fixed in this PR |
+| 13 | `path { position … orientation … size … }` | transform options on a path, used to place loft sections | not parsed inside a path block | fixed in this PR (lathe profiles excepted) |
 | 12 | `tau` constant | not defined (only `pi`) | defined | plugin extension, kept; docs steer the agent to `2 * pi` |
 | 11 | statement separators | one statement per line (line break, `}` or EOF) | also accepts several per line | documented only; ours is a superset, so scripts written for upstream parse here |
 

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -24,6 +24,8 @@ These are the highest-value fixes: valid upstream scripts render, but incorrectl
 | 6 | `seed N` command | scoped reseed of the `rnd` sequence; LCG `x = x * 1664525 + 1013904223 mod 2^32`, default seed 0 | no keyword (tool option `randomSeed` only); mulberry32 | fixed in this PR |
 | 7 | single-value rotation `orientation 0.25` | roll only (`0.25 0 0`) | uniform `0.25 0.25 0.25` | fixed in this PR |
 | 8 | angle-axis rotation `orientation 0.5 0 1 0` | supported (1.11.0) | not supported | fixed in this PR |
+| 9 | call arguments `max(0 (j - 1))` | space-separated (C-like parens) or bare `max 0 (j - 1)` | comma-separated only, so no script with a 2-arg call could open in both | parenthesised form fixed in this PR; bare form still unsupported |
+| 10 | ordinal members `.first` … `.last`, `.allButFirst`, `.allButLast` | supported | only `[i]` and `.x/.y/.z` | fixed in this PR |
 
 Conventions that already matched and stay: trig functions in radians, `size` on `cube` /
 `square` = edge length, single-value `size` = uniform, `translate` / `scale` as relative
@@ -55,9 +57,10 @@ Known remaining deviations inside phase 1 scope (documented in the README):
 - **Rotation values**: `rotation` function, quaternion-style multiplication of rotations,
   `{ yaw 0.5 }` / `{ axis … angle … }` block syntax (1.11.0 – 1.11.2).
 - **Object syntax** for `color`, `size`, `point`, `path`, `polygon`, `mesh` (1.11.0).
-- **Expressions**: ranges as values (`1 to 5`), partial ranges, `allButFirst` / `allButLast`,
-  `if` / `switch` / `for` inside expressions (1.10.0), `split`, `bounds` members,
-  mesh members (`polygons`, `triangles`).
+- **Expressions**: ranges as values (`1 to 5`), partial ranges, bare function calls without
+  parentheses (`max 0 1`), `if` / `switch` / `for` inside expressions (1.10.0), `split`,
+  `bounds` members, mesh members (`polygons`, `triangles`), string `lines` / `words` /
+  `characters`.
 - **Custom functions** with return values (we only have custom shapes with `option`s).
 - **Scene**: `text` / `font`, `light`, `camera`, `import`, raw `mesh`, `smoothing`, `name`,
   `debug`, `print`, `assert`, `focus`.

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -1,0 +1,76 @@
+# ShapeScript plugin: upstream parity tracker
+
+**Status**: phase 1 in progress (semantic mismatches)
+**Upstream**: [nicklockwood/ShapeScript](https://github.com/nicklockwood/ShapeScript) 1.11.4 (2026-09-04)
+**Ours**: `packages/plugins/shapescript-plugin` (ported from `@gui-chat-plugin/present3d`)
+**Last updated**: 2026-09-10
+
+The plugin ships its own ShapeScript parser / evaluator / Three.js converter. It was ported
+from the present3D plugin, which had invented its own unit conventions. The result is that a
+script written against the upstream docs (which is what an LLM has read) renders wrong here
+without any error. This file tracks every known gap so they can be closed in order.
+
+## Phase 1 — semantic mismatches (silent wrong output)
+
+These are the highest-value fixes: valid upstream scripts render, but incorrectly.
+
+| # | Feature | Upstream | Ours (before) | Status |
+|---|---|---|---|---|
+| 1 | `rotation` / `orientation` property | `roll yaw pitch` in **half-turns** (0.5 = 90°), applied Z → Y → X, positive = clockwise | `x y z` in radians, XYZ order | fixed in this PR |
+| 2 | `rotate` command (shapes + paths) | half-turns, same axis order | full turns (1 = 360°), XYZ order | fixed in this PR |
+| 3 | `sphere` / `cylinder` / `cone` / `circle` / `polygon` `size` | **diameter** (default 1) | radius, so every curved shape rendered twice as large | fixed in this PR |
+| 4 | path `point` / `curve` coordinates | absolute, in the path's local frame; `translate` / `rotate` / `scale` inside a path move that frame | relative steps from the pen | fixed in this PR |
+| 5 | `curve x y` | a quadratic Bézier **control point**; consecutive controls get an implicit on-curve midpoint | an end point with an optional 4-arg control offset | fixed in this PR |
+| 6 | `seed N` command | scoped reseed of the `rnd` sequence; LCG `x = x * 1664525 + 1013904223 mod 2^32`, default seed 0 | no keyword (tool option `randomSeed` only); mulberry32 | fixed in this PR |
+| 7 | single-value rotation `orientation 0.25` | roll only (`0.25 0 0`) | uniform `0.25 0.25 0.25` | fixed in this PR |
+| 8 | angle-axis rotation `orientation 0.5 0 1 0` | supported (1.11.0) | not supported | fixed in this PR |
+
+Conventions that already matched and stay: trig functions in radians, `size` on `cube` /
+`square` = edge length, single-value `size` = uniform, `translate` / `scale` as relative
+transforms, `detail`, `rnd`.
+
+Known remaining deviations inside phase 1 scope (documented in the README):
+
+- An **open** path whose first or last point is a `curve` treats that point as a corner;
+  upstream extrapolates a tangent. Closed all-curve paths (the octagon-circle idiom) match.
+- `curve` and `point` take 2D coordinates; a third `z` component is not parsed.
+- `torus` is a plugin extension (upstream has none). Its `size` is now the outer diameter so it
+  follows the same rule as the other curved primitives.
+
+## Phase 2 — commands that parse but fail to render
+
+- `background` and `texture` parse into AST nodes but the converter throws
+  "Unsupported command". Upstream scripts use `background` routinely. Accept `background` as
+  a scene-level colour and ignore `texture` with a diagnostic rather than an error.
+
+## Phase 3 — missing language features (by likely impact on generated scripts)
+
+- **Materials**: hex colours (`#FF0000`), HSB colours, named colours (`red`, `green`, …),
+  `material` blocks, `glow`, `metallicity`, `roughness`, `opacity` textures, `normals`.
+- **Primitives**: `icosphere` (1.11.0).
+- **Builders**: `minkowski`; `extrude` options `along`, `twist`, `axisAligned`, `miterLimit`;
+  `inset` (1.11.0).
+- **Paths**: `arc`, `roundrect`, `svgpath`, `angle`, nested / compound paths with holes,
+  `path.color`, 3D path points.
+- **Rotation values**: `rotation` function, quaternion-style multiplication of rotations,
+  `{ yaw 0.5 }` / `{ axis … angle … }` block syntax (1.11.0 – 1.11.2).
+- **Object syntax** for `color`, `size`, `point`, `path`, `polygon`, `mesh` (1.11.0).
+- **Expressions**: ranges as values (`1 to 5`), partial ranges, `allButFirst` / `allButLast`,
+  `if` / `switch` / `for` inside expressions (1.10.0), `split`, `bounds` members,
+  mesh members (`polygons`, `triangles`).
+- **Custom functions** with return values (we only have custom shapes with `option`s).
+- **Scene**: `text` / `font`, `light`, `camera`, `import`, raw `mesh`, `smoothing`, `name`,
+  `debug`, `print`, `assert`, `focus`.
+
+## Things we have that upstream does not
+
+USDZ export, server-side PNG rendering, deterministic server/browser double evaluation,
+explicit node / vertex / iteration / wall-clock limits, the `torus` and `polygon` primitives.
+Keep these; they are the product, not the gap.
+
+## Compatibility note for phase 1
+
+The unit changes are **breaking for saved `.shape` files** written against the old
+conventions (spheres shrink by half, rotations change). That is why the plugin goes to
+`2.0.0`. MulmoTerminal consumes the same package and shares workspace data, so it must
+pick up the same major (see `project_mulmoterminal_host_route_port` memory).

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -26,6 +26,7 @@ These are the highest-value fixes: valid upstream scripts render, but incorrectl
 | 8 | angle-axis rotation `orientation 0.5 0 1 0` | supported (1.11.0) | not supported | fixed in this PR |
 | 9 | call arguments `max(0 (j - 1))` | space-separated (C-like parens) or bare `max 0 (j - 1)` | comma-separated only, so no script with a 2-arg call could open in both | parenthesised form fixed in this PR; bare form still unsupported |
 | 10 | ordinal members `.first` … `.last`, `.allButFirst`, `.allButLast` | supported | only `[i]` and `.x/.y/.z` | fixed in this PR |
+| 12 | `tau` constant | not defined (only `pi`) | defined | plugin extension, kept; docs steer the agent to `2 * pi` |
 | 11 | statement separators | one statement per line (line break, `}` or EOF) | also accepts several per line | documented only; ours is a superset, so scripts written for upstream parse here |
 
 Conventions that already matched and stay: trig functions in radians, `size` on `cube` /

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -26,6 +26,7 @@ These are the highest-value fixes: valid upstream scripts render, but incorrectl
 | 8 | angle-axis rotation `orientation 0.5 0 1 0` | supported (1.11.0) | not supported | fixed in this PR |
 | 9 | call arguments `max(0 (j - 1))` | space-separated (C-like parens) or bare `max 0 (j - 1)` | comma-separated only, so no script with a 2-arg call could open in both | parenthesised form fixed in this PR; bare form still unsupported |
 | 10 | ordinal members `.first` … `.last`, `.allButFirst`, `.allButLast` | supported | only `[i]` and `.x/.y/.z` | fixed in this PR |
+| 11 | statement separators | one statement per line (line break, `}` or EOF) | also accepts several per line | documented only; ours is a superset, so scripts written for upstream parse here |
 
 Conventions that already matched and stay: trig functions in radians, `size` on `cube` /
 `square` = edge length, single-value `size` = uniform, `translate` / `scale` as relative


### PR DESCRIPTION
## Why

Comparing our plugin against upstream [ShapeScript 1.11.4](https://github.com/nicklockwood/ShapeScript) showed that valid upstream scripts render **wrong without any error** here, because the port inherited present3D's own unit conventions. An LLM writes ShapeScript the way the upstream docs describe it, so this is the highest-value gap to close. The full gap list (phases 2 and 3) is tracked in the new `plans/feat-shapescript-upstream-parity.md`.

## What changes (all verified against the upstream docs and Euclid's source)

| Feature | Upstream | Before | Now |
|---|---|---|---|
| `orientation` / `rotation` property | `roll yaw pitch` in half-turns, Z → Y → X, positive = clockwise | radians, XYZ | upstream |
| `rotate` command, path `rotate` | half-turns | full turns | upstream |
| lone rotation value `orientation 0.25` | roll only | uniform tuple | upstream (+ `angle x y z` form) |
| `sphere` / `cylinder` / `cone` / `circle` / `polygon` `size` | diameter | radius (2× too big) | upstream (`torus` follows the same rule, overall diameter) |
| path `point` / `curve` | absolute in the path's frame; `rotate` / `translate` / `scale` move the frame | relative steps | upstream |
| `curve x y` | Bézier control point, implicit midpoints between consecutive controls | end point + optional 4-arg control offset | upstream (the 4-arg form no longer parses) |
| `seed N` | scoped reseed; LCG `x·1664525+1013904223 mod 2³²`, seed 0 | not a keyword; mulberry32 | upstream, bit for bit |
| call arguments `max(0 (j - 1))` | space-separated (or bare `max 0 1`) | comma-separated only | both spellings accepted; bare form still unsupported |
| ordinal members `.first` … `.last`, `.allButFirst`, `.allButLast` | supported | only `[i]` | upstream |

Sign and order were checked against Euclid's `Rotation.swift` (`.roll * .yaw * .pitch`, negated stored angle, `simd_act`) and the `arc { orientation -0.25 angle 0.75 }` example in the docs.

Remaining deviations, documented in the README: an *open* path whose first/last point is a `curve` is treated as a corner (upstream extrapolates a tangent), and path points are 2D.

## Verification beyond the unit tests

Three real old-dialect models (a 108-mesh helmet, a 74-mesh character, a 683-mesh vehicle) were converted to upstream syntax and rendered under this branch; every mesh's bounding box matches the old renderer on `main` to within 2e-4. The converted scripts also open in the upstream ShapeScript app, which is what the call-syntax change is for.

## Also

- Path parsing in `parser.ts` is de-duplicated: the `for`-inside-path body used to be a second copy of the command switch; both now go through `parsePathBody`.
- Tool description, system prompt and README describe the units explicitly and steer the agent to the space-separated call form so generated scripts stay portable.
- Tests: the old expectations that encoded relative paths / radius sizes are rewritten, plus a new `upstream conventions` suite (diameters, roll/yaw/pitch order and sign, angle-axis, absolute paths with frame transforms, the octagon-circle and semicircle idioms from the upstream docs, `seed` scoping and the exact LCG values, both call spellings, ordinal members).

## Version

`@mulmoclaude/shapescript-plugin` → **2.0.0** (breaking for saved `.shape` files written against the old conventions), launcher range and the CHANGELOG `Ships` line ratcheted in lockstep. Not published — that is a separate step after merge. MulmoTerminal consumes the same package and shares workspace data, so it should move to 2.0.0 together.

## Checks

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn test` (root + plugin), `yarn check:launcher-sync` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz

work in mulmoclaude

## Summary by Sourcery

Adopt upstream ShapeScript units and path semantics in the plugin, making the 2.0.0 release a breaking compatibility update for existing saved shape files.

New Features:
- Add upstream-compatible ShapeScript path transforms and Bézier control-point semantics.
- Support scoped `seed` behavior with upstream-compatible random generation, value-list call arguments, and ordinal sequence members.

Bug Fixes:
- Correct curved primitive sizes to use diameters and align orientation and rotation behavior with upstream ShapeScript.
- Make upstream-authored scripts render correctly by adopting absolute path coordinates and upstream rotation conventions.

Enhancements:
- Refactor path parsing through a shared path-body parser and document units, syntax, compatibility limits, and remaining parity gaps.

Build:
- Bump `@mulmoclaude/shapescript-plugin` to 2.0.0 and update its consuming package and changelog.

Documentation:
- Update the ShapeScript README, tool definition, and system prompt with upstream units, path semantics, and portable syntax guidance.
- Add an upstream parity plan documenting completed and remaining compatibility work.

Tests:
- Update existing geometry and path expectations for the new conventions and add coverage for upstream dimensions, rotations, paths, random seeding, calls, ordinal members, and path placements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Updated ShapeScript sizing, orientation, rotation, path, curve, and transform conventions to align with upstream behavior.
  - Curved primitive sizes now use diameters.
  - Added seeded randomness through the `seed` command.
  - Added space- and comma-separated function arguments, plus ordinal and collection members.
  - Updated the plugin to version 2.0.0; existing `.shape` files using earlier conventions may require updates.
- **Documentation**
  - Expanded syntax, compatibility, and upstream-parity documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->