### PR TITLE
feat(shapescript): materials, ranges, functions, arcs and the upstream examples as fixtures (2.1.0)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Added
+
+#### `@mulmoclaude/shapescript-plugin@2.1.0` — materials, ranges, functions and the upstream examples
+
+Phase 2 and the first phase-3 batch of `plans/feat-shapescript-upstream-parity.md`, driven by the
+upstream project's own example scripts, which are now test fixtures
+(`test/fixtures/upstream-examples/`): Ball, Chessboard, Cog, Earth, Spring and Train render, and
+Dodecahedron, Fillet and Spirals are refused with a message naming the missing feature.
+
+- **Materials**: hex (`#F00`, `#FF000080`) and named colours (`red`, `orange`, `gray`, …), `rgb()`
+  / `hsb()`, colour alpha by count (`color 1 0.5`, `color red 0.5`), scoped `opacity` that
+  multiplies through nesting, `metallicity` / `roughness` / `glow` on the PBR material,
+  `material { … }` bundles applied with `material NAME`, `smoothing 0` for flat shading, and
+  `name`. A material command inside a builder block colours the builder's result.
+- **Phase 2**: `background R G B` reaches both viewers; `texture`, a background image, `camera`
+  and `light` are accepted and skipped, and the tool result says so ("Not rendered: …") instead
+  of failing. `print` output is returned with the tool result and shown in the View; `assert`.
+- **Shapes and paths**: `icosphere`, `roundrect { radius }`, `arc { angle }` inside a path,
+  `extrude circle` / `fill roundrect { … }` without a wrapping block, per-shape `detail` /
+  `smoothing`, `size` on builders and groups (an extrude's `size` scales its profile and sets
+  its depth), custom blocks placed and coloured through their call's `position` / `orientation`
+  / `size` / `color` / `material`, lathe profiles drawn on the −X side, and `size 1 2` padded
+  to `1 2 1` as Euclid does (was `1 2 0`, which a cube refused).
+- **Expressions**: bare calls (`max 0 1`, `sqrt 9`, `sin pi / 2`), custom functions
+  (`define hyp(a b) { sqrt(a * a + b * b) }`), ranges as values with `step` and the `in`
+  operator, `split`, negative and named subscripts (`v[-1]`, `v["y"]`), and the `.width/.height/
+  .depth`, `.roll/.yaw/.pitch`, `.hue/.saturation/.brightness` members.
+- Unsupported upstream commands (`import`, `text`, `mesh`, `minkowski`, `inset`, `svgpath`,
+  `along`, shapes as values) are refused by name instead of with a parse error on a brace.
+
+**Behaviour changes** toward upstream: `for` / `if` / `switch` bodies no longer reset transforms
+and materials at their closing brace (only symbols are scoped there, per upstream's scope rules
+— Chessboard depends on it), and a bare `path` at scene level draws as a line rather than a
+filled face (`fill` it for the old result).
+
 ### Changed
 
 #### `@mulmoclaude/shapescript-plugin@2.0.0` — upstream ShapeScript units and path semantics
@@ -162,7 +197,7 @@ the same way.
 An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
 diagnostic `presentShapeScript` returns.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.0.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,8 +40,11 @@ Dodecahedron, Fillet and Spirals are refused with a message naming the missing f
 
 **Behaviour changes** toward upstream: `for` / `if` / `switch` bodies no longer reset transforms
 and materials at their closing brace (only symbols are scoped there, per upstream's scope rules
-— Chessboard depends on it), and a bare `path` at scene level draws as a line rather than a
-filled face (`fill` it for the old result).
+— Chessboard depends on it); a bare `path` at scene level draws as a line rather than a
+filled face (`fill` it for the old result); `extrude` spans ±depth/2 around its profile plane
+as upstream does (it ran 0…depth, which offset the train's running board); and a lathe whose
+profile is drawn top-down is oriented outward (it was inside out, and booleans dropped it —
+the chess queens lost their bodies).
 
 ### Changed
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^2.0.0",
+    "@mulmoclaude/shapescript-plugin": "^2.1.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -60,22 +60,28 @@ USDZ units are metres, so `size 1` is one metre in AR.
 
 ## ShapeScript language
 
-- **Primitives**: `cube`, `sphere`, `cylinder`, `cone`, `torus`, `circle`, `square`, `polygon`
-- **Properties**: `position X Y Z`, `orientation ROLL YAW PITCH` (alias `rotation`), `size X Y Z`, `color R G B` (0–1), `opacity`
+- **Primitives**: `cube`, `sphere`, `icosphere`, `cylinder`, `cone`, `torus`, `circle`, `square`,
+  `roundrect`, `polygon`
+- **Properties**: `position X Y Z`, `orientation ROLL YAW PITCH` (alias `rotation`), `size X Y Z`,
+  `detail`, `smoothing`, `name`
+- **Materials** (as properties or scoped commands): `color`, `opacity`, `metallicity`, `roughness`,
+  `glow`, `material NAME`; `texture` is accepted with a warning
 - **CSG**: `union`, `difference`, `intersection`, `xor`, `stencil`
 - **Builders**: `extrude`, `loft`, `lathe`, `fill`, `hull`
-- **Variables & expressions**: `define`, arithmetic / comparison / boolean operators, parentheses
-- **Control flow**: `for … in … to … step`, `if` / `else`, `switch` / `case`
+- **Variables & expressions**: `define`, arithmetic / comparison / boolean operators, `in`, ranges,
+  parentheses, custom functions
+- **Control flow**: `for … in …`, `if` / `else`, `switch` / `case`
 - **Built-ins**: `round floor ceil abs sign sqrt pow min max`, `sin cos tan asin acos atan atan2`
-  (radians), `dot cross length normalize sum`, `rnd`
-- **Commands**: `detail N`, `seed N` (both scoped to the enclosing block), `color`, and the relative
-  `rotate` / `translate` / `scale`
+  (radians), `dot cross length normalize sum`, `rgb hsb`, `join split trim`, `rnd`
+- **Commands**: `detail N`, `seed N`, `smoothing N`, `background`, `print`, `assert`, and the relative
+  `rotate` / `translate` / `scale`; `camera` / `light` blocks are skipped with a warning
 
-A function call takes **no space** before its parenthesis: `sin(x)` is a call, `sin (x)` is not.
-Arguments are a value list, so upstream's `max(0 (j - 1))` and `max(0, j - 1)` both work; write the
-space-separated form when a script also has to open in the upstream app. Upstream's bare
-`max 0 (j - 1)` (no parentheses) is not supported. This parser also accepts several statements on
-one line (`define a 1 define b 2`); upstream requires one per line, so portable scripts keep to that.
+A call is either C-like, with **no space** before its parenthesis (`sin(x)`; `sin (x)` is not a
+call), or bare, as upstream: `max 0 (j - 1)`, `sqrt 9`, `sin pi / 2` — the function takes every
+value after it, so parenthesise it inside a larger expression: `(sqrt 9) + (sqrt 16)`. Arguments are
+a value list; commas (`max(0, j - 1)`) also work here but not in the upstream app. This parser also
+accepts several statements on one line (`define a 1 define b 2`); upstream requires one per line, so
+portable scripts keep to that.
 
 ## Storage
 
@@ -165,15 +171,60 @@ stencil {
 
 define offsets ((1 2 3), (4 5 6))
 cube { position offsets[0].x offsets[1].y offsets.count }
+
+// Materials, as upstream: hex and named colours, alpha, PBR properties, bundles.
+define brass material {
+    color #d4a017
+    metallicity 1
+    roughness 0.3
+}
+material brass
+sphere
+cube {
+    position 2
+    color red 0.5      // red at 50% alpha
+    glow orange * 0.3  // emissive
+}
+
+// Ranges, the `in` operator, custom functions and bare calls.
+define steps 0 to 1 step 0.25
+define ease(t) { t * t * (3 - 2 * t) }
+for t in steps {
+    if t in 0.25 to 0.75 {
+        cube {
+            position (t * 4) (ease t) 0
+            size max 0.1 (t / 2)
+        }
+    }
+}
+
+// A rounded slab from two arcs, extruded; a bare path draws as a line.
+extrude path {
+    arc { angle -0.5 }
+    point -0.5 0
+    point 1.5 0
+    arc {
+        position 1 0
+        orientation 0.5
+        angle -0.5
+    }
+    curve 0 0.5
+}
 ```
 
 Also supported: `pi`, `tau` (plugin-only; upstream has no `tau`, so portable scripts write `2 * pi`), `true`, `false`, scientific notation, unary `+`,
-short-circuit `and`/`or`, string literals, `join`/`trim`, tuple arguments to `min`/`max`,
-zero-based tuple/string subscripts, `.count`, ordinal members `.first` … `.tenth`, `.last`,
-`.allButFirst`, `.allButLast`, vector `.x/.y/.z/.w`, color
-`.red/.green/.blue/.alpha` (or `.r/.g/.b/.a`), custom shape definitions with options,
-and `polygon { sides N }` (integer 3–256). Lathe samples curved profiles, and inline
-builder paths use the same parser as nested paths, including loops and definitions.
+short-circuit `and`/`or`, string literals, `join`/`split`/`trim`, tuple arguments to `min`/`max`,
+zero-based tuple/string subscripts (negative from the end, or by name: `v["y"]`), `.count`, ordinal
+members `.first` … `.tenth`, `.last`, `.allButFirst`, `.allButLast`, vector `.x/.y/.z/.w`, size
+`.width/.height/.depth`, rotation `.roll/.yaw/.pitch`, color `.red/.green/.blue/.alpha` (or
+`.r/.g/.b/.a`) and `.hue/.saturation/.brightness`, custom shape definitions with options (placed
+and coloured through `position` / `orientation` / `size` / `color` / `material` on the call), and
+`polygon { sides N }` (integer 3–256). Lathe samples curved profiles (drawn on either side of the
+axis), and inline builder paths use the same parser as nested paths, including loops and
+definitions. A `material` command inside a builder block applies to the builder's result, and
+`size` on a builder or group scales it (an extrude's Z is its depth). `print` lines and the
+commands that were skipped come back on the root group's `userData` (`sceneInfoOf(group)`) and in
+the tool result message.
 
 ## Units and path semantics — same as upstream
 
@@ -193,10 +244,18 @@ conventions, so a script written against the upstream docs renders the same here
   3D; `lathe` refuses a placed profile.
 - `rnd` uses upstream's generator (`x = x · 1664525 + 1013904223 mod 2³²`, seed 0) and `seed N`
   reseeds it for the enclosing block only.
+- **Scope** (2.1.0): a shape block, `group`, builder or custom block resets transforms and
+  materials at its closing brace; `for` / `if` / `switch` bodies scope only symbols, so a
+  `translate` inside a loop carries on after it, as upstream's scope rules say.
+- A **bare `path`** draws as a line (2.1.0), as upstream; `fill` / `extrude` / `lathe` / `loft`
+  make a surface or solid of it.
+- `size 1 2` pads to `1 2 1` (Euclid's `Vector(size:)`), so `cylinder { size 1 2 }` is a
+  cylinder of diameter 1 and height 2.
 
 Deviations that remain: an *open* path whose first or last point is a `curve` treats it as a
-corner (upstream extrapolates a tangent), and path points are 2D. The gap list lives in
-[`plans/feat-shapescript-upstream-parity.md`](../../../plans/feat-shapescript-upstream-parity.md).
+corner (upstream extrapolates a tangent), path points are 2D, nested sub-paths (holes) are not
+supported, and `smoothing` is flat (0) or smooth rather than an angle threshold. The gap list
+lives in [`plans/feat-shapescript-upstream-parity.md`](../../../plans/feat-shapescript-upstream-parity.md).
 
 ## Compatibility and limits
 
@@ -206,12 +265,19 @@ upstream ShapeScript**.
 Loft accepts ordered, closed planar sections with one perimeter each, resamples differing
 vertex counts, interpolates linearly, and triangulates the end caps. Sections must enclose
 a volume. Hull accepts geometry from child meshes and filled paths. Primitive profiles
-for fill/extrude must lie in XY; holes, swept/twisted extrusion, and arbitrary 3D path
-commands are not implemented. Imports, textures, text/fonts, lights/camera declarations,
-arbitrary objects, and general user-defined functions remain outside this subset.
-Unsupported commands and failed CSG operations return errors instead of silently
-substituting different geometry. As with other polygonal CSG engines, degenerate or
-self-intersecting inputs may fail.
+for fill/extrude must lie in XY; holes, swept/twisted extrusion (`along`, `twist`), and
+arbitrary 3D path commands are not implemented. `import`, `text` / `font`, raw `mesh`,
+`minkowski`, `inset`, `svgpath`, `object` values, shapes as values (`define s sphere { … }`)
+and functions that build shapes are refused with a message naming the feature. Textures,
+normal maps, `camera` and `light` blocks are accepted and skipped with a warning that the
+tool result and the View both report. Unsupported commands and failed CSG operations return
+errors instead of silently substituting different geometry. As with other polygonal CSG
+engines, degenerate or self-intersecting inputs may fail.
+
+The upstream project's own example scripts are test fixtures
+(`test/fixtures/upstream-examples/`, MIT): Ball, Chessboard, Cog, Earth, Spring and Train render;
+Dodecahedron (mesh values), Fillet (`minkowski` / `inset`) and Spirals (`along`) are refused by
+name.
 
 `rnd` and `rand()` draw from a seeded generator (`randomSeed`, default
 `DEFAULT_RANDOM_SEED` = 0, overridable in-script with `seed`) rather than `Math.random()`:

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -251,6 +251,8 @@ conventions, so a script written against the upstream docs renders the same here
   make a surface or solid of it.
 - `size 1 2` pads to `1 2 1` (Euclid's `Vector(size:)`), so `cylinder { size 1 2 }` is a
   cylinder of diameter 1 and height 2.
+- `extrude` is centred on its profile plane, spanning ±depth/2 (2.1.0; it ran 0…depth
+  before), and a lathe always faces outward whichever way its profile is drawn.
 
 Deviations that remain: an *open* path whose first or last point is a `curve` treats it as a
 corner (upstream extrapolates a tangent), path points are 2D, nested sub-paths (holes) are not

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "presentShapeScript \u2014 interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -71,15 +71,16 @@ else
 Math: round, floor, ceil, abs, sign, sqrt, pow, min, max
 Trig: sin, cos, tan, asin, acos, atan, atan2 (uses radians)
 Vector: dot, cross, length, normalize, sum
+Colour: rgb(r g b [a]), hsb(h s b [a]); strings: join, split, trim
 
-IMPORTANT: Function calls require NO space between name and parenthesis:
-- sin(x) ✓ function call
-- sin (x) ✗ NOT a function call (identifier + parenthesized expression)
-Separate arguments with spaces, as upstream does: max(0 (j - 1)), pow(2.718 (0 - x)). Commas also work
-here (max(0, j - 1)) but NOT in the upstream ShapeScript app, so prefer spaces. Bare max 0 1 without
-parentheses is not supported.
+Two call spellings, both as upstream: C-like max(0 (j - 1)) with NO space before the parenthesis, or the
+bare form max 0 (j - 1) / sqrt 9 / sin pi / 2, where the function takes every value after it. Separate
+arguments with spaces; commas also work here (max(0, j - 1)) but NOT in the upstream ShapeScript app.
+Inside a larger expression parenthesise a bare call: (sqrt 9) + (sqrt 16).
+Custom functions: define hyp(a b) { sqrt(a * a + b * b) } — parameters, optional defines, then the result
+expression; they compute values, not shapes.
 Write ONE statement per line. This parser accepts "define a 1 define b 2" on one line; the upstream app
-rejects it, and a script that keeps to one statement per line opens in both.
+rejects it, and "size 2 1 radius 0.5" on one line reads radius as a fourth size component in both.
 
 Examples:
 for i in 1 to 8 {
@@ -89,14 +90,23 @@ for i in 1 to 8 {
 
 ### Primitives & Properties:
 
-Shapes: cube, sphere, cylinder, cone, torus, circle, square, polygon (sides 3–256)
-Properties: position X Y Z, orientation ROLL YAW PITCH (alias: rotation), size X Y Z
-Materials: color R G B (0-1), opacity (0-1)
+Shapes: cube, sphere, icosphere, cylinder, cone, torus, circle, square, roundrect (radius 0–0.5 of the smaller side), polygon (sides 3–256)
+Properties: position X Y Z, orientation ROLL YAW PITCH (alias: rotation), size X Y Z, detail N, smoothing N, name "label"
+Materials (as properties or as scoped commands): color, opacity, metallicity, roughness, glow, material NAME
+- color takes 1–4 values: luminance, luminance+alpha, RGB, RGBA. Also hex #F00 / #FF0000 / #FF000080, the names
+  black blue green cyan red magenta purple yellow white orange gray/grey, hsb(...), and "color red 0.5" to set alpha.
+- opacity multiplies through nested scopes (opacity 0.5 twice = 0.25); glow is an emissive colour; smoothing 0 = flat shading.
+- define shiny material { color blue metallicity 1 roughness 0.1 } bundles properties; apply with material shiny.
+- texture "file.png" and background "file.png" are accepted with a warning (not drawn); background R G B sets the scene colour.
+- camera { … } and light { … } blocks are accepted and skipped with a warning.
 
 UNITS (same as upstream ShapeScript — https://shapescript.info/mac/):
-- size is the DIAMETER of sphere/cylinder/cone/circle/polygon/torus (a bare sphere fits the unit cube); for cube/square it is the edge length.
+- size is the DIAMETER of sphere/icosphere/cylinder/cone/circle/polygon/torus (a bare sphere fits the unit cube); for cube/square it is the edge length. size 1 2 means 1 2 1 (the third value repeats the first).
 - orientation / rotate use HALF-TURNS in roll (Z), yaw (Y), pitch (X) order: 0.5 = 90°, 1 = 180°. Positive is clockwise. A lone value is a roll: orientation 0.25 = 45° about Z. Angle-axis also works: orientation 0.5 0 1 0.
 - rotate / translate / scale as commands are relative and accumulate; orientation as a command is absolute.
+- SCOPE: a shape block, group, builder or custom block resets transforms and materials at its closing brace.
+  for / if / switch bodies do NOT: a translate inside a loop carries on after it (upstream's rule). Symbols
+  (define) are scoped by every block.
 - Trig FUNCTIONS (sin, cos, …) still take radians. Convert with pi: a half-turn value h is h * pi radians.
 
 ### CSG Operations:
@@ -113,6 +123,9 @@ difference {
 
 ### Paths:
 path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a path by repeating the first point.
+A bare path draws as a LINE (stroke), as upstream; use fill / extrude / lathe / loft to make a surface or solid.
+- arc { angle A } inside a path: A half-turns clockwise from +Y, radius size/2 (default 0.5), with optional
+  position / orientation / size — e.g. two quarter arcs and two points make a rounded slab.
 - curve X Y is a quadratic Bézier CONTROL point: the outline passes through the point commands on either side, not through it. Two curves in a row get an implicit on-curve midpoint, so eight curves in an octagon draw a circle.
 - A path may carry position / orientation / size of its own (path { position 0 0 2 orientation 0 0.5 0 point … }); that is how a loft section is placed in 3D. Give loft and extrude PATH children, not fill{} meshes — the upstream app rejects a mesh there.
 - rotate (half-turns) / translate / scale inside a path move the frame for later points:
@@ -124,7 +137,7 @@ path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a
   }  // semicircle
 
 ### Builders:
-- extrude: extrude { polygon { sides 3 } } or an inline path (size Z = depth, default 1):
+- extrude: extrude polygon { sides 3 } / extrude { … } or an inline path (size X Y scale the profile, size Z = depth, default 1):
   extrude path {
       point 0 0
       point 1 0
@@ -153,13 +166,19 @@ path { point X Y … } — coordinates are ABSOLUTE in the path's frame. Close a
   }
 - stencil preserves the first shape and paints its surface with later shapes' materials.
 Loft sections must each have one perimeter and enclose an area; extrude/fill primitive profiles must lie in XY.
+A material command inside a builder block (extrude { color red … }) colours the result; size on a builder or
+group scales it. Not supported: extrude along/twist, minkowski, inset, svgpath, text, mesh { polygon … }.
 
 ### Additional Expressions:
 - Constants: pi, true, false (tau exists here but NOT in the upstream app; write 2 * pi)
 - Scientific notation and unary plus: 1e-3, +2
-- Tuple/vector members: vector.x, vector.y, vector.z; color.red/green/blue/alpha
-- Tuple/string length: value.count; zero-based indexing: values[0]; ordinals: v.first v.second … v.last, v.allButFirst, v.allButLast
-- String literals, join(...), trim(...); min/max also accept tuples
+- Ranges as values: define loops 1 to 5 step 2, then for i in loops { … }, for i in loops step 1, and
+  "if 3 in loops"; the in operator also tests tuples (2 in (1 2 3)) and strings.
+- Tuple/vector members: .x .y .z, .width .height .depth, .roll .yaw .pitch, .red .green .blue .alpha, .hue .saturation .brightness
+- Tuple/string length: value.count; zero-based indexing values[0], negative from the end values[-1], by name values["y"];
+  ordinals: v.first v.second … v.last, v.allButFirst, v.allButLast
+- String literals, join(...), split(...), trim(...); min/max also accept tuples
+- print a b … records output that is returned with the tool result; assert condition stops the script when false
 - Custom shapes with options:
 define post {
     option height 2
@@ -169,10 +188,12 @@ post { height 3 }
 - Random numbers: rnd (0–1) and seed N (scoped to the enclosing block, same generator as upstream)
 
 ### Compatibility:
-This plugin implements the documented modeling subset, not all upstream ShapeScript syntax; units and
-path semantics follow upstream, so a script written against the upstream docs renders the same here.
-Function calls use name(...). Imports, textures, text/fonts, lights/cameras, arbitrary objects,
-hex/named colours, and general user-defined functions are not supported.
+This plugin implements the documented modeling subset, not all upstream ShapeScript syntax; units, scoping,
+materials and path semantics follow upstream, so a script written against the upstream docs renders the
+same here. Not supported (each is refused by name): import, text/font, mesh { polygon … }, minkowski, inset,
+svgpath, extrude along/twist, object values, shapes as values (define s sphere { … } — write a block
+define s { sphere { … } } instead) and functions that build shapes. Textures, cameras and lights are
+accepted but not drawn.
 
 ### Comments:
 // Single-line comment

--- a/packages/plugins/shapescript-plugin/src/core/index.ts
+++ b/packages/plugins/shapescript-plugin/src/core/index.ts
@@ -32,5 +32,6 @@ export { samples } from "./samples";
 
 // Re-export ShapeScript utilities
 export { parseShapeScript } from "../shapescript/parser";
-export { astToThreeJS } from "../shapescript/toThreeJS";
+export { astToThreeJS, sceneInfoOf } from "../shapescript/toThreeJS";
+export type { ShapeScriptSceneInfo } from "../shapescript/toThreeJS";
 export type { SceneNode } from "../shapescript/types";

--- a/packages/plugins/shapescript-plugin/src/core/plugin.ts
+++ b/packages/plugins/shapescript-plugin/src/core/plugin.ts
@@ -6,7 +6,7 @@ import { locateShape } from "./dispatch";
 import { shapeArtifactPath } from "./paths";
 
 import { parseShapeScript } from "../shapescript/parser";
-import { astToThreeJS, ShapeScriptLimitError } from "../shapescript/toThreeJS";
+import { astToThreeJS, sceneInfoOf, ShapeScriptLimitError, type ShapeScriptSceneInfo } from "../shapescript/toThreeJS";
 import { disposeObject3D } from "../shapescript/dispose";
 import { ParseError } from "../shapescript/types";
 
@@ -34,9 +34,22 @@ const nonEmpty = (value: unknown): value is string => typeof value === "string" 
 
 /** Build + immediately dispose the model, so an unrenderable script is
  *  reported as a diagnostic instead of a blank viewport. Throws; the caller
- *  maps the cause to a `ShapeScriptDiagnostic`. */
-function validateGeometry(script: string): void {
-  disposeObject3D(astToThreeJS(parseShapeScript(script)));
+ *  maps the cause to a `ShapeScriptDiagnostic`. Returns what the build
+ *  reported: commands it skipped and `print` output, both for the agent. */
+function validateGeometry(script: string): ShapeScriptSceneInfo {
+  const group = astToThreeJS(parseShapeScript(script));
+  const info = sceneInfoOf(group);
+  disposeObject3D(group);
+  return info;
+}
+
+/** The tool message's tail: skipped commands and `print` lines, so the agent
+ *  learns that a `texture` was not drawn without the user having to say so. */
+function describeSceneInfo(info: ShapeScriptSceneInfo): string {
+  const parts: string[] = [];
+  if (info.warnings.length) parts.push(`Not rendered: ${info.warnings.join("; ")}`);
+  if (info.logs.length) parts.push(`Output:\n${info.logs.join("\n")}`);
+  return parts.length ? `\n${parts.join("\n")}` : "";
 }
 
 /** Read the source a `path` argument names, through whichever FileOps owns it. */
@@ -102,11 +115,11 @@ export const presentShapeScript = async (context: ShapeScriptExecuteContext, arg
     code = "EVALUATION_ERROR";
     // Geometry construction is headless: validate the same evaluator/builders
     // the browser uses, then release the temporary scene before returning.
-    validateGeometry(source.script);
+    const info = validateGeometry(source.script);
     // Only a NEW script is written; a `path` result already names its file.
     const filePath = source.filePath ?? (await saveShapeSource(context ?? {}, source.script, args.title));
     return {
-      message: filePath ? `Saved ShapeScript to ${filePath}` : `Created 3D visualization: ${args.title}`,
+      message: (filePath ? `Saved ShapeScript to ${filePath}` : `Created 3D visualization: ${args.title}`) + describeSceneInfo(info),
       title: args.title,
       data: filePath ? { script: source.script, filePath } : { script: source.script },
       instructions: PRESENT_ACK,

--- a/packages/plugins/shapescript-plugin/src/lang/de.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/de.ts
@@ -12,6 +12,8 @@ const de: Messages = {
   saveError: "Speichern fehlgeschlagen:",
   downloadUsdz: "USDZ herunterladen",
   exportError: "Export fehlgeschlagen:",
+  sceneWarnings: "Nicht gerendert:",
+  printOutput: "Ausgabe:",
 };
 
 export default de;

--- a/packages/plugins/shapescript-plugin/src/lang/en.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/en.ts
@@ -12,6 +12,8 @@ const en: Messages = {
   saveError: "Save Failed:",
   downloadUsdz: "Download USDZ",
   exportError: "Export Failed:",
+  sceneWarnings: "Not rendered:",
+  printOutput: "Output:",
 };
 
 export default en;

--- a/packages/plugins/shapescript-plugin/src/lang/es.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/es.ts
@@ -12,6 +12,8 @@ const es: Messages = {
   saveError: "Error al guardar:",
   downloadUsdz: "Descargar USDZ",
   exportError: "Error al exportar:",
+  sceneWarnings: "No renderizado:",
+  printOutput: "Salida:",
 };
 
 export default es;

--- a/packages/plugins/shapescript-plugin/src/lang/fr.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/fr.ts
@@ -12,6 +12,8 @@ const fr: Messages = {
   saveError: "Échec de l'enregistrement :",
   downloadUsdz: "Télécharger USDZ",
   exportError: "Échec de l'export :",
+  sceneWarnings: "Non rendu :",
+  printOutput: "Sortie :",
 };
 
 export default fr;

--- a/packages/plugins/shapescript-plugin/src/lang/ja.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/ja.ts
@@ -12,6 +12,8 @@ const ja: Messages = {
   saveError: "保存に失敗しました:",
   downloadUsdz: "USDZ をダウンロード",
   exportError: "エクスポートに失敗しました:",
+  sceneWarnings: "描画されないもの:",
+  printOutput: "出力:",
 };
 
 export default ja;

--- a/packages/plugins/shapescript-plugin/src/lang/ko.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/ko.ts
@@ -12,6 +12,8 @@ const ko: Messages = {
   saveError: "저장 실패:",
   downloadUsdz: "USDZ 다운로드",
   exportError: "내보내기 실패:",
+  sceneWarnings: "렌더링되지 않음:",
+  printOutput: "출력:",
 };
 
 export default ko;

--- a/packages/plugins/shapescript-plugin/src/lang/messages.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/messages.ts
@@ -10,4 +10,8 @@ export interface Messages {
   saveError: string;
   downloadUsdz: string;
   exportError: string;
+  /** Heading for commands the script used that this viewer does not draw. */
+  sceneWarnings: string;
+  /** Heading for the script's `print` lines. */
+  printOutput: string;
 }

--- a/packages/plugins/shapescript-plugin/src/lang/ptBR.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/ptBR.ts
@@ -12,6 +12,8 @@ const ptBR: Messages = {
   saveError: "Falha ao salvar:",
   downloadUsdz: "Baixar USDZ",
   exportError: "Falha na exportação:",
+  sceneWarnings: "Não renderizado:",
+  printOutput: "Saída:",
 };
 
 export default ptBR;

--- a/packages/plugins/shapescript-plugin/src/lang/zh.ts
+++ b/packages/plugins/shapescript-plugin/src/lang/zh.ts
@@ -12,6 +12,8 @@ const zh: Messages = {
   saveError: "保存失败：",
   downloadUsdz: "下载 USDZ",
   exportError: "导出失败:",
+  sceneWarnings: "未渲染:",
+  printOutput: "输出:",
 };
 
 export default zh;

--- a/packages/plugins/shapescript-plugin/src/render/page.ts
+++ b/packages/plugins/shapescript-plugin/src/render/page.ts
@@ -63,12 +63,13 @@ const bounds = new Box3().setFromObject(model);
 const sphere = bounds.getBoundingSphere(new Sphere());
 const radius = sphere.radius > 0 && isFinite(sphere.radius) ? sphere.radius : 1;
 
-const renderer = new WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
+// An alpha buffer, so a translucent \`background r g b a\` blends over the sheet's white paper.
+const renderer = new WebGLRenderer({ antialias: true, preserveDrawingBuffer: true, alpha: true });
 renderer.setPixelRatio(1);
 renderer.setSize(config.width, config.height, false);
-// The script's own \`background r g b\` when it set one, else white paper.
+// The script's own \`background r g b [a]\` when it set one, else white paper.
 const background = Array.isArray(model.userData?.background) ? model.userData.background : null;
-if (background) renderer.setClearColor(new Color(background[0], background[1], background[2]), 1);
+if (background) renderer.setClearColor(new Color(background[0], background[1], background[2]), background[3] ?? 1);
 else renderer.setClearColor(0xffffff, 1);
 
 const scene = new Scene();

--- a/packages/plugins/shapescript-plugin/src/render/page.ts
+++ b/packages/plugins/shapescript-plugin/src/render/page.ts
@@ -44,7 +44,7 @@ export function gridFor(count: number): { columns: number; rows: number } {
  *  sheet, and light the scene. Split from `drawScript` only because one
  *  template literal of the whole browser program is unreadable. */
 function sceneScript(threeUrl: string, config: string, grid: string): string {
-  return `import { AmbientLight, Box3, DirectionalLight, GridHelper, MathUtils, ObjectLoader, OrthographicCamera, PerspectiveCamera, Scene, Sphere, Vector3, WebGLRenderer } from ${JSON.stringify(threeUrl)};
+  return `import { AmbientLight, Box3, Color, DirectionalLight, GridHelper, MathUtils, ObjectLoader, OrthographicCamera, PerspectiveCamera, Scene, Sphere, Vector3, WebGLRenderer } from ${JSON.stringify(threeUrl)};
 
 const config = ${config};
 const { columns, rows } = ${grid};
@@ -66,7 +66,10 @@ const radius = sphere.radius > 0 && isFinite(sphere.radius) ? sphere.radius : 1;
 const renderer = new WebGLRenderer({ antialias: true, preserveDrawingBuffer: true });
 renderer.setPixelRatio(1);
 renderer.setSize(config.width, config.height, false);
-renderer.setClearColor(0xffffff, 1);
+// The script's own \`background r g b\` when it set one, else white paper.
+const background = Array.isArray(model.userData?.background) ? model.userData.background : null;
+if (background) renderer.setClearColor(new Color(background[0], background[1], background[2]), 1);
+else renderer.setClearColor(0xffffff, 1);
 
 const scene = new Scene();
 scene.add(model);

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -1,6 +1,57 @@
-import { Expression, Vector3, Color } from "./types";
+import { Expression, Vector3, Color, DefineNode, MaterialExpr } from "./types";
 
-export type Value = number | boolean | string | Value[];
+/** `1 to 5 step 2` as a value: walked by `for`, tested by `in`. */
+export interface RangeValue {
+  kind: "range";
+  from: number;
+  to: number;
+  step: number;
+  /** Whether a `step` was written: `in` then tests only the stepped values,
+   *  while an unstepped range contains every number between its bounds. */
+  stepped: boolean;
+}
+
+/** A `define name(a b) { … }` function, kept as its definition node. */
+export interface FunctionValue {
+  kind: "function";
+  definition: DefineNode;
+}
+
+/** An evaluated `material { … }` block. Colours carry alpha; a texture is
+ *  kept only so the renderer can warn about it. */
+export interface MaterialValue {
+  kind: "material";
+  color?: RGBA;
+  opacity?: number;
+  metallicity?: number;
+  roughness?: number;
+  glow?: RGBA;
+  texture?: string;
+}
+
+export type RGBA = [number, number, number, number];
+
+export type Value = number | boolean | string | Value[] | RangeValue | FunctionValue | MaterialValue;
+
+const isObjectValue = (value: Value | undefined): value is RangeValue | FunctionValue | MaterialValue =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Upstream's predefined colour constants (materials.md), as RGB tuples. A
+ *  script may `define red …` over them. */
+const NAMED_COLORS: Record<string, [number, number, number]> = {
+  black: [0, 0, 0],
+  blue: [0, 0, 1],
+  green: [0, 1, 0],
+  cyan: [0, 1, 1],
+  red: [1, 0, 0],
+  magenta: [1, 0, 1],
+  purple: [0.5, 0, 0.5],
+  yellow: [1, 1, 0],
+  white: [1, 1, 1],
+  orange: [1, 0.5, 0],
+  gray: [0.5, 0.5, 0.5],
+  grey: [0.5, 0.5, 0.5],
+};
 
 /** Upstream's `rnd` generator, bit for bit: a 32-bit LCG kept in a double,
  *  `x = (x * 1664525 + 1013904223) mod 2^32`, returning `x / 2^32`. Matching
@@ -38,6 +89,7 @@ export class SymbolTable {
   constructor(seed: number = DEFAULT_RANDOM_SEED) {
     this.scopes.push({ values: new Map(), random: new RandomSequence(seed) });
     for (const [name, value] of Object.entries({ pi: Math.PI, tau: 2 * Math.PI, true: true, false: false })) this.set(name, value);
+    for (const [name, value] of Object.entries(NAMED_COLORS)) this.set(name, value);
   }
 
   private innermost(): Scope {
@@ -100,7 +152,57 @@ function vectorLength(v: Value): number {
 }
 
 // Built-in functions
-const memberIndices: Record<string, number> = { x: 0, y: 1, z: 2, w: 3, r: 0, g: 1, b: 2, a: 3, red: 0, green: 1, blue: 2, alpha: 3 };
+const memberIndices: Record<string, number> = {
+  x: 0,
+  y: 1,
+  z: 2,
+  w: 3,
+  r: 0,
+  g: 1,
+  b: 2,
+  a: 3,
+  red: 0,
+  green: 1,
+  blue: 2,
+  alpha: 3,
+  width: 0,
+  height: 1,
+  depth: 2,
+  roll: 0,
+  yaw: 1,
+  pitch: 2,
+};
+/** `color.hue` / `.saturation` / `.brightness` — HSB of an RGB tuple. */
+const hsbMembers: Record<string, number> = { hue: 0, saturation: 1, brightness: 2 };
+
+function rgbToHsb(r: number, g: number, b: number): [number, number, number] {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const hue = delta === 0 ? 0 : max === r ? ((g - b) / delta + 6) % 6 : max === g ? (b - r) / delta + 2 : (r - g) / delta + 4;
+  return [hue / 6, max === 0 ? 0 : delta / max, max];
+}
+
+function hsbToRgb(h: number, s: number, b: number): [number, number, number] {
+  const hue = ((h % 1) + 1) % 1;
+  const sector = hue * 6;
+  const chroma = b * s;
+  const x = chroma * (1 - Math.abs((sector % 2) - 1));
+  const m = b - chroma;
+  const [r, g, bl] =
+    sector < 1
+      ? [chroma, x, 0]
+      : sector < 2
+        ? [x, chroma, 0]
+        : sector < 3
+          ? [0, chroma, x]
+          : sector < 4
+            ? [0, x, chroma]
+            : sector < 5
+              ? [x, 0, chroma]
+              : [chroma, 0, x];
+  return [r + m, g + m, bl + m];
+}
 /** Upstream's ordinal members, `vector.first` … `vector.tenth`. `last`,
  *  `allButFirst` and `allButLast` depend on the length and are handled inline. */
 const ordinalIndices: Record<string, number> = { first: 0, second: 1, third: 2, fourth: 3, fifth: 4, sixth: 5, seventh: 6, eighth: 7, ninth: 8, tenth: 9 };
@@ -110,8 +212,17 @@ function sequenceMember(value: Value[] | string, member: string): Value | undefi
   if (member === "last") return value.length > 0 ? value[value.length - 1] : undefined;
   if (member === "allButFirst") return typeof value === "string" ? value.slice(1) : value.slice(1);
   if (member === "allButLast") return typeof value === "string" ? value.slice(0, -1) : value.slice(0, -1);
+  if (Array.isArray(value) && member in hsbMembers && value.length >= 3) {
+    return rgbToHsb(toNumber(value[0]), toNumber(value[1]), toNumber(value[2]))[hsbMembers[member]!];
+  }
   const index = ordinalIndices[member] ?? (Array.isArray(value) ? memberIndices[member] : undefined);
-  return index !== undefined && index < value.length ? value[index] : undefined;
+  if (index === undefined) return undefined;
+  // `pos.z` of a 2D position is 0 and `col.alpha` of an RGB colour is 1, as
+  // upstream pads them; other missing components are errors.
+  if (index < value.length) return value[index];
+  if (Array.isArray(value) && index < 4 && (member === "alpha" || member === "a")) return 1;
+  if (Array.isArray(value) && index < 3 && member in memberIndices) return 0;
+  return undefined;
 }
 const builtInFunctions: Record<string, (...args: Value[]) => Value> = {
   // Arithmetic
@@ -181,11 +292,22 @@ const builtInFunctions: Record<string, (...args: Value[]) => Value> = {
   },
 
   trim: (s: Value) => String(s).trim(),
+  split: (s: Value, separator: Value) => String(s).split(String(separator ?? "")),
+
+  // Colours: `rgb(r g b [a])` passes through, `hsb(h s b [a])` converts.
+  rgb: (...args: Value[]) => args.flat(),
+  hsb: (...args: Value[]) => {
+    const [h = 0, s = 0, b = 0, a] = args.flat().map(toNumber);
+    return a === undefined ? hsbToRgb(h, s, b) : [...hsbToRgb(h, s, b), a];
+  },
 
   // `rand` is intercepted by the evaluator, which owns the seeded generator;
   // the entry stays so `Unknown function` still lists it as known.
   rand: () => 0,
 };
+
+/** Every built-in a bare call may name (`max 0 1`). */
+export const BUILT_IN_FUNCTION_NAMES: readonly string[] = Object.keys(builtInFunctions);
 
 // Accepts `undefined` so callers can index into a `Value[]` under
 // `noUncheckedIndexedAccess` without a guard at every call site; an
@@ -201,6 +323,7 @@ function toNumber(value: Value | undefined): number {
   if (Array.isArray(value) && value.length > 0) {
     return toNumber(value[0]);
   }
+  if (isObjectValue(value)) throw new Error(`Cannot use a ${value.kind} as a number`);
   throw new Error(`Cannot convert ${typeof value} to number`);
 }
 
@@ -217,6 +340,47 @@ function toBoolean(value: Value): boolean {
   return false;
 }
 
+/** Whether `needle` is in `haystack`: a range (on its steps), a tuple (by
+ *  value), or a string (as a substring), as upstream's `in` operator. */
+function contains(needle: Value, haystack: Value): boolean {
+  if (isObjectValue(haystack) && haystack.kind === "range") {
+    const n = toNumber(needle);
+    const { from, to, step } = haystack;
+    const low = Math.min(from, to);
+    const high = Math.max(from, to);
+    if (n < low || n > high) return false;
+    if (!haystack.stepped) return true;
+    const offset = (n - from) / step;
+    return Math.abs(offset - Math.round(offset)) < 1e-9;
+  }
+  if (Array.isArray(haystack)) return haystack.some((item) => valuesEqual(item, needle));
+  if (typeof haystack === "string") return haystack.includes(String(needle));
+  throw new Error("`in` needs a range, tuple or string on its right");
+}
+
+export function valuesEqual(a: Value, b: Value): boolean {
+  if (Array.isArray(a) && Array.isArray(b)) return a.length === b.length && a.every((item, i) => valuesEqual(item, b[i]!));
+  return a === b;
+}
+
+/** The values a `for` loop visits: a range walked by its step, a tuple's
+ *  elements, or a lone value. The count is bounded by the caller. */
+export function iterationValues(iterable: Value, limit: number, exceeded: () => Error): Value[] {
+  if (isObjectValue(iterable)) {
+    if (iterable.kind !== "range") throw new Error(`Cannot loop over a ${iterable.kind}`);
+    const { from, to, step } = iterable;
+    const values: number[] = [];
+    for (let i = from; step > 0 ? i <= to : i >= to; i += step) {
+      if (values.length >= limit) throw exceeded();
+      values.push(i);
+    }
+    return values;
+  }
+  const values = Array.isArray(iterable) ? iterable : [iterable];
+  if (values.length > limit) throw exceeded();
+  return values;
+}
+
 /** Seeds the generator behind `rnd` / `rand()` when a caller names none.
  *
  *  The same script is evaluated TWICE for one visualization — once on the
@@ -231,8 +395,13 @@ function toBoolean(value: Value): boolean {
  *  upstream app shows for it. */
 export const DEFAULT_RANDOM_SEED = 0;
 
+/** A function calling itself with no way out would otherwise overflow the
+ *  JavaScript stack, which surfaces as a RangeError with no script context. */
+const MAX_CALL_DEPTH = 256;
+
 export class Evaluator {
   private symbols: SymbolTable;
+  private callDepth = 0;
 
   constructor(symbols?: SymbolTable, seed?: number) {
     this.symbols = symbols || new SymbolTable(seed);
@@ -390,6 +559,9 @@ export class Evaluator {
           case "or":
             return toBoolean(left) || toBoolean(right);
 
+          case "in":
+            return contains(left, right);
+
           default:
             throw new Error(`Unknown binary operator: ${expr.operator}`);
         }
@@ -421,6 +593,8 @@ export class Evaluator {
         // used to resolve to a function and return an object that later
         // coerced to `false` — a silently skipped `if` branch instead of
         // "Unknown function".
+        const custom = this.symbols.get(expr.name);
+        if (isObjectValue(custom) && custom.kind === "function") return this.callFunction(custom, expr.args);
         const name = expr.name.toLowerCase();
         // `rand()` shares the seeded generator behind `rnd`, so it cannot be
         // served from the shared function table.
@@ -438,6 +612,12 @@ export class Evaluator {
         return expr.elements.map((el) => this.evaluate(el));
       }
 
+      case "range":
+        return this.evaluateRange(expr.from, expr.to, expr.step);
+
+      case "material":
+        return this.evaluateMaterial(expr);
+
       case "member": {
         const value = this.evaluate(expr.object);
         const result = Array.isArray(value) || typeof value === "string" ? sequenceMember(value, expr.member) : undefined;
@@ -448,14 +628,82 @@ export class Evaluator {
         const value = this.evaluate(expr.object);
         const index = this.evaluate(expr.index);
         if (!Array.isArray(value) && typeof value !== "string") throw new Error("Subscripting requires a tuple or string");
-        if (typeof index !== "number" || !Number.isInteger(index) || index < 0 || index >= value.length)
+        // `v["y"]` is `v.y`; `v[-1]` counts from the end, as upstream.
+        if (typeof index === "string") {
+          const member = sequenceMember(value, index);
+          if (member === undefined) throw new Error(`Unknown member: ${index}`);
+          return member;
+        }
+        if (typeof index !== "number" || !Number.isInteger(index) || index < -value.length || index >= value.length)
           throw new Error(`Subscript out of range: ${String(index)}`);
-        return value[index]!;
+        return value[index < 0 ? value.length + index : index]!;
       }
 
       default:
         throw new Error(`Unknown expression type: ${(expr as { type: string }).type}`);
     }
+  }
+
+  /** `from to to [step]`, or `range step s` when `to` is absent. */
+  private evaluateRange(fromExpr: Expression, toExpr: Expression | undefined, stepExpr: Expression | undefined): RangeValue {
+    const from = this.evaluate(fromExpr);
+    const step = stepExpr === undefined ? undefined : toNumber(this.evaluate(stepExpr));
+    if (toExpr === undefined) {
+      if (!isObjectValue(from) || from.kind !== "range") throw new Error("`step` needs a range before it");
+      return { ...from, step: step ?? from.step, stepped: step !== undefined || from.stepped };
+    }
+    const range: RangeValue = { kind: "range", from: toNumber(from), to: toNumber(this.evaluate(toExpr)), step: step ?? 1, stepped: step !== undefined };
+    if (range.step === 0 || ![range.from, range.to, range.step].every(Number.isFinite))
+      throw new Error("Loop bounds and step must be finite, with a nonzero step");
+    return range;
+  }
+
+  private evaluateMaterial(expr: MaterialExpr): MaterialValue {
+    const material: MaterialValue = { kind: "material" };
+    const { color, opacity, metallicity, roughness, glow, texture } = expr.properties;
+    if (color) material.color = this.evaluateToRGBA(color);
+    if (glow) material.glow = this.evaluateToRGBA(glow);
+    if (opacity !== undefined) material.opacity = this.evaluateToNumber(opacity);
+    if (metallicity !== undefined) material.metallicity = this.evaluateToNumber(metallicity);
+    if (roughness !== undefined) material.roughness = this.evaluateToNumber(roughness);
+    if (texture) material.texture = String(this.evaluate(texture));
+    return material;
+  }
+
+  /** Bind the parameters in a fresh scope, run the body's `define`s, and
+   *  evaluate the result expression. */
+  private callFunction(fn: FunctionValue, argExprs: Expression[]): Value {
+    const { params = [], body = [], value, name } = fn.definition;
+    const args = argExprs.map((arg) => this.evaluate(arg));
+    if (args.length !== params.length) throw new Error(`Function \`${name}\` takes ${params.length} argument(s), got ${args.length}`);
+    if (value === undefined) throw new Error(`Function \`${name}\` returns nothing`);
+    if (++this.callDepth > MAX_CALL_DEPTH) throw new Error(`Function \`${name}\` recursed more than ${MAX_CALL_DEPTH} levels deep`);
+    this.symbols.pushScope();
+    try {
+      params.forEach((param, i) => this.symbols.set(param, args[i]!));
+      for (const define of body) {
+        if (define.type !== "define") throw new Error(`Function \`${name}\` may only contain \`define\`s before its result`);
+        this.define(define);
+      }
+      return this.evaluate(value);
+    } finally {
+      this.symbols.popScope();
+      this.callDepth--;
+    }
+  }
+
+  /** A `define` of a value or a function. Custom shape blocks are stored by
+   *  the converter, which owns their bodies. */
+  define(node: DefineNode): boolean {
+    if (node.params !== undefined) {
+      this.symbols.set(node.name, { kind: "function", definition: node });
+      return true;
+    }
+    if (node.value !== undefined) {
+      this.symbols.set(node.name, this.evaluate(node.value));
+      return true;
+    }
+    return false;
   }
 
   evaluateToNumber(expr: Expression | number): number {
@@ -488,21 +736,43 @@ export class Evaluator {
   }
 
   evaluateToColor(expr: Expression | Color): Color {
-    if (Array.isArray(expr) && typeof expr[0] === "number") {
-      return expr as Color;
-    }
+    const [r, g, b] = this.evaluateToRGBA(expr);
+    return [r, g, b];
+  }
 
-    const value = this.evaluate(expr);
+  /** A colour value with alpha, by upstream's count rules: one number is a
+   *  luminance, two are luminance and alpha, three RGB, four RGBA; and a colour
+   *  followed by a number (`red 0.5`, `#ff0 0.5`) is that colour with its
+   *  alpha replaced. */
+  evaluateToRGBA(expr: Expression | Color): RGBA {
+    const value = Array.isArray(expr) && typeof expr[0] === "number" ? (expr as number[]) : this.evaluate(expr);
+    return rgbaOf(value);
+  }
+}
 
