### PR TITLE
fix(mulmoscript-plugin): デッキ編集の保存失敗を Edit タブに出す

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -729,7 +729,7 @@ function commitScript(next: MulmoScript): void {
 // interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
-const { canEditBeats, deckScriptInput, deckSaveError, clearDeckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
+const { canEditBeats, deckScriptInput, deckSaveError, resetForScriptChange, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
   api,
   filePath,
   effectiveScript,
@@ -1187,8 +1187,9 @@ async function initializeScript() {
     beatDragOver,
   );
   // Same reason as `beatSaveErrors` above: this View re-initializes in place on a result
-  // switch, so a deck-save failure left on screen would sit over a different script.
-  clearDeckSaveError();
+  // switch, so anything the previous script left behind — the failure banner, an answer still
+  // in flight, an edit still queued — would land on the new one.
+  resetForScriptChange();
   resetCharacters();
   resetBeatMovies();
   resetMedia();

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -729,7 +729,7 @@ function commitScript(next: MulmoScript): void {
 // interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
-const { canEditBeats, deckScriptInput, deckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
+const { canEditBeats, deckScriptInput, deckSaveError, clearDeckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
   api,
   filePath,
   effectiveScript,
@@ -1186,6 +1186,9 @@ async function initializeScript() {
     audioErrors,
     beatDragOver,
   );
+  // Same reason as `beatSaveErrors` above: this View re-initializes in place on a result
+  // switch, so a deck-save failure left on screen would sit over a different script.
+  clearDeckSaveError();
   resetCharacters();
   resetBeatMovies();
   resetMedia();

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -100,6 +100,19 @@
       </button>
     </div>
 
+    <!-- A deck save that failed, in the server's own words (#3070). The editor keeps showing the
+         edit either way, so without this the only difference between a save and a silent failure
+         is what comes back on the next reload. Shown in both panes: switching tabs does not make
+         an unsaved edit saved. -->
+    <div
+      v-if="deckSaveError"
+      class="shrink-0 mx-2 mt-1 px-2 py-1 rounded bg-red-50 border border-red-200 text-xs text-red-700 break-words"
+      role="alert"
+      data-testid="mulmo-script-deck-save-error"
+    >
+      {{ m.saveErrorSaveFailed(deckSaveError) }}
+    </div>
+
     <div v-if="showBeatEditor" class="flex-1 overflow-hidden" data-testid="mulmo-script-deck-editor" @focusout="onDeckFocusOut">
       <BeatListEditor :beats="deckBeats" @update:beats="onDeckBeatsUpdate" />
     </div>
@@ -716,7 +729,7 @@ function commitScript(next: MulmoScript): void {
 // interactive deck editor (@mulmocast/beat-editor). Mixed scripts (any non-slide
 // beat) fall back to the existing list. The debounce + flush-on-unmount live
 // in the composable.
-const { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
+const { canEditBeats, deckScriptInput, deckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
   api,
   filePath,
   effectiveScript,

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -4,9 +4,10 @@
 // quiet stretch (300ms — short enough to feel live, long enough that typing in
 // the Inspector doesn't carpet-bomb the server).
 
-import { computed, type ComputedRef } from "vue";
+import { computed, ref, type ComputedRef, type Ref } from "vue";
 import { hasEditableBeats } from "../helpers";
-import type { MulmoScriptTransport } from "../transport";
+import type { MulmoScriptDispatchResult } from "../../core/contract";
+import type { MulmoScriptTransport, TransportResult } from "../transport";
 import type { DeckScriptShape, MulmoScript } from "../viewTypes";
 
 const DECK_SAVE_DEBOUNCE_MS = 300;
@@ -23,8 +24,23 @@ const DECK_SAVE_DEBOUNCE_MS = 300;
  */
 const EDITOR_ORIGIN = `deck-editor-${Math.random().toString(36).slice(2)}`;
 
+/**
+ * The slice of the transport this composable uses.
+ *
+ * `MulmoScriptTransport["call"]` is generic in the dispatch kind, so a fake standing in for it
+ * has to answer every kind — impossible to write without a cast. Naming the ONE call made here
+ * is what lets the save path (and its failure) be tested; the real transport satisfies this
+ * structurally, so the View passes the same object it always did.
+ */
+export type DeckEditorTransport = Pick<MulmoScriptTransport, "onScriptChanged"> & {
+  call(
+    kind: "updateScript",
+    args: { filePath: string; script: MulmoScript; origin: string },
+  ): Promise<TransportResult<MulmoScriptDispatchResult["updateScript"]>>;
+};
+
 export interface UseDeckEditorOptions {
-  api: MulmoScriptTransport;
+  api: DeckEditorTransport;
   filePath: ComputedRef<string>;
   effectiveScript: ComputedRef<MulmoScript>;
   /** Persist the saved script back into the parent's toolResult so the
@@ -38,6 +54,18 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
 
   let deckSaveTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingDeckScript: MulmoScript | null = null;
+
+  /**
+   * The last save that failed, in the server's own words — or null.
+   *
+   * A failed save leaves the editor showing the user's edit (see `flushDeckSave`), which is
+   * right for a transient failure and indistinguishable from success without this: #3070 was
+   * filed after edits that only reverted on the next reload. Cleared by the next SUCCESSFUL
+   * save, not by the next keystroke — clearing on edit blanks the message for the debounce
+   * window and then brings it back, and an edit that is still unsaved has not stopped being
+   * unsaved.
+   */
+  const deckSaveError: Ref<string | null> = ref(null);
 
   function scheduleDeckSave(next: MulmoScript): void {
     pendingDeckScript = next;
@@ -54,12 +82,14 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     if (!next || !filePath.value) return;
     const response = await api.call("updateScript", { filePath: filePath.value, script: next, origin: EDITOR_ORIGIN });
     if (!response.ok) {
-      // Surface via console; the deck editor still holds the latest edit in
-      // its props until the next refresh, so the view doesn't snap back on a
-      // transient failure. A full toast UI is P2.
+      // The deck editor still holds the latest edit in its props until the next refresh, so
+      // the view doesn't snap back on a transient failure — which is why the failure has to be
+      // said out loud (#3070). Console too: it is where the existing bug reports start.
+      deckSaveError.value = response.error;
       console.error("[presentMulmoScript] deck save failed:", response.error);
       return;
     }
+    deckSaveError.value = null;
     commitScript(next);
   }
 
@@ -97,5 +127,5 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     });
   }
 
-  return { canEditBeats, deckScriptInput, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
+  return { canEditBeats, deckScriptInput, deckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
 }

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -68,17 +68,20 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
   const deckSaveError: Ref<string | null> = ref(null);
 
   /**
-   * Which save is the current one.
+   * Which edit the in-flight save is answering for.
    *
-   * Two writes can be in flight at once: the debounce only spaces their STARTS 300ms apart, and
-   * the failing kind is the slow kind — a timeout costs the whole budget. If the older one
-   * answers last, its answer wins: a red banner over a save that actually landed, or the older
-   * script committed over the newer one. Only the newest save's answer is acted on.
+   * Advanced when an edit is QUEUED, not when its save is dispatched — those are up to 300ms
+   * apart, and a write can outlive the gap (the failing kind is the slow kind: a timeout costs
+   * the whole budget). An answer about superseded content must not be acted on either way
+   * round: committing it puts the older script back over what the user is typing, and its
+   * verdict is about text that is no longer on screen — a green light for an edit that never
+   * reached the server, or a red banner for one already replaced.
    */
-  let latestSaveId = 0;
+  let editRevision = 0;
 
   function scheduleDeckSave(next: MulmoScript): void {
     pendingDeckScript = next;
+    editRevision += 1;
     if (deckSaveTimer) clearTimeout(deckSaveTimer);
     deckSaveTimer = setTimeout(() => {
       void flushDeckSave();
@@ -90,9 +93,9 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     const next = pendingDeckScript;
     pendingDeckScript = null;
     if (!next || !filePath.value) return;
-    const saveId = ++latestSaveId;
+    const revision = editRevision;
     const response = await api.call("updateScript", { filePath: filePath.value, script: next, origin: EDITOR_ORIGIN });
-    if (saveId !== latestSaveId) return;
+    if (revision !== editRevision) return;
     if (!response.ok) {
       // The deck editor still holds the latest edit in its props until the next refresh, so
       // the view doesn't snap back on a transient failure — which is why the failure has to be
@@ -139,5 +142,18 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     });
   }
 
-  return { canEditBeats, deckScriptInput, deckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
+  /**
+   * Forget a failed save — the View has moved to a different script, or this one was written
+   * whole by another route.
+   *
+   * Without it the banner outlives what it is about: this View re-initializes in place on a
+   * result switch rather than remounting (`watch(() => props.selectedResult, initializeScript)`),
+   * so the message would sit over someone else's deck. The per-beat errors beside it are reset
+   * the same way, in the same function.
+   */
+  function clearDeckSaveError(): void {
+    deckSaveError.value = null;
+  }
+
+  return { canEditBeats, deckScriptInput, deckSaveError, clearDeckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
 }

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -67,6 +67,16 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
    */
   const deckSaveError: Ref<string | null> = ref(null);
 
+  /**
+   * Which save is the current one.
+   *
+   * Two writes can be in flight at once: the debounce only spaces their STARTS 300ms apart, and
+   * the failing kind is the slow kind — a timeout costs the whole budget. If the older one
+   * answers last, its answer wins: a red banner over a save that actually landed, or the older
+   * script committed over the newer one. Only the newest save's answer is acted on.
+   */
+  let latestSaveId = 0;
+
   function scheduleDeckSave(next: MulmoScript): void {
     pendingDeckScript = next;
     if (deckSaveTimer) clearTimeout(deckSaveTimer);
@@ -80,7 +90,9 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     const next = pendingDeckScript;
     pendingDeckScript = null;
     if (!next || !filePath.value) return;
+    const saveId = ++latestSaveId;
     const response = await api.call("updateScript", { filePath: filePath.value, script: next, origin: EDITOR_ORIGIN });
+    if (saveId !== latestSaveId) return;
     if (!response.ok) {
       // The deck editor still holds the latest edit in its props until the next refresh, so
       // the view doesn't snap back on a transient failure — which is why the failure has to be

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -143,17 +143,28 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
   }
 
   /**
-   * Forget a failed save — the View has moved to a different script, or this one was written
-   * whole by another route.
+   * The script this composable was editing is gone — the View moved to a different result, or
+   * this one was rewritten whole by another route.
    *
-   * Without it the banner outlives what it is about: this View re-initializes in place on a
-   * result switch rather than remounting (`watch(() => props.selectedResult, initializeScript)`),
-   * so the message would sit over someone else's deck. The per-beat errors beside it are reset
-   * the same way, in the same function.
+   * Clearing the banner is not enough, because this View re-initializes in place rather than
+   * remounting (`watch(() => props.selectedResult, initializeScript)`), so everything the old
+   * script left behind survives the switch and lands on the new one:
+   *
+   * - an answer still IN FLIGHT would repopulate the banner, or commit the old script into the
+   *   new result — its revision is still current, since no new edit has been queued;
+   * - an edit still QUEUED would be written out by its own timer against `filePath.value`,
+   *   which by then names the NEW file. That one writes one deck's beats into another deck.
+   *
+   * So the revision advances (every in-flight answer becomes stale) and the queue is dropped.
+   * The per-beat errors beside this are reset the same way, in the same function.
    */
-  function clearDeckSaveError(): void {
+  function resetForScriptChange(): void {
+    if (deckSaveTimer) clearTimeout(deckSaveTimer);
+    deckSaveTimer = null;
+    pendingDeckScript = null;
+    editRevision += 1;
     deckSaveError.value = null;
   }
 
-  return { canEditBeats, deckScriptInput, deckSaveError, clearDeckSaveError, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
+  return { canEditBeats, deckScriptInput, deckSaveError, resetForScriptChange, onDeckUpdate, flushPendingDeckSave, watchForeignWrites };
 }

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -60,10 +60,11 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
    *
    * A failed save leaves the editor showing the user's edit (see `flushDeckSave`), which is
    * right for a transient failure and indistinguishable from success without this: #3070 was
-   * filed after edits that only reverted on the next reload. Cleared by the next SUCCESSFUL
-   * save, not by the next keystroke — clearing on edit blanks the message for the debounce
-   * window and then brings it back, and an edit that is still unsaved has not stopped being
-   * unsaved.
+   * filed after edits that only reverted on the next reload. Within one script the only thing
+   * that clears it is the next SUCCESSFUL save — never the next keystroke, which would blank
+   * the message for the debounce window and then bring it back, and an edit that is still
+   * unsaved has not stopped being unsaved. Leaving the script clears it too, for a different
+   * reason: see `resetForScriptChange`.
    */
   const deckSaveError: Ref<string | null> = ref(null);
 

--- a/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
@@ -99,6 +99,70 @@ describe("a deck save that failed", () => {
   });
 });
 
+describe("two saves in flight at once", () => {
+  /**
+   * The debounce spaces the STARTS of two writes 300ms apart, not their answers — and the
+   * failing kind is the slow kind. An older answer arriving last must not overwrite a newer one,
+   * or a save that landed shows a red banner over it.
+   */
+  function overlappingHarness() {
+    const script: MulmoScript = { title: "deck", beats: [{ text: "one" }] };
+    const committed: MulmoScript[] = [];
+    const pending: ((outcome: SaveOutcome) => void)[] = [];
+
+    const api: DeckEditorTransport = {
+      call: () => new Promise<SaveOutcome>((resolve) => pending.push(resolve)),
+      onScriptChanged: () => () => {},
+    };
+
+    const editor = useDeckEditor({
+      api,
+      filePath: computed(() => "stories/deck/launch.json"),
+      effectiveScript: computed(() => script),
+      commitScript: (next) => committed.push(next),
+    });
+
+    function startSave(title: string): void {
+      editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
+      editor.flushPendingDeckSave();
+    }
+
+    async function answer(index: number, outcome: SaveOutcome): Promise<void> {
+      const resolve = pending[index];
+      assert.ok(resolve, `save ${index} is in flight`);
+      resolve(outcome);
+      await new Promise((settled) => setImmediate(settled));
+    }
+
+    return { ...editor, startSave, answer, committed, inFlight: () => pending.length };
+  }
+
+  it("ignores the older save's failure when the newer one already succeeded", async () => {
+    const { deckSaveError, startSave, answer, committed, inFlight } = overlappingHarness();
+    startSave("first");
+    startSave("second");
+    assert.equal(inFlight(), 2);
+    await answer(1, OK);
+    assert.equal(deckSaveError.value, null);
+    await answer(0, failedWith("ETIMEDOUT"));
+    assert.equal(deckSaveError.value, null, "a save that landed does not get a red banner over it");
+    assert.deepEqual(
+      committed.map((script) => script.title),
+      ["second"],
+    );
+  });
+
+  it("ignores the older save's success when the newer one already failed", async () => {
+    const { deckSaveError, startSave, answer, committed } = overlappingHarness();
+    startSave("first");
+    startSave("second");
+    await answer(1, failedWith("EACCES: permission denied"));
+    await answer(0, OK);
+    assert.equal(deckSaveError.value, "EACCES: permission denied");
+    assert.deepEqual(committed, []);
+  });
+});
+
 describe("a deck save that succeeds", () => {
   it("never puts a message on screen", async () => {
     const { deckSaveError, edit, committed, sentTitles } = harness([OK, OK]);

--- a/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
@@ -58,6 +58,75 @@ function harness(outcomes: SaveOutcome[]) {
   return { ...editor, edit, settle, committed, sentTitles };
 }
 
+/**
+ * A harness whose saves are answered by hand, so a test can build an interleaving.
+ *
+ * The debounce spaces the STARTS of two writes 300ms apart, not their answers — and the failing
+ * kind is the slow kind. An older answer arriving last must not overwrite a newer one, or a save
+ * that landed shows a red banner over it.
+ */
+function overlappingHarness() {
+  const script: MulmoScript = { title: "deck", beats: [{ text: "one" }] };
+  const committed: MulmoScript[] = [];
+  const pending: ((outcome: SaveOutcome) => void)[] = [];
+
+  const api: DeckEditorTransport = {
+    call: () => new Promise<SaveOutcome>((resolve) => pending.push(resolve)),
+    onScriptChanged: () => () => {},
+  };
+
+  const editor = useDeckEditor({
+    api,
+    filePath: computed(() => "stories/deck/launch.json"),
+    effectiveScript: computed(() => script),
+    commitScript: (next) => committed.push(next),
+  });
+
+  function startSave(title: string): void {
+    queueEdit(title);
+    editor.flushPendingDeckSave();
+  }
+
+  /** An edit sitting in the 300ms debounce: queued, no request sent. */
+  function queueEdit(title: string): void {
+    editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
+  }
+
+  /**
+   * Answer one in-flight save.
+   *
+   * Answering the same one twice is refused rather than ignored: resolving a settled promise
+   * is a silent no-op, so a test that did it would assert against a branch it never reached
+   * and pass (Codex P3, round 2).
+   */
+  const answered = new Set<number>();
+  async function answer(index: number, outcome: SaveOutcome): Promise<void> {
+    const resolve = pending[index];
+    assert.ok(resolve, `save ${index} is in flight`);
+    assert.ok(!answered.has(index), `save ${index} has not been answered yet`);
+    answered.add(index);
+    resolve(outcome);
+    await new Promise((settled) => setImmediate(settled));
+  }
+
+  return { ...editor, startSave, queueEdit, answer, committed, inFlight: () => pending.length };
+}
+
+it("ignores the older save's failure when the newer one already succeeded", async () => {
+  const { deckSaveError, startSave, answer, committed, inFlight } = overlappingHarness();
+  startSave("first");
+  startSave("second");
+  assert.equal(inFlight(), 2);
+  await answer(1, OK);
+  assert.equal(deckSaveError.value, null);
+  await answer(0, failedWith("ETIMEDOUT"));
+  assert.equal(deckSaveError.value, null, "a save that landed does not get a red banner over it");
+  assert.deepEqual(
+    committed.map((script) => script.title),
+    ["second"],
+  );
+});
+
 describe("a deck save that failed", () => {
   it("starts with nothing to report", () => {
     const { deckSaveError } = harness([]);
@@ -100,73 +169,6 @@ describe("a deck save that failed", () => {
 });
 
 describe("two saves in flight at once", () => {
-  /**
-   * The debounce spaces the STARTS of two writes 300ms apart, not their answers — and the
-   * failing kind is the slow kind. An older answer arriving last must not overwrite a newer one,
-   * or a save that landed shows a red banner over it.
-   */
-  function overlappingHarness() {
-    const script: MulmoScript = { title: "deck", beats: [{ text: "one" }] };
-    const committed: MulmoScript[] = [];
-    const pending: ((outcome: SaveOutcome) => void)[] = [];
-
-    const api: DeckEditorTransport = {
-      call: () => new Promise<SaveOutcome>((resolve) => pending.push(resolve)),
-      onScriptChanged: () => () => {},
-    };
-
-    const editor = useDeckEditor({
-      api,
-      filePath: computed(() => "stories/deck/launch.json"),
-      effectiveScript: computed(() => script),
-      commitScript: (next) => committed.push(next),
-    });
-
-    function startSave(title: string): void {
-      queueEdit(title);
-      editor.flushPendingDeckSave();
-    }
-
-    /** An edit sitting in the 300ms debounce: queued, no request sent. */
-    function queueEdit(title: string): void {
-      editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
-    }
-
-    /**
-     * Answer one in-flight save.
-     *
-     * Answering the same one twice is refused rather than ignored: resolving a settled promise
-     * is a silent no-op, so a test that did it would assert against a branch it never reached
-     * and pass (Codex P3, round 2).
-     */
-    const answered = new Set<number>();
-    async function answer(index: number, outcome: SaveOutcome): Promise<void> {
-      const resolve = pending[index];
-      assert.ok(resolve, `save ${index} is in flight`);
-      assert.ok(!answered.has(index), `save ${index} has not been answered yet`);
-      answered.add(index);
-      resolve(outcome);
-      await new Promise((settled) => setImmediate(settled));
-    }
-
-    return { ...editor, startSave, queueEdit, answer, committed, inFlight: () => pending.length };
-  }
-
-  it("ignores the older save's failure when the newer one already succeeded", async () => {
-    const { deckSaveError, startSave, answer, committed, inFlight } = overlappingHarness();
-    startSave("first");
-    startSave("second");
-    assert.equal(inFlight(), 2);
-    await answer(1, OK);
-    assert.equal(deckSaveError.value, null);
-    await answer(0, failedWith("ETIMEDOUT"));
-    assert.equal(deckSaveError.value, null, "a save that landed does not get a red banner over it");
-    assert.deepEqual(
-      committed.map((script) => script.title),
-      ["second"],
-    );
-  });
-
   it("does not commit an in-flight save once a newer edit is merely QUEUED — it has not been dispatched yet", async () => {
     const { startSave, queueEdit, answer, committed } = overlappingHarness();
     startSave("first");
@@ -207,11 +209,34 @@ describe("a deck save that succeeds", () => {
 
 describe("moving to a different script", () => {
   it("forgets the failure — the banner must not sit over someone else's deck", async () => {
-    const { deckSaveError, clearDeckSaveError, edit } = harness([failedWith("File not found")]);
+    const { deckSaveError, resetForScriptChange, edit } = harness([failedWith("File not found")]);
     await edit("renamed");
     assert.equal(deckSaveError.value, "File not found");
-    clearDeckSaveError();
+    resetForScriptChange();
     assert.equal(deckSaveError.value, null);
+  });
+
+  it("ignores an answer that was already in flight — it is about the script that is gone", async () => {
+    const { deckSaveError, resetForScriptChange, startSave, answer, committed } = overlappingHarness();
+    startSave("first");
+    resetForScriptChange();
+    await answer(0, failedWith("File not found"));
+    assert.equal(deckSaveError.value, null, "no banner from the previous script's save");
+
+    const second = overlappingHarness();
+    second.startSave("first");
+    second.resetForScriptChange();
+    await second.answer(0, OK);
+    assert.deepEqual(second.committed, [], "and the old script is not committed into the new result");
+    assert.deepEqual(committed, []);
+  });
+
+  it("drops an edit that was only queued — its timer would write it to the NEW file path", async () => {
+    const { resetForScriptChange, queueEdit, flushPendingDeckSave, inFlight } = overlappingHarness();
+    queueEdit("typed just before switching");
+    resetForScriptChange();
+    flushPendingDeckSave();
+    assert.equal(inFlight(), 0, "nothing may be written out for the script that is gone");
   });
 });
 
@@ -227,11 +252,11 @@ describe("the View's save-failure banner", () => {
   });
 
   it("resets the failure in initializeScript, beside the per-beat errors it already resets", () => {
-    assert.match(viewSource, /const \{[^}]*\bclearDeckSaveError\b[^}]*\} = useDeckEditor\(/);
+    assert.match(viewSource, /const \{[^}]*\bresetForScriptChange\b[^}]*\} = useDeckEditor\(/);
     const initialize = /async function initializeScript\(\)[\s\S]*?\n {2}await refreshScriptFromDisk\(\);/.exec(viewSource);
     assert.ok(initialize, "initializeScript is found");
     assert.match(initialize[0], /beatSaveErrors,/);
-    assert.match(initialize[0], /clearDeckSaveError\(\);/);
+    assert.match(initialize[0], /resetForScriptChange\(\);/);
   });
 
   it("renders it as an alert carrying the server's message", () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
@@ -123,18 +123,24 @@ describe("two saves in flight at once", () => {
     });
 
     function startSave(title: string): void {
-      editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
+      queueEdit(title);
       editor.flushPendingDeckSave();
     }
 
-    async function answer(index: number, outcome: SaveOutcome): Promise<void> {
+    /** An edit sitting in the 300ms debounce: queued, no request sent. */
+    function queueEdit(title: string): void {
+      editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
+    }
+
+    async function answer(index: number, outcome: SaveOutcome, options?: { alreadyAnswered: boolean }): Promise<void> {
       const resolve = pending[index];
       assert.ok(resolve, `save ${index} is in flight`);
+      assert.ok(options?.alreadyAnswered !== true || index === 0, "only the first save is answered twice");
       resolve(outcome);
       await new Promise((settled) => setImmediate(settled));
     }
 
-    return { ...editor, startSave, answer, committed, inFlight: () => pending.length };
+    return { ...editor, startSave, queueEdit, answer, committed, inFlight: () => pending.length };
   }
 
   it("ignores the older save's failure when the newer one already succeeded", async () => {
@@ -150,6 +156,16 @@ describe("two saves in flight at once", () => {
       committed.map((script) => script.title),
       ["second"],
     );
+  });
+
+  it("ignores an in-flight save once a newer edit is merely QUEUED — it has not been dispatched yet", async () => {
+    const { deckSaveError, startSave, queueEdit, answer, committed } = overlappingHarness();
+    startSave("first");
+    queueEdit("second");
+    await answer(0, OK);
+    assert.deepEqual(committed, [], "the older script must not be put back over what the user is typing");
+    await answer(0, failedWith("File not found"), { alreadyAnswered: true });
+    assert.equal(deckSaveError.value, null, "and its verdict is about text that is no longer on screen");
   });
 
   it("ignores the older save's success when the newer one already failed", async () => {
@@ -174,6 +190,16 @@ describe("a deck save that succeeds", () => {
   });
 });
 
+describe("moving to a different script", () => {
+  it("forgets the failure — the banner must not sit over someone else's deck", async () => {
+    const { deckSaveError, clearDeckSaveError, edit } = harness([failedWith("File not found")]);
+    await edit("renamed");
+    assert.equal(deckSaveError.value, "File not found");
+    clearDeckSaveError();
+    assert.equal(deckSaveError.value, null);
+  });
+});
+
 /**
  * The View is where the message becomes visible. Read from source rather than mounted: mounting
  * it needs a gui-chat-protocol runtime, a transport and a host adapter to assert one element.
@@ -183,6 +209,14 @@ describe("the View's save-failure banner", () => {
 
   it("takes deckSaveError off the composable", () => {
     assert.match(viewSource, /const \{[^}]*\bdeckSaveError\b[^}]*\} = useDeckEditor\(/);
+  });
+
+  it("resets the failure in initializeScript, beside the per-beat errors it already resets", () => {
+    assert.match(viewSource, /const \{[^}]*\bclearDeckSaveError\b[^}]*\} = useDeckEditor\(/);
+    const initialize = /async function initializeScript\(\)[\s\S]*?\n {2}await refreshScriptFromDisk\(\);/.exec(viewSource);
+    assert.ok(initialize, "initializeScript is found");
+    assert.match(initialize[0], /beatSaveErrors,/);
+    assert.match(initialize[0], /clearDeckSaveError\(\);/);
   });
 
   it("renders it as an alert carrying the server's message", () => {

--- a/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
@@ -1,0 +1,136 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { computed } from "vue";
+import { useDeckEditor, type DeckEditorTransport } from "../src/vue/composables/useDeckEditor";
+import type { TransportResult } from "../src/vue/transport";
+import type { MulmoScript } from "../src/vue/viewTypes";
+
+/**
+ * A deck save that fails has to say so (#3070).
+ *
+ * The editor keeps showing the user's edit whether the write landed or not — deliberately, so a
+ * transient failure doesn't eat keystrokes. That makes "saved" and "silently refused" look
+ * identical on screen until the next reload puts the old value back, which is how edits were
+ * lost. What is pinned here is the lifecycle of the message, not its wording.
+ */
+
+type SaveOutcome = TransportResult<Record<string, never>>;
+const OK: SaveOutcome = { ok: true, data: {} };
+const failedWith = (error: string): SaveOutcome => ({ ok: false, error });
+
+/** The debounce is 300ms; every test drives `flushPendingDeckSave` rather than waiting it out. */
+function harness(outcomes: SaveOutcome[]) {
+  const script: MulmoScript = { title: "deck", beats: [{ text: "one" }] };
+  const committed: MulmoScript[] = [];
+  const sentTitles: (string | undefined)[] = [];
+
+  const api: DeckEditorTransport = {
+    call: async (_kind, args) => {
+      sentTitles.push(args.script.title);
+      const outcome = outcomes.shift();
+      assert.ok(outcome, "the test queued an outcome for every save it lets fly");
+      return outcome;
+    },
+    onScriptChanged: () => () => {},
+  };
+
+  const editor = useDeckEditor({
+    api,
+    filePath: computed(() => "stories/deck/launch.json"),
+    effectiveScript: computed(() => script),
+    commitScript: (next) => committed.push(next),
+  });
+
+  /** Let any armed debounce fire and the write settle. `setImmediate` runs after microtasks. */
+  async function settle(): Promise<void> {
+    editor.flushPendingDeckSave();
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
+  async function edit(title: string): Promise<void> {
+    editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
+    await settle();
+  }
+
+  return { ...editor, edit, settle, committed, sentTitles };
+}
+
+describe("a deck save that failed", () => {
+  it("starts with nothing to report", () => {
+    const { deckSaveError } = harness([]);
+    assert.equal(deckSaveError.value, null);
+  });
+
+  it("keeps the server's own words, and does not commit the edit", async () => {
+    const { deckSaveError, edit, committed } = harness([failedWith("File not found: stories/deck/launch.json")]);
+    await edit("renamed");
+    assert.equal(deckSaveError.value, "File not found: stories/deck/launch.json");
+    assert.deepEqual(committed, []);
+  });
+
+  it("stays put while the next edit is only pending — an unsaved edit has not become saved", async () => {
+    const { deckSaveError, onDeckUpdate, edit, settle } = harness([failedWith("EACCES: permission denied"), OK]);
+    await edit("renamed");
+    onDeckUpdate({ title: "renamed again" });
+    assert.equal(deckSaveError.value, "EACCES: permission denied");
+    await settle();
+  });
+
+  it("clears once a save actually lands, and that one commits", async () => {
+    const { deckSaveError, edit, committed } = harness([failedWith("File not found"), OK]);
+    await edit("renamed");
+    assert.equal(deckSaveError.value, "File not found");
+    await edit("renamed again");
+    assert.equal(deckSaveError.value, null);
+    assert.deepEqual(
+      committed.map((script) => script.title),
+      ["renamed again"],
+    );
+  });
+
+  it("is replaced, not added to, when a second save fails differently", async () => {
+    const { deckSaveError, edit } = harness([failedWith("File not found"), failedWith("ETIMEDOUT")]);
+    await edit("renamed");
+    await edit("renamed again");
+    assert.equal(deckSaveError.value, "ETIMEDOUT");
+  });
+});
+
+describe("a deck save that succeeds", () => {
+  it("never puts a message on screen", async () => {
+    const { deckSaveError, edit, committed, sentTitles } = harness([OK, OK]);
+    await edit("one");
+    await edit("two");
+    assert.equal(deckSaveError.value, null);
+    assert.deepEqual(sentTitles, ["one", "two"]);
+    assert.equal(committed.length, 2);
+  });
+});
+
+/**
+ * The View is where the message becomes visible. Read from source rather than mounted: mounting
+ * it needs a gui-chat-protocol runtime, a transport and a host adapter to assert one element.
+ */
+describe("the View's save-failure banner", () => {
+  const viewSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "src", "vue", "View.vue"), "utf-8");
+
+  it("takes deckSaveError off the composable", () => {
+    assert.match(viewSource, /const \{[^}]*\bdeckSaveError\b[^}]*\} = useDeckEditor\(/);
+  });
+
+  it("renders it as an alert carrying the server's message", () => {
+    assert.match(viewSource, /data-testid="mulmo-script-deck-save-error"/);
+    assert.match(viewSource, /v-if="deckSaveError"/);
+    assert.match(viewSource, /m\.saveErrorSaveFailed\(deckSaveError\)/);
+  });
+
+  it("is not gated on the Edit pane — switching tabs does not make the edit saved", () => {
+    const banner = /<div\s+v-if="deckSaveError"[\s\S]*?<\/div>/.exec(viewSource);
+    assert.ok(banner, "the banner block is found");
+    assert.doesNotMatch(banner[0], /showBeatEditor|beatPane/);
+    assert.match(banner[0], /role="alert"/);
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
@@ -132,10 +132,19 @@ describe("two saves in flight at once", () => {
       editor.onDeckUpdate({ title, beats: [{ text: "one" }] });
     }
 
-    async function answer(index: number, outcome: SaveOutcome, options?: { alreadyAnswered: boolean }): Promise<void> {
+    /**
+     * Answer one in-flight save.
+     *
+     * Answering the same one twice is refused rather than ignored: resolving a settled promise
+     * is a silent no-op, so a test that did it would assert against a branch it never reached
+     * and pass (Codex P3, round 2).
+     */
+    const answered = new Set<number>();
+    async function answer(index: number, outcome: SaveOutcome): Promise<void> {
       const resolve = pending[index];
       assert.ok(resolve, `save ${index} is in flight`);
-      assert.ok(options?.alreadyAnswered !== true || index === 0, "only the first save is answered twice");
+      assert.ok(!answered.has(index), `save ${index} has not been answered yet`);
+      answered.add(index);
       resolve(outcome);
       await new Promise((settled) => setImmediate(settled));
     }
@@ -158,14 +167,20 @@ describe("two saves in flight at once", () => {
     );
   });
 
-  it("ignores an in-flight save once a newer edit is merely QUEUED — it has not been dispatched yet", async () => {
-    const { deckSaveError, startSave, queueEdit, answer, committed } = overlappingHarness();
+  it("does not commit an in-flight save once a newer edit is merely QUEUED — it has not been dispatched yet", async () => {
+    const { startSave, queueEdit, answer, committed } = overlappingHarness();
     startSave("first");
     queueEdit("second");
     await answer(0, OK);
     assert.deepEqual(committed, [], "the older script must not be put back over what the user is typing");
-    await answer(0, failedWith("File not found"), { alreadyAnswered: true });
-    assert.equal(deckSaveError.value, null, "and its verdict is about text that is no longer on screen");
+  });
+
+  it("does not show the failure of an in-flight save once a newer edit is merely QUEUED", async () => {
+    const { deckSaveError, startSave, queueEdit, answer } = overlappingHarness();
+    startSave("first");
+    queueEdit("second");
+    await answer(0, failedWith("File not found"));
+    assert.equal(deckSaveError.value, null, "the verdict is about text that is no longer on screen");
   });
 
   it("ignores the older save's success when the newer one already failed", async () => {

--- a/plans/fix-3070-deck-save-error-visible.md
+++ b/plans/fix-3070-deck-save-error-visible.md
@@ -15,7 +15,7 @@ Canvas の Deck editor（Edit タブ）で保存が失敗しても、**画面に
 ```ts
 if (!response.ok) {
   console.error("[presentMulmoScript] deck save failed:", response.error);
-  return;   // ← 画面に伝える経路が無い
+  return; // ← 画面に伝える経路が無い
 }
 ```
 
@@ -33,15 +33,27 @@ Media タブの既存の扱い（ビート保存の失敗はそのビートに�
    - 失敗 → `deckSaveError.value = response.error`（`TransportResult` の失敗側は必ず `error: string`）
    - 成功 → `null` にクリアしてから `commitScript`
    - console.error は残す（既存の調査導線）
+   - **応答は「今の編集」のものだけ採用する**（`editRevision`）。debounce が 300ms 空けるのは
+     write の**開始**であって応答ではなく、失敗する write は遅い（タイムアウトは予算を丸ごと使う）。
+     revision は保存を投げたときではなく**編集をキューに入れたとき**に進める —— その2点は最大 300ms
+     離れていて、その隙間を write が生き延びる。古い内容についての応答は、通ったなら画面で打っている
+     テキストの上に古い script を commit し、落ちたならもう画面に無いテキストについて赤を出す。
+   - **別の script に移ったら忘れる**（`clearDeckSaveError()`）。この View は result 切替で
+     remount せずその場で再初期化する（`watch(() => props.selectedResult, initializeScript)`）ので、
+     残したままだと他人のデッキの上にメッセージが居座る。`beatSaveErrors` と同じ関数で同じ理由でリセット。
 2. `View.vue` のタブ行直下に赤いバナーを出す。文言は既存の i18n キー
    `m.saveErrorSaveFailed(error)`（「⚠ Save failed: …」）を再利用 —— 新しいキーは足さない。
    - `role="alert"`、`data-testid="mulmo-script-deck-save-error"`
    - `v-if="deckSaveError"` だけで足りる（デッキ保存を試みない限り non-null にならない）。
      Edit タブから離れても消えないのは意図どおり —— 保存されていない事実は変わらない。
 
-**クリアの条件は「次の保存成功」だけ**にする。編集のたびに消すと、再保存が飛ぶ 300ms の間だけ
-バナーが消えて点滅し、しかも次も失敗すれば戻ってくる。失敗したまま放置された編集が
-見えている方が正しい。
+**編集ではクリアしない。** 消えるのは「次の保存が成功したとき」と「別の script に移ったとき」の
+2つだけ。編集のたびに消すと、再保存が飛ぶ 300ms の間だけバナーが消えて点滅し、しかも次も失敗すれば
+戻ってくる。失敗したまま放置された編集が見えている方が正しい。
+
+**foreign write でのリロードでは消さない。** agent などが同じファイルを書いて画面が disk の内容に
+入れ替わるとき、ユーザーの編集は確実に失われている。バナーはその唯一の痕跡なので残す
+（消すと #3070 の「黙って消える」が狭い形で戻る）。
 
 ## テスト
 
@@ -52,8 +64,13 @@ Media タブの既存の扱い（ビート保存の失敗はそのビートに�
 - 続けて成功 → `deckSaveError` が null に戻り、`commitScript` が呼ばれる
 - 成功のみ → 一度も non-null にならない
 - 失敗の後に編集をスケジュールしただけでは消えない（点滅防止の意図を固定する）
+- 2回目の失敗は文言が**置き換わる**（積み上がらない）
+- **2本同時飛び**（deferred promise で順序を作る）: 新しい方が成功 → 古い方が後から失敗しても
+  バナーは出ない / 新しい方が失敗 → 古い方が後から成功しても commit しない
+- **debounce 中にキューされただけの編集**でも、飛んでいる古い保存の応答は捨てる
+- `clearDeckSaveError()` で消える
 
-View 側は `data-testid` と `deckSaveError` の結線をソース読み取りで検証
+View 側は `data-testid` と `deckSaveError` / `clearDeckSaveError` の結線をソース読み取りで検証
 （`test_beatPaneDefault.ts` と同じ手法 —— View を mount するにはランタイム一式が要る）。
 
 ## バージョン

--- a/plans/fix-3070-deck-save-error-visible.md
+++ b/plans/fix-3070-deck-save-error-visible.md
@@ -68,6 +68,8 @@ Media タブの既存の扱い（ビート保存の失敗はそのビートに�
 - **2本同時飛び**（deferred promise で順序を作る）: 新しい方が成功 → 古い方が後から失敗しても
   バナーは出ない / 新しい方が失敗 → 古い方が後から成功しても commit しない
 - **debounce 中にキューされただけの編集**でも、飛んでいる古い保存の応答は捨てる
+  （成功を commit しない / 失敗をバナーに出さない、を別々のケースで —— 1つの promise を
+  2度 resolve しても no-op なので、まとめると失敗側が何も見ないテストになる）
 - `clearDeckSaveError()` で消える
 
 View 側は `data-testid` と `deckSaveError` / `clearDeckSaveError` の結線をソース読み取りで検証

--- a/plans/fix-3070-deck-save-error-visible.md
+++ b/plans/fix-3070-deck-save-error-visible.md
@@ -38,9 +38,14 @@ Media タブの既存の扱い（ビート保存の失敗はそのビートに�
      revision は保存を投げたときではなく**編集をキューに入れたとき**に進める —— その2点は最大 300ms
      離れていて、その隙間を write が生き延びる。古い内容についての応答は、通ったなら画面で打っている
      テキストの上に古い script を commit し、落ちたならもう画面に無いテキストについて赤を出す。
-   - **別の script に移ったら忘れる**（`clearDeckSaveError()`）。この View は result 切替で
-     remount せずその場で再初期化する（`watch(() => props.selectedResult, initializeScript)`）ので、
-     残したままだと他人のデッキの上にメッセージが居座る。`beatSaveErrors` と同じ関数で同じ理由でリセット。
+   - **別の script に移ったら、その script が残したものを全部捨てる**（`resetForScriptChange()`）。
+     この View は result 切替で remount せずその場で再初期化する
+     （`watch(() => props.selectedResult, initializeScript)`）ので、バナーを消すだけでは足りない:
+     **飛んでいる途中の応答**は（新しい編集がキューされていない以上 revision が現役のままなので）
+     バナーを復活させるか古い script を新しい result に commit するし、**キューされたままの編集**は
+     自分のタイマーで `filePath.value` —— そのときには**新しいファイル**を指している —— に書き出される。
+     なので revision を進め（飛んでいる応答を全部 stale にする）、キューとタイマーを捨てる。
+     `beatSaveErrors` と同じ関数で同じ理由でリセット。
 2. `View.vue` のタブ行直下に赤いバナーを出す。文言は既存の i18n キー
    `m.saveErrorSaveFailed(error)`（「⚠ Save failed: …」）を再利用 —— 新しいキーは足さない。
    - `role="alert"`、`data-testid="mulmo-script-deck-save-error"`
@@ -70,9 +75,11 @@ Media タブの既存の扱い（ビート保存の失敗はそのビートに�
 - **debounce 中にキューされただけの編集**でも、飛んでいる古い保存の応答は捨てる
   （成功を commit しない / 失敗をバナーに出さない、を別々のケースで —— 1つの promise を
   2度 resolve しても no-op なので、まとめると失敗側が何も見ないテストになる）
-- `clearDeckSaveError()` で消える
+- `resetForScriptChange()` で消える
+- script 切替で、**飛んでいる途中の応答**は採用されない（バナーも commit も）
+- script 切替で、**キューされただけの編集**は書き出されない（新しい filePath に書くのを防ぐ）
 
-View 側は `data-testid` と `deckSaveError` / `clearDeckSaveError` の結線をソース読み取りで検証
+View 側は `data-testid` と `deckSaveError` / `resetForScriptChange` の結線をソース読み取りで検証
 （`test_beatPaneDefault.ts` と同じ手法 —— View を mount するにはランタイム一式が要る）。
 
 ## バージョン

--- a/plans/fix-3070-deck-save-error-visible.md
+++ b/plans/fix-3070-deck-save-error-visible.md
@@ -1,0 +1,68 @@
+# デッキ編集の保存失敗を画面に出す (#3070)
+
+## 症状
+
+Canvas の Deck editor（Edit タブ）で保存が失敗しても、**画面には何も出ない**。出るのは
+ブラウザコンソールの `[presentMulmoScript] deck save failed: …` だけ。
+
+入力欄には書き換えた値が残る（editor は props の最新編集を保持し続ける）ので、画面上は
+保存されたように見える。気づくのはリロードして値が戻ってから。
+
+## 原因
+
+`packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts` の `flushDeckSave()`:
+
+```ts
+if (!response.ok) {
+  console.error("[presentMulmoScript] deck save failed:", response.error);
+  return;   // ← 画面に伝える経路が無い
+}
+```
+
+失敗が composable の中で終わっていて、View がそれを知る手段が無い。
+
+なお「スナップバックさせない」設計自体は正しい（一時的な失敗で打鍵を捨てない）。
+だからこそ **失敗が見えない = 成功に見える** という最悪の組み合わせになっている。
+変えるのは可視性だけで、スナップバックしない挙動は変えない。
+
+## 直し方
+
+Media タブの既存の扱い（ビート保存の失敗はそのビートに赤字でサーバ文言を出す）に合わせる。
+
+1. `useDeckEditor` が `deckSaveError: Ref<string | null>` を返す。
+   - 失敗 → `deckSaveError.value = response.error`（`TransportResult` の失敗側は必ず `error: string`）
+   - 成功 → `null` にクリアしてから `commitScript`
+   - console.error は残す（既存の調査導線）
+2. `View.vue` のタブ行直下に赤いバナーを出す。文言は既存の i18n キー
+   `m.saveErrorSaveFailed(error)`（「⚠ Save failed: …」）を再利用 —— 新しいキーは足さない。
+   - `role="alert"`、`data-testid="mulmo-script-deck-save-error"`
+   - `v-if="deckSaveError"` だけで足りる（デッキ保存を試みない限り non-null にならない）。
+     Edit タブから離れても消えないのは意図どおり —— 保存されていない事実は変わらない。
+
+**クリアの条件は「次の保存成功」だけ**にする。編集のたびに消すと、再保存が飛ぶ 300ms の間だけ
+バナーが消えて点滅し、しかも次も失敗すれば戻ってくる。失敗したまま放置された編集が
+見えている方が正しい。
+
+## テスト
+
+`test/test_useDeckEditor.ts` を新規作成（node:test、vue の `computed`/`ref` を直接使う。
+`api` はフェイクを注入するので DOM もランタイムも要らない）。
+
+- 保存失敗 → `deckSaveError` にサーバ文言が入り、`commitScript` は呼ばれない
+- 続けて成功 → `deckSaveError` が null に戻り、`commitScript` が呼ばれる
+- 成功のみ → 一度も non-null にならない
+- 失敗の後に編集をスケジュールしただけでは消えない（点滅防止の意図を固定する）
+
+View 側は `data-testid` と `deckSaveError` の結線をソース読み取りで検証
+（`test_beatPaneDefault.ts` と同じ手法 —— View を mount するにはランタイム一式が要る）。
+
+## バージョン
+
+`@mulmoclaude/mulmoscript-plugin` の bump は publish 時にまとめる（`@mulmoclaude/*` は
+publish 時に決める運用）。
+
+## 関連
+
+- receptron/mulmoterminal#1970 — 報告元（@ystknsh の「考えられるアプローチ」3点目）
+- #3014 — `File not found` になる経路そのもの（別軸・未着手）
+- receptron/mulmoterminal#2036 — MulmoTerminal 側は絶対パスで回避済み


### PR DESCRIPTION
## Summary

Canvas の Deck editor で保存が失敗しても画面に何も出ず、入力欄には書き換えた値が残るため
「保存された」ように見えていた（#3070）。気づくのはリロードして値が戻ってから。

- `useDeckEditor` が `deckSaveError: Ref<string | null>` を持ち、失敗時にサーバの文言をそのまま入れる。
  **編集ではクリアしない** —— 編集のたびに消すと 300ms の debounce 中だけ消えて点滅し、次も失敗すれば
  戻ってくる。消えるのは「次の保存が成功したとき」と「別の script に移ったとき」の2つだけ。
- **応答は「今の編集」のものだけ採用する**（`editRevision`）。revision は保存を投げたときではなく
  **編集をキューに入れたとき**に進める —— その2点は最大 300ms 離れていて、その隙間を write が生き延びる。
- **別の script に移ったら、その script が残したものを全部捨てる**（`resetForScriptChange()` を
  `initializeScript` から呼ぶ）。この View は result 切替で remount せずその場で再初期化するので、
  バナーを消すだけでは足りない —— 飛んでいる途中の応答はバナーを復活させるか古い script を新しい
  result に commit し、キューされたままの編集は自分のタイマーで**新しい filePath** に書き出される。
  revision を進め、キューとタイマーも捨てます。
  foreign write でのリロードでは**消さない**（ユーザーの編集が失われた唯一の痕跡なので）。
- `View.vue` のタブ行直下に赤いバナー（`role="alert"` / `data-testid="mulmo-script-deck-save-error"`）。
  文言は既存の i18n キー `saveErrorSaveFailed`（8ロケール既存）を再利用 —— **新しいキーは足していない**。
- `console.error` は残した。既存のバグ報告はそこから始まっている。
- スナップバックしない挙動（失敗しても打鍵を捨てない）は**変えていない**。変えたのは可視性だけ。

Media タブのビート保存失敗（そのビートに赤字でサーバ文言）と同じ扱いに揃えた形です。

## Items to Confirm / Review

1. **バナーを Edit タブに限定していない** —— `v-if="deckSaveError"` だけで、Media タブに切り替えても
   出たままになります。タブを切り替えても保存されていない事実は変わらないので意図的ですが、
   issue の文面は「Edit タブ」なので、Edit 限定にすべきならそう言ってください。
2. **クリア条件** —— 同じ script の中では「次の保存が成功したとき」だけです。編集しても消えないし、
   閉じるボタンも付けていません。これとは別に、**別の script に移ったとき**は
   `resetForScriptChange()` が消します（バナーだけでなく、飛んでいる応答とキュー済み編集も捨てる）。
3. **foreign write でのリロードではバナーを消していない** —— agent が同じファイルを書いて画面が disk の
   内容に入れ替わるとき、ユーザーの編集は確実に失われていて、バナーはその唯一の痕跡です。消すと
   #3070 の「黙って消える」が狭い形で戻る、と判断しました（Codex もこの理由を ACCEPTED）。
4. **`DeckEditorTransport` の追加** —— `MulmoScriptTransport["call"]` は dispatch kind に対して generic で、
   フェイクを立てるには 17 種全部に答える必要があり、`as` 無しでは書けませんでした。この composable が
   実際に投げる 1 本だけを型として切り出しています（実 transport は構造的に満たすので View 側は無改変）。
   公開 API ではありません（`src/vue/index.ts` から export していない）。
5. **実アプリでの目視は未実施** —— 下の「検証」参照。保存失敗を実アプリで起こすには #3014 の経路を
   再現する必要があり、そこまではやっていません。

## 検証

- `yarn test`（プラグイン）: **388 pass / 0 fail**。うち新規 `test/test_useDeckEditor.ts` が 17 件。
- **fix を戻して赤くなることを確認済み**（6つとも個別に）—— `deckSaveError` への代入2行を消すと4件、
  順序ガードを消すと2件、revision の前進位置を「投げたとき」に戻すと2件、`resetForScriptChange()` の
  呼び出しを消すと1件、その中の revision 前進を消すと1件、キュー/タイマー破棄を消すと1件が落ちる。
  テストが本当にその欠陥を見ているという確認。
- `yarn format` / `eslint`（変更3ファイル）/ `yarn typecheck`（vue-tsc）/ `yarn build`: すべて green。
- **実レンダリング** —— View.vue からバナーの markup をそのまま取り出し、実 Vue コンパイラで
  コンパイルして描画。エラー無し → `<!--v-if-->`（何も出ない）、エラーあり →
  `<div ... role="alert" data-testid="mulmo-script-deck-save-error">⚠ 保存失敗: File not found: …</div>`。
- **Tailwind** —— バナーが使う 11 クラス（`text-red-700` / `break-words` を含む）が
  ビルド後の `dist/style.css` に全て生成されていることを確認。`yarn check:plugin-css` も OK。
- **やっていないこと**: アプリを起動して実際に保存を失敗させる目視確認。上の Items 4 のとおりです。

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/3070 なおせる？

## 関連

- receptron/mulmoterminal#1970 — 報告元（@ystknsh の「考えられるアプローチ」3点目）
- #3014 — `File not found` になる経路そのもの（別軸・未着手）
- receptron/mulmoterminal#2036 — MulmoTerminal 側は絶対パスで回避済み

work in mulmoclaude2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgM174UftqbfGd9Y5kuUwg

## Summary by Sourcery

Make failed deck-editor saves visible without discarding the user’s edits, while ignoring stale save activity across edits and script changes.

New Features:
- Display deck save failures in the MulmoScript view with the server-provided error message and accessible alert markup.

Bug Fixes:
- Prevent stale or cross-script deck-save responses and queued edits from overwriting current content or reporting misleading errors.
- Preserve unsaved edits after a failed save while making the failure visible until a subsequent successful save or script change.

Enhancements:
- Scope deck-save state to the active script and expose a focused transport type for composable testing.

Tests:
- Add coverage for save-error lifecycle, concurrent and stale responses, script changes, queued edits, and View banner wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deck-save failures are now shown directly in the editor as an alert with the server-provided error message.
  * Error messages remain visible until a save succeeds, preventing failed edits from appearing to have been saved.
  * Save errors are displayed in both the edit and media panes.
  * Errors are cleared when switching to another script.
  * Overlapping saves are handled correctly so outdated results do not replace newer save status or content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->