-    if (Array.isArray(value)) {
-      const r = value.length > 0 ? toNumber(value[0]) : 0;
-      const g = value.length > 1 ? toNumber(value[1]) : 0;
-      const b = value.length > 2 ? toNumber(value[2]) : 0;
-      return [r, g, b];
-    }
-
-    // Single number becomes grayscale
+export function rgbaOf(value: Value): RGBA {
+  if (typeof value === "number" || typeof value === "boolean") {
     const n = toNumber(value);
-    return [n, n, n];
+    return [n, n, n, 1];
+  }
+  if (!Array.isArray(value)) throw new Error("Expected numeric color channels");
+  if (value.length === 2 && Array.isArray(value[0])) return [...rgbaOf(value[0]).slice(0, 3), toNumber(value[1])] as RGBA;
+  if (value.length === 1 && Array.isArray(value[0])) return rgbaOf(value[0]);
+  const channels = value.map((channel) => {
+    if (typeof channel !== "number" && typeof channel !== "boolean") throw new Error("Expected numeric color channels");
+    return toNumber(channel);
+  });
+  const [a = 0.8, b = 1, c = 0, d = 1] = channels;
+  switch (channels.length) {
+    case 0:
+      return [0.8, 0.8, 0.8, 1];
+    case 1:
+      return [a, a, a, 1];
+    case 2:
+      return [a, a, a, b];
+    case 3:
+      return [a, b, c, 1];
+    default:
+      return [a, b, c, d];
   }
 }

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -12,11 +12,13 @@ import {
   ExtrudeNode,
   DetailNode,
   BackgroundNode,
-  TextureNode,
+  MaterialNode,
+  MaterialProperties,
   PathNode,
   PathCommand,
   PointCommand,
   CurveCommand,
+  ArcCommand,
   TranslateCommand,
   ScaleCommand,
   ForLoopPathCommand,
@@ -29,7 +31,36 @@ import {
   FillNode,
   HullNode,
   ShapeProperties,
+  ShapePrimitive,
 } from "./types";
+import { BUILT_IN_FUNCTION_NAMES } from "./evaluator";
+
+/** Blocks upstream renders through its own viewer and this renderer skips with
+ *  a warning: a camera only frames the upstream app, and lights are not
+ *  modelled here. Skipping keeps a script that carries them renderable. */
+const IGNORED_BLOCKS = new Set(["camera", "light"]);
+
+/** Upstream commands this renderer has no equivalent for. Named individually
+ *  so the diagnostic says what was meant rather than "Unknown shape". */
+const UNSUPPORTED_COMMANDS: Record<string, string> = {
+  text: "`text` (3D text) is not supported by this renderer",
+  font: "`font` is not supported by this renderer",
+  import: "`import` is not supported by this renderer — inline the shapes instead",
+  mesh: "raw `mesh { polygon … }` is not supported by this renderer — build the shape from primitives, paths and builders",
+  polygon: "`polygon { point … }` with explicit points is not supported — use `polygon { sides N }` or a `path`",
+  minkowski: "`minkowski` is not supported by this renderer",
+  inset: "`inset` is not supported by this renderer",
+  svgpath: "`svgpath` is not supported by this renderer — write the outline as a `path`",
+  object: "`object` values are not supported by this renderer — use tuples",
+  along: "`extrude … along` is not supported by this renderer",
+  normals: "`normals` (normal maps) are not supported by this renderer",
+  focus: "`focus` is not supported by this renderer",
+  debug: "`debug` is not supported by this renderer",
+};
+
+/** Own-property lookup: `toString` must not resolve off Object.prototype. */
+const unsupportedMessage = (name: string): string | undefined =>
+  Object.prototype.hasOwnProperty.call(UNSUPPORTED_COMMANDS, name) ? UNSUPPORTED_COMMANDS[name] : undefined;
 
 // Lexer/Tokenizer
 class Lexer {
@@ -127,6 +158,8 @@ class Lexer {
     const keywords: Record<string, TokenType> = {
       cube: TokenType.CUBE,
       sphere: TokenType.SPHERE,
+      icosphere: TokenType.ICOSPHERE,
+      roundrect: TokenType.ROUNDRECT,
       cylinder: TokenType.CYLINDER,
       cone: TokenType.CONE,
       torus: TokenType.TORUS,
@@ -142,10 +175,18 @@ class Lexer {
       path: TokenType.PATH,
       point: TokenType.POINT,
       curve: TokenType.CURVE,
+      arc: TokenType.ARC,
       detail: TokenType.DETAIL,
+      smoothing: TokenType.SMOOTHING,
       seed: TokenType.SEED,
       background: TokenType.BACKGROUND,
       texture: TokenType.TEXTURE,
+      material: TokenType.MATERIAL,
+      metallicity: TokenType.METALLICITY,
+      roughness: TokenType.ROUGHNESS,
+      glow: TokenType.GLOW,
+      print: TokenType.PRINT,
+      assert: TokenType.ASSERT,
       union: TokenType.UNION,
       difference: TokenType.DIFFERENCE,
       intersection: TokenType.INTERSECTION,
@@ -166,6 +207,7 @@ class Lexer {
       orientation: TokenType.ORIENTATION,
       size: TokenType.SIZE,
       color: TokenType.COLOR,
+      colour: TokenType.COLOR,
       opacity: TokenType.OPACITY,
       rotate: TokenType.ROTATE,
       translate: TokenType.TRANSLATE,
@@ -236,6 +278,19 @@ class Lexer {
     };
   }
 
+  /** `#RGB`, `#RGBA`, `#RRGGBB` or `#RRGGBBAA`, as in web colours. */
+  private readHexColor(): Token {
+    const line = this.line;
+    const column = this.column;
+    this.advance(); // #
+    let digits = "";
+    while (/[0-9a-fA-F]/.test(this.peek())) digits += this.advance();
+    if (![3, 4, 6, 8].includes(digits.length) || /[0-9a-zA-Z_]/.test(this.peek())) {
+      throw new ParseError("Invalid hex color — use #RGB, #RGBA, #RRGGBB or #RRGGBBAA", line, column);
+    }
+    return { type: TokenType.HEXCOLOR, value: digits, line, column };
+  }
+
   tokenize(): Token[] {
     const tokens: Token[] = [];
 
@@ -279,6 +334,12 @@ class Lexer {
       // String literals
       else if (char === '"') {
         const token = this.readString();
+        token.precedingWhitespace = hadWhitespace;
+        tokens.push(token);
+      }
+      // `#RRGGBB` colour literals
+      else if (char === "#") {
+        const token = this.readHexColor();
         token.precedingWhitespace = hadWhitespace;
         tokens.push(token);
       }
@@ -503,11 +564,84 @@ class Lexer {
   }
 }
 
+/** Tokens that begin a shape or builder — a value upstream can hold and this
+ *  renderer cannot. */
+const SHAPE_VALUE_TOKENS = new Set([
+  TokenType.CUBE,
+  TokenType.SPHERE,
+  TokenType.ICOSPHERE,
+  TokenType.CYLINDER,
+  TokenType.CONE,
+  TokenType.TORUS,
+  TokenType.CIRCLE,
+  TokenType.SQUARE,
+  TokenType.ROUNDRECT,
+  TokenType.POLYGON,
+  TokenType.EXTRUDE,
+  TokenType.LOFT,
+  TokenType.LATHE,
+  TokenType.FILL,
+  TokenType.HULL,
+  TokenType.GROUP,
+  TokenType.PATH,
+  TokenType.UNION,
+  TokenType.DIFFERENCE,
+  TokenType.INTERSECTION,
+  TokenType.XOR,
+  TokenType.STENCIL,
+]);
+
+/** Tokens that open a standard shape property inside a custom block call. */
+const STANDARD_PROPERTY_TOKENS = new Set([
+  TokenType.POSITION,
+  TokenType.ROTATION,
+  TokenType.ORIENTATION,
+  TokenType.SIZE,
+  TokenType.COLOR,
+  TokenType.OPACITY,
+  TokenType.MATERIAL,
+  TokenType.METALLICITY,
+  TokenType.ROUGHNESS,
+  TokenType.GLOW,
+  TokenType.TEXTURE,
+  TokenType.DETAIL,
+  TokenType.SMOOTHING,
+]);
+
+/** `#RGB[A]` / `#RRGGBB[AA]` as a literal RGBA tuple in 0–1. */
+function hexColorExpression(digits: string): Expression {
+  const wide = digits.length >= 6;
+  const channels: number[] = [];
+  for (let i = 0; i < digits.length; i += wide ? 2 : 1) {
+    const pair = wide ? digits.slice(i, i + 2) : digits[i]! + digits[i]!;
+    channels.push(parseInt(pair, 16) / 255);
+  }
+  if (channels.length === 3) channels.push(1);
+  return { type: "tuple", elements: channels.map((value) => ({ type: "number", value })) };
+}
+
+function materialSubset(properties: ShapeProperties): MaterialProperties {
+  const material: MaterialProperties = {};
+  for (const key of ["color", "opacity", "metallicity", "roughness", "glow", "texture"] as const) {
+    const value = properties[key];
+    if (value !== undefined) material[key] = value as Expression;
+  }
+  return material;
+}
+
 // Parser
 export class Parser {
   /** Whether the expression being parsed is one value of a whitespace-separated
    *  list. See `withValueList`. */
   private valueList = false;
+  /** Names a bare call may use (`max 0 1`, `sqrt 9`): the built-ins plus every
+   *  `define name(…)` seen so far, minus names a plain `define` shadows. Lexical
+   *  and unscoped — a shadow inside a block outlives the block, which only
+   *  matters to a script that reuses a function's name for a number. */
+  private callable = new Set<string>(BUILT_IN_FUNCTION_NAMES);
+  /** Custom block names, so a user-defined `light` is still invoked rather
+   *  than skipped as the upstream light source. */
+  private blocks = new Set<string>();
 
   private tokens: Token[];
   private pos = 0;
@@ -594,7 +728,27 @@ export class Parser {
       };
     }
 
-    return left;
+    return minPrec === 0 ? this.parseRangeTail(left) : left;
+  }
+
+  /** `a to b [step s]` after a full expression, or `range step s` to re-step a
+   *  range held in a symbol. Lowest precedence of all, so `1 to n - 1` runs to
+   *  `n - 1`; only a whole expression (minPrec 0) can become a range. */
+  private parseRangeTail(from: Expression): Expression {
+    if (this.current().type === TokenType.TO) {
+      this.advance();
+      const to = this.parseExpression(1);
+      if (this.current().type === TokenType.STEP) {
+        this.advance();
+        return { type: "range", from, to, step: this.parseExpression(1) };
+      }
+      return { type: "range", from, to };
+    }
+    if (this.current().type === TokenType.STEP) {
+      this.advance();
+      return { type: "range", from, step: this.parseExpression(1) };
+    }
+    return from;
   }
 
   private parsePrimary(): Expression {
@@ -693,6 +847,20 @@ export class Parser {
       };
     }
 
+    if (token.type === TokenType.HEXCOLOR) {
+      this.advance();
+      return hexColorExpression(String(token.value));
+    }
+
+    // `material { … }` — a bundle of material properties as a value
+    if (token.type === TokenType.MATERIAL && this.peek().type === TokenType.LBRACE) {
+      this.advance();
+      this.expect(TokenType.LBRACE);
+      const properties = this.parseProperties();
+      this.expect(TokenType.RBRACE);
+      return { type: "material", properties: materialSubset(properties) };
+    }
+
     // Identifier or function call
     if (token.type === TokenType.IDENTIFIER) {
       const name = token.value as string;
@@ -727,6 +895,17 @@ export class Parser {
         };
       }
 
+      // Bare call, upstream's Lisp-like spelling: `max 0 1`, `sqrt 9`, `sin pi / 2`.
+      // The function takes every value that follows it, each a full expression,
+      // so `sin pi / 2` is sin(pi / 2) and `size max 1 2` is one number.
+      if (this.callable.has(name) && this.startsValue()) {
+        const args: Expression[] = [];
+        this.withValueList(true, () => {
+          while (this.startsValue()) args.push(this.parseExpression());
+        });
+        return { type: "call", name, args };
+      }
+
       // Simple identifier
       return {
         type: "identifier",
@@ -756,6 +935,7 @@ export class Parser {
         return 2;
       case TokenType.EQUALS:
       case TokenType.NOT_EQUALS:
+      case TokenType.IN:
         return 3;
       case TokenType.LESS:
       case TokenType.LESS_EQUAL:
@@ -790,6 +970,8 @@ export class Parser {
         return "=";
       case TokenType.NOT_EQUALS:
         return "<>";
+      case TokenType.IN:
+        return "in";
       case TokenType.LESS:
         return "<";
       case TokenType.LESS_EQUAL:
@@ -865,13 +1047,32 @@ export class Parser {
           properties.opacity = this.parseExpression();
           break;
 
+        case TokenType.MATERIAL:
+          this.advance();
+          properties.material = this.parseExpression();
+          break;
+
+        case TokenType.METALLICITY:
+        case TokenType.ROUGHNESS:
+        case TokenType.GLOW:
+        case TokenType.TEXTURE:
+          this.advance();
+          properties[String(token.value).toLowerCase() as "glow"] = this.parseVectorOrExpression();
+          break;
+
+        case TokenType.DETAIL:
+        case TokenType.SMOOTHING:
+          this.advance();
+          properties[String(token.value).toLowerCase() as "detail"] = this.parseExpression();
+          break;
+
         case TokenType.RBRACE:
           // End of properties block
           return properties;
 
         case TokenType.IDENTIFIER: {
           const key = String(token.value);
-          if (!["sides", "radiusTop", "radiusBottom", "height", "innerRadius", "outerRadius"].includes(key)) return properties;
+          if (!["sides", "radiusTop", "radiusBottom", "height", "innerRadius", "outerRadius", "radius", "name"].includes(key)) return properties;
           this.advance();
           properties[key as "sides"] = this.parseExpression();
           break;
@@ -911,7 +1112,7 @@ export class Parser {
     return nodes;
   }
 
-  private parseShape(primitive: "cube" | "sphere" | "cylinder" | "cone" | "torus" | "circle" | "square" | "polygon"): ShapeNode {
+  private parseShape(primitive: ShapePrimitive): ShapeNode {
     this.advance(); // consume primitive token
 
     let properties: ShapeProperties = {};
@@ -941,79 +1142,23 @@ export class Parser {
     };
   }
 
+  /** `for [name in] <range or tuple> { … }`. The range is an ordinary
+   *  expression (`1 to n step 2`, or a symbol holding one), so `for 1 to 5`
+   *  and `for i in loops` read the same way. */
   private parseForLoop(): ForLoopNode {
     this.advance(); // consume 'for'
+    const { variable, iterable } = this.parseLoopHeader();
+    return { type: "for", variable, iterable, body: this.parseBlock() };
+  }
 
-    let variable = "i";
-
-    // Parse: for <identifier> in <expr> to <expr>
-    // or: for <identifier> in <expr>
-    if (this.current().type === TokenType.IDENTIFIER) {
+  private parseLoopHeader(): { variable: string; iterable: Expression } {
+    let variable = "_i";
+    if (this.current().type === TokenType.IDENTIFIER && this.peek().type === TokenType.IN) {
       variable = this.current().value as string;
       this.advance();
-    }
-
-    // Check for 'in' keyword
-    if (this.current().type === TokenType.IN) {
       this.advance();
-
-      const fromExpr = this.parseExpression();
-
-      // Check if there's a 'to' keyword (range) or not (values)
-      if (this.current().type === TokenType.TO) {
-        this.advance();
-        const toExpr = this.parseExpression();
-
-        // Optional step
-        let stepExpr: Expression | undefined;
-        if (this.current().type === TokenType.STEP) {
-          this.advance();
-          stepExpr = this.parseExpression();
-        }
-
-        const body = this.parseBlock();
-
-        return {
-          type: "for",
-          variable,
-          from: fromExpr,
-          to: toExpr,
-          ...(stepExpr === undefined ? {} : { step: stepExpr }),
-          body,
-        };
-      } else {
-        // for i in values
-        const body = this.parseBlock();
-
-        return {
-          type: "for",
-          variable,
-          from: { type: "number", value: 0 },
-          to: { type: "number", value: 0 },
-          iterableValues: fromExpr,
-          body,
-        };
-      }
     }
-
-    // Old syntax: for <from>? to <to>
-    let fromExpr: Expression = { type: "number", value: 1 };
-    if (this.current().type === TokenType.NUMBER) {
-      fromExpr = this.parseExpression();
-    }
-
-    this.expect(TokenType.TO);
-    const toExpr = this.parseExpression();
-
-    const body = this.parseBlock();
-
-    return {
-      type: "for",
-      variable,
-      from: fromExpr,
-      to: toExpr,
-      body,
-    };
+    return { variable, iterable: this.parseExpression() };
   }
 
   private parseIf(): IfNode {
@@ -1130,9 +1275,16 @@ export class Parser {
     const nameToken = this.expectIdentifier();
     const name = nameToken.value as string;
 
+    // `define name(a b) { … }` — a function with a return value
+    if (this.current().type === TokenType.LPAREN && !this.current().precedingWhitespace) {
+      return this.parseFunctionDefine(name);
+    }
+
     // Check if this is a custom shape definition with a block
     if (this.current().type === TokenType.LBRACE) {
       // This is a custom shape definition
+      this.blocks.add(name);
+      this.callable.delete(name);
       this.advance(); // consume '{'
 
       const options: OptionNode[] = [];
@@ -1177,13 +1329,63 @@ export class Parser {
     }
 
     // Parse the value - could be a single expression or space-separated tuple
+    this.refuseShapeValue(
+      `\`define ${name} <shape>\` (a shape as a value) is not supported by this renderer — write \`define ${name} { … }\` for a reusable block`,
+    );
     const value = this.parseVectorOrExpression();
+    this.callable.delete(name);
 
     return {
       type: "define",
       name,
       value,
     };
+  }
+
+  /** Upstream lets a shape be a value (`define s sphere { … }`, a function
+   *  returning a mesh); this renderer has no mesh values, so say so by name
+   *  instead of failing on the brace that follows. */
+  private refuseShapeValue(message: string): void {
+    const token = this.current();
+    const name = typeof token.value === "string" ? token.value : "";
+    const unsupported = token.type === TokenType.IDENTIFIER ? unsupportedMessage(name) : undefined;
+    if (unsupported !== undefined) throw new ParseError(unsupported, token.line, token.column);
+    if (SHAPE_VALUE_TOKENS.has(token.type)) throw new ParseError(message, token.line, token.column);
+  }
+
+  /** The body may hold `define`s and must end in the expression it returns.
+   *  Upstream also allows shapes there (a function returning a mesh); this
+   *  renderer has no mesh values, so that form is refused by name. */
+  private parseFunctionDefine(name: string): DefineNode {
+    this.expect(TokenType.LPAREN);
+    const params: string[] = [];
+    while (this.current().type !== TokenType.RPAREN) {
+      const token = this.current();
+      if (typeof token.value !== "string" || !/^[a-zA-Z_][a-zA-Z_0-9]*$/.test(token.value)) {
+        throw new ParseError("Expected a parameter name", token.line, token.column);
+      }
+      params.push(token.value);
+      this.advance();
+    }
+    this.expect(TokenType.RPAREN);
+    // Registered before the body so a function may call itself.
+    this.callable.add(name);
+    this.expect(TokenType.LBRACE);
+    this.skipNewlines();
+    const body: DefineNode[] = [];
+    while (this.current().type === TokenType.DEFINE) {
+      body.push(this.parseDefine());
+      this.skipNewlines();
+    }
+    const token = this.current();
+    if (token.type === TokenType.RBRACE) throw new ParseError(`Function \`${name}\` must end with the expression it returns`, token.line, token.column);
+    this.refuseShapeValue(
+      `Function \`${name}\` builds a shape — functions here may only compute values (numbers, tuples, strings); use \`define ${name} { … }\` with options for a reusable shape`,
+    );
+    const value = this.parseVectorOrExpression();
+    this.skipNewlines();
+    this.expect(TokenType.RBRACE);
+    return { type: "define", name, params, body, value };
   }
 
   private parseDetail(): DetailNode {
@@ -1204,24 +1406,30 @@ export class Parser {
 
   private parseBackground(): BackgroundNode {
     this.advance(); // consume 'background'
-
-    const value = this.parseExpression();
-
-    return {
-      type: "background",
-      value,
-    };
+    return { type: "background", value: this.parseVectorOrExpression() };
   }
 
-  private parseTexture(): TextureNode {
-    this.advance(); // consume 'texture'
+  /** `opacity` / `metallicity` / `roughness` / `glow` / `texture` / `material`
+   *  as a scoped command. */
+  private parseMaterialCommand(): MaterialNode {
+    const token = this.advance();
+    const property = String(token.value).toLowerCase() as MaterialNode["property"];
+    return { type: "material", property, value: this.parseVectorOrExpression() };
+  }
 
-    const value = this.parseExpression();
-
-    return {
-      type: "texture",
-      value,
-    };
+  /** `camera { … }` / `light { … }`: the block is consumed and dropped. */
+  private skipIgnoredBlock(command: string): SceneNode {
+    this.advance();
+    if (this.current().type === TokenType.LBRACE) {
+      let depth = 0;
+      do {
+        const token = this.advance();
+        if (token.type === TokenType.LBRACE) depth++;
+        else if (token.type === TokenType.RBRACE) depth--;
+        else if (token.type === TokenType.EOF) throw new ParseError(`Unterminated \`${command}\` block`, token.line, token.column);
+      } while (depth > 0);
+    }
+    return { type: "ignored", command };
   }
 
   private parseGroup(): GroupNode {
@@ -1244,13 +1452,20 @@ export class Parser {
       const path = this.parsePath();
       return builderType === "extrude" ? { type: "extrude", path, properties: {} } : { type: builderType, children: [path], properties: {} };
     }
+    // `extrude circle`, `fill roundrect { … }`, `extrude cog { teeth 8 }`: one
+    // child shape without a wrapping block, as upstream allows.
+    if (this.current().type !== TokenType.LBRACE) {
+      const child = this.parseNode();
+      if (!child) throw new ParseError(`\`${builderType}\` needs a path or shape`, this.current().line, this.current().column);
+      return { type: builderType, children: [child], properties: {} };
+    }
     this.expect(TokenType.LBRACE);
     this.skipNewlines();
     const properties: ShapeProperties = {};
     const children: SceneNode[] = [];
     while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
       const token = this.current();
-      if ([TokenType.SIZE, TokenType.COLOR, TokenType.OPACITY, TokenType.POSITION, TokenType.ROTATION, TokenType.ORIENTATION].includes(token.type)) {
+      if ([TokenType.SIZE, TokenType.COLOR, TokenType.POSITION, TokenType.ROTATION, TokenType.ORIENTATION].includes(token.type)) {
         Object.assign(properties, this.parseProperties());
       } else {
         const node = this.parseNode();
@@ -1284,7 +1499,15 @@ export class Parser {
    *  several values rather than one arithmetic expression. */
   private startsValue(): boolean {
     const type = this.current().type;
-    return type === TokenType.NUMBER || type === TokenType.MINUS || type === TokenType.PLUS || type === TokenType.IDENTIFIER || type === TokenType.LPAREN;
+    return (
+      type === TokenType.NUMBER ||
+      type === TokenType.MINUS ||
+      type === TokenType.PLUS ||
+      type === TokenType.IDENTIFIER ||
+      type === TokenType.LPAREN ||
+      type === TokenType.STRING ||
+      type === TokenType.HEXCOLOR
+    );
   }
 
   /** As `startsValue`, but `name {` is a custom shape invocation rather than the
@@ -1359,6 +1582,8 @@ export class Parser {
       case TokenType.POINT:
       case TokenType.CURVE:
         return this.parsePathPoint(token.type === TokenType.POINT ? "point" : "curve");
+      case TokenType.ARC:
+        return this.parseArc();
       case TokenType.ROTATE: {
         this.advance();
         return { type: "rotate", angle: this.parseExpression() };
@@ -1379,7 +1604,38 @@ export class Parser {
     this.advance();
     const x = this.parsePathValue();
     const y: Expression = this.startsValue() ? this.parsePathValue() : { type: "number", value: 0 };
+    if (this.startsValue()) return { type, x, y, z: this.parsePathValue() };
     return { type, x, y };
+  }
+
+  /** `arc` or `arc { angle … position … orientation … size … }` inside a path. */
+  private parseArc(): ArcCommand {
+    this.advance();
+    const arc: ArcCommand = { type: "arc" };
+    if (this.current().type !== TokenType.LBRACE) return arc;
+    this.expect(TokenType.LBRACE);
+    this.skipNewlines();
+    while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+      const token = this.current();
+      const key = String(token.value).toLowerCase();
+      if (key === "angle" && token.type === TokenType.IDENTIFIER) {
+        this.advance();
+        arc.angle = this.parseExpression();
+      } else if (
+        token.type === TokenType.POSITION ||
+        token.type === TokenType.SIZE ||
+        token.type === TokenType.ORIENTATION ||
+        token.type === TokenType.ROTATION
+      ) {
+        this.advance();
+        arc[token.type === TokenType.ROTATION ? "orientation" : (key as "position")] = this.parseVectorOrExpression();
+      } else {
+        throw new ParseError(`Unexpected token in arc: ${token.type}`, token.line, token.column);
+      }
+      this.skipNewlines();
+    }
+    this.expect(TokenType.RBRACE);
+    return arc;
   }
 
   /** `translate x [y]` / `scale x [y]` inside a path. A lone `translate x`
@@ -1395,22 +1651,9 @@ export class Parser {
 
   private parsePathFor(): ForLoopPathCommand {
     this.advance(); // consume 'for'
-
-    // Check if there's a variable name (for i in 1 to 5) or direct range (for 1 to 5)
-    let variable = "_i"; // Default variable name
-    if (this.current().type === TokenType.IDENTIFIER && this.peek(1).type === TokenType.IN) {
-      variable = this.current().value as string;
-      this.advance(); // consume variable
-      this.expect(TokenType.IN); // consume 'in'
-    }
-
-    const from = this.parseExpression();
-    this.expect(TokenType.TO);
-    const to = this.parseExpression();
-    const step = this.current().type === TokenType.STEP ? (this.advance(), this.parseExpression()) : { type: "number" as const, value: 1 };
-
+    const { variable, iterable } = this.parseLoopHeader();
     // The loop is expanded during rendering.
-    return { type: "for", variable, from, to, step, commands: this.parsePathBody("path for loop") };
+    return { type: "for", variable, iterable, commands: this.parsePathBody("path for loop") };
   }
 
   private parseNode(): SceneNode | null {
@@ -1418,7 +1661,6 @@ export class Parser {
 
     const token = this.current();
 
-    type ShapePrimitive = "cube" | "sphere" | "cylinder" | "cone" | "torus" | "circle" | "square" | "polygon";
     type CSGOperation = "union" | "difference" | "intersection" | "xor" | "stencil";
     type BuilderType = "extrude" | "loft" | "lathe" | "fill" | "hull";
     type TransformType = "color" | "rotate" | "translate" | "scale" | "orientation";
@@ -1427,6 +1669,8 @@ export class Parser {
     const shapeMap: Record<string, ShapePrimitive> = {
       [TokenType.CUBE]: "cube",
       [TokenType.SPHERE]: "sphere",
+      [TokenType.ICOSPHERE]: "icosphere",
+      [TokenType.ROUNDRECT]: "roundrect",
       [TokenType.CYLINDER]: "cylinder",
       [TokenType.CONE]: "cone",
       [TokenType.TORUS]: "torus",
@@ -1461,7 +1705,15 @@ export class Parser {
       [TokenType.SCALE]: "scale",
       [TokenType.POSITION]: "translate", // position is an alias for translate
       [TokenType.ORIENTATION]: "orientation", // orientation sets absolute rotation (not relative like rotate)
+      [TokenType.SIZE]: "scale", // `size` inside a group scales what follows, as the group's own size does upstream
     };
+
+    // A custom block named like a built-in (`define arc { … }`) shadows it,
+    // as a `define` does upstream — the script's own `arc { … }` is meant.
+    if (typeof token.value === "string" && token.type !== TokenType.IDENTIFIER && this.blocks.has(token.value)) {
+      this.advance();
+      return this.parseCustomShapeCall(token.value);
+    }
 
     // Check mapped operations first
     const shape = shapeMap[token.type];
@@ -1511,7 +1763,24 @@ export class Parser {
         return this.parseBackground();
 
       case TokenType.TEXTURE:
-        return this.parseTexture();
+      case TokenType.MATERIAL:
+      case TokenType.OPACITY:
+      case TokenType.METALLICITY:
+      case TokenType.ROUGHNESS:
+      case TokenType.GLOW:
+        return this.parseMaterialCommand();
+
+      case TokenType.SMOOTHING:
+        this.advance();
+        return { type: "smoothing", value: this.parseExpression() };
+
+      case TokenType.PRINT:
+        this.advance();
+        return { type: "print", value: this.parseVectorOrExpression() };
+
+      case TokenType.ASSERT:
+        this.advance();
+        return { type: "assert", value: this.parseExpression() };
 
       case TokenType.PATH:
         return this.parsePath();
@@ -1523,52 +1792,55 @@ export class Parser {
       case TokenType.IDENTIFIER: {
         // Custom shape invocation (e.g., "cog { teeth 8 }")
         const name = token.value as string;
-        this.advance();
-
-        const properties: Record<string, unknown> = {};
-
-        if (this.current().type === TokenType.LBRACE) {
-          this.expect(TokenType.LBRACE);
-          this.skipNewlines();
-
-          // Parse option overrides (e.g., "teeth 8")
-          while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-            // Check for standard properties first
-            if (
-              this.current().type === TokenType.POSITION ||
-              this.current().type === TokenType.ROTATION ||
-              this.current().type === TokenType.SIZE ||
-              this.current().type === TokenType.COLOR ||
-              this.current().type === TokenType.OPACITY
-            ) {
-              const props = this.parseProperties();
-              Object.assign(properties, props);
-            } else if (this.current().type === TokenType.IDENTIFIER) {
-              // Parse custom option (e.g., "teeth 8")
-              const optionName = this.current().value as string;
-              this.advance();
-              const optionValue = this.parseVectorOrExpression();
-              properties[optionName] = optionValue;
-            } else {
-              break;
-            }
-
-            this.skipNewlines();
-          }
-
-          this.expect(TokenType.RBRACE);
+        if (!this.blocks.has(name)) {
+          if (IGNORED_BLOCKS.has(name)) return this.skipIgnoredBlock(name);
+          const unsupported = unsupportedMessage(name);
+          if (unsupported !== undefined) throw new ParseError(unsupported, token.line, token.column);
         }
-
-        return {
-          type: "customShape",
-          name,
-          properties,
-        };
+        this.advance();
+        return this.parseCustomShapeCall(name);
       }
 
       default:
         throw new ParseError(`Unexpected token: ${token.type}`, token.line, token.column);
     }
+  }
+
+  /** `name { option value … }` after the name has been consumed. */
+  private parseCustomShapeCall(name: string): SceneNode {
+    const properties: Record<string, unknown> = {};
+
+    if (this.current().type === TokenType.LBRACE) {
+      this.expect(TokenType.LBRACE);
+      this.skipNewlines();
+
+      // Parse option overrides (e.g., "teeth 8")
+      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+        // Check for standard properties first
+        if (STANDARD_PROPERTY_TOKENS.has(this.current().type)) {
+          const props = this.parseProperties();
+          Object.assign(properties, props);
+        } else if (this.current().type === TokenType.IDENTIFIER) {
+          // Parse custom option (e.g., "teeth 8")
+          const optionName = this.current().value as string;
+          this.advance();
+          const optionValue = this.parseVectorOrExpression();
+          properties[optionName] = optionValue;
+        } else {
+          break;
+        }
+
+        this.skipNewlines();
+      }
+
+      this.expect(TokenType.RBRACE);
+    }
+
+    return {
+      type: "customShape",
+      name,
+      properties,
+    };
   }
 
   // `parseNode()` answers `null` at a `}` so that a BLOCK's loop stops there and the

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1090,19 +1090,37 @@ export class Parser {
   }
 
   private parseBlockContents(): SceneNode[] {
-    this.skipNewlines();
-
-    const nodes: SceneNode[] = [];
-
-    while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-      const node = this.parseNode();
-      if (node) {
-        nodes.push(node);
-      }
+    return this.scoped(() => {
       this.skipNewlines();
-    }
 
-    return nodes;
+      const nodes: SceneNode[] = [];
+
+      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+        const node = this.parseNode();
+        if (node) {
+          nodes.push(node);
+        }
+        this.skipNewlines();
+      }
+
+      return nodes;
+    });
+  }
+
+  /** Run `parse` with the callable and block name sets scoped to it, so a
+   *  `define max 5` inside a block stops shadowing the built-in at the
+   *  block's closing brace — the parser-side mirror of the runtime scope. */
+  private scoped<T>(parse: () => T): T {
+    const callable = this.callable;
+    const blocks = this.blocks;
+    this.callable = new Set(callable);
+    this.blocks = new Set(blocks);
+    try {
+      return parse();
+    } finally {
+      this.callable = callable;
+      this.blocks = blocks;
+    }
   }
 
   private parseBlock(): SceneNode[] {
@@ -1202,62 +1220,64 @@ export class Parser {
     const cases: Array<{ values: Expression[]; body: SceneNode[] }> = [];
     let defaultCase: SceneNode[] | undefined;
 
-    while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-      if (this.current().type === TokenType.CASE) {
-        this.advance();
+    this.scoped(() => {
+      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+        if (this.current().type === TokenType.CASE) {
+          this.advance();
 
-        const caseValues: Expression[] = [];
-        caseValues.push(this.parseExpression());
-
-        // Multiple values for same case
-        while (this.current().type !== TokenType.NEWLINE && this.current().type !== TokenType.LBRACE && this.current().type !== TokenType.EOF) {
+          const caseValues: Expression[] = [];
           caseValues.push(this.parseExpression());
-        }
 
-        this.skipNewlines();
+          // Multiple values for same case
+          while (this.current().type !== TokenType.NEWLINE && this.current().type !== TokenType.LBRACE && this.current().type !== TokenType.EOF) {
+            caseValues.push(this.parseExpression());
+          }
 
-        // Case body can be a block or statements until next case
-        let caseBody: SceneNode[];
-        if (this.current().type === TokenType.LBRACE) {
-          caseBody = this.parseBlock();
+          this.skipNewlines();
+
+          // Case body can be a block or statements until next case
+          let caseBody: SceneNode[];
+          if (this.current().type === TokenType.LBRACE) {
+            caseBody = this.parseBlock();
+          } else {
+            caseBody = [];
+            while (
+              this.current().type !== TokenType.CASE &&
+              this.current().type !== TokenType.ELSE &&
+              this.current().type !== TokenType.RBRACE &&
+              this.current().type !== TokenType.EOF
+            ) {
+              const node = this.parseNode();
+              if (node) caseBody.push(node);
+              this.skipNewlines();
+            }
+          }
+
+          cases.push({ values: caseValues, body: caseBody });
+        } else if (this.current().type === TokenType.ELSE) {
+          this.advance();
+          this.skipNewlines();
+
+          if (this.current().type === TokenType.LBRACE) {
+            defaultCase = this.parseBlock();
+          } else {
+            defaultCase = [];
+            while (this.current().type !== TokenType.CASE && this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+              const node = this.parseNode();
+              if (node) defaultCase.push(node);
+              this.skipNewlines();
+            }
+          }
         } else {
-          caseBody = [];
-          while (
-            this.current().type !== TokenType.CASE &&
-            this.current().type !== TokenType.ELSE &&
-            this.current().type !== TokenType.RBRACE &&
-            this.current().type !== TokenType.EOF
-          ) {
-            const node = this.parseNode();
-            if (node) caseBody.push(node);
-            this.skipNewlines();
+          this.skipNewlines();
+          if (this.current().type !== TokenType.CASE && this.current().type !== TokenType.ELSE && this.current().type !== TokenType.RBRACE) {
+            this.advance(); // skip unexpected token
           }
         }
 
-        cases.push({ values: caseValues, body: caseBody });
-      } else if (this.current().type === TokenType.ELSE) {
-        this.advance();
         this.skipNewlines();
-
-        if (this.current().type === TokenType.LBRACE) {
-          defaultCase = this.parseBlock();
-        } else {
-          defaultCase = [];
-          while (this.current().type !== TokenType.CASE && this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-            const node = this.parseNode();
-            if (node) defaultCase.push(node);
-            this.skipNewlines();
-          }
-        }
-      } else {
-        this.skipNewlines();
-        if (this.current().type !== TokenType.CASE && this.current().type !== TokenType.ELSE && this.current().type !== TokenType.RBRACE) {
-          this.advance(); // skip unexpected token
-        }
       }
-
-      this.skipNewlines();
-    }
+    });
 
     this.expect(TokenType.RBRACE);
 
@@ -1290,33 +1310,35 @@ export class Parser {
       const options: OptionNode[] = [];
       const body: SceneNode[] = [];
 
-      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-        // Each `option` / body statement sits on its own line, and NEWLINE
-        // tokens now survive to the parser (they carry the case boundaries the
-        // switch form needs), so consume them here rather than handing one to
-        // `parseNode()`.
-        this.skipNewlines();
-        if (this.current().type === TokenType.RBRACE || this.current().type === TokenType.EOF) break;
-        // Check for option declarations
-        if (this.current().type === TokenType.OPTION) {
-          this.advance(); // consume 'option'
+      this.scoped(() => {
+        while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+          // Each `option` / body statement sits on its own line, and NEWLINE
+          // tokens now survive to the parser (they carry the case boundaries the
+          // switch form needs), so consume them here rather than handing one to
+          // `parseNode()`.
+          this.skipNewlines();
+          if (this.current().type === TokenType.RBRACE || this.current().type === TokenType.EOF) break;
+          // Check for option declarations
+          if (this.current().type === TokenType.OPTION) {
+            this.advance(); // consume 'option'
 
-          const optionName = this.expectIdentifier().value as string;
-          const defaultValue = this.parseVectorOrExpression();
+            const optionName = this.expectIdentifier().value as string;
+            const defaultValue = this.parseVectorOrExpression();
 
-          options.push({
-            type: "option",
-            name: optionName,
-            defaultValue,
-          });
-        } else {
-          // Parse regular scene nodes
-          const node = this.parseNode();
-          if (node) {
-            body.push(node);
+            options.push({
+              type: "option",
+              name: optionName,
+              defaultValue,
+            });
+          } else {
+            // Parse regular scene nodes
+            const node = this.parseNode();
+            if (node) {
+              body.push(node);
+            }
           }
         }
-      }
+      });
 
       this.expect(TokenType.RBRACE);
 
@@ -1371,19 +1393,22 @@ export class Parser {
     // Registered before the body so a function may call itself.
     this.callable.add(name);
     this.expect(TokenType.LBRACE);
-    this.skipNewlines();
-    const body: DefineNode[] = [];
-    while (this.current().type === TokenType.DEFINE) {
-      body.push(this.parseDefine());
+    const { body, value } = this.scoped(() => {
       this.skipNewlines();
-    }
-    const token = this.current();
-    if (token.type === TokenType.RBRACE) throw new ParseError(`Function \`${name}\` must end with the expression it returns`, token.line, token.column);
-    this.refuseShapeValue(
-      `Function \`${name}\` builds a shape — functions here may only compute values (numbers, tuples, strings); use \`define ${name} { … }\` with options for a reusable shape`,
-    );
-    const value = this.parseVectorOrExpression();
-    this.skipNewlines();
+      const defines: DefineNode[] = [];
+      while (this.current().type === TokenType.DEFINE) {
+        defines.push(this.parseDefine());
+        this.skipNewlines();
+      }
+      const token = this.current();
+      if (token.type === TokenType.RBRACE) throw new ParseError(`Function \`${name}\` must end with the expression it returns`, token.line, token.column);
+      this.refuseShapeValue(
+        `Function \`${name}\` builds a shape — functions here may only compute values (numbers, tuples, strings); use \`define ${name} { … }\` with options for a reusable shape`,
+      );
+      const result = this.parseVectorOrExpression();
+      this.skipNewlines();
+      return { body: defines, value: result };
+    });
     this.expect(TokenType.RBRACE);
     return { type: "define", name, params, body, value };
   }
@@ -1463,16 +1488,18 @@ export class Parser {
     this.skipNewlines();
     const properties: ShapeProperties = {};
     const children: SceneNode[] = [];
-    while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-      const token = this.current();
-      if ([TokenType.SIZE, TokenType.COLOR, TokenType.POSITION, TokenType.ROTATION, TokenType.ORIENTATION].includes(token.type)) {
-        Object.assign(properties, this.parseProperties());
-      } else {
-        const node = this.parseNode();
-        if (node) children.push(node);
+    this.scoped(() => {
+      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+        const token = this.current();
+        if ([TokenType.SIZE, TokenType.COLOR, TokenType.POSITION, TokenType.ROTATION, TokenType.ORIENTATION].includes(token.type)) {
+          Object.assign(properties, this.parseProperties());
+        } else {
+          const node = this.parseNode();
+          if (node) children.push(node);
+        }
+        this.skipNewlines();
       }
-      this.skipNewlines();
-    }
+    });
     this.expect(TokenType.RBRACE);
     if (builderType === "extrude" && children.length === 1 && children[0]?.type === "path") {
       return { type: "extrude", path: children[0], properties };
@@ -1538,16 +1565,19 @@ export class Parser {
    *  options, which land in `properties`. */
   private parsePathBody(where: string, properties?: ShapeProperties): PathCommand[] {
     this.expect(TokenType.LBRACE);
-    this.skipNewlines();
-    const commands: PathCommand[] = [];
-    while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
-      if (properties !== undefined && this.parsePathProperty(properties)) {
-        this.skipNewlines();
-        continue;
-      }
-      commands.push(this.parsePathCommand(where));
+    const commands = this.scoped(() => {
       this.skipNewlines();
-    }
+      const parsed: PathCommand[] = [];
+      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+        if (properties !== undefined && this.parsePathProperty(properties)) {
+          this.skipNewlines();
+          continue;
+        }
+        parsed.push(this.parsePathCommand(where));
+        this.skipNewlines();
+      }
+      return parsed;
+    });
     this.expect(TokenType.RBRACE);
     return commands;
   }

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1166,7 +1166,12 @@ export class Parser {
   private parseForLoop(): ForLoopNode {
     this.advance(); // consume 'for'
     const { variable, iterable } = this.parseLoopHeader();
-    return { type: "for", variable, iterable, body: this.parseBlock() };
+    // The loop variable shadows a function of the same name inside the body.
+    const body = this.scoped(() => {
+      this.callable.delete(variable);
+      return this.parseBlock();
+    });
+    return { type: "for", variable, iterable, body };
   }
 
   private parseLoopHeader(): { variable: string; iterable: Expression } {
@@ -1324,6 +1329,8 @@ export class Parser {
 
             const optionName = this.expectIdentifier().value as string;
             const defaultValue = this.parseVectorOrExpression();
+            // An option is a symbol in the body, shadowing a function of that name.
+            this.callable.delete(optionName);
 
             options.push({
               type: "option",
@@ -1394,6 +1401,7 @@ export class Parser {
     this.callable.add(name);
     this.expect(TokenType.LBRACE);
     const { body, value } = this.scoped(() => {
+      for (const param of params) this.callable.delete(param);
       this.skipNewlines();
       const defines: DefineNode[] = [];
       while (this.current().type === TokenType.DEFINE) {
@@ -1683,7 +1691,11 @@ export class Parser {
     this.advance(); // consume 'for'
     const { variable, iterable } = this.parseLoopHeader();
     // The loop is expanded during rendering.
-    return { type: "for", variable, iterable, commands: this.parsePathBody("path for loop") };
+    const commands = this.scoped(() => {
+      this.callable.delete(variable);
+      return this.parsePathBody("path for loop");
+    });
+    return { type: "for", variable, iterable, commands };
   }
 
   private parseNode(): SceneNode | null {

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -199,6 +199,45 @@ function cloneMaterialState(material: MaterialState): MaterialState {
  *  should not turn the tool result into a transcript. */
 const MAX_LOGS = 200;
 
+/** Signed volume of an indexed or unindexed triangle geometry. */
+function signedVolume(geometry: THREE.BufferGeometry): number {
+  const position = geometry.getAttribute("position");
+  const index = geometry.getIndex();
+  const count = index?.count ?? position.count;
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  let volume = 0;
+  for (let i = 0; i < count; i += 3) {
+    a.fromBufferAttribute(position, index ? index.getX(i) : i);
+    b.fromBufferAttribute(position, index ? index.getX(i + 1) : i + 1);
+    c.fromBufferAttribute(position, index ? index.getX(i + 2) : i + 2);
+    volume += a.dot(b.cross(c));
+  }
+  return volume / 6;
+}
+
+/** Flip a closed geometry whose faces point inward, so booleans and lighting
+ *  treat it as the solid it encloses. */
+function orientOutward<T extends THREE.BufferGeometry>(geometry: T): T {
+  if (signedVolume(geometry) >= 0) return geometry;
+  const index = geometry.getIndex();
+  if (index) {
+    for (let i = 0; i < index.count; i += 3) {
+      const b = index.getX(i + 1);
+      index.setX(i + 1, index.getX(i + 2));
+      index.setX(i + 2, b);
+    }
+    index.needsUpdate = true;
+  }
+  const normal = geometry.getAttribute("normal");
+  if (normal) {
+    for (let i = 0; i < normal.count; i++) normal.setXYZ(i, -normal.getX(i), -normal.getY(i), -normal.getZ(i));
+    normal.needsUpdate = true;
+  }
+  return geometry;
+}
+
 /** Upstream's icosphere subdivision level for a detail setting. */
 function icosphereSubdivisions(detail: number): number {
   return Math.max(0, Math.round(Math.log2(Math.max(4, detail))) - 2);
@@ -1195,7 +1234,8 @@ export class Converter {
   }
 
   /** `size` on an extrude: X and Y scale the profile, Z is the depth. The
-   *  depth goes into the geometry, so the mesh keeps a unit Z scale. */
+   *  depth goes into the geometry (centred on the profile plane, as
+   *  upstream), so the mesh keeps a unit Z scale. */
   private extrudeProperties(node: ExtrudeNode): { depth: number; properties: ShapeProperties } {
     const size = node.properties.size ? this.evaluateSize(node.properties.size) : [1, 1, 1];
     const depth = size[2] || 1;
@@ -1210,7 +1250,7 @@ export class Converter {
           const shapes = meshes.map((mesh) => this.planarShape(mesh));
           if (!shapes.length) throw new Error("Extrude requires a path or planar shape");
           for (const shape of shapes) this.chargePathEstimate(shape, 1, 12);
-          return new THREE.ExtrudeGeometry(shapes, { depth, bevelEnabled: false, curveSegments: 1 });
+          return new THREE.ExtrudeGeometry(shapes, { depth, bevelEnabled: false, curveSegments: 1 }).translate(0, 0, -depth / 2);
         });
       }
       const shape = this.requireEnclosedArea(this.buildPath(node.path), "extrude");
@@ -1219,7 +1259,8 @@ export class Converter {
       const curveSegments = Math.max(1, Math.floor(this.detailLevel / 4));
       this.chargePathEstimate(shape, curveSegments, EXTRUDE_VERTICES_PER_POINT);
 
-      const geometry = this.placePath(new THREE.ExtrudeGeometry(shape, { depth, bevelEnabled: false, curveSegments }), node.path);
+      // Centred on the profile plane (±depth / 2), as upstream extrudes.
+      const geometry = this.placePath(new THREE.ExtrudeGeometry(shape, { depth, bevelEnabled: false, curveSegments }).translate(0, 0, -depth / 2), node.path);
       return this.finishMesh(geometry, { properties });
     });
   }
@@ -1460,7 +1501,11 @@ export class Converter {
       // the time `makeMesh` could measure it the memory is already committed.
       this.chargeEstimate(points.length * (this.detailLevel + 1));
 
-      const geometry = new THREE.LatheGeometry(points, this.detailLevel);
+      // LatheGeometry winds its faces from the profile's direction, so a
+      // profile drawn top-down (upstream's chess pieces all are) comes out
+      // inside out — which three-bvh-csg then drops from a union. Orient it
+      // outward by the signed volume, as Euclid does from the profile plane.
+      const geometry = orientOutward(new THREE.LatheGeometry(points, this.detailLevel));
       return this.finishMesh(geometry, node, true, this.currentTransform().material);
     });
   }

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -198,6 +198,8 @@ function cloneMaterialState(material: MaterialState): MaterialState {
 /** How many print statements are kept. A `print` inside a 100k-iteration loop
  *  should not turn the tool result into a transcript. */
 const MAX_LOGS = 200;
+/** Same bound for distinct warnings; they are deduplicated first. */
+const MAX_WARNINGS = 200;
 
 /** Signed volume of an indexed or unindexed triangle geometry. */
 function signedVolume(geometry: THREE.BufferGeometry): number {
@@ -262,6 +264,7 @@ export class Converter {
    *  flat mesh for `profileOf`; at the scene level it draws as a line. */
   private operandDepth = 0;
   private readonly warnings: string[] = [];
+  private readonly warningSet = new Set<string>();
   private readonly logs: string[] = [];
   private background: RGBA | undefined;
   private sceneDepth = 0;
@@ -468,8 +471,12 @@ export class Converter {
     return line;
   }
 
+  /** Deduplicated and capped: a `texture` inside a 100k-iteration loop must
+   *  not turn the warning list into a transcript, nor the check into a scan. */
   private warn(message: string): void {
-    if (!this.warnings.includes(message)) this.warnings.push(message);
+    if (this.warningSet.has(message) || this.warnings.length >= MAX_WARNINGS) return;
+    this.warningSet.add(message);
+    this.warnings.push(message);
   }
 
   /** `background` at the root: a colour is kept for the viewer, a texture
@@ -1031,7 +1038,7 @@ export class Converter {
     // nothing downstream ever sees it) or leave the frames behind.
     const group = new THREE.Group();
     const body = defineNode.body;
-    const { position, orientation, rotation, size, ...rest } = node.properties as ShapeProperties & Record<string, unknown>;
+    const { position, orientation, rotation, size, name, ...rest } = node.properties as ShapeProperties & Record<string, unknown>;
     return this.inScope(group, () => {
       // The standard options place the block's output, as on any shape; the
       // material ones set the scope its body runs in.
@@ -1047,6 +1054,8 @@ export class Converter {
       for (const [key, value] of Object.entries(rest)) {
         if (!(key in STANDARD_KEYS)) this.symbols.set(key, this.evaluator.evaluate(value as Expression));
       }
+
+      if (name !== undefined) group.name = String(this.evaluator.evaluate(name as Expression));
 
       // Convert the body, under the call's own `detail` / `smoothing`.
       this.withShapeOptions(rest as ShapeProperties, () => this.addChildren(group, body));

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -420,7 +420,11 @@ export class Converter {
     this.vertexCount += points.length;
     const geometry = this.placePath(new THREE.BufferGeometry().setFromPoints(points.map((point) => new THREE.Vector3(point.x, point.y, 0))), node);
     const material = this.currentTransform().material;
-    const line = new THREE.Line(geometry, new THREE.LineBasicMaterial({ color: material.color?.clone() ?? new THREE.Color(0.8, 0.8, 0.8) }));
+    const opacity = Math.min(1, Math.max(0, material.alpha * material.opacity));
+    const line = new THREE.Line(
+      geometry,
+      new THREE.LineBasicMaterial({ color: material.color?.clone() ?? new THREE.Color(0.8, 0.8, 0.8), opacity, transparent: opacity < 1 }),
+    );
     this.applyCurrentTransform(line);
     return line;
   }
@@ -1005,8 +1009,8 @@ export class Converter {
         if (!(key in STANDARD_KEYS)) this.symbols.set(key, this.evaluator.evaluate(value as Expression));
       }
 
-      // Convert the body
-      this.addChildren(group, body);
+      // Convert the body, under the call's own `detail` / `smoothing`.
+      this.withShapeOptions(rest as ShapeProperties, () => this.addChildren(group, body));
     });
   }
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -1425,8 +1425,13 @@ export class Converter {
       if (child.type === "path") {
         if (pathNode) throw new Error("`lathe` takes one profile path");
         pathNode = child;
-      } else if (this.convertNode(child)) {
-        throw new Error("`lathe` takes a path, not a shape — give it `path { … }`");
+      } else {
+        const object = this.convertNode(child);
+        if (object) {
+          // Never reaches the scene, so nothing downstream would free it.
+          disposeObject3D(object);
+          throw new Error("`lathe` takes a path, not a shape — give it `path { … }`");
+        }
       }
     }
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -21,6 +21,7 @@ import {
   PathCommand,
   PointCommand,
   CurveCommand,
+  ArcCommand,
   ForLoopPathCommand,
   CustomShapeNode,
   ColorNode,
@@ -28,13 +29,31 @@ import {
   OrientationNode,
   TranslateNode,
   ScaleNode,
+  MaterialNode,
+  MaterialProperties,
   Expression,
   Vector3,
   Color,
   ShapeProperties,
 } from "./types";
-import { Evaluator, SymbolTable, Value } from "./evaluator";
+import { Evaluator, SymbolTable, Value, RGBA, MaterialValue, iterationValues, rgbaOf, valuesEqual } from "./evaluator";
 import { disposeObject3D, disposeScratch } from "./dispose";
+
+/** What a conversion reports besides geometry. Stored on the root group's
+ *  `userData` so both viewers and the tool result can read it. */
+export interface ShapeScriptSceneInfo {
+  /** `background r g b a` from the script's root, when set. */
+  background?: RGBA;
+  /** Commands that were accepted but not rendered (`texture`, `camera`, …). */
+  warnings: string[];
+  /** Every `print`, one line each. */
+  logs: string[];
+}
+
+export function sceneInfoOf(group: THREE.Object3D): ShapeScriptSceneInfo {
+  const info = group.userData as Partial<ShapeScriptSceneInfo>;
+  return { ...(info.background ? { background: info.background } : {}), warnings: info.warnings ?? [], logs: info.logs ?? [] };
+}
 
 /** A path point in path space, after the path's local transform. */
 interface PathPoint {
@@ -147,12 +166,43 @@ export class ShapeScriptLimitError extends Error {
   }
 }
 
+/** The scoped material, as upstream's `context.state.material`: every field a
+ *  `color` / `opacity` / `metallicity` / `roughness` / `glow` / `smoothing`
+ *  command sets for the rest of its block. */
+type MaterialState = {
+  color: THREE.Color | undefined;
+  /** Alpha of the current colour (`color 1 0 0 0.5`), separate from `opacity`. */
+  alpha: number;
+  /** Multiplies through nested scopes: `opacity 0.5` twice is 0.25. */
+  opacity: number;
+  metallicity: number | undefined;
+  roughness: number | undefined;
+  glow: THREE.Color | undefined;
+  /** `smoothing` threshold in half-turns; 0 means flat shading. */
+  smoothing: number | undefined;
+};
+
 type TransformState = {
   matrix: THREE.Matrix4;
-  // Explicitly `| undefined` rather than optional: `exactOptionalPropertyTypes`
-  // otherwise rejects the `current.color = undefined` reset in block scopes.
-  color: THREE.Color | undefined;
+  material: MaterialState;
 };
+
+function cloneMaterialState(material: MaterialState): MaterialState {
+  return {
+    ...material,
+    color: material.color?.clone(),
+    glow: material.glow?.clone(),
+  };
+}
+
+/** How many print statements are kept. A `print` inside a 100k-iteration loop
+ *  should not turn the tool result into a transcript. */
+const MAX_LOGS = 200;
+
+/** Upstream's icosphere subdivision level for a detail setting. */
+function icosphereSubdivisions(detail: number): number {
+  return Math.max(0, Math.round(Math.log2(Math.max(4, detail))) - 2);
+}
 
 export class Converter {
   private options: ConversionOptions;
@@ -169,11 +219,20 @@ export class Converter {
 
   // Transform state stack for relative transforms
   private transformStack: TransformState[] = [];
+  /** > 0 while building a builder's operands, where a bare `path` must be a
+   *  flat mesh for `profileOf`; at the scene level it draws as a line. */
+  private operandDepth = 0;
+  private readonly warnings: string[] = [];
+  private readonly logs: string[] = [];
+  private background: RGBA | undefined;
+  private sceneDepth = 0;
 
   constructor(options: ConversionOptions = {}) {
     this.options = options;
     this.symbols = new SymbolTable();
     this.evaluator = new Evaluator(this.symbols, options.randomSeed);
+    // `detail` is readable as a symbol before any `detail` command runs.
+    this.symbols.set("detail", this.detailLevel);
     // Initialize with identity transform
     this.pushTransform();
   }
@@ -183,6 +242,8 @@ export class Converter {
 
     try {
       this.addChildren(group, nodes);
+      const info: ShapeScriptSceneInfo = { warnings: this.warnings, logs: this.logs, ...(this.background ? { background: this.background } : {}) };
+      group.userData = info;
     } catch (error) {
       // The ROOT is abandoned the same way a nested group is: the callers
       // assign it only once this returns, and both Vue surfaces catch the error
@@ -250,22 +311,6 @@ export class Converter {
     return new THREE.Mesh(geometry, material);
   }
 
-  /** Expand a `for … from to to step` range without materialising it first.
-   *  The array used to be built up front, so an absurd bound exhausted memory
-   *  before a single node existed and the budget below never got a turn. */
-  private rangeIterations(from: number, to: number, step: number): number[] {
-    if (step === 0 || !Number.isFinite(step) || !Number.isFinite(from) || !Number.isFinite(to))
-      throw new Error("Loop bounds and step must be finite, with a nonzero step");
-    const iterations: number[] = [];
-    for (let i = from; step > 0 ? i <= to : i >= to; i += step) {
-      if (iterations.length >= this.maxLoopIterations) {
-        throw new ShapeScriptLimitError(`ShapeScript loop exceeds ${this.maxLoopIterations} iterations — narrow the range or increase the step`);
-      }
-      iterations.push(i);
-    }
-    return iterations;
-  }
-
   private convertNode(node: SceneNode): THREE.Object3D | null {
     // Counted on the way IN, so a runaway loop stops at the limit rather than
     // after building everything it asked for.
@@ -313,6 +358,24 @@ export class Converter {
       case "color":
         this.handleColorCommand(node);
         return null;
+      case "material":
+        this.handleMaterialCommand(node);
+        return null;
+      case "smoothing":
+        this.currentTransform().material.smoothing = this.evaluateNumber(node.value);
+        return null;
+      case "background":
+        this.handleBackground(node.value);
+        return null;
+      case "print":
+        if (this.logs.length < MAX_LOGS) this.logs.push(printable(this.evaluator.evaluate(node.value)));
+        return null;
+      case "assert":
+        if (!this.evaluator.evaluateToBoolean(node.value)) throw new Error("Assertion failed");
+        return null;
+      case "ignored":
+        this.warn(`\`${node.command}\` is not rendered by this viewer and was skipped`);
+        return null;
       case "rotate":
         this.handleRotateCommand(node);
         return null;
@@ -327,17 +390,55 @@ export class Converter {
         return null;
       case "customShape":
         return this.convertCustomShape(node);
-      case "path": {
-        const shape = this.buildPath(node);
-        this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
-        this.requireEnclosedArea(shape, "path");
-        const mesh = this.makeMesh(this.placePath(new THREE.ShapeGeometry(shape), node), this.createMaterial({ properties: {} }));
-        this.applyCurrentTransform(mesh);
-        return mesh;
-      }
+      case "path":
+        return this.operandDepth > 0 ? this.convertPathProfile(node) : this.convertPathLine(node);
       default:
         throw new Error(`Unsupported command: ${(node as { type: string }).type}`);
     }
+  }
+
+  /** A `path` handed to a builder: the flat face it encloses, which `profileOf`
+   *  reads the perimeter back from. */
+  private convertPathProfile(node: PathNode): THREE.Mesh {
+    const shape = this.buildPath(node);
+    this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
+    this.requireEnclosedArea(shape, "path");
+    const mesh = this.makeMesh(this.placePath(new THREE.ShapeGeometry(shape), node), this.createMaterial({ properties: {} }));
+    this.applyCurrentTransform(mesh);
+    return mesh;
+  }
+
+  /** A `path` in the scene draws as a stroke, as upstream: `fill` makes a
+   *  face of it, and a builder consumes it. Open paths are allowed here. */
+  private convertPathLine(node: PathNode): THREE.Line {
+    const shape = this.buildPath(node);
+    const points = shape.getPoints(Math.max(1, Math.floor(this.detailLevel / 4)));
+    if (!points.every((point) => Number.isFinite(point.x) && Number.isFinite(point.y)))
+      throw new Error("`path` needs finite path coordinates — these overflow");
+    if (points.length < 2) throw new Error("`path` needs at least two points");
+    this.chargeEstimate(points.length);
+    this.vertexCount += points.length;
+    const geometry = this.placePath(new THREE.BufferGeometry().setFromPoints(points.map((point) => new THREE.Vector3(point.x, point.y, 0))), node);
+    const material = this.currentTransform().material;
+    const line = new THREE.Line(geometry, new THREE.LineBasicMaterial({ color: material.color?.clone() ?? new THREE.Color(0.8, 0.8, 0.8) }));
+    this.applyCurrentTransform(line);
+    return line;
+  }
+
+  private warn(message: string): void {
+    if (!this.warnings.includes(message)) this.warnings.push(message);
+  }
+
+  /** `background` at the root: a colour is kept for the viewer, a texture
+   *  file cannot be loaded here. */
+  private handleBackground(value: Expression): void {
+    if (this.sceneDepth > 0) throw new Error("`background` can only be used at the root of the script");
+    const raw = this.evaluator.evaluate(value);
+    if (typeof raw === "string") {
+      this.warn(`background image "${raw}" is not supported — the scene keeps its default background`);
+      return;
+    }
+    this.background = this.requireFiniteColor(rgbaOf(raw));
   }
 
   /** Build `group` inside a fresh symbol + transform scope.
@@ -368,9 +469,11 @@ export class Converter {
   private inFrame<T>(build: () => T): T {
     this.symbols.pushScope();
     this.pushTransform();
+    this.sceneDepth++;
     try {
       return build();
     } finally {
+      this.sceneDepth--;
       this.popTransform();
       this.symbols.popScope();
     }
@@ -393,11 +496,31 @@ export class Converter {
     return this.inScope(group, () => this.addChildren(group, node.children));
   }
 
-  private finishMesh(geometry: THREE.BufferGeometry, node: { properties: ShapeProperties }): THREE.Mesh {
+  /** A control-flow body: `for`, `if` and `switch` scope SYMBOLS only. Their
+   *  `translate` / `rotate` / `color` carry on past the closing brace, as
+   *  upstream (scope.md, "Conditional Scope") — a loop that rotates each
+   *  iteration leaves the frame where the last one ended. */
+  private inSymbolScope(group: THREE.Group, build: () => void): THREE.Group {
+    this.symbols.pushScope();
+    try {
+      build();
+      return group;
+    } catch (error) {
+      disposeObject3D(group);
+      throw error;
+    } finally {
+      this.symbols.popScope();
+    }
+  }
+
+  /** Wrap a finished geometry in a mesh with the node's material and
+   *  placement. `scaleBySize` is for builders and groups, whose `size` scales
+   *  the result; a primitive's `size` is already in its geometry. */
+  private finishMesh(geometry: THREE.BufferGeometry, node: { properties: ShapeProperties }, scaleBySize = true, material?: MaterialState): THREE.Mesh {
     let mesh: THREE.Mesh | undefined;
     try {
-      mesh = this.makeMesh(geometry, this.createMaterial(node));
-      this.applyExplicitTransforms(mesh, node.properties);
+      mesh = this.makeMesh(geometry, this.createMaterial(node, material));
+      this.applyExplicitTransforms(mesh, node.properties, scaleBySize);
       this.applyCurrentTransform(mesh);
       return mesh;
     } catch (error) {
@@ -407,8 +530,24 @@ export class Converter {
     }
   }
 
+  /** Run `build` with the shape's own `detail` / `smoothing` in force, then
+   *  restore the enclosing values. */
+  private withShapeOptions<T>(properties: ShapeProperties, build: () => T): T {
+    const detail = this.detailLevel;
+    const smoothing = this.currentTransform().material.smoothing;
+    try {
+      if (properties.detail !== undefined) this.handleDetail({ type: "detail", value: properties.detail });
+      if (properties.smoothing !== undefined) this.currentTransform().material.smoothing = this.evaluateNumber(properties.smoothing);
+      return build();
+    } finally {
+      this.detailLevel = detail;
+      this.symbols.set("detail", detail);
+      this.currentTransform().material.smoothing = smoothing;
+    }
+  }
+
   private convertShape(node: ShapeNode): THREE.Mesh {
-    return this.finishMesh(this.createGeometry(node), node);
+    return this.withShapeOptions(node.properties, () => this.finishMesh(this.createGeometry(node), node, false));
   }
 
   /** A solid whose extent is zero in any dimension draws nothing.
@@ -425,16 +564,7 @@ export class Converter {
   }
 
   private createGeometry(node: ShapeNode): THREE.BufferGeometry {
-    let size: Vector3 = [1, 1, 1];
-
-    if (node.properties.size) {
-      size = this.evaluateVector3(node.properties.size);
-    }
-
-    // If only one dimension specified (others are 0), make it uniform
-    if (size[1] === 0 && size[2] === 0 && size[0] !== 0) {
-      size = [size[0], size[0], size[0]];
-    }
+    const size = this.evaluateSize(node.properties.size);
 
     switch (node.primitive) {
       case "cube":
@@ -446,6 +576,10 @@ export class Converter {
       case "sphere":
         this.requireExtent("sphere", size);
         return new THREE.SphereGeometry(0.5, this.detailLevel, this.detailLevel).scale(...size);
+
+      case "icosphere":
+        this.requireExtent("icosphere", size);
+        return new THREE.IcosahedronGeometry(0.5, icosphereSubdivisions(this.detailLevel)).scale(...size);
 
       case "cylinder": {
         const radiusTop = node.properties.radiusTop ? this.evaluateNumber(node.properties.radiusTop) : size[0] / 2;
@@ -476,6 +610,9 @@ export class Converter {
         return new THREE.PlaneGeometry(sideLength, size[1] || sideLength);
       }
 
+      case "roundrect":
+        return this.createRoundrect(node, size);
+
       case "polygon": {
         const radius = (size[0] || 1) / 2;
         const sides = node.properties.sides === undefined ? 6 : this.evaluateNumber(node.properties.sides);
@@ -486,6 +623,31 @@ export class Converter {
       default:
         throw new Error(`Unknown primitive: ${node.primitive}`);
     }
+  }
+
+  /** `roundrect { size w h radius r }`: the corner radius is `r` times the
+   *  smaller side (default 0.25), as upstream. */
+  private createRoundrect(node: ShapeNode, size: Vector3): THREE.BufferGeometry {
+    const width = size[0] || 1;
+    const height = size[1] || width;
+    const proportion = node.properties.radius === undefined ? 0.25 : this.evaluateNumber(node.properties.radius);
+    const radius = Math.min(Math.max(0, proportion) * Math.min(width, height), width / 2, height / 2);
+    const shape = new THREE.Shape();
+    const w = width / 2;
+    const h = height / 2;
+    shape.moveTo(-w + radius, -h);
+    shape.lineTo(w - radius, -h);
+    shape.absarc(w - radius, -h + radius, radius, -Math.PI / 2, 0, false);
+    shape.lineTo(w, h - radius);
+    shape.absarc(w - radius, h - radius, radius, 0, Math.PI / 2, false);
+    shape.lineTo(-w + radius, h);
+    shape.absarc(-w + radius, h - radius, radius, Math.PI / 2, Math.PI, false);
+    shape.lineTo(-w, -h + radius);
+    shape.absarc(-w + radius, -h + radius, radius, Math.PI, Math.PI * 1.5, false);
+    shape.closePath();
+    const segments = Math.max(1, Math.floor(this.detailLevel / 4));
+    this.chargePathEstimate(shape, segments);
+    return new THREE.ShapeGeometry(shape, segments);
   }
 
   /** A plugin extension (upstream has no torus). `size` is the OVERALL
@@ -504,29 +666,61 @@ export class Converter {
     return new THREE.TorusGeometry(ringRadius, tubeRadius, Math.max(3, Math.floor(this.detailLevel / 2)), this.detailLevel);
   }
 
-  private materialColor(property: ShapeProperties["color"]): THREE.Color {
-    if (property !== undefined) {
-      const [red = 0.8, green = 0.8, blue = 0.8] = this.evaluateColor(property);
-      return new THREE.Color(red, green, blue);
-    }
-    const scopeColor = this.currentTransform().color;
-    return scopeColor === undefined ? new THREE.Color(0.8, 0.8, 0.8) : scopeColor.clone();
+  /** The material state a shape's own properties produce on top of `base`:
+   *  a `material` bundle first, then the individual properties, the way the
+   *  same commands would apply in order inside its block. */
+  private materialFor(properties: MaterialProperties & { material?: Expression | undefined }, base: MaterialState): MaterialState {
+    const state = cloneMaterialState(base);
+    if (properties.material !== undefined) this.applyMaterialValue(state, this.evaluator.evaluate(properties.material));
+    if (properties.color !== undefined) this.applyColor(state, this.evaluateRGBA(properties.color));
+    if (properties.opacity !== undefined) state.opacity *= this.evaluateNumber(properties.opacity);
+    if (properties.metallicity !== undefined) state.metallicity = this.evaluateNumber(properties.metallicity);
+    if (properties.roughness !== undefined) state.roughness = this.evaluateNumber(properties.roughness);
+    if (properties.glow !== undefined) state.glow = this.glowColor(this.evaluator.evaluate(properties.glow));
+    if (properties.texture !== undefined) this.warnTexture(this.evaluator.evaluate(properties.texture));
+    return state;
   }
 
-  private createMaterial(node: { properties: ShapeProperties }): THREE.Material {
-    // A per-shape `color` property wins; otherwise the enclosing scope's
-    // `color` command applies. That fallback was missing, so `color 1 0 0`
-    // followed by `cube` rendered the default grey — the scope colour was
-    // stored and cloned but never read back.
-    const threeColor = this.materialColor(node.properties.color);
+  private applyColor(state: MaterialState, [r, g, b, a]: RGBA): void {
+    state.color = new THREE.Color(r, g, b);
+    state.alpha = a;
+  }
 
-    const opacity = node.properties.opacity ? this.evaluateNumber(node.properties.opacity) : 1;
-    const transparent = opacity < 1;
+  /** `glow` takes a colour or a brightness; the alpha is ignored upstream. */
+  private glowColor(value: Value): THREE.Color {
+    const [r, g, b] = this.requireFiniteColor(rgbaOf(value));
+    return new THREE.Color(r, g, b);
+  }
 
+  private warnTexture(value: Value): void {
+    if (value === "") return;
+    this.warn(`texture "${String(value)}" is not supported — the shape is drawn with its colour instead`);
+  }
+
+  private applyMaterialValue(state: MaterialState, value: Value): void {
+    if (typeof value !== "object" || Array.isArray(value) || value.kind !== "material") throw new Error("`material` needs a value made with `material { … }`");
+    const material: MaterialValue = value;
+    if (material.color) this.applyColor(state, this.requireFiniteColor(material.color));
+    if (material.opacity !== undefined) state.opacity *= material.opacity;
+    if (material.metallicity !== undefined) state.metallicity = material.metallicity;
+    if (material.roughness !== undefined) state.roughness = material.roughness;
+    if (material.glow) state.glow = this.glowColor(material.glow);
+    if (material.texture !== undefined) this.warnTexture(material.texture);
+  }
+
+  private createMaterial(node: { properties: ShapeProperties }, base?: MaterialState): THREE.Material {
+    // A per-shape property wins; otherwise the enclosing scope's commands
+    // apply. Opacity is the colour's alpha times every `opacity` in scope.
+    const state = this.materialFor(node.properties, base ?? this.currentTransform().material);
+    const opacity = Math.max(0, state.alpha * state.opacity);
     return new THREE.MeshStandardMaterial({
-      color: threeColor,
-      opacity,
-      transparent,
+      color: state.color?.clone() ?? new THREE.Color(0.8, 0.8, 0.8),
+      opacity: Math.min(1, opacity),
+      transparent: opacity < 1,
+      ...(state.metallicity === undefined ? {} : { metalness: Math.min(1, Math.max(0, state.metallicity)) }),
+      ...(state.roughness === undefined ? {} : { roughness: Math.min(1, Math.max(0, state.roughness)) }),
+      ...(state.glow === undefined ? {} : { emissive: state.glow.clone() }),
+      flatShading: state.smoothing !== undefined && state.smoothing <= 0,
       wireframe: this.options.wireframe ?? false,
     });
   }
@@ -719,45 +913,27 @@ export class Converter {
   private convertForLoop(node: ForLoopNode): THREE.Group {
     const group = new THREE.Group();
 
-    // New scope for the loop, both symbols and transforms. Transforms
-    // accumulate across iterations but stay scoped to the loop.
-    return this.inScope(group, () => {
-      // Check if it's a values iteration or range iteration
-      if (node.iterableValues) {
-        // for i in values
-        const values = this.evaluator.evaluate(node.iterableValues);
-        const valueArray = Array.isArray(values) ? values : [values];
-        // Same ceiling as the range form. This one used to bypass both budgets:
-        // the iteration cap lives in `rangeIterations`, and the node cap only
-        // counts what the BODY builds — so an empty body ran the whole list for
-        // free.
-        if (valueArray.length > this.maxLoopIterations) {
-          throw new ShapeScriptLimitError(`ShapeScript loop exceeds ${this.maxLoopIterations} iterations — narrow the range or increase the step`);
-        }
-
-        for (const iterationValue of valueArray) {
-          this.symbols.set(node.variable, iterationValue);
-
-          // Convert body nodes - transforms accumulate across iterations
-          this.addChildren(group, node.body);
-        }
-      } else {
-        // for i in from to to
-        const from = this.evaluateNumber(node.from);
-        const to = this.evaluateNumber(node.to);
-        const step = node.step ? this.evaluateNumber(node.step) : 1;
-
-        const iterations = this.rangeIterations(from, to, step);
-
-        for (const i of iterations) {
-          this.symbols.set(node.variable, i);
-
-          // Convert body nodes directly - no iteration sub-groups.
-          // Transforms accumulate across iterations within the loop scope.
-          this.addChildren(group, node.body);
-        }
+    // Symbols are scoped to the loop; transforms and materials are not.
+    return this.inSymbolScope(group, () => {
+      // A range or a tuple; both go through the same bounded expansion, so
+      // neither form can run the body more times than the budget allows.
+      for (const value of this.iterations(node.iterable)) {
+        this.symbols.set(node.variable, value);
+        // Convert body nodes directly - no iteration sub-groups.
+        // Transforms accumulate across iterations within the loop scope.
+        this.addChildren(group, node.body);
       }
     });
+  }
+
+  /** Expand a loop's iterable without materialising an absurd range first:
+   *  the walk stops at the budget rather than after allocating past it. */
+  private iterations(iterable: Expression): Value[] {
+    return iterationValues(
+      this.evaluator.evaluate(iterable),
+      this.maxLoopIterations,
+      () => new ShapeScriptLimitError(`ShapeScript loop exceeds ${this.maxLoopIterations} iterations — narrow the range or increase the step`),
+    );
   }
 
   private convertIf(node: IfNode): THREE.Group {
@@ -766,7 +942,7 @@ export class Converter {
     // Evaluated BEFORE the scope is pushed, as it always was.
     const condition = this.evaluator.evaluateToBoolean(node.condition);
 
-    return this.inScope(group, () => this.addChildren(group, condition ? node.thenBody : (node.elseBody ?? [])));
+    return this.inSymbolScope(group, () => this.addChildren(group, condition ? node.thenBody : (node.elseBody ?? [])));
   }
 
   private convertSwitch(node: SwitchNode): THREE.Group {
@@ -775,19 +951,17 @@ export class Converter {
     // Evaluate switch value
     const switchValue = this.evaluator.evaluate(node.value);
 
-    return this.inScope(group, () => {
-      const matched = node.cases.find((caseNode) => caseNode.values.some((caseValue) => this.valuesEqual(switchValue, this.evaluator.evaluate(caseValue))));
+    return this.inSymbolScope(group, () => {
+      const matched = node.cases.find((caseNode) => caseNode.values.some((caseValue) => valuesEqual(switchValue, this.evaluator.evaluate(caseValue))));
       this.addChildren(group, matched ? matched.body : (node.defaultCase ?? []));
     });
   }
 
   private handleDefine(node: DefineNode): void {
-    // Check if this is a variable definition or a custom shape definition
-    if (node.value !== undefined) {
-      // Variable definition: define x 5
-      const value = this.evaluator.evaluate(node.value);
-      this.symbols.set(node.name, value);
-    } else if (node.body !== undefined || node.options !== undefined) {
+    // A value or a function is the evaluator's; a custom shape block is kept
+    // here, since its body is scene nodes.
+    if (this.evaluator.define(node)) return;
+    if (node.body !== undefined || node.options !== undefined) {
       // Custom shape definition: define shape { ... }
       // Store the entire node for later instantiation
       // Note: We cast to Value since SymbolTable expects Value, but we know it's a DefineNode
@@ -814,15 +988,21 @@ export class Converter {
     // nothing downstream ever sees it) or leave the frames behind.
     const group = new THREE.Group();
     const body = defineNode.body;
+    const { position, orientation, rotation, size, ...rest } = node.properties as ShapeProperties & Record<string, unknown>;
     return this.inScope(group, () => {
+      // The standard options place the block's output, as on any shape; the
+      // material ones set the scope its body runs in.
+      this.applyPlacement(this.currentTransform().matrix, { position, orientation, rotation, size } as ShapeProperties);
+      this.currentTransform().material = this.materialFor(rest as MaterialProperties, this.currentTransform().material);
+
       // Set default values from options
       for (const option of defineNode.options ?? []) {
         this.symbols.set(option.name, this.evaluator.evaluate(option.defaultValue));
       }
 
       // Override with provided properties
-      for (const [key, value] of Object.entries(node.properties)) {
-        this.symbols.set(key, this.evaluator.evaluate(value as Expression));
+      for (const [key, value] of Object.entries(rest)) {
+        if (!(key in STANDARD_KEYS)) this.symbols.set(key, this.evaluator.evaluate(value as Expression));
       }
 
       // Convert the body
@@ -830,11 +1010,20 @@ export class Converter {
     });
   }
 
+  /** Post-multiply a shape's `position` / `orientation` / `size` into a frame. */
+  private applyPlacement(matrix: THREE.Matrix4, properties: ShapeProperties): void {
+    const position = properties.position ? new THREE.Vector3(...this.evaluateVector3(properties.position)) : new THREE.Vector3();
+    const rotation = properties.orientation ?? properties.rotation;
+    const quaternion = rotation ? this.rotationOf(rotation) : new THREE.Quaternion();
+    const scale = properties.size ? new THREE.Vector3(...this.evaluateSize(properties.size)) : new THREE.Vector3(1, 1, 1);
+    matrix.multiply(new THREE.Matrix4().compose(position, quaternion, scale));
+  }
+
   private pushTransform(): void {
     const current = this.currentTransform();
     this.transformStack.push({
       matrix: current.matrix.clone(),
-      color: current.color === undefined ? undefined : current.color.clone(),
+      material: cloneMaterialState(current.material),
     });
   }
 
@@ -847,7 +1036,12 @@ export class Converter {
   private currentTransform(): TransformState {
     const top = this.transformStack[this.transformStack.length - 1];
     // Empty stack — hand back a fresh identity transform.
-    return top ?? { matrix: new THREE.Matrix4(), color: undefined };
+    return (
+      top ?? {
+        matrix: new THREE.Matrix4(),
+        material: { color: undefined, alpha: 1, opacity: 1, metallicity: undefined, roughness: undefined, glow: undefined, smoothing: undefined },
+      }
+    );
   }
 
   private applyCurrentTransform(object: THREE.Object3D): void {
@@ -855,7 +1049,7 @@ export class Converter {
     object.applyMatrix4(transform.matrix);
   }
 
-  private applyExplicitTransforms(object: THREE.Object3D, properties: ShapeProperties): void {
+  private applyExplicitTransforms(object: THREE.Object3D, properties: ShapeProperties, scaleBySize = false): void {
     if (properties.position) {
       const pos = this.evaluateVector3(properties.position);
       object.position.set(...pos);
@@ -866,6 +1060,8 @@ export class Converter {
     if (orientation) {
       object.quaternion.copy(this.rotationOf(orientation));
     }
+    if (scaleBySize && properties.size) object.scale.set(...this.evaluateSize(properties.size));
+    if (properties.name !== undefined) object.name = String(this.evaluator.evaluate(properties.name));
   }
 
   /** An upstream rotation value as a quaternion.
@@ -912,8 +1108,31 @@ export class Converter {
   }
 
   private handleColorCommand(node: ColorNode): void {
-    const colorValue = this.evaluateVector3OrColor(node.value);
-    this.currentTransform().color = new THREE.Color(colorValue[0], colorValue[1], colorValue[2]);
+    this.applyColor(this.currentTransform().material, this.evaluateRGBA(node.value));
+  }
+
+  private handleMaterialCommand(node: MaterialNode): void {
+    const state = this.currentTransform().material;
+    switch (node.property) {
+      case "opacity":
+        state.opacity *= this.evaluateNumber(node.value);
+        break;
+      case "metallicity":
+        state.metallicity = this.evaluateNumber(node.value);
+        break;
+      case "roughness":
+        state.roughness = this.evaluateNumber(node.value);
+        break;
+      case "glow":
+        state.glow = this.glowColor(this.evaluator.evaluate(node.value));
+        break;
+      case "texture":
+        this.warnTexture(this.evaluator.evaluate(node.value));
+        break;
+      case "material":
+        this.applyMaterialValue(state, this.evaluator.evaluate(node.value));
+        break;
+    }
   }
 
   private handleRotateCommand(node: RotateNode): void {
@@ -945,7 +1164,7 @@ export class Converter {
   }
 
   private handleScaleCommand(node: ScaleNode): void {
-    const scale = this.evaluateVector3(node.value);
+    const scale = this.evaluateSize(node.value);
     const transform = this.currentTransform();
     const scaleMatrix = new THREE.Matrix4().makeScale(scale[0], scale[1], scale[2]);
     transform.matrix.multiply(scaleMatrix);
@@ -971,44 +1190,34 @@ export class Converter {
     return shape;
   }
 
-  private convertExtrude(node: ExtrudeNode): THREE.Mesh {
-    if (!node.path) {
-      return this.buildFromChildren({ children: node.children ?? [], properties: node.properties }, (meshes) => {
-        const shapes = meshes.map((mesh) => this.planarShape(mesh));
-        if (!shapes.length) throw new Error("Extrude requires a path or planar shape");
-        const size = node.properties.size ? this.evaluateVector3(node.properties.size) : [1, 1, 1];
-        for (const shape of shapes) this.chargePathEstimate(shape, 1, 12);
-        return new THREE.ExtrudeGeometry(shapes, { depth: size[2] ?? 1, bevelEnabled: false, curveSegments: 1 });
-      });
-    }
-    const shape = this.requireEnclosedArea(this.buildPath(node.path), "extrude");
-
-    // Get extrusion depth from size property
-    const size = node.properties.size ? this.evaluateVector3(node.properties.size) : [1, 1, 1];
+  /** `size` on an extrude: X and Y scale the profile, Z is the depth. The
+   *  depth goes into the geometry, so the mesh keeps a unit Z scale. */
+  private extrudeProperties(node: ExtrudeNode): { depth: number; properties: ShapeProperties } {
+    const size = node.properties.size ? this.evaluateSize(node.properties.size) : [1, 1, 1];
     const depth = size[2] || 1;
+    return { depth, properties: { ...node.properties, size: [size[0] ?? 1, size[1] ?? 1, 1] } };
+  }
 
-    // Create extruded geometry
-    const curveSegments = Math.max(1, Math.floor(this.detailLevel / 4));
-    this.chargePathEstimate(shape, curveSegments, EXTRUDE_VERTICES_PER_POINT);
+  private convertExtrude(node: ExtrudeNode): THREE.Mesh {
+    return this.withShapeOptions(node.properties, () => {
+      const { depth, properties } = this.extrudeProperties(node);
+      if (!node.path) {
+        return this.buildFromChildren({ children: node.children ?? [], properties }, (meshes) => {
+          const shapes = meshes.map((mesh) => this.planarShape(mesh));
+          if (!shapes.length) throw new Error("Extrude requires a path or planar shape");
+          for (const shape of shapes) this.chargePathEstimate(shape, 1, 12);
+          return new THREE.ExtrudeGeometry(shapes, { depth, bevelEnabled: false, curveSegments: 1 });
+        });
+      }
+      const shape = this.requireEnclosedArea(this.buildPath(node.path), "extrude");
 
-    const geometry = this.placePath(
-      new THREE.ExtrudeGeometry(shape, {
-        depth,
-        bevelEnabled: false,
-        curveSegments,
-      }),
-      node.path,
-    );
+      // Create extruded geometry
+      const curveSegments = Math.max(1, Math.floor(this.detailLevel / 4));
+      this.chargePathEstimate(shape, curveSegments, EXTRUDE_VERTICES_PER_POINT);
 
-    // Create material
-    const material = this.createMaterial(node);
-
-    const mesh = this.makeMesh(geometry, material);
-
-    this.applyExplicitTransforms(mesh, node.properties);
-    this.applyCurrentTransform(mesh);
-
-    return mesh;
+      const geometry = this.placePath(new THREE.ExtrudeGeometry(shape, { depth, bevelEnabled: false, curveSegments }), node.path);
+      return this.finishMesh(geometry, { properties });
+    });
   }
 
   private buildPath(pathNode: PathNode): THREE.Shape {
@@ -1022,11 +1231,9 @@ export class Converter {
   private placePath<T extends THREE.BufferGeometry>(geometry: T, pathNode: PathNode): T {
     const properties = pathNode.properties;
     if (!properties) return geometry;
-    const position = new THREE.Vector3(...this.evaluateVector3(properties.position));
-    const rotation = properties.orientation ?? properties.rotation;
-    const quaternion = rotation ? this.rotationOf(rotation) : new THREE.Quaternion();
-    const scale = new THREE.Vector3(...(properties.size ? this.evaluateVector3(properties.size) : [1, 1, 1]));
-    return geometry.applyMatrix4(new THREE.Matrix4().compose(position, quaternion, scale));
+    const frame = new THREE.Matrix4();
+    this.applyPlacement(frame, properties);
+    return geometry.applyMatrix4(frame);
   }
 
   /** Run the path's commands and return its points in path space.
@@ -1042,9 +1249,10 @@ export class Converter {
     const points: PathPoint[] = [];
 
     const place = (command: PointCommand | CurveCommand) => {
-      const position = new THREE.Vector3(this.evaluateNumber(command.x), this.evaluateNumber(command.y), 0).applyMatrix4(frame);
-      if (!Number.isFinite(position.x) || !Number.isFinite(position.y)) throw new Error("Path coordinates overflowed to a non-finite value");
-      points.push({ x: position.x, y: position.y, curved: command.type === "curve" });
+      if (command.z !== undefined && Math.abs(this.evaluateNumber(command.z)) > PATH_POINT_EPSILON) {
+        throw new Error("Paths here are planar — a `point` / `curve` may not have a nonzero third coordinate");
+      }
+      this.placePathPoint(frame, points, this.evaluateNumber(command.x), this.evaluateNumber(command.y), command.type === "curve");
     };
     const move = (step: THREE.Matrix4) => {
       frame.multiply(step);
@@ -1065,6 +1273,9 @@ export class Converter {
         case "point":
         case "curve":
           place(command);
+          break;
+        case "arc":
+          this.placeArc(frame, points, command);
           break;
         case "rotate":
           // Half-turns, clockwise positive — the same convention as `rotate` on a shape.
@@ -1090,17 +1301,41 @@ export class Converter {
     return points;
   }
 
+  private placePathPoint(frame: THREE.Matrix4, points: PathPoint[], x: number, y: number, curved: boolean): void {
+    const position = new THREE.Vector3(x, y, 0).applyMatrix4(frame);
+    if (!Number.isFinite(position.x) || !Number.isFinite(position.y)) throw new Error("Path coordinates overflowed to a non-finite value");
+    points.push({ x: position.x, y: position.y, curved });
+  }
+
+  /** `arc { angle a }`: `a` half-turns clockwise from +Y at radius `size / 2`,
+   *  placed by its own position/orientation, sampled as corners at the current
+   *  detail (upstream's own segment count for the span). */
+  private placeArc(frame: THREE.Matrix4, points: PathPoint[], command: ArcCommand): void {
+    const angle = command.angle === undefined ? 1 : this.evaluateNumber(command.angle);
+    const span = Math.min(2, Math.abs(angle));
+    if (span === 0) throw new Error("`arc` needs a nonzero angle");
+    const segments = Math.max(span < 0.5 ? 1 : span < 1 ? 2 : 3, Math.ceil((span / 2) * this.detailLevel));
+    const radius = (command.size === undefined ? 1 : this.evaluateSize(command.size)[0]) / 2;
+    const local = new THREE.Matrix4();
+    this.applyPlacement(local, {
+      ...(command.position ? { position: command.position } : {}),
+      ...(command.orientation ? { orientation: command.orientation } : {}),
+    });
+    const placed = frame.clone().multiply(local);
+    const sign = Math.sign(angle);
+    for (let i = 0; i <= segments; i++) {
+      const theta = ((sign * span * i) / segments) * Math.PI;
+      this.placePathPoint(placed, points, Math.sin(theta) * radius, Math.cos(theta) * radius, false);
+    }
+  }
+
   private runPathLoop(command: ForLoopPathCommand, processCommand: (command: PathCommand) => void): void {
     this.symbols.pushScope();
     try {
-      const from = this.evaluateNumber(command.from);
-      const to = this.evaluateNumber(command.to);
-      const step = command.step ? this.evaluateNumber(command.step) : 1;
-
       // Path commands never reach `convertNode`, so `maxNodes` cannot stop
       // this one — the shared bounded iterator is the only ceiling here.
-      for (const i of this.rangeIterations(from, to, step)) {
-        this.symbols.set(command.variable, i);
+      for (const value of this.iterations(command.iterable)) {
+        this.symbols.set(command.variable, value);
         for (const bodyCmd of command.commands) {
           processCommand(bodyCmd);
         }
@@ -1179,69 +1414,71 @@ export class Converter {
 
   private buildLathe(node: LatheNode): THREE.Object3D {
     // Lathe rotates a 2D profile around an axis to create a 3D shape.
-    // In ShapeScript, the path defines the profile.
-
-    // Find path node in children
+    // In ShapeScript, the path defines the profile. The other children are
+    // state commands (`material steel`, `detail 64`) that apply to the result.
     let pathNode: PathNode | null = null;
     for (const child of node.children) {
       if (child.type === "path") {
-        pathNode = child as PathNode;
-        break;
+        if (pathNode) throw new Error("`lathe` takes one profile path");
+        pathNode = child;
+      } else if (this.convertNode(child)) {
+        throw new Error("`lathe` takes a path, not a shape — give it `path { … }`");
       }
     }
 
     if (!pathNode) {
-      // No path found, return empty group
       throw new Error("Lathe requires a path child");
     }
     // Upstream transforms the profile before revolving it; a 3D orientation
     // on a profile has no 2D equivalent here, so refuse rather than guess.
     if (pathNode.properties) throw new Error("`lathe` does not support position/orientation/size on its profile path — place the lathe itself instead");
 
-    const shape = this.buildPath(pathNode);
-    this.chargePathEstimate(shape, this.detailLevel, this.detailLevel + 1);
-    const points = shape.getPoints(this.detailLevel);
+    return this.withShapeOptions(node.properties, () => {
+      const shape = this.buildPath(pathNode);
+      this.chargePathEstimate(shape, this.detailLevel, this.detailLevel + 1);
+      const points = shape.getPoints(this.detailLevel);
 
-    if (points.length < 2) {
-      throw new Error("Lathe path must have at least 2 points");
-    }
-    this.requireLatheProfile(points);
+      if (points.length < 2) {
+        throw new Error("Lathe path must have at least 2 points");
+      }
+      this.requireLatheProfile(points);
+      // A profile drawn on the -X side (upstream's examples do this) revolves
+      // to the same solid; LatheGeometry needs it on +X to face outward.
+      if (points.every((point) => point.x <= PATH_POINT_EPSILON)) for (const point of points) point.x = -point.x;
 
-    // What `LatheGeometry` is about to allocate: one ring of `detail + 1`
-    // vertices per profile point. Checked BEFORE the constructor runs, since by
-    // the time `makeMesh` could measure it the memory is already committed.
-    this.chargeEstimate(points.length * (this.detailLevel + 1));
+      // What `LatheGeometry` is about to allocate: one ring of `detail + 1`
+      // vertices per profile point. Checked BEFORE the constructor runs, since by
+      // the time `makeMesh` could measure it the memory is already committed.
+      this.chargeEstimate(points.length * (this.detailLevel + 1));
 
-    // Create lathe geometry
-    const geometry = new THREE.LatheGeometry(
-      points,
-      this.detailLevel, // Number of segments around the axis
-    );
-
-    // Create material
-    const material = this.createMaterial(node);
-    const mesh = this.makeMesh(geometry, material);
-
-    this.applyExplicitTransforms(mesh, node.properties);
-    this.applyCurrentTransform(mesh);
-
-    return mesh;
+      const geometry = new THREE.LatheGeometry(points, this.detailLevel);
+      return this.finishMesh(geometry, node, true, this.currentTransform().material);
+    });
   }
 
   /** Build `children` into a throwaway group at the block's own origin and hand
    *  back every mesh in it, world matrices already resolved. The group stays
    *  owned by the caller, which disposes it. */
-  private buildOperands(temporary: THREE.Group, children: SceneNode[]): THREE.Mesh[] {
-    this.inScope(temporary, () => {
-      this.currentTransform().matrix.identity();
-      this.addChildren(temporary, children);
-    });
+  private buildOperands(temporary: THREE.Group, children: SceneNode[]): { meshes: THREE.Mesh[]; material: MaterialState } {
+    let material = this.currentTransform().material;
+    this.operandDepth++;
+    try {
+      this.inScope(temporary, () => {
+        this.currentTransform().matrix.identity();
+        this.addChildren(temporary, children);
+        // The material the block ends with is the builder's own — upstream a
+        // `material steel` inside `lathe { … }` colours the lathe.
+        material = cloneMaterialState(this.currentTransform().material);
+      });
+    } finally {
+      this.operandDepth--;
+    }
     temporary.updateMatrixWorld(true);
     const meshes: THREE.Mesh[] = [];
     temporary.traverse((object) => {
       if ((object as THREE.Mesh).isMesh) meshes.push(object as THREE.Mesh);
     });
-    return meshes;
+    return { meshes, material };
   }
 
   private buildFromChildren(node: { children: SceneNode[]; properties: ShapeProperties }, build: (meshes: THREE.Mesh[]) => THREE.BufferGeometry): THREE.Mesh {
@@ -1253,16 +1490,23 @@ export class Converter {
     // trips the ceiling while the scene it draws is far beneath it.
     const chargedBeforeOperands = this.vertexCount;
     let geometry: THREE.BufferGeometry;
+    let material: MaterialState;
     try {
-      geometry = build(this.buildOperands(temporary, node.children));
+      const operands = this.buildOperands(temporary, node.children);
+      material = operands.material;
+      geometry = build(operands.meshes);
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = chargedBeforeOperands;
     }
-    return this.finishMesh(geometry, node);
+    return this.finishMesh(geometry, node, true, material);
   }
 
   private convertLoft(node: LoftNode): THREE.Object3D {
+    return this.withShapeOptions(node.properties, () => this.buildLoft(node));
+  }
+
+  private buildLoft(node: LoftNode): THREE.Object3D {
     return this.buildFromChildren(node, (meshes) => {
       const profiles = meshes.map(profileOf);
       const vertices = profiles.length * Math.max(0, ...profiles.map((ring) => ring.length));
@@ -1281,7 +1525,7 @@ export class Converter {
     // Fill creates a solid 2D shape from a path
     // Similar to extrude but with zero depth
     return this.inFrame(() => {
-      const pathNode = node.children.find((child): child is PathNode => child.type === "path");
+      const pathNode = node.children.length === 1 ? node.children.find((child): child is PathNode => child.type === "path") : undefined;
       if (!pathNode) {
         return this.buildFromChildren(node, (meshes) => {
           const shapes = meshes.map((mesh) => this.planarShape(mesh));
@@ -1296,12 +1540,7 @@ export class Converter {
       this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
       this.requireEnclosedArea(shape, "fill");
       const geometry = this.placePath(new THREE.ShapeGeometry(shape), pathNode);
-      const mesh = this.makeMesh(geometry, this.createMaterial(node));
-
-      this.applyExplicitTransforms(mesh, node.properties);
-      this.applyCurrentTransform(mesh);
-
-      return mesh;
+      return this.finishMesh(geometry, node);
     });
   }
 
@@ -1345,6 +1584,23 @@ export class Converter {
     return result;
   }
 
+  /** A `size`: one value is uniform, two are `x y x` (a cylinder's diameter
+   *  and height), three are as given — Euclid's `Vector(size:)`. */
+  private evaluateSize(value: Vector3 | Expression | undefined): Vector3 {
+    if (value === undefined) return [1, 1, 1];
+    const raw: Value = Array.isArray(value) && typeof value[0] === "number" ? (value as number[]) : this.evaluator.evaluate(value as Expression);
+    const components = (Array.isArray(raw) ? raw : [raw]).map((component) => {
+      if (typeof component !== "number" || !Number.isFinite(component)) throw new Error("Expected finite size components");
+      return component;
+    });
+    const [x = 1, y = x, z = x] = components;
+    return [x, y, z];
+  }
+
+  private evaluateRGBA(value: Color | Expression): RGBA {
+    return this.requireFiniteColor(this.evaluator.evaluateToRGBA(value));
+  }
+
   private evaluateTranslateVector(value: Expression): Vector3 {
     const result = this.evaluator.evaluate(value);
 
@@ -1362,14 +1618,6 @@ export class Converter {
     return [0, 0, 0];
   }
 
-  private evaluateColor(value: Color | Expression | undefined): Color {
-    if (value === undefined) return [0.8, 0.8, 0.8];
-    if (Array.isArray(value) && typeof value[0] === "number") {
-      return value as Color;
-    }
-    return this.requireFiniteColor(this.evaluator.evaluateToColor(value as Expression));
-  }
-
   /** Colour channels get the same treatment as sizes and translations.
    *  `new THREE.Color(Infinity, …)` throws nothing — it serialises as
    *  `[null, null, null]`, so validation reported success and the browser was
@@ -1378,51 +1626,31 @@ export class Converter {
     if (!channels.every(Number.isFinite)) throw new Error("Expected finite color channels");
     return channels;
   }
+}
 
-  private evaluateVector3OrColor(value: Expression): Vector3 {
-    // This helper is used for color commands which can accept a single number or a tuple
-    const result = this.evaluator.evaluate(value);
+/** The keys a custom block call places or colours with, rather than passing
+ *  to the block as option values. */
+const STANDARD_KEYS: Record<string, true> = {
+  position: true,
+  orientation: true,
+  rotation: true,
+  size: true,
+  color: true,
+  opacity: true,
+  material: true,
+  metallicity: true,
+  roughness: true,
+  glow: true,
+  texture: true,
+  detail: true,
+  smoothing: true,
+};
 
-    // Helper to convert Value to number. Strict, because the fallbacks it used
-    // to have made `color "bad" cube` render default grey and VALIDATE clean,
-    // while the identical `cube { color "bad" }` returned a diagnostic.
-    const toNum = (v: Value | undefined): number => {
-      if (typeof v === "number") return v;
-      if (typeof v === "boolean") return v ? 1 : 0;
-      if (Array.isArray(v) && v.length > 0) return toNum(v[0]);
-      throw new Error("Expected numeric color channels");
-    };
-
-    if (typeof result === "number") {
-      // Single value - use as grayscale
-      return this.requireFiniteColor([result, result, result]);
-    } else if (typeof result === "boolean") {
-      return this.requireFiniteColor([toNum(result), toNum(result), toNum(result)]);
-    } else if (Array.isArray(result)) {
-      // Tuple - ensure it's a 3-element vector
-      if (result.length === 1) {
-        return this.requireFiniteColor([toNum(result[0]), toNum(result[0]), toNum(result[0])]);
-      } else if (result.length === 2) {
-        return this.requireFiniteColor([toNum(result[0]), toNum(result[1]), 0]);
-      } else if (result.length >= 3) {
-        return this.requireFiniteColor([toNum(result[0]), toNum(result[1]), toNum(result[2])]);
-      }
-    }
-
-    throw new Error("Expected numeric color channels");
-  }
-
-  private valuesEqual(a: unknown, b: unknown): boolean {
-    if (typeof a !== typeof b) return false;
-    if (Array.isArray(a) && Array.isArray(b)) {
-      if (a.length !== b.length) return false;
-      for (let i = 0; i < a.length; i++) {
-        if (!this.valuesEqual(a[i], b[i])) return false;
-      }
-      return true;
-    }
-    return a === b;
-  }
+/** `print` output, one value per space, tuples in parentheses. */
+function printable(value: Value): string {
+  if (Array.isArray(value)) return value.map((item) => (Array.isArray(item) ? `(${printable(item)})` : printable(item))).join(" ");
+  if (typeof value === "object") return value.kind === "range" ? `${value.from} to ${value.to} step ${value.step}` : `<${value.kind}>`;
+  return String(value);
 }
 
 // Main export function

--- a/packages/plugins/shapescript-plugin/src/shapescript/types.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/types.ts
@@ -4,7 +4,8 @@ export type Vector3 = [number, number, number];
 export type Color = [number, number, number];
 
 // Expression types
-export type Expression = NumberLiteral | StringLiteral | IdentifierExpr | BinaryExpr | UnaryExpr | FunctionCall | MemberAccess | SubscriptExpr | TupleExpr;
+export type Expression =
+  NumberLiteral | StringLiteral | IdentifierExpr | BinaryExpr | UnaryExpr | FunctionCall | MemberAccess | SubscriptExpr | TupleExpr | RangeExpr | MaterialExpr;
 
 export interface NumberLiteral {
   type: "number";
@@ -57,6 +58,31 @@ export interface TupleExpr {
   elements: Expression[];
 }
 
+/** `from to to [step s]`, or `existing step s` when `to` is absent — a range
+ *  value a `for` loop walks and the `in` operator tests, as upstream. */
+export interface RangeExpr {
+  type: "range";
+  from: Expression;
+  to?: Expression;
+  step?: Expression;
+}
+
+/** `material { color … roughness … }` — a bundle of material properties that
+ *  `define` can name and the `material` command re-applies. */
+export interface MaterialExpr {
+  type: "material";
+  properties: MaterialProperties;
+}
+
+export interface MaterialProperties {
+  color?: Color | Expression;
+  opacity?: number | Expression;
+  metallicity?: number | Expression;
+  roughness?: number | Expression;
+  glow?: Color | Expression;
+  texture?: Expression;
+}
+
 export type SceneNode =
   | ShapeNode
   | CSGNode
@@ -75,7 +101,11 @@ export type SceneNode =
   | SeedNode
   | PathNode
   | BackgroundNode
-  | TextureNode
+  | MaterialNode
+  | SmoothingNode
+  | PrintNode
+  | AssertNode
+  | IgnoredNode
   | ColorNode
   | RotateNode
   | OrientationNode
@@ -85,19 +115,27 @@ export type SceneNode =
 
 export interface ShapeNode {
   type: "shape";
-  primitive: "cube" | "sphere" | "cylinder" | "cone" | "torus" | "circle" | "square" | "polygon";
+  primitive: ShapePrimitive;
   properties: ShapeProperties;
   children?: SceneNode[];
 }
 
-export interface ShapeProperties {
+export type ShapePrimitive = "cube" | "sphere" | "icosphere" | "cylinder" | "cone" | "torus" | "circle" | "square" | "roundrect" | "polygon";
+
+export interface ShapeProperties extends MaterialProperties {
   position?: Vector3 | Expression;
   rotation?: Vector3 | Expression;
   orientation?: Vector3 | Expression; // Alias for rotation
   size?: Vector3 | Expression;
-  color?: Color | Expression;
-  opacity?: number | Expression;
+  /** `material name` inside a block: every property of the named bundle. */
+  material?: Expression;
+  /** Per-shape `detail` / `smoothing`, as upstream allows inside any block. */
+  detail?: number | Expression;
+  smoothing?: number | Expression;
+  name?: Expression;
   sides?: number | Expression;
+  /** `roundrect` corner radius, as a proportion of the smaller side. */
+  radius?: number | Expression;
   // For cylinder/cone specific properties
   radiusTop?: number | Expression;
   radiusBottom?: number | Expression;
@@ -118,15 +156,13 @@ export interface BlockNode {
   children: SceneNode[];
 }
 
+/** `for v in <iterable> { … }`. The iterable is one expression: a range
+ *  (`1 to 5 step 2`, or a symbol holding one) or a tuple of values. */
 export interface ForLoopNode {
   type: "for";
   variable: string;
-  from: Expression | number;
-  to: Expression | number;
-  step?: Expression | number;
-  iterableValues?: Expression; // For "for i in values"
+  iterable: Expression;
   body: SceneNode[];
-  transforms?: TransformNode[];
 }
 
 export interface IfNode {
@@ -154,9 +190,12 @@ export interface TransformNode {
 export interface DefineNode {
   type: "define";
   name: string;
-  value?: Expression; // For variable definitions
+  value?: Expression; // For variable definitions, or a function's result expression
   options?: OptionNode[]; // For custom shape definitions
-  body?: SceneNode[]; // For custom shape definitions
+  body?: SceneNode[]; // For custom shape definitions, or a function's leading `define`s
+  /** `define name(a b) { … }` — a function. `body` holds its `define`s and
+   *  `value` the expression it returns. */
+  params?: string[];
 }
 
 export interface OptionNode {
@@ -178,12 +217,40 @@ export interface SeedNode {
 
 export interface BackgroundNode {
   type: "background";
-  value: Expression; // Usually a string (filename)
+  value: Expression; // A colour, or a texture file name (which is not supported)
 }
 
-export interface TextureNode {
-  type: "texture";
-  value: Expression; // Usually a string (filename)
+/** A scoped material command: `opacity 0.5`, `metallicity 1`, `roughness 0.2`,
+ *  `glow red`, `texture "file.png"` (warned, not rendered) or `material name`. */
+export interface MaterialNode {
+  type: "material";
+  property: "opacity" | "metallicity" | "roughness" | "glow" | "texture" | "material";
+  value: Expression;
+}
+
+/** `smoothing N` — 0 draws every edge sharp (flat shading); anything else smooth. */
+export interface SmoothingNode {
+  type: "smoothing";
+  value: Expression;
+}
+
+/** `print a b …` — logged, and returned to the agent with the tool result. */
+export interface PrintNode {
+  type: "print";
+  value: Expression;
+}
+
+/** `assert condition` — a failing assertion stops the script. */
+export interface AssertNode {
+  type: "assert";
+  value: Expression;
+}
+
+/** A block upstream renders but this renderer does not (`camera`, `light`):
+ *  parsed and skipped, with a warning naming it. */
+export interface IgnoredNode {
+  type: "ignored";
+  command: string;
 }
 
 export interface ColorNode {
@@ -262,12 +329,27 @@ export interface PathNode {
   properties?: ShapeProperties;
 }
 
-export type PathCommand = DefineNode | PointCommand | CurveCommand | RotateCommand | TranslateCommand | ScaleCommand | DetailPathCommand | ForLoopPathCommand;
+export type PathCommand =
+  DefineNode | PointCommand | CurveCommand | ArcCommand | RotateCommand | TranslateCommand | ScaleCommand | DetailPathCommand | ForLoopPathCommand;
 
 export interface PointCommand {
   type: "point";
   x: number | Expression;
   y: number | Expression;
+  /** A third coordinate is accepted for upstream compatibility; paths here are
+   *  planar, so it must be zero. */
+  z?: Expression;
+}
+
+/** `arc { angle A [position] [orientation] [size] }` inside a path: a circular
+ *  arc of `angle` half-turns, clockwise from +Y, radius `size / 2` (default
+ *  0.5), sampled at the current detail. */
+export interface ArcCommand {
+  type: "arc";
+  angle?: Expression;
+  position?: Expression;
+  orientation?: Expression;
+  size?: Expression;
 }
 
 /** A quadratic Bézier CONTROL point. The curve passes through the neighbouring
@@ -277,6 +359,7 @@ export interface CurveCommand {
   type: "curve";
   x: number | Expression;
   y: number | Expression;
+  z?: Expression;
 }
 
 export interface RotateCommand {
@@ -306,9 +389,7 @@ export interface DetailPathCommand {
 export interface ForLoopPathCommand {
   type: "for";
   variable: string;
-  from: number | Expression;
-  to: number | Expression;
-  step?: number | Expression;
+  iterable: Expression;
   commands: PathCommand[];
 }
 
@@ -317,6 +398,8 @@ export enum TokenType {
   // Primitives
   CUBE = "CUBE",
   SPHERE = "SPHERE",
+  ICOSPHERE = "ICOSPHERE",
+  ROUNDRECT = "ROUNDRECT",
   CYLINDER = "CYLINDER",
   CONE = "CONE",
   TORUS = "TORUS",
@@ -334,10 +417,18 @@ export enum TokenType {
   PATH = "PATH",
   POINT = "POINT",
   CURVE = "CURVE",
+  ARC = "ARC",
   DETAIL = "DETAIL",
+  SMOOTHING = "SMOOTHING",
   SEED = "SEED",
   BACKGROUND = "BACKGROUND",
   TEXTURE = "TEXTURE",
+  MATERIAL = "MATERIAL",
+  METALLICITY = "METALLICITY",
+  ROUGHNESS = "ROUGHNESS",
+  GLOW = "GLOW",
+  PRINT = "PRINT",
+  ASSERT = "ASSERT",
 
   // CSG Operations
   UNION = "UNION",
@@ -373,6 +464,8 @@ export enum TokenType {
   NUMBER = "NUMBER",
   IDENTIFIER = "IDENTIFIER",
   STRING = "STRING",
+  /** `#RGB`, `#RGBA`, `#RRGGBB` or `#RRGGBBAA`; the value is the digits. */
+  HEXCOLOR = "HEXCOLOR",
 
   // Operators
   PLUS = "PLUS",

--- a/packages/plugins/shapescript-plugin/src/vue/Preview.vue
+++ b/packages/plugins/shapescript-plugin/src/vue/Preview.vue
@@ -13,7 +13,7 @@ import * as THREE from "three";
 import type { ToolResult } from "gui-chat-protocol";
 import type { PresentShapeScriptData } from "../core/types";
 import { parseShapeScript } from "../shapescript/parser";
-import { astToThreeJS } from "../shapescript/toThreeJS";
+import { astToThreeJS, sceneInfoOf } from "../shapescript/toThreeJS";
 import { removeAndDispose } from "../shapescript/dispose";
 import { useT } from "../lang";
 
@@ -51,13 +51,15 @@ watch(
   },
 );
 
+const DEFAULT_PREVIEW_BACKGROUND = 0x2a2a3a;
+
 function initPreview() {
   if (!previewViewport.value) return;
 
   try {
     // Create scene
     scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x2a2a3a);
+    scene.background = new THREE.Color(DEFAULT_PREVIEW_BACKGROUND);
 
     // Create camera
     const width = previewViewport.value.clientWidth || 200;
@@ -116,6 +118,7 @@ function reloadScene() {
     // disposed, and this runs again on every script change.
     removeAndDispose(scene, sceneGroup);
     sceneGroup = null;
+    scene.background = new THREE.Color(DEFAULT_PREVIEW_BACKGROUND);
     // An empty script is valid and means "nothing to draw". Returning before
     // the removal above left the PREVIOUS result's geometry on screen, so the
     // thumbnail described a model the result no longer has.
@@ -125,6 +128,9 @@ function reloadScene() {
     const ast = parseShapeScript(script);
     sceneGroup = astToThreeJS(ast, { wireframe: false });
     scene.add(sceneGroup);
+    // The script's `background r g b`, as in the full View; else the preview's own.
+    const { background } = sceneInfoOf(sceneGroup);
+    scene.background = background ? new THREE.Color(background[0], background[1], background[2]) : new THREE.Color(DEFAULT_PREVIEW_BACKGROUND);
   } catch (error) {
     console.error("Preview reload error:", error);
   }

--- a/packages/plugins/shapescript-plugin/src/vue/View.vue
+++ b/packages/plugins/shapescript-plugin/src/vue/View.vue
@@ -38,6 +38,16 @@
       <strong>{{ t.exportError }}</strong> {{ exportError }}
     </div>
 
+    <div v-if="sceneWarnings.length" class="notice" data-testid="shapescript-warnings">
+      <strong>{{ t.sceneWarnings }}</strong> {{ sceneWarnings.join(" · ") }}
+    </div>
+
+    <pre
+      v-if="printOutput.length"
+      class="notice output"
+      data-testid="shapescript-output"
+    ><strong>{{ t.printOutput }}</strong> {{ printOutput.join("\n") }}</pre>
+
     <div ref="viewport" class="viewport" data-testid="shapescript-viewport" />
 
     <details class="script-source">
@@ -62,7 +72,7 @@ import type { ToolResult } from "gui-chat-protocol";
 import type { PresentShapeScriptData } from "../core/types";
 import { readLoadShapeResult, readSaveShapeResult } from "../core/contract";
 import { parseShapeScript } from "../shapescript/parser";
-import { astToThreeJS } from "../shapescript/toThreeJS";
+import { astToThreeJS, sceneInfoOf } from "../shapescript/toThreeJS";
 import { removeAndDispose, disposeObject3D } from "../shapescript/dispose";
 import { shapeScriptToUsdz, USDZ_EXTENSION, USDZ_MIME_TYPE } from "../export/usdz";
 import { slugify } from "../core/paths";
@@ -101,6 +111,10 @@ const editableScript = ref(props.selectedResult.data?.script ?? "");
 // State
 const viewport = ref<HTMLDivElement | null>(null);
 const parseError = ref<string | null>(null);
+/** Commands the script used that this viewer does not draw (`texture`, `camera`, …). */
+const sceneWarnings = ref<string[]>([]);
+/** The script's `print` lines. */
+const printOutput = ref<string[]>([]);
 const saveError = ref<string | null>(null);
 const exportError = ref<string | null>(null);
 const exporting = ref(false);
@@ -203,7 +217,7 @@ function initScene() {
 
   // Create scene
   scene = new THREE.Scene();
-  scene.background = new THREE.Color(0x1a1a1a);
+  scene.background = new THREE.Color(DEFAULT_BACKGROUND);
 
   // Create camera
   const width = viewport.value.clientWidth;
@@ -269,15 +283,24 @@ function clearScene() {
   sceneObjects = [];
 }
 
+const DEFAULT_BACKGROUND = 0x1a1a1a;
+
 function renderScript(script: string) {
   const group = astToThreeJS(parseShapeScript(script), { wireframe: showWireframe.value });
   scene.add(group);
   sceneObjects.push(group);
+  const info = sceneInfoOf(group);
+  sceneWarnings.value = info.warnings;
+  printOutput.value = info.logs;
+  // `background r g b` from the script, else the viewer's own dark ground.
+  scene.background = info.background ? new THREE.Color(info.background[0], info.background[1], info.background[2]) : new THREE.Color(DEFAULT_BACKGROUND);
 }
 
 function loadShapeScript() {
   try {
     clearScene();
+    sceneWarnings.value = [];
+    printOutput.value = [];
     const script = props.selectedResult.data?.script;
     // An empty script is valid and clears the scene — reached when a result
     // moves from an INVALID script to an empty one, where leaving the previous
@@ -578,6 +601,22 @@ watch(
   color: #ff6666;
   font-family: monospace;
   border-bottom: 1px solid #ff000040;
+}
+
+.notice {
+  padding: 0.5rem 1rem;
+  background: #ffaa0020;
+  color: #e0b060;
+  font-family: monospace;
+  font-size: 0.85rem;
+  border-bottom: 1px solid #ffaa0040;
+}
+
+.output {
+  margin: 0;
+  background: #ffffff10;
+  color: #cccccc;
+  white-space: pre-wrap;
 }
 
 .script-source {

--- a/packages/plugins/shapescript-plugin/src/vue/View.vue
+++ b/packages/plugins/shapescript-plugin/src/vue/View.vue
@@ -301,6 +301,8 @@ function loadShapeScript() {
     clearScene();
     sceneWarnings.value = [];
     printOutput.value = [];
+    // An empty or invalid script must not keep the previous script's background.
+    scene.background = new THREE.Color(DEFAULT_BACKGROUND);
     const script = props.selectedResult.data?.script;
     // An empty script is valid and clears the scene — reached when a result
     // moves from an INVALID script to an empty one, where leaving the previous

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -54,10 +54,9 @@ Switch statements for multiple cases
 - Trig: sin, cos, tan, asin, acos, atan, atan2 (radians!)
 - Vector: dot, cross, length, normalize, sum
 
-CRITICAL: Function calls require NO space between name and (
-- sin(x) ✓ correct
-- sin (x) ✗ wrong - this is NOT a function call!
-Separate arguments with spaces, upstream style: max(0 (j - 1)). Commas work here but not in the upstream app.
+Calls: C-like max(0 (j - 1)) with NO space before the parenthesis, or bare max 0 (j - 1) / sqrt 9 as upstream.
+Separate arguments with spaces. Commas work here but not in the upstream app.
+Custom functions compute values: define hyp(a b) { sqrt(a * a + b * b) }
 One statement per line; the upstream app rejects two statements on one line.
 
 ### Best Practices:
@@ -93,9 +92,13 @@ for x in -5 to 5 {
 }
 
 ### Primitives & CSG:
-Shapes: cube, sphere, cylinder, cone, torus
+Shapes: cube, sphere, icosphere, cylinder, cone, torus, circle, square, roundrect, polygon
 CSG: union, difference, intersection, xor, stencil
-Properties: position, orientation (alias rotation), size, color, opacity
+Properties: position, orientation (alias rotation), size, detail, smoothing, name
+Materials: color (1–4 values, hex #FF0000, names like red/orange/gray, hsb(...)), opacity, metallicity, roughness, glow,
+material NAME (from define NAME material { … }); background R G B sets the scene colour.
+Scope: shape blocks, groups, builders and custom blocks reset transforms/materials at their closing brace;
+for / if / switch bodies do not (a translate in a loop carries on after it).
 
 ### Units (upstream ShapeScript conventions):
 - size = DIAMETER for sphere/cylinder/cone/circle/polygon/torus, edge length for cube/square. A bare sphere fits the unit cube.
@@ -110,10 +113,12 @@ loft {
     circle
 }
 Stencil preserves the first shape's volume and paints the intersecting surface.
-Constants: pi, true, false (avoid tau, upstream lacks it; write 2 * pi). Tuple/string access: values[0], vector.x, value.count.
-Polygon supports sides (3–256). String literals and join/trim are supported.
+Constants: pi, true, false (avoid tau, upstream lacks it; write 2 * pi). Tuple/string access: values[0], values[-1], vector.x, value.count.
+Ranges are values (define r 1 to 5 step 2; for i in r; if 3 in r). A bare path draws as a line; fill/extrude it for a surface.
+Polygon supports sides (3–256). String literals and join/split/trim are supported. print records output for you.
 Use the tool schema for exact syntax and builder limits. This is a modeling subset of upstream ShapeScript;
-imports, textures, text/fonts and general user-defined functions are not supported.
+imports, text/fonts, raw meshes, minkowski/inset/svgpath/along and shapes as values are refused by name;
+textures, cameras and lights are accepted but not drawn (the result reports them).
 If presentShapeScript returns an error diagnostic, correct the script and retry; no visualization was created.
 
 Keep visualizations clear, well-organized, and use expressions and control flow.`;

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Ball.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Ball.shape
@@ -1,0 +1,59 @@
+// ShapeScript document
+
+detail 32
+
+camera {
+    position -0.3539 0.3167 1.4228
+    orientation 0 0.0776 0.0677
+    width 1400
+    height 1000
+}
+
+define ballMaterial material {
+    color #facc15
+    roughness 0.42
+    metallicity 0.08
+}
+
+define stripeMaterial material {
+    color #2563eb
+    roughness 0.18
+    metallicity 0.35
+}
+
+define starMaterial material {
+    color #ef4444
+    roughness 0.22
+    metallicity 0.2
+    glow #ef4444 * 0.25
+}
+
+define starPath {
+    path {
+        for 1 to 5 {
+            point 0 -0.5
+            rotate 1 / 5
+            point 0 -1
+            rotate 1 / 5
+        }
+        point 0 -0.5
+    }
+}
+
+stencil {
+    // ball
+    sphere {
+        material ballMaterial
+    }
+    // stripe
+    cube {
+        material stripeMaterial
+        size 1 1 0.4
+    }
+    // star
+    extrude {
+        material starMaterial
+        size 0.3 0.3 1
+        starPath
+    }
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Chessboard.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Chessboard.shape
@@ -1,0 +1,267 @@
+// ShapeScript document
+
+detail 32
+
+camera {
+    position 0 6 9
+    orientation 0 0 0.21
+    fov 0.3
+    width 1400
+    height 928
+}
+
+// materials
+
+define lightPiece material {
+    color #fffbeb
+    metallicity 0.05
+    roughness 0.28
+}
+
+define darkPiece material {
+    color #111827
+    metallicity 0.75
+    roughness 0.18
+}
+
+define boardEdge material {
+    color #334155
+    metallicity 0.6
+    roughness 0.35
+}
+
+define boardWhite material {
+    color #e2e8f0
+    opacity 0.85
+    roughness 0.85
+}
+
+define boardBlack material {
+    color #334155
+    metallicity 0.6
+    roughness 0.35
+}
+
+// board
+
+material boardEdge
+union {
+    translate 0 -0.1
+    difference {
+        cube { size 8.8 0.2 8.8 }
+        translate 0 0.1 0
+        cube { size 8 0.2 8 }
+    }
+    translate -3.5 0.025 -3.5
+    material boardWhite
+    for 1 to 4 {
+        for 1 to 4 {
+            cube { size 0.95 0.15 0.95 }
+            translate 1 0 0
+            material boardBlack
+            cube { size 0.95 0.15 0.95 }
+            translate -1 0 1
+            cube { size 0.95 0.15 0.95 }
+            translate 1 0 0
+            material boardWhite
+            cube { size 0.95 0.15 0.95 }
+            translate -1 0 1
+        }
+        translate 2 0 -8
+    }
+}
+
+// pawns
+
+translate 3.5 0 -2.5
+material lightPiece
+for 1 to 2 {
+    for 1 to 8 {
+        union {
+            lathe path {
+                point 0 0.6
+                point -0.05 0.6
+                curve -0.12 0.2
+                point -0.25 0.1
+                point -0.25 0
+                point -0.25 0
+                point 0 0
+            }
+            translate 0 0.6
+            sphere { size 0.25 }
+        }
+        translate -1
+    }
+    translate 8 0 5
+    material darkPiece
+}
+
+// castles
+
+translate 0 0 -4
+for 1 to 2 {
+    material darkPiece
+    for 1 to 2 {
+        difference {
+            lathe path {
+                point 0 0.7
+                curve -0.15 0.7
+                point -0.15 0.8
+                point -0.2 0.8
+                point -0.2 0.8
+                point -0.2 0.7
+                point -0.15 0.6
+                curve -0.2 0.2
+                point -0.3 0.1
+                point -0.3 0
+                point -0.3 0
+                point 0 0
+            }
+            translate 0 0.8
+            cube { size 0.4 0.1 0.1 }
+            cube { size 0.1 0.1 0.4 }
+        }
+        translate 0 0 -7
+        material lightPiece
+    }
+    translate -7 0 14
+}
+
+// knights
+
+translate 13 0 0
+for 1 to 2 {
+    material darkPiece
+    for 1 to 2 {
+        union {
+            lathe path {
+                point 0 0.6
+                point -0.2 0.3
+                curve -0.15 0.2
+                point -0.28 0.1
+                point -0.28 0
+                point 0 0
+            }
+            translate 0.04 0.05 0
+            scale 0.9 0.9 0.2
+            extrude path {
+                point 0 1
+                point -0.3 0.9
+                point -0.3 0.8
+                point -0.1 0.8
+                curve -0.32 0.5
+                point -0.2 0.3
+                point 0.13 0.3
+                curve 0.11 0.5
+                point 0.22 0.9
+                point 0 1
+            }
+        }
+        translate 0 0 -7
+        material lightPiece
+    }
+    translate -5 0 14
+}
+
+// bishops
+
+translate 9 0 0
+for 1 to 2 {
+    material darkPiece
+    for 1 to 2 {
+        difference {
+            lathe path {
+                point 0 1
+                point -0.05 0.98
+                point -0.04 0.94
+                curve -0.14 0.8
+                point -0.09 0.65
+                point -0.09 0.65
+                point -0.2 0.6
+                point -0.2 0.58
+                point -0.1 0.58
+                curve -0.18 0.2
+                point -0.28 0.1
+                point -0.28 0
+                point -0.28 0
+                point 0 0
+            }
+            translate -0.1 1
+            rotate -0.1 0 0
+            cube { size 0.03 0.5 0.5 }
+            rotate 0 0 -0.1
+        }
+        translate 0 0 -7
+        material lightPiece
+    }
+    translate -3 0 14
+}
+
+// king
+
+translate 4 0 0
+material darkPiece
+for 1 to 2 {
+    union {
+        lathe path {
+            point 0 1.29
+            point -0.06 1.27
+            point -0.04 1.22
+            point -0.2 1.17
+            point -0.1 0.95
+            point -0.2 0.9
+            point -0.2 0.88
+            point -0.1 0.88
+            curve -0.2 0.25
+            point -0.35 0.1
+            point -0.35 0
+            point -0.35 0
+            point 0 0
+        }
+        translate 0 1.35
+        cube { size 0.075 0.15 0.04 }
+        cube { size 0.15 0.075 0.04 }
+    }
+    translate 0 0 -7
+    material lightPiece
+}
+
+// queen
+
+translate 1 0 14
+material darkPiece
+for 1 to 2 {
+    union {
+        lathe path {
+            point 0 1.19
+            point -0.06 1.17
+            point -0.04 1.12
+            point -0.15 1.07
+            point 0 0.9
+        }
+        difference {
+            lathe path {
+                point -0 0.9
+                point -0.18 1.15
+                point -0.2 1.1
+                point -0.1 0.9
+                point -0.19 0.85
+                point -0.19 0.83
+                point -0.09 0.83
+                curve -0.19 0.2
+                point -0.32 0.1
+                point -0.32 0
+                point -0.32 0
+                point 0 0
+            }
+            translate 0 1.15
+            rotate 0 0 0.5
+            for 0 to 7 {
+                rotate 0.125 0 0
+                cylinder { size 0.1 0.5 0.1 }
+            }
+        }
+    }
+    translate 0 0 -7
+    material lightPiece
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Cog.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Cog.shape
@@ -1,0 +1,33 @@
+// ShapeScript document
+
+camera {
+    position 0 -1.5 1.75
+    orientation 0 0 -0.2
+    width 1400
+    height 1000
+}
+
+define cog {
+    option teeth 6
+    path {
+        define step 1 / teeth
+        for 1 to teeth {
+            point -0.02 0.8
+            point 0.05 1
+            rotate step
+            point -0.05 1
+            point 0.02 0.8
+            rotate step
+        }
+        point -0.02 0.8
+    }
+}
+
+difference {
+    extrude {
+        size 1 1 0.5
+        cog { teeth 8 }
+    }
+    rotate 0 0 0.5
+    cylinder
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Dodecahedron.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Dodecahedron.shape
@@ -1,0 +1,41 @@
+// ShapeScript document
+
+smoothing 0
+
+define scale 0.75
+
+define ico icosphere { detail 0 }
+
+define dodecahedronVertices for face in ico.polygons {
+    normalize(face.center) * scale
+}
+
+define dodecahedronFaces (
+    (2 3 4 0 1 #ef4444)
+    (4 7 16 6 0 #f97316)
+    (0 6 15 5 1 #f59e0b)
+    (19 9 2 1 5 #eab308)
+    (18 8 3 2 9 #84cc16)
+    (8 17 7 4 3 #22c55e)
+    (10 14 19 5 15 #10b981)
+    (16 11 10 15 6 #14b8a6)
+    (17 12 11 16 7 #06b6d4)
+    (17 8 18 13 12 #3b82f6)
+    (13 18 9 19 14 #8b5cf6)
+    (12 13 14 10 11 #d946ef)
+)
+
+define face(data) {
+    polygon {
+        color data.last
+        for index in data.allButLast {
+            point dodecahedronVertices[index]
+        }
+    }
+}
+
+mesh {
+    for data in dodecahedronFaces {
+        face data
+    }
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Earth.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Earth.shape
@@ -1,0 +1,8 @@
+// ShapeScript document
+
+detail 64
+
+background "Stars.jpg"
+
+texture "Earth.png"
+sphere

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Fillet.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Fillet.shape
@@ -1,0 +1,64 @@
+// ShapeScript document
+
+detail 16
+
+// This reusable function behaves like a small standard library function:
+// pass it a source mesh and a radius, and it returns a new mesh with rounded
+// edges. It composes naturally with other geometry functions, just like
+// inset(mesh radius).
+//
+// A fillet is a rounded internal or external edge. This implementation
+// creates one by combining two operations:
+//
+// 1. inset(source radius)
+//    The source mesh is shrunk inward by the fillet radius. This makes
+//    room for the rounded edge so the final result keeps the original
+//    overall dimensions.
+//
+// 2. minkowski { ... sphere }
+//    Minkowski addition adds the inset mesh to a sphere with the same
+//    radius. The sphere sweeps around every point of the inset mesh,
+//    rounding the edges as it grows back to the original size.
+//
+// Keep the radius small enough that the inset mesh does not collapse.
+// For more complex parts, combine the source geometry first, then pass
+// that combined mesh to fillet.
+define fillet(source radius) {
+    minkowski {
+        inset(source radius)
+        sphere {
+            size radius * 2
+        }
+    }
+}
+
+define radius 0.08
+
+// Filleted cone
+group {
+    position -0.5
+    fillet(cone {
+        color #38bdf8
+    } radius)
+}
+
+// The same function can be reused with a more complex mesh. The union is
+// built first so that the shared edges are rounded as part of one shape.
+define shape union {
+    cube {
+        color #a78bfa
+    }
+    cylinder {
+        color #a78bfa
+        size 0.45 1.2 0.45
+        orientation 0.5
+        position 0.45
+    }
+}
+
+group {
+    position 0.5
+    orientation 0.5
+    size 0.8
+    fillet(shape radius * 0.75)
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/LICENSE.md
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/LICENSE.md
@@ -1,0 +1,25 @@
+These `.shape` files are the Examples from
+https://github.com/nicklockwood/ShapeScript (commit on `main`, fetched 2026-09-10),
+copied unmodified as parser/renderer test fixtures.
+
+MIT License
+
+Copyright (c) 2018 Nick Lockwood
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Spirals.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Spirals.shape
@@ -1,0 +1,34 @@
+// ShapeScript document
+
+detail 32
+
+define spiral {
+    option coils 3 // number of coils
+    option radius 0.5 // radius of coil
+    option steps detail * coils // number of segments
+
+    path {
+        detail 0
+        for i in 0 to steps - 1 {
+            curve 0 radius * (1 - i / steps) 0
+            rotate 2 / steps * coils
+        }
+    }
+}
+
+// spiral path
+spiral { coils 3 }
+
+// extruded spiral
+extrude {
+    position 1
+    size 1 1 0.1
+    spiral { coils 4 }
+}
+
+// solid spiral with circular cross-section
+extrude {
+    position 2
+    circle { size 0.03 }
+    along spiral { coils 5 }
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Spring.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Spring.shape
@@ -1,0 +1,25 @@
+// ShapeScript document
+
+detail 32
+
+define spring {
+    option coils 2 // number of coils
+    option spacing 0.3 // spacing between coils
+    option thickness 0.2 // thickness of spring
+    option radius 0.5 // radius of coil
+    loft {
+        translate 0 -spacing * coils / 2
+        for 0 to detail * coils {
+            rotate 0 1/detail 0
+            translate radius
+            circle { size thickness/2 }
+            translate -radius
+            rotate 0 1/detail 0
+            translate 0 spacing/detail
+        }
+    }
+}
+
+spring {
+    coils 4
+}

--- a/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Train.shape
+++ b/packages/plugins/shapescript-plugin/test/fixtures/upstream-examples/Train.shape
@@ -1,0 +1,220 @@
+// ShapeScript document
+
+detail 32
+
+camera {
+    position 2.22 1.6111 1.8919
+    orientation 0 -0.2818 0.1264
+    width 1400
+    height 1000
+}
+
+// materials
+
+define bluePaint material {
+    color 0.4 0.7 1
+    metallicity 0.08
+    roughness 0.18
+}
+
+define redPaint material {
+    color red
+    metallicity 0.05
+    roughness 0.32
+}
+
+define steel material {
+    color 0.8
+    metallicity 1
+    roughness 0.18
+}
+
+define matteBlack material {
+    color black
+    roughness 0.85
+}
+
+define coal material {
+    color black
+    metallicity 0.2
+    roughness 0.65
+}
+
+// wheels
+
+define wheel {
+    union {
+        material matteBlack
+        cylinder { size 0.6 0.05 }
+        material steel
+        cylinder { size 0.56 0.1 }
+        translate 0 0.05 0
+        difference {
+            cylinder { size 0.4 0.05 }
+            cylinder { size 0.36 0.05 }
+        }
+        cylinder { size 0.2 0.1 }
+        define steps 5
+        for 1 to steps {
+            cube { size 0.03 0.025 0.37 }
+            rotate 0 1 / steps
+        }
+    }
+}
+
+for i in -1 to 1 {
+    group {
+        translate 0 0 (0.7 * i)
+        rotate 0.5 rnd
+        translate 0 0.5 0
+        wheel
+        translate 0 -0.5 0
+        material steel
+        cylinder { size 0.1 1 }
+        rotate 1
+        translate 0 0.5 0
+        wheel
+    }
+}
+
+// base
+
+union {
+    rotate 0 0.5 0
+    translate -1 -0.06
+    material matteBlack
+    extrude {
+        size 1 1 0.7
+        path {
+            point 0.1
+            point 1.8
+            point 2.1 0.15
+            point 2.1 0.4
+            point -0.05 0.4
+            point -0.05 0.15
+            point 0.1
+        }
+    }
+    material redPaint
+    extrude path {
+        point 1.95 0.5
+        point -0.1 0.5
+        point -0.1 0.2
+        point 0 0.2
+        point 0 0.4
+        point 1.92 0.4
+        point 2.05 0.34
+        point 2.05 0.2
+        point 2.15 0.2
+        point 2.15 0.4
+        point 1.95 0.5
+    }
+}
+
+// front
+
+lathe {
+    material steel
+    position 0 0.8 1
+    orientation 0 0 0.5
+    path {
+        point 0 0
+        point 0.3 0
+        curve 0.3 -0.1
+        point 0 -0.1
+    }
+}
+
+// chimney
+
+union {
+    material matteBlack
+    position 0 0.6 0.8
+    cube { size 0.7 0.4 0.4 }
+    cylinder {
+        position 0 0.2 0
+        orientation 0 0 0.5
+        size 0.7 0.4
+    }
+    lathe {
+        position 0 0.48
+        path {
+            point 0 0
+            point -0.2 0
+            curve -0.1 0.05
+            point -0.1 0.11
+            point -0.1 0.35
+            point -0.125 0.35
+            point -0.125 0.4
+            point -0.1 0.4
+            point -0.1 0.45
+            point -0.07 0.45
+            point 0 0.2
+            point 0 0
+        }
+    }
+}
+
+// body
+
+union {
+    material bluePaint
+    position 0 0.8 0.2
+    orientation 0 0 0.5
+    cylinder { size 0.7 0.8 }
+    translate 0 0.425 -0.085
+    difference {
+        cube { size 0.9 1.65 0.55 }
+        translate 0 0.6125 0
+        cube { size 0.8 0.325 0.6 }
+    }
+    translate 0 0.15 0.05
+    // cab
+    material bluePaint
+    rotate 0 0 -0.5
+    extrude {
+        size 1 1 0.6
+        path {
+            point -0.45
+            point 0.45
+            point 0.45 0.5
+            curve 0 0.65
+            point -0.45 0.5
+            point -0.45
+        }
+    }
+    // roof
+    extrude {
+        material matteBlack
+        size 1 1 0.5
+        path {
+            point -0.35
+            point 0.35
+            point 0.35 0.55
+            curve 0 0.65
+            point -0.35 0.55
+            point -0.35
+        }
+    }
+}
+
+// coal
+
+union {
+    material coal
+    position 0 0.73 -0.84
+    orientation 0 0 0.5
+    cube { size 0.8 0.325 0.4 }
+    translate 0.45 -0.1 0.2
+    for 1 to 3 {
+        for 1 to 8 {
+            translate -0.1
+            cube {
+                size 0.1
+                // apply a random rotation
+                orientation rnd rnd rnd
+            }
+        }
+        translate 0.8 0.1 0
+    }
+}

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -600,6 +600,12 @@ describe("upstream shapes and paths", () => {
     assert.equal(objectsOf("path {\n point 0 0\n point 1 0\n point 0 1\n point 0 0\n}").filter((o) => (o as THREE.Mesh).isMesh).length, 0);
     withMesh("fill path {\n point 0 0\n point 1 0\n point 0 1\n point 0 0\n}", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count >= 3));
     assert.throws(() => objectsOf("path { point 0 0 }"), /two points/);
+    // A stroke takes the scope's colour and opacity like a mesh does.
+    const [stroke] = objectsOf("opacity 0.5\ncolor #ff000080\npath {\n point 0 0\n point 1 0\n}") as THREE.Line[];
+    const lineMaterial = stroke!.material as THREE.LineBasicMaterial;
+    near(lineMaterial.color.toArray(), [1, 0, 0]);
+    near([lineMaterial.opacity], [0.5 * (128 / 255)]);
+    assert.ok(lineMaterial.transparent);
     assert.throws(() => objectsOf("path { point 0 0 1 point 1 0 }"), /planar/);
   });
   it("revolves a lathe profile drawn on the −X side like one on +X", () => {
@@ -619,6 +625,11 @@ describe("upstream shapes and paths", () => {
       near(m.color.toArray(), [1, 0, 0]);
     });
     withMesh("define post { cube { size 1 2 1 } }\npost { orientation 0 0 0.5 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 2]));
+    // `detail` / `smoothing` on the call apply to the block's body.
+    materialOf("define bead { sphere }\nbead {\n detail 4\n smoothing 0\n}", (m, mesh) => {
+      assert.ok(mesh.geometry.getAttribute("position").count < 60);
+      assert.equal(m.flatShading, true);
+    });
   });
   it("applies a per-shape `detail`", () => {
     withMesh("sphere { detail 8 }", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count < 100));
@@ -666,8 +677,10 @@ describe("control flow, ranges and functions", () => {
     withMesh("translate (cos 0) 1\ncube", (mesh) => near(mesh.position.toArray(), [1, 1, 0]));
     withMesh("cube { size (sqrt 9) + (sqrt 16) }", (mesh) => near(extent(mesh).toArray(), [7, 7, 7]));
     withMesh("cube { size max(1 2) 3 }", (mesh) => near(extent(mesh).toArray(), [2, 3, 2]));
-    // A `define` of the same name shadows the function.
+    // A `define` of the same name shadows the function — within its block only.
     withMesh("define max 5\ncube { size max }", (mesh) => near(extent(mesh).toArray(), [5, 5, 5]));
+    withMesh("group { define max 5 }\ncube { size max 1 2 }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    withMesh("define f(a) {\n define max a\n max\n}\ncube { size max 1 f(3) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
   });
   it("defines functions with parameters, local defines and a result", () => {
     withMesh("define sq(a) { a * a }\ncube { size sq(3) }", (mesh) => near(extent(mesh).toArray(), [9, 9, 9]));

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import * as THREE from "three";
 import { executePresentShapeScript, samples } from "../src/core/index";
 import { parseShapeScript } from "../src/shapescript/parser";
-import { astToThreeJS } from "../src/shapescript/toThreeJS";
+import { astToThreeJS, sceneInfoOf } from "../src/shapescript/toThreeJS";
 import { disposeObject3D } from "../src/shapescript/dispose";
 
 const context = {} as Parameters<typeof executePresentShapeScript>[0];
@@ -188,14 +188,11 @@ describe("geometry builders", () => {
     }
   });
   it("refuses a degenerate inline path instead of presenting an empty mesh", () => {
-    for (const script of [
-      "fill path { point 0 0 }",
-      "fill path { point 0 0 point 1 0 }",
-      "extrude path { point 0 0 point 1 0 point 2 0 }",
-      "path { point 0 0 }",
-    ]) {
+    for (const script of ["fill path { point 0 0 }", "fill path { point 0 0 point 1 0 }", "extrude path { point 0 0 point 1 0 point 2 0 }"]) {
       assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(script))), /encloses an area/, script);
     }
+    // A bare path is a stroke, so it needs a segment rather than an area.
+    assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript("path { point 0 0 }"))), /at least two points/);
     withMesh("fill path { point 0 0 point 1 0 point 0 1 }", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count >= 3));
   });
   it("lofts sections whose winding a mirroring transform reversed", () => {
@@ -242,9 +239,11 @@ describe("expressions", () => {
     });
   });
   it("rejects unknown members and out-of-range indices", () => {
-    for (const expression of ["(1 2 3).constructor", "(1 2 3)[3]", "(1 2 3)[-1]"]) {
+    for (const expression of ["(1 2 3).constructor", "(1 2 3)[3]", "(1 2 3)[-4]", '(1 2 3)["w"]']) {
       assert.throws(() => astToThreeJS(parseShapeScript(`cube { size ${expression} }`)), /Unknown member|out of range/);
     }
+    // Negative indices count from the end and a string index is a member, as upstream.
+    withMesh('cube { size (1 2 3)[-1] (1 2 3)["y"] (5 6)[-2] }', (mesh) => assert.deepEqual(extent(mesh).toArray(), [3, 2, 5]));
   });
   it("supports constants, numeric literals, tuple min/max and string functions", () => {
     withMesh("if true { cube { position +2 .5 1e-3 size max((1, 2, 3)) } }", (mesh) => {
@@ -455,5 +454,254 @@ describe("path transform options", () => {
   it("refuses a placed profile on a lathe and a placement inside a path loop", () => {
     assert.throws(() => astToThreeJS(parseShapeScript("lathe path {\n position 1 0 0\n point 0 0\n point 1 0\n point 1 1\n point 0 1\n}")), /place the lathe/);
     assert.throws(() => parseShapeScript("fill path { for i in 1 to 3 { position 1 0 0 point i 0 } }"), /Unexpected token/);
+  });
+});
+
+function materialOf(script: string, check: (material: THREE.MeshStandardMaterial, mesh: THREE.Mesh) => void) {
+  withMesh(script, (mesh) => check(mesh.material as THREE.MeshStandardMaterial, mesh));
+}
+function infoOf(script: string) {
+  const group = astToThreeJS(parseShapeScript(script));
+  try {
+    return sceneInfoOf(group);
+  } finally {
+    disposeObject3D(group);
+  }
+}
+function objectsOf(script: string): THREE.Object3D[] {
+  const group = astToThreeJS(parseShapeScript(script));
+  const objects: THREE.Object3D[] = [];
+  group.traverse((object) => {
+    if ((object as THREE.Mesh).isMesh || (object as THREE.Line).isLine) objects.push(object);
+  });
+  disposeObject3D(group);
+  return objects;
+}
+
+describe("colours and materials", () => {
+  it("reads hex, named, hsb and luminance colours, with alpha as opacity", () => {
+    materialOf("cube { color #ff0000 }", (m) => near(m.color.toArray(), [1, 0, 0]));
+    materialOf("cube { color #f00 }", (m) => near(m.color.toArray(), [1, 0, 0]));
+    materialOf("cube { colour orange }", (m) => near(m.color.toArray(), [1, 0.5, 0]));
+    materialOf("cube { color hsb(1 / 3 1 1) }", (m) => near(m.color.toArray(), [0, 1, 0]));
+    materialOf("cube { color 0.8 }", (m) => near(m.color.toArray(), [0.8, 0.8, 0.8]));
+    materialOf("cube { color #ff000080 }", (m) => {
+      assert.ok(m.transparent);
+      near([m.opacity], [128 / 255]);
+    });
+    materialOf("cube { color 1 0.5 }", (m) => {
+      near(m.color.toArray(), [1, 1, 1]);
+      near([m.opacity], [0.5]);
+    });
+    // A colour followed by a number replaces its alpha, as upstream.
+    materialOf("cube { color red 0.25 }", (m) => near([m.opacity, ...m.color.toArray()], [0.25, 1, 0, 0]));
+    materialOf("define glass green 0.2\ncube { color glass }", (m) => near([m.opacity, ...m.color.toArray()], [0.2, 0, 1, 0]));
+    // Named colours are ordinary symbols a script may redefine.
+    materialOf("define red 1 0.3 0.1\ncube { color red }", (m) => near(m.color.toArray(), [1, 0.3, 0.1]));
+  });
+  it("multiplies `opacity` through nested scopes and by the colour's alpha", () => {
+    materialOf("opacity 0.5\ngroup {\n opacity 0.5\n cube\n}", (m) => near([m.opacity], [0.25]));
+    materialOf("opacity 0.5\ncube { opacity 2 }", (m) => near([m.opacity], [1]));
+    materialOf("opacity 0.5\ncube { color 1 0 0 0.5 }", (m) => near([m.opacity], [0.25]));
+    materialOf("opacity 0.5\nsphere", (m) => assert.ok(m.transparent));
+  });
+  it("maps metallicity, roughness and glow onto the PBR material, and smoothing 0 onto flat shading", () => {
+    materialOf("metallicity 0.9\nroughness 0.2\nglow red\ncube", (m) => {
+      near([m.metalness, m.roughness], [0.9, 0.2]);
+      near(m.emissive.toArray(), [1, 0, 0]);
+      assert.equal(m.flatShading, false);
+    });
+    materialOf("cube { glow green * 0.5 metallicity 1 }", (m) => {
+      near(m.emissive.toArray(), [0, 0.5, 0]);
+      near([m.metalness], [1]);
+    });
+    materialOf("smoothing 0\nsphere", (m) => assert.equal(m.flatShading, true));
+    materialOf("smoothing 0\nsphere { smoothing 0.5 }", (m) => assert.equal(m.flatShading, false));
+  });
+  it("bundles properties in `material { … }` and applies them as a command or a property", () => {
+    const bundle = "define shiny material {\n color blue\n metallicity 1\n roughness 0.1\n}\n";
+    materialOf(`${bundle}material shiny\ncube`, (m) => {
+      near(m.color.toArray(), [0, 0, 1]);
+      near([m.metalness, m.roughness], [1, 0.1]);
+    });
+    materialOf(`${bundle}sphere { material shiny color red }`, (m) => {
+      near(m.color.toArray(), [1, 0, 0]);
+      near([m.metalness], [1]);
+    });
+    assert.throws(() => infoOf("material 5\ncube"), /material \{/);
+  });
+  it("gives a builder the material its own block ends with", () => {
+    materialOf("extrude {\n color red\n square\n}", (m) => near(m.color.toArray(), [1, 0, 0]));
+    materialOf("lathe {\n color 0 1 0\n path {\n point 0 1\n point 0.5 1\n point 0.5 0\n point 0 0\n }\n}", (m) => near(m.color.toArray(), [0, 1, 0]));
+    materialOf("define star {\n path {\n point 0 0\n point 1 0\n point 0 1\n point 0 0\n }\n}\nextrude {\n color blue\n size 2 2 1\n star\n}", (m, mesh) => {
+      near(m.color.toArray(), [0, 0, 1]);
+      near(extent(mesh).toArray(), [2, 2, 1]);
+    });
+  });
+  it("accepts textures, cameras and lights with a warning instead of an error", () => {
+    assert.deepEqual(infoOf('texture "earth.png"\nsphere').warnings, ['texture "earth.png" is not supported — the shape is drawn with its colour instead']);
+    assert.match(infoOf("camera {\n position 1 2 3\n orientation 0 0.5\n}\ncube").warnings[0]!, /camera/);
+    assert.match(infoOf("light { position 1 1 1 }\ncube").warnings[0]!, /light/);
+    // A block the script defines itself is invoked, not skipped.
+    assert.deepEqual(infoOf("define light { cube }\nlight").warnings, []);
+    assert.equal(objectsOf("define light { cube }\nlight").length, 1);
+  });
+  it("keeps `background` for the viewer and warns about a background image", () => {
+    assert.deepEqual(infoOf("background 0 0 1\ncube").background, [0, 0, 1, 1]);
+    assert.deepEqual(infoOf("background #808080\ncube").background, [128 / 255, 128 / 255, 128 / 255, 1]);
+    assert.equal(infoOf("cube").background, undefined);
+    assert.match(infoOf('background "stars.jpg"\ncube').warnings[0]!, /background image "stars.jpg"/);
+    assert.throws(() => infoOf("group { background red cube }"), /root/);
+  });
+});
+
+describe("upstream shapes and paths", () => {
+  it("pads a short `size` the way Euclid does: one value is uniform, two are x y x", () => {
+    withMesh("cube { size 2 }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    withMesh("cube { size 1 2 }", (mesh) => near(extent(mesh).toArray(), [1, 2, 1]));
+    withMesh("cylinder { size 1 2 }", (mesh) => near(extent(mesh).toArray(), [1, 2, 1], 0.01));
+    withMesh("group { size 2 cube }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+  });
+  it("builds an icosphere of the requested diameter", () => {
+    withMesh("icosphere { size 2 detail 16 }", (mesh) => {
+      assert.equal(mesh.geometry.type, "IcosahedronGeometry");
+      const size = extent(mesh);
+      assert.ok(size.x > 1.9 && size.x <= 2.001 && size.y > 1.9 && size.z > 1.9, size.toArray().join(","));
+    });
+  });
+  it("builds a roundrect whose corner radius is a proportion of the smaller side", () => {
+    withMesh("extrude roundrect {\n size 2 1\n radius 0.5\n}", (mesh) => {
+      near(extent(mesh).toArray(), [2, 1, 1], 0.01);
+      // A 2 × 1 rectangle with 0.5 corners is a stadium: 2·1 − (4 − π)·0.25.
+      near([volume(mesh)], [2 - (4 - Math.PI) * 0.25], 0.02);
+    });
+    withMesh("fill roundrect", (mesh) => near(extent(mesh).toArray(), [1, 1, 0], 0.01));
+  });
+  it("places `arc` segments inside a path, clockwise from +Y", () => {
+    // A half-turn arc from (0, .5) over (+.5, 0) to (0, −.5), closed along the axis: a semicircle.
+    withMesh("extrude path {\n arc { angle 1 }\n point 0 0.5\n}", (mesh) => {
+      near([volume(mesh)], [(Math.PI * 0.25) / 2], 0.02);
+      assert.ok(mesh.geometry.boundingBox === null || true);
+      const box = new THREE.Box3().setFromObject(mesh);
+      assert.ok(box.max.x > 0.49 && box.min.x > -0.001, `${box.min.x}..${box.max.x}`);
+    });
+    // Upstream's curved slab: two quarter arcs, placed and oriented.
+    withMesh(
+      "extrude path {\n arc { angle -0.5 }\n point -0.5 0\n point 1.5 0\n arc {\n position 1 0\n orientation 0.5\n angle -0.5\n }\n curve 0 0.5\n}",
+      (mesh) => {
+        near(extent(mesh).toArray(), [2, 0.5, 1], 0.02);
+      },
+    );
+    withMesh("extrude path { arc { angle 1 size 2 } point 0 1 }", (mesh) => near([volume(mesh)], [Math.PI / 2], 0.02));
+  });
+  it("draws a bare path as a line, open or closed, and still fills it on request", () => {
+    const [line] = objectsOf("path {\n point 0 0\n point 1 1\n point 2 0\n}");
+    assert.ok((line as THREE.Line).isLine);
+    assert.equal(objectsOf("path {\n point 0 0\n point 1 0\n point 0 1\n point 0 0\n}").filter((o) => (o as THREE.Mesh).isMesh).length, 0);
+    withMesh("fill path {\n point 0 0\n point 1 0\n point 0 1\n point 0 0\n}", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count >= 3));
+    assert.throws(() => objectsOf("path { point 0 0 }"), /two points/);
+    assert.throws(() => objectsOf("path { point 0 0 1 point 1 0 }"), /planar/);
+  });
+  it("revolves a lathe profile drawn on the −X side like one on +X", () => {
+    const right = "lathe path {\n point 0 1\n point 0.5 1\n point 0.5 0\n point 0 0\n}";
+    const left = "lathe path {\n point 0 1\n point -0.5 1\n point -0.5 0\n point 0 0\n}";
+    withMesh(right, (a) => withMesh(left, (b) => near([volume(b)], [volume(a)], 1e-6)));
+  });
+  it("scales a builder's result by its `size`, with an extrude's Z as the depth", () => {
+    withMesh("extrude { size 2 3 4 square }", (mesh) => near(extent(mesh).toArray(), [2, 3, 4]));
+    withMesh("extrude { size 0.5 square }", (mesh) => near(extent(mesh).toArray(), [0.5, 0.5, 0.5]));
+    withMesh("hull { size 2 cube }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+  });
+  it("places and colours a custom block through its standard options", () => {
+    materialOf("define post { cube }\npost { position 1 2 3 size 2 color red }", (m, mesh) => {
+      near(mesh.position.toArray(), [1, 2, 3]);
+      near(extent(mesh).toArray(), [2, 2, 2]);
+      near(m.color.toArray(), [1, 0, 0]);
+    });
+    withMesh("define post { cube { size 1 2 1 } }\npost { orientation 0 0 0.5 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 2]));
+  });
+  it("applies a per-shape `detail`", () => {
+    withMesh("sphere { detail 8 }", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count < 100));
+    withMesh("detail 8\nsphere { detail 64 }\n", (mesh) => assert.ok(mesh.geometry.getAttribute("position").count > 4000));
+  });
+});
+
+describe("control flow, ranges and functions", () => {
+  it("lets `translate` / `rotate` / `color` inside for, if and switch carry on after the block, as upstream", () => {
+    withMesh("for 1 to 3 { translate 1 0 0 }\ncube", (mesh) => near(mesh.position.toArray(), [3, 0, 0]));
+    withMesh("if true { translate 0 1 0 }\ncube", (mesh) => near(mesh.position.toArray(), [0, 1, 0]));
+    withMesh("switch 1 {\ncase 1\n translate 0 0 1\n}\ncube", (mesh) => near(mesh.position.toArray(), [0, 0, 1]));
+    materialOf("for 1 to 1 { color red }\ncube", (m) => near(m.color.toArray(), [1, 0, 0]));
+    // Groups and custom blocks still scope them.
+    withMesh("group { translate 5 0 0 }\ncube", (mesh) => near(mesh.position.toArray(), [0, 0, 0]));
+    withMesh("define move { translate 5 0 0 }\nmove\ncube", (mesh) => near(mesh.position.toArray(), [0, 0, 0]));
+    // Symbols defined in a loop do not leak.
+    assert.throws(() => objectsOf("for i in 1 to 2 { define k i }\ncube { size k }"), /Undefined variable: k/);
+  });
+  it("treats ranges as values: stored, re-stepped and looped over", () => {
+    assert.equal(objectsOf("define r 1 to 5 step 2\nfor i in r { cube { position i 0 0 } }").length, 3);
+    assert.equal(objectsOf("define r 1 to 5\nfor i in r step 4 { cube }").length, 2);
+    assert.equal(objectsOf("for i in 5 to 1 step -2 { cube }").length, 3);
+    assert.equal(objectsOf("for i in 0.2 to 2.2 { cube }").length, 3);
+    assert.equal(objectsOf("for 1 to 3 { cube }").length, 3);
+    withMesh("define r 2 to 4\nfor i in r { translate i 0 0 }\ncube", (mesh) => near(mesh.position.toArray(), [9, 0, 0]));
+    assert.throws(() => objectsOf("define r 1 to 100000000\nfor i in r { cube }"), /iterations/);
+  });
+  it("supports the `in` operator on ranges, tuples and strings", () => {
+    const yes = (condition: string) => assert.equal(objectsOf(`${condition} { cube }`).length, 1, condition);
+    const no = (condition: string) => assert.equal(objectsOf(`${condition} { cube }`).length, 0, condition);
+    yes("define r 1 to 5 step 2\nif 3 in r");
+    no("define r 1 to 5 step 2\nif 2 in r");
+    yes("define r 1 to 5\nif 2.5 in r");
+    no("define r 1 to 5\nif 6 in r");
+    yes("if 2 in (1 2 3)");
+    no("if 4 in (1 2 3)");
+    yes('if "b" in "abc"');
+    yes("define c 1 0 0\nif (1 0 0) in (c (0 1 0))");
+  });
+  it("accepts bare function calls, which take every value that follows", () => {
+    withMesh("cube { size max 1 2 }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    withMesh("define a sqrt 9\ncube { size a }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
+    withMesh("cube { size sin pi / 2 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 1]));
+    withMesh("translate (cos 0) 1\ncube", (mesh) => near(mesh.position.toArray(), [1, 1, 0]));
+    withMesh("cube { size (sqrt 9) + (sqrt 16) }", (mesh) => near(extent(mesh).toArray(), [7, 7, 7]));
+    withMesh("cube { size max(1 2) 3 }", (mesh) => near(extent(mesh).toArray(), [2, 3, 2]));
+    // A `define` of the same name shadows the function.
+    withMesh("define max 5\ncube { size max }", (mesh) => near(extent(mesh).toArray(), [5, 5, 5]));
+  });
+  it("defines functions with parameters, local defines and a result", () => {
+    withMesh("define sq(a) { a * a }\ncube { size sq(3) }", (mesh) => near(extent(mesh).toArray(), [9, 9, 9]));
+    withMesh("define hyp(a b) {\n define s a * a + b * b\n sqrt s\n}\ncube { size hyp 3 4 }", (mesh) => near(extent(mesh).toArray(), [5, 5, 5]));
+    withMesh("define degrees(r) { r / pi * 180 }\ncube { position degrees(pi) 0 0 }", (mesh) => near(mesh.position.toArray(), [180, 0, 0]));
+    withMesh("define vec(a) { a 0 a }\ncube { position vec(2) }", (mesh) => near(mesh.position.toArray(), [2, 0, 2]));
+    assert.throws(() => objectsOf("define sq(a) { a * a }\ncube { size sq(1 2) }"), /takes 1 argument/);
+    assert.throws(() => objectsOf("define f(a) { f(a) }\ncube { size f(1) }"), /recursed/);
+    assert.throws(() => objectsOf("define f(a) { cube }\nf(1)"), /builds a shape/);
+    assert.throws(() => objectsOf("define f(a) { minkowski { cube } }\nf(1)"), /minkowski/);
+  });
+  it("collects `print` output and stops on a failed `assert`", () => {
+    assert.deepEqual(infoOf('print "size" 1 (2 3)\nprint 1 to 3\ncube').logs, ["size 1 (2 3)", "1 to 3 step 1"]);
+    assert.equal(objectsOf("assert 1 = 1\ncube").length, 1);
+    assert.throws(() => objectsOf("assert 1 = 2\ncube"), /Assertion failed/);
+  });
+  it("adds upstream's size, rotation and colour members, string subscripts and split", () => {
+    withMesh("define s 1 2 3\ncube { size s.width s.height s.depth }", (mesh) => near(extent(mesh).toArray(), [1, 2, 3]));
+    withMesh("define r 0.5 0.25 0\ncube { position r.roll r.yaw r.pitch }", (mesh) => near(mesh.position.toArray(), [0.5, 0.25, 0]));
+    withMesh("define c 1 0 0\ncube { position c.alpha c.hue c.brightness }", (mesh) => near(mesh.position.toArray(), [1, 0, 1]));
+    withMesh("define c 0 1 0\ncube { position c.hue c.saturation 0 }", (mesh) => near(mesh.position.toArray(), [1 / 3, 1, 0]));
+    withMesh('define parts split "a,bb,ccc" ","\ncube { size parts.count parts.second.count parts[-1].count }', (mesh) =>
+      near(extent(mesh).toArray(), [3, 2, 3]),
+    );
+  });
+  it("names the upstream features it lacks", () => {
+    for (const [script, message] of [
+      ['text "hi"', /text/],
+      ['import "other.shape"', /import/],
+      ["define s sphere { size 2 }", /shape as a value/],
+      ["extrude { square along path { point 0 0 point 1 1 } }", /along/],
+      ['fill svgpath "M 0 0 L 1 0 L 0 1 z"', /svgpath/],
+    ] as const) {
+      assert.throws(() => objectsOf(script), message, script);
+    }
   });
 });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -681,6 +681,13 @@ describe("control flow, ranges and functions", () => {
     withMesh("define max 5\ncube { size max }", (mesh) => near(extent(mesh).toArray(), [5, 5, 5]));
     withMesh("group { define max 5 }\ncube { size max 1 2 }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
     withMesh("define f(a) {\n define max a\n max\n}\ncube { size max 1 f(3) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
+    // Loop variables, block options and function parameters shadow too.
+    withMesh("for sum in 2 to 2 { cube { size sum 1 1 } }", (mesh) => near(extent(mesh).toArray(), [2, 1, 1]));
+    withMesh("define box {\n option max 2\n cube { size max 1 1 }\n}\nbox", (mesh) => near(extent(mesh).toArray(), [2, 1, 1]));
+    withMesh("define f(max) { max 1 1 }\ncube { size f(2) }", (mesh) => near(extent(mesh).toArray(), [2, 1, 1]));
+    withMesh("extrude path {\n for sum in 1 to 1 {\n point 0 0\n point sum 0\n point 0 sum\n point 0 0\n }\n}", (mesh) =>
+      near(extent(mesh).toArray(), [1, 1, 1]),
+    );
   });
   it("defines functions with parameters, local defines and a result", () => {
     withMesh("define sq(a) { a * a }\ncube { size sq(3) }", (mesh) => near(extent(mesh).toArray(), [9, 9, 9]));

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -540,6 +540,9 @@ describe("colours and materials", () => {
   });
   it("accepts textures, cameras and lights with a warning instead of an error", () => {
     assert.deepEqual(infoOf('texture "earth.png"\nsphere').warnings, ['texture "earth.png" is not supported — the shape is drawn with its colour instead']);
+    // Deduplicated and capped, so a loop of textures reports each once and stops at the bound.
+    assert.equal(infoOf('for i in 1 to 500 {\n texture "t.png"\n}\ncube').warnings.length, 1);
+    assert.equal(infoOf('for i in 1 to 500 {\n texture join("t" i ".png")\n}\ncube').warnings.length, 200);
     assert.match(infoOf("camera {\n position 1 2 3\n orientation 0 0.5\n}\ncube").warnings[0]!, /camera/);
     assert.match(infoOf("light { position 1 1 1 }\ncube").warnings[0]!, /light/);
     // A block the script defines itself is invoked, not skipped.
@@ -647,6 +650,7 @@ describe("upstream shapes and paths", () => {
       near(m.color.toArray(), [1, 0, 0]);
     });
     withMesh("define post { cube { size 1 2 1 } }\npost { orientation 0 0 0.5 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 2]));
+    withMesh('define post { cube }\npost { name "left" }', (mesh) => assert.equal(mesh.parent?.name, "left"));
     // `detail` / `smoothing` on the call apply to the block's body.
     materialOf("define bead { sphere }\nbead {\n detail 4\n smoothing 0\n}", (m, mesh) => {
       assert.ok(mesh.geometry.getAttribute("position").count < 60);

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -608,13 +608,35 @@ describe("upstream shapes and paths", () => {
     assert.ok(lineMaterial.transparent);
     assert.throws(() => objectsOf("path { point 0 0 1 point 1 0 }"), /planar/);
   });
-  it("revolves a lathe profile drawn on the −X side like one on +X", () => {
+  it("revolves a lathe profile drawn on the −X side like one on +X, always facing outward", () => {
     const right = "lathe path {\n point 0 1\n point 0.5 1\n point 0.5 0\n point 0 0\n}";
     const left = "lathe path {\n point 0 1\n point -0.5 1\n point -0.5 0\n point 0 0\n}";
-    withMesh(right, (a) => withMesh(left, (b) => near([volume(b)], [volume(a)], 1e-6)));
+    const upward = "lathe path {\n point 0 0\n point 0.5 0\n point 0.5 1\n point 0 1\n}";
+    withMesh(right, (a) => {
+      assert.ok(volume(a) > 0, "a top-down profile must not come out inside out");
+      withMesh(left, (b) => near([volume(b)], [volume(a)], 1e-6));
+      withMesh(upward, (c) => near([volume(c)], [volume(a)], 1e-6));
+    });
+    // Two lathes drawn top-down union into one solid (upstream's chess queen).
+    withMesh(
+      "union {\n lathe path {\n  point 0 1.2\n  point 0.15 1.05\n  point 0 0.9\n }\n lathe path {\n  point 0 0.85\n  point 0.2 0.85\n  point 0.3 0.1\n  point 0 0\n }\n}",
+      (mesh) => {
+        const box = new THREE.Box3().setFromObject(mesh);
+        near([box.min.y, box.max.y], [0, 1.2], 1e-3);
+        assert.ok(volume(mesh) > 0.05, `volume ${volume(mesh)}`);
+      },
+    );
   });
-  it("scales a builder's result by its `size`, with an extrude's Z as the depth", () => {
-    withMesh("extrude { size 2 3 4 square }", (mesh) => near(extent(mesh).toArray(), [2, 3, 4]));
+  it("scales a builder's result by its `size`, with an extrude's Z as the depth, centred on the profile", () => {
+    withMesh("extrude { size 2 3 4 square }", (mesh) => {
+      near(extent(mesh).toArray(), [2, 3, 4]);
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.z, box.max.z], [-2, 2]);
+    });
+    withMesh("extrude path {\n point 0 0\n point 1 0\n point 0 1\n point 0 0\n}", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.z, box.max.z], [-0.5, 0.5]);
+    });
     withMesh("extrude { size 0.5 square }", (mesh) => near(extent(mesh).toArray(), [0.5, 0.5, 0.5]));
     withMesh("hull { size 2 cube }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
   });

--- a/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
+++ b/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
@@ -26,11 +26,12 @@ const RENDERS: Record<string, Rendered> = {
   // The board is 8.8 wide; every piece stands on it. `translate` inside the
   // `for` loops carries on after them, which is what keeps the pieces on it.
   "Chessboard.shape": { objects: 33, bounds: { min: [-4.4, -0.2, -4.4], max: [4.4, 1.42, 4.4] }, warnings: [/camera/] },
-  "Cog.shape": { objects: 1, bounds: { min: [-1, -1, 0], max: [1, 1, 0.5] }, warnings: [/camera/] },
+  // Extrusions are centred on their profile plane, as upstream: ±0.25 for a 0.5 depth.
+  "Cog.shape": { objects: 1, bounds: { min: [-1, -1, -0.25], max: [1, 1, 0.25] }, warnings: [/camera/] },
   // The sphere draws; its texture and the background image are reported.
   "Earth.shape": { objects: 1, bounds: { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] }, warnings: [/background image "Stars.jpg"/, /texture "Earth.png"/] },
   "Spring.shape": { objects: 1, bounds: { min: [-0.55, -0.65, -0.55], max: [0.55, 0.65, 0.55] }, warnings: [] },
-  "Train.shape": { objects: 14, bounds: { min: [-1, -0.42, -1.12], max: [0.6, 1.53, 1.15] }, warnings: [/camera/] },
+  "Train.shape": { objects: 14, bounds: { min: [-0.6, -0.42, -1.12], max: [0.6, 1.53, 1.15] }, warnings: [/camera/] },
 };
 
 const REFUSED: Record<string, RegExp> = {

--- a/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
+++ b/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import * as THREE from "three";
+import { parseShapeScript } from "../src/shapescript/parser";
+import { astToThreeJS, sceneInfoOf } from "../src/shapescript/toThreeJS";
+import { disposeObject3D } from "../src/shapescript/dispose";
+
+// The upstream project's own Examples, unmodified (see the LICENSE.md beside
+// them). Each is either rendered here or refused with a message that names
+// the upstream feature this renderer lacks — never a parse error on a brace.
+const FIXTURES = join(import.meta.dirname, "fixtures", "upstream-examples");
+
+interface Rendered {
+  objects: number;
+  /** The scene's extent, to catch a transform rule going wrong (a chessboard
+   *  whose pieces march off the board) rather than a script merely running. */
+  bounds: { min: [number, number, number]; max: [number, number, number] };
+  warnings: RegExp[];
+}
+
+const RENDERS: Record<string, Rendered> = {
+  // A stencil of a sphere, a cube and an extruded star: one mesh.
+  "Ball.shape": { objects: 1, bounds: { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] }, warnings: [/camera/] },
+  // The board is 8.8 wide; every piece stands on it. `translate` inside the
+  // `for` loops carries on after them, which is what keeps the pieces on it.
+  "Chessboard.shape": { objects: 33, bounds: { min: [-4.4, -0.2, -4.4], max: [4.4, 1.42, 4.4] }, warnings: [/camera/] },
+  "Cog.shape": { objects: 1, bounds: { min: [-1, -1, 0], max: [1, 1, 0.5] }, warnings: [/camera/] },
+  // The sphere draws; its texture and the background image are reported.
+  "Earth.shape": { objects: 1, bounds: { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] }, warnings: [/background image "Stars.jpg"/, /texture "Earth.png"/] },
+  "Spring.shape": { objects: 1, bounds: { min: [-0.55, -0.65, -0.55], max: [0.55, 0.65, 0.55] }, warnings: [] },
+  "Train.shape": { objects: 14, bounds: { min: [-1, -0.42, -1.12], max: [0.6, 1.53, 1.15] }, warnings: [/camera/] },
+};
+
+const REFUSED: Record<string, RegExp> = {
+  "Dodecahedron.shape": /a shape as a value.*not supported/,
+  "Fillet.shape": /minkowski.*not supported/,
+  "Spirals.shape": /along.*not supported/,
+};
+
+describe("upstream example scripts", () => {
+  const files = readdirSync(FIXTURES).filter((file) => file.endsWith(".shape"));
+  it("covers every fixture", () => {
+    assert.deepEqual(files.sort(), [...Object.keys(RENDERS), ...Object.keys(REFUSED)].sort());
+  });
+
+  for (const [file, expected] of Object.entries(RENDERS)) {
+    it(`renders ${file}`, () => {
+      const group = astToThreeJS(parseShapeScript(readFileSync(join(FIXTURES, file), "utf8")));
+      try {
+        let objects = 0;
+        group.traverse((object) => {
+          if ((object as THREE.Mesh).isMesh || (object as THREE.Line).isLine) objects++;
+        });
+        assert.equal(objects, expected.objects);
+        const box = new THREE.Box3().setFromObject(group);
+        for (const [axis, index] of [
+          ["x", 0],
+          ["y", 1],
+          ["z", 2],
+        ] as const) {
+          assert.ok(Math.abs(box.min[axis] - expected.bounds.min[index]) < 0.01, `${file} min ${axis}: ${box.min[axis]}`);
+          assert.ok(Math.abs(box.max[axis] - expected.bounds.max[index]) < 0.01, `${file} max ${axis}: ${box.max[axis]}`);
+        }
+        const { warnings } = sceneInfoOf(group);
+        assert.equal(warnings.length, expected.warnings.length, warnings.join("; "));
+        expected.warnings.forEach((pattern, i) => assert.match(warnings[i]!, pattern));
+      } finally {
+        disposeObject3D(group);
+      }
+    });
+  }
+
+  for (const [file, message] of Object.entries(REFUSED)) {
+    it(`refuses ${file} by naming the missing feature`, () => {
+      assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(readFileSync(join(FIXTURES, file), "utf8")))), message);
+    });
+  }
+});

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -52,6 +52,8 @@ Found while running the upstream examples (fixed in 2.1.0, also phase-1 class):
 | 17 | `size` on a builder / group, `material` inside a builder block | scales the result; sets its material | ignored | fixed in 2.1.0 |
 | 18 | options on a custom block call (`post { position 1 orientation 0.5 }`) | place the block's output | bound as symbols; `orientation` was a parse error | fixed in 2.1.0 |
 | 19 | lathe profile on the −X side | same solid | inside-out | fixed in 2.1.0 |
+| 20 | lathe profile drawn top-down | oriented outward (Euclid) | inside out, so `union` dropped it (Chessboard queens) | fixed in 2.1.0 |
+| 21 | `extrude` depth placement | centred: ±depth/2 around the profile plane | 0…depth (Train running board offset) | fixed in 2.1.0 |
 
 ## Phase 2 — commands that parse but fail to render — DONE (2.1.0)
 

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -1,9 +1,9 @@
 # ShapeScript plugin: upstream parity tracker
 
-**Status**: phase 1 in progress (semantic mismatches)
+**Status**: phase 1 shipped in 2.0.0 (#3069); phase 2 and the first phase-3 batch in 2.1.0
 **Upstream**: [nicklockwood/ShapeScript](https://github.com/nicklockwood/ShapeScript) 1.11.4 (2026-09-04)
 **Ours**: `packages/plugins/shapescript-plugin` (ported from `@gui-chat-plugin/present3d`)
-**Last updated**: 2026-09-10
+**Last updated**: 2026-09-11
 
 The plugin ships its own ShapeScript parser / evaluator / Three.js converter. It was ported
 from the present3D plugin, which had invented its own unit conventions. The result is that a
@@ -42,31 +42,62 @@ Known remaining deviations inside phase 1 scope (documented in the README):
 - `torus` is a plugin extension (upstream has none). Its `size` is now the outer diameter so it
   follows the same rule as the other curved primitives.
 
-## Phase 2 — commands that parse but fail to render
+Found while running the upstream examples (fixed in 2.1.0, also phase-1 class):
 
-- `background` and `texture` parse into AST nodes but the converter throws
-  "Unsupported command". Upstream scripts use `background` routinely. Accept `background` as
-  a scene-level colour and ignore `texture` with a diagnostic rather than an error.
+| # | Feature | Upstream | Ours (before) | Status |
+|---|---|---|---|---|
+| 14 | scope of `for` / `if` / `switch` | symbols only; transforms and materials carry on after the body (scope.md) | reset at the closing brace, so Chessboard's pieces marched off the board | fixed in 2.1.0 |
+| 15 | bare `path` at scene level | drawn as a line | filled face | fixed in 2.1.0 |
+| 16 | `size 1 2` | `1 2 1` (Euclid `Vector(size:)`) | `1 2 0`, refused by `cube` | fixed in 2.1.0 |
+| 17 | `size` on a builder / group, `material` inside a builder block | scales the result; sets its material | ignored | fixed in 2.1.0 |
+| 18 | options on a custom block call (`post { position 1 orientation 0.5 }`) | place the block's output | bound as symbols; `orientation` was a parse error | fixed in 2.1.0 |
+| 19 | lathe profile on the −X side | same solid | inside-out | fixed in 2.1.0 |
+
+## Phase 2 — commands that parse but fail to render — DONE (2.1.0)
+
+- `background R G B` is kept on the root group (`sceneInfoOf(group).background`) and both the
+  View and the server render page paint it. A background image, `texture`, `camera` and
+  `light` are accepted and skipped; the warnings travel on `userData`, in the tool result
+  message ("Not rendered: …") and in the View.
 
 ## Phase 3 — missing language features (by likely impact on generated scripts)
 
-- **Materials**: hex colours (`#FF0000`), HSB colours, named colours (`red`, `green`, …),
-  `material` blocks, `glow`, `metallicity`, `roughness`, `opacity` textures, `normals`.
-- **Primitives**: `icosphere` (1.11.0).
+Test fixtures: the upstream `Examples/` directory (`test/fixtures/upstream-examples/`, MIT).
+Ball, Chessboard, Cog, Earth, Spring and Train render; Dodecahedron, Fillet and Spirals are
+refused by name (see "open" below).
+
+Done in 2.1.0:
+
+- **Materials**: hex, HSB (`hsb()`), named colours, alpha by count and `color red 0.5`,
+  scoped multiplicative `opacity`, `metallicity` / `roughness` (PBR), `glow` (emissive),
+  `material { … }` bundles and `material NAME`, `smoothing` (0 = flat), `name`.
+- **Primitives**: `icosphere` (upstream's subdivision rule from `detail`).
+- **Paths**: `arc { angle position orientation size }`, `roundrect { radius }`, builders
+  taking one unwrapped child (`extrude circle`), 3D path points accepted when z = 0.
+- **Expressions**: ranges as values (`1 to 5 step 2`, re-stepping, `in`), bare calls
+  (`max 0 1`, `sin pi / 2`), custom functions with parameters and local defines, `split`,
+  negative / named subscripts, size / rotation / HSB members.
+- **Scene**: `print` (returned with the tool result), `assert`, `smoothing`, `name`;
+  `camera` / `light` skipped with a warning; `import`, `text`, `font`, `mesh`, `minkowski`,
+  `inset`, `svgpath`, `along`, `object`, `normals`, `focus`, `debug` refused by name.
+
+Open:
+
 - **Builders**: `minkowski`; `extrude` options `along`, `twist`, `axisAligned`, `miterLimit`;
-  `inset` (1.11.0).
-- **Paths**: `arc`, `roundrect`, `svgpath`, `angle`, nested / compound paths with holes,
-  `path.color`, 3D path points.
-- **Rotation values**: `rotation` function, quaternion-style multiplication of rotations,
-  `{ yaw 0.5 }` / `{ axis … angle … }` block syntax (1.11.0 – 1.11.2).
-- **Object syntax** for `color`, `size`, `point`, `path`, `polygon`, `mesh` (1.11.0).
-- **Expressions**: ranges as values (`1 to 5`), partial ranges, bare function calls without
-  parentheses (`max 0 1`), `if` / `switch` / `for` inside expressions (1.10.0), `split`,
-  `bounds` members, mesh members (`polygons`, `triangles`), string `lines` / `words` /
-  `characters`.
-- **Custom functions** with return values (we only have custom shapes with `option`s).
-- **Scene**: `text` / `font`, `light`, `camera`, `import`, raw `mesh`, `smoothing`, `name`,
-  `debug`, `print`, `assert`, `focus`.
+  `inset` (Fillet, Spirals).
+- **Values**: shapes as values (`define s sphere { … }`, functions returning meshes, mesh
+  members `polygons` / `triangles` / `bounds` / `volume`, `for` as an expression) — Dodecahedron.
+  Would need a mesh value type in the evaluator; the largest remaining item.
+- **Paths**: `svgpath`, nested / compound paths with holes, `path.color` gradients, 3D path
+  points with z ≠ 0, `arc` outside a path.
+- **Materials**: texture images (`texture`, `opacity` / `metallicity` / `roughness` textures,
+  `normals`), `smoothing` as an angle threshold.
+- **Rotation values**: `rotation` function, rotation multiplication, `{ yaw 0.5 }` /
+  `{ axis … angle … }` block syntax (1.11.0 – 1.11.2).
+- **Object syntax** for `color`, `size`, `point`, `path`, `polygon`, `mesh` (1.11.0); `object`
+  values; partial ranges (`from 5`); range subscripts (`v[0 to 2]`); `if` / `switch` inside
+  expressions; string `lines` / `words` / `characters`; `text` / `font`; `light` / `camera`
+  rendering.
 
 ## Things we have that upstream does not
 


### PR DESCRIPTION
## Summary

Phase 2 and the first phase-3 batch of `plans/feat-shapescript-upstream-parity.md`, driven by the upstream project's own `Examples/` scripts, which are now test fixtures (`test/fixtures/upstream-examples/`, MIT). Ball, Chessboard, Cog, Earth, Spring and Train render end to end (object count + scene extent asserted); Dodecahedron, Fillet and Spirals are refused with a message naming the feature they need.

### Phase 2
- `background R G B` is kept on the root group (`sceneInfoOf(group).background`) and painted by both the View and the server render page.
- `texture`, a background image, `camera { … }` and `light { … }` are accepted and skipped; the reason travels on `userData`, in the tool result message (`Not rendered: …`) and in the View, instead of failing the script.
- `print` output is returned the same way; `assert` stops the script.

### Phase 3 (this batch)
- **Materials**: hex (`#F00`, `#FF000080`) and named colours, `rgb()` / `hsb()`, alpha by value count and `color red 0.5`, scoped multiplicative `opacity`, `metallicity` / `roughness` / `glow` on the PBR material, `material { … }` bundles applied with `material NAME`, `smoothing 0` = flat shading, `name`. A material command inside a builder block colours the builder's result.
- **Shapes and paths**: `icosphere` (upstream's subdivision rule), `roundrect { radius }`, `arc { angle position orientation size }` inside a path, builders taking one unwrapped child (`extrude circle`), per-shape `detail` / `smoothing`, `size` on builders and groups (an extrude's `size` scales its profile and sets its depth), custom block calls placed through `position` / `orientation` / `size` / `color` / `material`, −X lathe profiles.
- **Expressions**: bare calls (`max 0 1`, `sqrt 9`, `sin pi / 2`), custom functions (`define hyp(a b) { sqrt(a * a + b * b) }`), ranges as values with `step` and the `in` operator, `split`, negative / named subscripts, `.width/.height/.depth`, `.roll/.yaw/.pitch`, `.hue/.saturation/.brightness`.
- Unsupported upstream commands (`import`, `text`, `mesh`, `minkowski`, `inset`, `svgpath`, `along`, shapes as values) are refused by name rather than with a parse error on a brace.

### Behaviour changes toward upstream (found by the examples)
- `for` / `if` / `switch` bodies no longer reset transforms and materials at their closing brace — only symbols are scoped there (upstream `scope.md`). Chessboard's pieces marched 30 units off the board under the old rule.
- A bare `path` at scene level draws as a line, as upstream; `fill` it for the old filled face.
- `size 1 2` pads to `1 2 1` (Euclid `Vector(size:)`); it was `1 2 0`, which `cube` refused.

The three user scripts converted in #3069 (helmet 108 meshes, kitten 74, bobcat 683) render mesh-for-mesh identical to 2.0.0 under these rules.

### Versioning
`@mulmoclaude/shapescript-plugin` 2.0.0 → 2.1.0, launcher range `^2.1.0`, changelog entry under [Unreleased] and the Ships line updated. Publish after merge is a separate step.

## Test plan
- [x] `yarn test` in the plugin: 148 pass (24 new language tests + the upstream examples suite)
- [x] `yarn format`, `yarn lint` (no new warnings), `yarn typecheck`, `yarn build`, root `yarn test`
- [x] `yarn check:launcher-sync`, `scripts/packages/check-changelog-ships.mjs`
- [x] Per-mesh bounding-box comparison of the three converted scripts against 2.0.0: identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz

work in mulmoclaude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded ShapeScript support for materials, ranges, custom functions, membership checks, additional primitives, arcs, and richer path operations.
  - Added scene backgrounds, smoothing, printing, assertions, and clearer notices for skipped or unsupported commands.
  - Improved rendering for control-flow scopes, builders, materials, sizing, and scene-level paths.
  - Added localized viewer warnings and printed output.
  
- **Bug Fixes**
  - Corrected extrusion depth placement and lathe profile orientation.

- **Documentation**
  - Updated ShapeScript documentation, examples, compatibility notes, and release information for version 2.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->