### PR TITLE
feat(shapescript): shapes as values, polygon faces and mesh blocks — Dodecahedron renders (2.2.0)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### `@mulmoclaude/shapescript-plugin@2.2.0` — shapes as values, meshes from polygons, Dodecahedron
+
+The last upstream example that needed language work. A shape is now a value
+(`define ico icosphere { detail 0 }`): it can be placed by name, and read through `polygons` /
+`triangles` (with `.center`, `.points`, `.bounds`), `bounds` and `volume`. The icosphere is built
+with Euclid's vertex and face order so face indices match upstream. `for` and `if` are expressions
+(`define scales for i in 1 to 3 { i / 3 }`), functions may build shapes and be called bare as
+statements (`face data`), `polygon { point x y z … }` makes a face with a colour, and
+`mesh { … }` assembles polygons into one vertex-coloured mesh. Line breaks are allowed inside
+parentheses and call arguments. A keyword a script `define`s as a value (`define hull (…)`) keeps
+reading as that value. Dodecahedron now renders; Fillet and Spirals remain refused by name.
+
 #### `@mulmoclaude/shapescript-plugin@2.1.0` — materials, ranges, functions and the upstream examples
 
 Phase 2 and the first phase-3 batch of `plans/feat-shapescript-upstream-parity.md`, driven by the
@@ -200,7 +212,7 @@ the same way.
 An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
 diagnostic `presentShapeScript` returns.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.1.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.2.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^2.1.0",
+    "@mulmoclaude/shapescript-plugin": "^2.2.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -268,18 +268,31 @@ Loft accepts ordered, closed planar sections with one perimeter each, resamples 
 vertex counts, interpolates linearly, and triangulates the end caps. Sections must enclose
 a volume. Hull accepts geometry from child meshes and filled paths. Primitive profiles
 for fill/extrude must lie in XY; holes, swept/twisted extrusion (`along`, `twist`), and
-arbitrary 3D path commands are not implemented. `import`, `text` / `font`, raw `mesh`,
-`minkowski`, `inset`, `svgpath`, `object` values, shapes as values (`define s sphere { … }`)
-and functions that build shapes are refused with a message naming the feature. Textures,
+arbitrary 3D path commands are not implemented. `import`, `text` / `font`, `minkowski`, `inset`,
+`svgpath`, `object` values and paths as values are refused with a message naming the feature. Textures,
 normal maps, `camera` and `light` blocks are accepted and skipped with a warning that the
 tool result and the View both report. Unsupported commands and failed CSG operations return
 errors instead of silently substituting different geometry. As with other polygonal CSG
 engines, degenerate or self-intersecting inputs may fail.
 
 The upstream project's own example scripts are test fixtures
-(`test/fixtures/upstream-examples/`, MIT): Ball, Chessboard, Cog, Earth, Spring and Train render;
-Dodecahedron (mesh values), Fillet (`minkowski` / `inset`) and Spirals (`along`) are refused by
-name.
+(`test/fixtures/upstream-examples/`, MIT): Ball, Chessboard, Cog, Dodecahedron, Earth, Spring and
+Train render; Fillet (`minkowski` / `inset`) and Spirals (`along`) are refused by name.
+
+## Shapes as values, meshes and polygons
+
+Since 2.2.0 a shape is a value, as upstream: `define ico icosphere { detail 0 }` keeps its mesh, `ico`
+places it (with `position` / `orientation` / `size` on the call), and its members are readable —
+`polygons` and `triangles` (each with `.center`, `.points`, `.bounds`), `bounds` (`.min` `.max`
+`.center` `.size` `.width` `.height` `.depth`) and `volume`. The icosphere follows Euclid's
+construction face for face, so scripts that index its faces (upstream's Dodecahedron) get the same
+faces. `for v in … { expr }` and `if c { a } else { b }` are expressions, a function may build
+shapes (`define face(data) { polygon { … } }`) and be called bare as a statement (`face data`), and
+`mesh { … }` assembles the polygons its body produces — `polygon { color red point a point b point c }`
+with 3D points, a tuple per point allowed — into one flat-shaded, vertex-coloured mesh. A value a
+statement produces that is not a shape is an "unused value" error, as upstream. Paths as values and
+`object` values remain unsupported.
+
 
 `rnd` and `rand()` draw from a seeded generator (`randomSeed`, default
 `DEFAULT_RANDOM_SEED` = 0, overridable in-script with `seed`) rather than `Math.random()`:

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "presentShapeScript \u2014 interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -78,7 +78,7 @@ bare form max 0 (j - 1) / sqrt 9 / sin pi / 2, where the function takes every va
 arguments with spaces; commas also work here (max(0, j - 1)) but NOT in the upstream ShapeScript app.
 Inside a larger expression parenthesise a bare call: (sqrt 9) + (sqrt 16).
 Custom functions: define hyp(a b) { sqrt(a * a + b * b) } — parameters, optional defines, then the result
-expression; they compute values, not shapes.
+expression. A function may also build shapes: define face(data) { polygon { … } } returns what it built.
 Write ONE statement per line. This parser accepts "define a 1 define b 2" on one line; the upstream app
 rejects it, and "size 2 1 radius 0.5" on one line reads radius as a fourth size component in both.
 

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -167,7 +167,9 @@ A bare path draws as a LINE (stroke), as upstream; use fill / extrude / lathe / 
 - stencil preserves the first shape and paints its surface with later shapes' materials.
 Loft sections must each have one perimeter and enclose an area; extrude/fill primitive profiles must lie in XY.
 A material command inside a builder block (extrude { color red … }) colours the result; size on a builder or
-group scales it. Not supported: extrude along/twist, minkowski, inset, svgpath, text, mesh { polygon … }.
+group scales it. Not supported: extrude along/twist, minkowski, inset, svgpath, text.
+- mesh { polygon { point x y z … } … }: a mesh from explicit faces; polygon { color red point a point b point c }
+  takes 3D points (a tuple works: point v) and a colour per face. Faces may come from a function: mesh { for f in faces { face f } }.
 
 ### Additional Expressions:
 - Constants: pi, true, false (tau exists here but NOT in the upstream app; write 2 * pi)
@@ -186,14 +188,17 @@ define post {
 }
 post { height 3 }
 - Random numbers: rnd (0–1) and seed N (scoped to the enclosing block, same generator as upstream)
+- Shapes as values: define ico icosphere { detail 0 } then ico (places it), ico.polygons (faces, each with
+  .center .points .bounds), ico.triangles, ico.bounds (.min .max .center .size .width .height .depth), ico.volume.
+- for / if as expressions: define scales for i in 1 to 3 { i / 3 }; define c if big { red } else { white }
+- Functions may build shapes: define face(data) { polygon { … } } and are called bare as statements: face data
 
 ### Compatibility:
 This plugin implements the documented modeling subset, not all upstream ShapeScript syntax; units, scoping,
 materials and path semantics follow upstream, so a script written against the upstream docs renders the
-same here. Not supported (each is refused by name): import, text/font, mesh { polygon … }, minkowski, inset,
-svgpath, extrude along/twist, object values, shapes as values (define s sphere { … } — write a block
-define s { sphere { … } } instead) and functions that build shapes. Textures, cameras and lights are
-accepted but not drawn.
+same here. Not supported (each is refused by name): import, text/font, minkowski, inset, svgpath,
+extrude along/twist, object values and paths as values. Textures, cameras and lights are accepted but
+not drawn.
 
 ### Comments:
 // Single-line comment

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -1,4 +1,18 @@
-import { Expression, Vector3, Color, DefineNode, MaterialExpr } from "./types";
+import { Expression, Vector3, Color, DefineNode, MaterialExpr, SceneNode } from "./types";
+import {
+  type MeshValue,
+  type PolygonValue,
+  type BoundsValue,
+  type PointValue,
+  type Point3,
+  boundsOf,
+  centerOf,
+  meshPolygons,
+  meshVolume,
+  trianglesOf,
+} from "./meshValues";
+
+export type { MeshValue, PolygonValue, BoundsValue, PointValue } from "./meshValues";
 
 /** `1 to 5 step 2` as a value: walked by `for`, tested by `in`. */
 export interface RangeValue {
@@ -31,10 +45,18 @@ export interface MaterialValue {
 
 export type RGBA = [number, number, number, number];
 
-export type Value = number | boolean | string | Value[] | RangeValue | FunctionValue | MaterialValue;
+export type ObjectValue = RangeValue | FunctionValue | MaterialValue | MeshValue | PolygonValue | BoundsValue | PointValue;
 
-const isObjectValue = (value: Value | undefined): value is RangeValue | FunctionValue | MaterialValue =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+export type Value = number | boolean | string | Value[] | ObjectValue;
+
+export const isObjectValue = (value: Value | undefined): value is ObjectValue => typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** What the evaluator needs from the converter: shapes as values are built
+ *  there, and a function whose body builds shapes runs there. */
+export interface EvaluatorHooks {
+  shape(node: SceneNode): Value;
+  call(fn: FunctionValue, args: Value[]): Value;
+}
 
 /** Upstream's predefined colour constants (materials.md), as RGB tuples. A
  *  script may `define red …` over them. */
@@ -206,6 +228,65 @@ function hsbToRgb(h: number, s: number, b: number): [number, number, number] {
 /** Upstream's ordinal members, `vector.first` … `vector.tenth`. `last`,
  *  `allButFirst` and `allButLast` depend on the length and are handled inline. */
 const ordinalIndices: Record<string, number> = { first: 0, second: 1, third: 2, fourth: 3, fifth: 4, sixth: 5, seventh: 6, eighth: 7, ninth: 8, tenth: 9 };
+
+/** Members of the geometry-carrying values. */
+function objectMember(value: ObjectValue, member: string): Value | undefined {
+  switch (value.kind) {
+    case "mesh":
+      switch (member) {
+        case "polygons":
+          return meshPolygons(value);
+        case "triangles":
+          return trianglesOf(value.geometry);
+        case "bounds":
+          return boundsOf(meshPolygons(value).flatMap((polygon) => polygon.points));
+        case "volume":
+          return meshVolume(value);
+        case "name":
+          return value.name ?? "";
+        default:
+          return undefined;
+      }
+    case "polygon":
+      switch (member) {
+        case "points":
+          return value.points.map((position, i): PointValue => ({ kind: "point", position, ...(value.colors?.[i] ? { color: value.colors[i] } : {}) }));
+        case "center":
+          return centerOf(value.points);
+        case "bounds":
+          return boundsOf(value.points);
+        case "triangles":
+          return [value];
+        default:
+          return undefined;
+      }
+    case "bounds": {
+      const size: Point3 = [value.max[0] - value.min[0], value.max[1] - value.min[1], value.max[2] - value.min[2]];
+      switch (member) {
+        case "min":
+          return value.min;
+        case "max":
+          return value.max;
+        case "center":
+          return [(value.min[0] + value.max[0]) / 2, (value.min[1] + value.max[1]) / 2, (value.min[2] + value.max[2]) / 2];
+        case "size":
+          return size;
+        case "width":
+          return size[0];
+        case "height":
+          return size[1];
+        case "depth":
+          return size[2];
+        default:
+          return undefined;
+      }
+    }
+    case "point":
+      return member === "position" ? value.position : member === "color" ? (value.color ?? [1, 1, 1, 1]) : undefined;
+    default:
+      return undefined;
+  }
+}
 
 function sequenceMember(value: Value[] | string, member: string): Value | undefined {
   if (member === "count") return value.length;
@@ -399,9 +480,15 @@ export const DEFAULT_RANDOM_SEED = 0;
  *  JavaScript stack, which surfaces as a RangeError with no script context. */
 const MAX_CALL_DEPTH = 256;
 
+/** Same ceiling as a `for` statement; the converter's option is not reachable
+ *  from here, so the default stands. */
+const MAX_FOR_EXPRESSION_ITERATIONS = 100_000;
+
 export class Evaluator {
   private symbols: SymbolTable;
   private callDepth = 0;
+  /** Set by the converter, which owns geometry. */
+  hooks: EvaluatorHooks | undefined;
 
   constructor(symbols?: SymbolTable, seed?: number) {
     this.symbols = symbols || new SymbolTable(seed);
@@ -618,9 +705,41 @@ export class Evaluator {
       case "material":
         return this.evaluateMaterial(expr);
 
+      case "shape":
+        if (!this.hooks) throw new Error("A shape cannot be used as a value here");
+        return this.hooks.shape(expr.node);
+
+      case "for": {
+        const values = iterationValues(
+          this.evaluate(expr.iterable),
+          MAX_FOR_EXPRESSION_ITERATIONS,
+          () => new Error(`\`for\` expression exceeds ${MAX_FOR_EXPRESSION_ITERATIONS} iterations`),
+        );
+        this.symbols.pushScope();
+        try {
+          return values.map((value) => {
+            this.symbols.set(expr.variable, value);
+            return this.evaluate(expr.body);
+          });
+        } finally {
+          this.symbols.popScope();
+        }
+      }
+
+      case "if": {
+        if (this.evaluateToBoolean(expr.condition)) return this.evaluate(expr.then);
+        if (expr.else === undefined) throw new Error("`if` used as a value needs an `else`");
+        return this.evaluate(expr.else);
+      }
+
       case "member": {
         const value = this.evaluate(expr.object);
-        const result = Array.isArray(value) || typeof value === "string" ? sequenceMember(value, expr.member) : undefined;
+        const result =
+          Array.isArray(value) || typeof value === "string"
+            ? sequenceMember(value, expr.member)
+            : isObjectValue(value)
+              ? objectMember(value, expr.member)
+              : undefined;
         if (result === undefined) throw new Error(`Unknown member: ${expr.member}`);
         return result;
       }
@@ -676,19 +795,33 @@ export class Evaluator {
     const { params = [], body = [], value, name } = fn.definition;
     const args = argExprs.map((arg) => this.evaluate(arg));
     if (args.length !== params.length) throw new Error(`Function \`${name}\` takes ${params.length} argument(s), got ${args.length}`);
-    if (value === undefined) throw new Error(`Function \`${name}\` returns nothing`);
     if (++this.callDepth > MAX_CALL_DEPTH) throw new Error(`Function \`${name}\` recursed more than ${MAX_CALL_DEPTH} levels deep`);
+    try {
+      // A body that builds shapes runs in the converter, which collects what
+      // it produced; a body of plain defines and a result is evaluated here.
+      if (body.some((node) => node.type !== "define")) {
+        if (!this.hooks) throw new Error(`Function \`${name}\` builds shapes, which cannot be evaluated here`);
+        return this.hooks.call(fn, args);
+      }
+      if (value === undefined) throw new Error(`Function \`${name}\` returns nothing`);
+      return this.withArguments(params, args, () => {
+        for (const define of body) if (define.type === "define") this.define(define);
+        return this.evaluate(value);
+      });
+    } finally {
+      this.callDepth--;
+    }
+  }
+
+  /** Bind parameters in a fresh scope around `run`. Public so the converter
+   *  can run a shape-building function body under the same binding. */
+  withArguments<T>(params: readonly string[], args: readonly Value[], run: () => T): T {
     this.symbols.pushScope();
     try {
       params.forEach((param, i) => this.symbols.set(param, args[i]!));
-      for (const define of body) {
-        if (define.type !== "define") throw new Error(`Function \`${name}\` may only contain \`define\`s before its result`);
-        this.define(define);
-      }
-      return this.evaluate(value);
+      return run();
     } finally {
       this.symbols.popScope();
-      this.callDepth--;
     }
   }
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -10,6 +10,7 @@ import {
   meshPolygons,
   meshVolume,
   trianglesOf,
+  triangulatePolygon,
 } from "./meshValues";
 
 export type { MeshValue, PolygonValue, BoundsValue, PointValue } from "./meshValues";
@@ -256,7 +257,11 @@ function objectMember(value: ObjectValue, member: string): Value | undefined {
         case "bounds":
           return boundsOf(value.points);
         case "triangles":
-          return [value];
+          return triangulatePolygon(value.points).map((triangle): PolygonValue => ({
+            kind: "polygon",
+            points: triangle.map((i) => value.points[i]!),
+            ...(value.colors ? { colors: triangle.map((i) => value.colors![i] ?? value.colors![0]!) } : {}),
+          }));
         default:
           return undefined;
       }

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -480,15 +480,16 @@ export const DEFAULT_RANDOM_SEED = 0;
  *  JavaScript stack, which surfaces as a RangeError with no script context. */
 const MAX_CALL_DEPTH = 256;
 
-/** Same ceiling as a `for` statement; the converter's option is not reachable
- *  from here, so the default stands. */
-const MAX_FOR_EXPRESSION_ITERATIONS = 100_000;
+/** Default ceiling for a `for` expression; the converter sets its own option. */
+const DEFAULT_MAX_FOR_EXPRESSION_ITERATIONS = 100_000;
 
 export class Evaluator {
   private symbols: SymbolTable;
   private callDepth = 0;
   /** Set by the converter, which owns geometry. */
   hooks: EvaluatorHooks | undefined;
+  /** The same per-loop ceiling the converter applies to `for` statements. */
+  maxLoopIterations = DEFAULT_MAX_FOR_EXPRESSION_ITERATIONS;
 
   constructor(symbols?: SymbolTable, seed?: number) {
     this.symbols = symbols || new SymbolTable(seed);
@@ -712,8 +713,8 @@ export class Evaluator {
       case "for": {
         const values = iterationValues(
           this.evaluate(expr.iterable),
-          MAX_FOR_EXPRESSION_ITERATIONS,
-          () => new Error(`\`for\` expression exceeds ${MAX_FOR_EXPRESSION_ITERATIONS} iterations`),
+          this.maxLoopIterations,
+          () => new Error(`\`for\` expression exceeds ${this.maxLoopIterations} iterations`),
         );
         this.symbols.pushScope();
         try {

--- a/packages/plugins/shapescript-plugin/src/shapescript/meshValues.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/meshValues.ts
@@ -1,0 +1,223 @@
+import * as THREE from "three";
+import type { RGBA } from "./evaluator";
+
+/** The value types that hold geometry, shared by the evaluator (members) and
+ *  the converter (building and placing them). */
+
+export type Point3 = [number, number, number];
+
+/** A `polygon { point … }`, or one face of a mesh value. */
+export interface PolygonValue {
+  kind: "polygon";
+  points: Point3[];
+  /** Per-vertex colours when the polygon block set `color`; one per point. */
+  colors?: RGBA[];
+}
+
+/** A shape used as a value. The geometry is in the shape's own frame, with
+ *  the transform it was declared with already applied. */
+export interface MeshValue {
+  kind: "mesh";
+  geometry: THREE.BufferGeometry;
+  /** Kept when the mesh was built from polygons, so `.polygons` returns them
+   *  in the order the script (or Euclid) produced them. */
+  polygons?: PolygonValue[];
+  name?: string;
+}
+
+/** `shape.bounds` / `polygon.bounds`. */
+export interface BoundsValue {
+  kind: "bounds";
+  min: Point3;
+  max: Point3;
+}
+
+/** A vertex of a polygon, from `polygon.points`. */
+export interface PointValue {
+  kind: "point";
+  position: Point3;
+  color?: RGBA;
+}
+
+export function boundsOf(points: readonly Point3[]): BoundsValue {
+  const min: Point3 = [Infinity, Infinity, Infinity];
+  const max: Point3 = [-Infinity, -Infinity, -Infinity];
+  for (const point of points) {
+    for (let axis = 0; axis < 3; axis++) {
+      min[axis] = Math.min(min[axis]!, point[axis]!);
+      max[axis] = Math.max(max[axis]!, point[axis]!);
+    }
+  }
+  return points.length ? { kind: "bounds", min, max } : { kind: "bounds", min: [0, 0, 0], max: [0, 0, 0] };
+}
+
+export function centerOf(points: readonly Point3[]): Point3 {
+  const sum: Point3 = [0, 0, 0];
+  for (const point of points) {
+    sum[0] += point[0];
+    sum[1] += point[1];
+    sum[2] += point[2];
+  }
+  const n = Math.max(1, points.length);
+  return [sum[0] / n, sum[1] / n, sum[2] / n];
+}
+
+/** Every triangle of a geometry as a polygon, in buffer order. */
+export function trianglesOf(geometry: THREE.BufferGeometry): PolygonValue[] {
+  const position = geometry.getAttribute("position");
+  const index = geometry.getIndex();
+  const count = index?.count ?? position.count;
+  const triangles: PolygonValue[] = [];
+  for (let i = 0; i + 2 < count; i += 3) {
+    const points = [0, 1, 2].map((j) => {
+      const vertex = index ? index.getX(i + j) : i + j;
+      return [position.getX(vertex), position.getY(vertex), position.getZ(vertex)] as Point3;
+    });
+    triangles.push({ kind: "polygon", points });
+  }
+  return triangles;
+}
+
+export function meshPolygons(mesh: MeshValue): PolygonValue[] {
+  return mesh.polygons ?? trianglesOf(mesh.geometry);
+}
+
+export function meshPoints(mesh: MeshValue): Point3[] {
+  const position = mesh.geometry.getAttribute("position");
+  const points: Point3[] = [];
+  for (let i = 0; i < position.count; i++) points.push([position.getX(i), position.getY(i), position.getZ(i)]);
+  return points;
+}
+
+/** Signed volume of a closed triangle mesh. */
+export function meshVolume(mesh: MeshValue): number {
+  let volume = 0;
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  for (const triangle of trianglesOf(mesh.geometry)) {
+    a.fromArray(triangle.points[0]!);
+    b.fromArray(triangle.points[1]!);
+    c.fromArray(triangle.points[2]!);
+    volume += a.dot(b.cross(c));
+  }
+  return Math.abs(volume) / 6;
+}
+
+/** Triangulate a planar polygon (convex or not) into index triples. */
+export function triangulatePolygon(points: readonly Point3[]): [number, number, number][] {
+  if (points.length < 3) return [];
+  if (points.length === 3) return [[0, 1, 2]];
+  // Newell's normal, then a 2D basis in the polygon's plane for ShapeUtils.
+  const normal = new THREE.Vector3();
+  for (let i = 0; i < points.length; i++) {
+    const current = points[i]!;
+    const next = points[(i + 1) % points.length]!;
+    normal.x += (current[1] - next[1]) * (current[2] + next[2]);
+    normal.y += (current[2] - next[2]) * (current[0] + next[0]);
+    normal.z += (current[0] - next[0]) * (current[1] + next[1]);
+  }
+  if (normal.lengthSq() < 1e-18) return [];
+  normal.normalize();
+  const helper = Math.abs(normal.x) < 0.9 ? new THREE.Vector3(1, 0, 0) : new THREE.Vector3(0, 1, 0);
+  const u = new THREE.Vector3().crossVectors(normal, helper).normalize();
+  const v = new THREE.Vector3().crossVectors(normal, u);
+  const flat = points.map((point) => {
+    const p = new THREE.Vector3().fromArray(point);
+    return new THREE.Vector2(p.dot(u), p.dot(v));
+  });
+  return THREE.ShapeUtils.triangulateShape(flat, []).map(([a, b, c]) => [a!, b!, c!]);
+}
+
+/** Euclid's icosahedron, vertex for vertex and face for face, so that
+ *  `icosphere.polygons` indexes the same way upstream's scripts expect. */
+export function icosphereGeometry(radius: number, subdivisions: number): { geometry: THREE.BufferGeometry; polygons: PolygonValue[] } {
+  const t = 1 + Math.sqrt(2) / 2;
+  const raw: Point3[] = [
+    [-1, t, 0],
+    [1, t, 0],
+    [-1, -t, 0],
+    [1, -t, 0],
+    [0, -1, t],
+    [0, 1, t],
+    [0, -1, -t],
+    [0, 1, -t],
+    [t, 0, -1],
+    [t, 0, 1],
+    [-t, 0, -1],
+    [-t, 0, 1],
+  ];
+  // Euclid scales to the radius and pitches by atan(t); its pitch is the
+  // negated X rotation in three's terms (see `rotationOf`).
+  const frame = new THREE.Matrix4()
+    .makeRotationX(-Math.atan(t))
+    .multiply(new THREE.Matrix4().makeScale(1 / Math.sqrt(t * t + 1), 1 / Math.sqrt(t * t + 1), 1 / Math.sqrt(t * t + 1)));
+  const v = raw.map((point) => new THREE.Vector3().fromArray(point).applyMatrix4(frame));
+  const faces: [number, number, number][] = [
+    [0, 11, 5],
+    [0, 5, 1],
+    [0, 1, 7],
+    [0, 7, 10],
+    [0, 10, 11],
+    [1, 5, 9],
+    [5, 11, 4],
+    [11, 10, 2],
+    [10, 7, 6],
+    [7, 1, 8],
+    [3, 9, 4],
+    [3, 4, 2],
+    [3, 2, 6],
+    [3, 6, 8],
+    [3, 8, 9],
+    [4, 9, 5],
+    [2, 4, 11],
+    [6, 2, 10],
+    [8, 6, 7],
+    [9, 8, 1],
+  ];
+  let triangles: THREE.Vector3[][] = faces.map((face) => face.map((i) => v[i]!.clone()));
+  for (let level = 0; level < subdivisions; level++) {
+    triangles = triangles.flatMap(([a, b, c]) => {
+      const ab = a!.clone().lerp(b!, 0.5);
+      const bc = b!.clone().lerp(c!, 0.5);
+      const ca = c!.clone().lerp(a!, 0.5);
+      return [
+        [a!, ab, ca],
+        [ab, b!, bc],
+        [bc, c!, ca],
+        [ab, bc, ca],
+      ];
+    });
+  }
+  const polygons: PolygonValue[] = triangles.map((triangle) => ({
+    kind: "polygon",
+    points: triangle.map((point) => point.clone().normalize().multiplyScalar(radius).toArray() as Point3),
+  }));
+  return { geometry: geometryFromPolygons(polygons, false), polygons };
+}
+
+/** A flat-shaded, non-indexed geometry from polygons, with per-vertex
+ *  colours when any polygon carries them. */
+export function geometryFromPolygons(polygons: readonly PolygonValue[], withColors: boolean): THREE.BufferGeometry {
+  const positions: number[] = [];
+  const colors: number[] = [];
+  const uvs: number[] = [];
+  for (const polygon of polygons) {
+    for (const [a, b, c] of triangulatePolygon(polygon.points)) {
+      for (const i of [a, b, c]) {
+        positions.push(...polygon.points[i]!);
+        uvs.push(0, 0);
+        if (withColors) {
+          const [r = 0.8, g = 0.8, b2 = 0.8] = polygon.colors?.[i] ?? polygon.colors?.[0] ?? [];
+          colors.push(r, g, b2);
+        }
+      }
+    }
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+  geometry.setAttribute("uv", new THREE.Float32BufferAttribute(uvs, 2));
+  if (withColors) geometry.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3));
+  geometry.computeVertexNormals();
+  return geometry;
+}

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -621,6 +621,30 @@ const STATEMENT_TOKENS = new Set([
   TokenType.SIZE,
 ]);
 
+/** Tokens that can only begin a value, never a statement. */
+const VALUE_START_TOKENS = new Set([TokenType.NUMBER, TokenType.STRING, TokenType.HEXCOLOR, TokenType.LPAREN, TokenType.MINUS, TokenType.PLUS]);
+
+/** After a bare symbol, these mean an expression rather than a block call. */
+const EXPRESSION_CONTINUATION_TOKENS = new Set([
+  TokenType.DOT,
+  TokenType.LBRACKET,
+  TokenType.PLUS,
+  TokenType.MINUS,
+  TokenType.STAR,
+  TokenType.DIVIDE,
+  TokenType.PERCENT,
+  TokenType.EQUALS,
+  TokenType.NOT_EQUALS,
+  TokenType.LESS,
+  TokenType.LESS_EQUAL,
+  TokenType.GREATER,
+  TokenType.GREATER_EQUAL,
+  TokenType.AND,
+  TokenType.OR,
+  TokenType.IN,
+  TokenType.TO,
+]);
+
 /** Tokens that open a standard shape property inside a custom block call. */
 const STANDARD_PROPERTY_TOKENS = new Set([
   TokenType.POSITION,
@@ -811,9 +835,28 @@ export class Parser {
    *  Both a grouped expression and a space- or comma-separated tuple live here,
    *  so its elements are read as a VALUE LIST: `(1 +2 +3)` is three components,
    *  the same as `1 +2 +3` written without the parens. */
+  /** Line breaks inside parentheses carry no meaning (literals.md): a tuple of
+   *  tuples may be laid out one row per line, and an expression may continue
+   *  on the next line. Dropping the NEWLINE tokens up to the matching `)` lets
+   *  the one-line rules decide, with the break counted as whitespace. */
+  private stripNewlinesInParens(): void {
+    let depth = 1;
+    for (let i = this.pos; i < this.tokens.length && depth > 0;) {
+      const token = this.tokens[i]!;
+      if (token.type === TokenType.EOF) break;
+      if (token.type === TokenType.LPAREN) depth++;
+      else if (token.type === TokenType.RPAREN) depth--;
+      if (token.type === TokenType.NEWLINE) {
+        this.tokens.splice(i, 1);
+        const next = this.tokens[i];
+        if (next) next.precedingWhitespace = true;
+        continue;
+      }
+      i++;
+    }
+  }
+
   private parseParenthesized(): Expression {
-    // Line breaks inside parentheses carry no meaning (literals.md), so a
-    // tuple of tuples may be laid out one row per line.
     this.skipNewlines();
     if (this.current().type === TokenType.RPAREN) {
       this.advance();
@@ -872,6 +915,7 @@ export class Parser {
     // Parenthesized expression or tuple
     if (token.type === TokenType.LPAREN) {
       this.advance();
+      this.stripNewlinesInParens();
       return this.withValueList(true, () => this.parseParenthesized());
     }
 
@@ -936,8 +980,8 @@ export class Parser {
         // `max(0 (j - 1))` is upstream's C-like spelling and `max(0, j - 1)`
         // the one this plugin always took. Reading both through the tuple
         // rules means a script can be written once for either parser.
+        this.stripNewlinesInParens();
         this.withValueList(true, () => {
-          this.skipNewlines();
           if (this.current().type === TokenType.RPAREN) return;
           args.push(this.parseExpression());
           if (this.current().type === TokenType.COMMA) {
@@ -993,7 +1037,7 @@ export class Parser {
     this.advance();
     const { variable, iterable } = this.parseLoopHeader();
     const body = this.scoped(() => {
-      this.callable.delete(variable);
+      this.bindName(variable);
       return this.parseBracedExpression();
     });
     return { type: "for", variable, iterable, body };
@@ -1278,16 +1322,30 @@ export class Parser {
     const { variable, iterable } = this.parseLoopHeader();
     // The loop variable shadows a function of the same name inside the body.
     const body = this.scoped(() => {
-      this.callable.delete(variable);
+      this.bindName(variable);
       return this.parseBlock();
     });
     return { type: "for", variable, iterable, body };
   }
 
+  /** A shape keyword that a binding in scope has claimed as a value. */
+  private isBoundKeyword(token: Token): boolean {
+    return SHAPE_VALUE_TOKENS.has(token.type) && typeof token.value === "string" && this.values.has(token.value);
+  }
+
+  /** A name bound in the current scope — loop variable, parameter, option —
+   *  is a value there: not a callable, and not the shape it may spell. */
+  private bindName(name: string): void {
+    this.callable.delete(name);
+    this.values.add(name);
+  }
+
   private parseLoopHeader(): { variable: string; iterable: Expression } {
     let variable = "_i";
-    if (this.current().type === TokenType.IDENTIFIER && this.peek().type === TokenType.IN) {
-      variable = this.current().value as string;
+    // Any symbol name may be the loop variable, a keyword's spelling included.
+    const token = this.current();
+    if (typeof token.value === "string" && /^[a-zA-Z_][a-zA-Z_0-9]*$/.test(token.value) && this.peek().type === TokenType.IN) {
+      variable = token.value;
       this.advance();
       this.advance();
     }
@@ -1440,7 +1498,7 @@ export class Parser {
             const optionName = this.expectIdentifier().value as string;
             const defaultValue = this.parseVectorOrExpression();
             // An option is a symbol in the body, shadowing a function of that name.
-            this.callable.delete(optionName);
+            this.bindName(optionName);
 
             options.push({
               type: "option",
@@ -1491,6 +1549,7 @@ export class Parser {
   /** Whether `token` opens a statement rather than an expression — used where
    *  either may appear, such as a function body. */
   private startsStatement(token: Token): boolean {
+    if (this.isBoundKeyword(token)) return false;
     if (STATEMENT_TOKENS.has(token.type)) return !(token.type === TokenType.MATERIAL && this.peek().type === TokenType.LBRACE);
     if (token.type !== TokenType.IDENTIFIER) return false;
     const name = String(token.value);
@@ -1516,7 +1575,7 @@ export class Parser {
     this.callable.add(name);
     this.expect(TokenType.LBRACE);
     const { body, value } = this.scoped(() => {
-      for (const param of params) this.callable.delete(param);
+      for (const param of params) this.bindName(param);
       this.skipNewlines();
       const statements: SceneNode[] = [];
       let result: Expression | undefined;
@@ -1818,7 +1877,7 @@ export class Parser {
     const { variable, iterable } = this.parseLoopHeader();
     // The loop is expanded during rendering.
     const commands = this.scoped(() => {
-      this.callable.delete(variable);
+      this.bindName(variable);
       return this.parsePathBody("path for loop");
     });
     return { type: "for", variable, iterable, commands };
@@ -1882,6 +1941,11 @@ export class Parser {
       this.advance();
       return this.parseCustomShapeCall(token.value);
     }
+
+    // A value as a statement: the result a function body ends with (`a * a`,
+    // `data.last`, `1`, a parameter named `cube`), which the converter
+    // collects; elsewhere an error.
+    if (VALUE_START_TOKENS.has(token.type) || this.isBoundKeyword(token)) return { type: "expression", value: this.parseVectorOrExpression() };
 
     // Check mapped operations first
     const shape = shapeMap[token.type];
@@ -1969,8 +2033,11 @@ export class Parser {
           const unsupported = unsupportedMessage(name);
           if (unsupported !== undefined) throw new ParseError(unsupported, token.line, token.column);
           // A function called as a statement (`face data`), whose result is a
-          // shape to place — or, inside `mesh`, a polygon to add.
-          if (this.callable.has(name)) return { type: "expression", value: this.parseVectorOrExpression() };
+          // shape to place — or, inside `mesh`, a polygon to add; or an
+          // expression that starts with a symbol (`i / 3`, `data.last`).
+          if (this.callable.has(name) || EXPRESSION_CONTINUATION_TOKENS.has(this.peek().type)) {
+            return { type: "expression", value: this.parseVectorOrExpression() };
+          }
         }
         this.advance();
         return this.parseCustomShapeCall(name);

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -621,6 +621,22 @@ const STATEMENT_TOKENS = new Set([
   TokenType.SIZE,
 ]);
 
+/** Keyword tokens a binding may claim as a value (see `isBoundKeyword`). */
+const BINDABLE_KEYWORD_TOKENS = new Set([
+  ...SHAPE_VALUE_TOKENS,
+  TokenType.FOR,
+  TokenType.IF,
+  TokenType.SWITCH,
+  TokenType.CASE,
+  TokenType.ELSE,
+  TokenType.OPTION,
+  TokenType.POINT,
+  TokenType.CURVE,
+  TokenType.ARC,
+  TokenType.PRINT,
+  TokenType.ASSERT,
+]);
+
 /** Tokens that can only begin a value, never a statement. */
 const VALUE_START_TOKENS = new Set([TokenType.NUMBER, TokenType.STRING, TokenType.HEXCOLOR, TokenType.LPAREN, TokenType.MINUS, TokenType.PLUS]);
 
@@ -940,6 +956,12 @@ export class Parser {
     if (token.type === TokenType.HEXCOLOR) {
       this.advance();
       return hexColorExpression(String(token.value));
+    }
+
+    // A keyword a binding in scope has claimed is that symbol.
+    if (this.isBoundKeyword(token)) {
+      this.advance();
+      return { type: "identifier", name: token.value as string };
     }
 
     // `for v in … { expr }` and `if c { a } else { b }` as values
@@ -1328,9 +1350,13 @@ export class Parser {
     return { type: "for", variable, iterable, body };
   }
 
-  /** A shape keyword that a binding in scope has claimed as a value. */
+  /** A keyword that a binding in scope has claimed as a value — a shape,
+   *  builder or control-flow word used as a parameter or loop variable.
+   *  Property and transform commands (`size`, `color`, `scale`, …) are not
+   *  included: `define size 1 2` must not turn a later `size` command into a
+   *  value, and inside a block they are read as properties anyway. */
   private isBoundKeyword(token: Token): boolean {
-    return SHAPE_VALUE_TOKENS.has(token.type) && typeof token.value === "string" && this.values.has(token.value);
+    return BINDABLE_KEYWORD_TOKENS.has(token.type) && typeof token.value === "string" && this.values.has(token.value);
   }
 
   /** A name bound in the current scope — loop variable, parameter, option —
@@ -1715,6 +1741,7 @@ export class Parser {
    *  several values rather than one arithmetic expression. */
   private startsValue(): boolean {
     const type = this.current().type;
+    if (this.isBoundKeyword(this.current())) return true;
     return (
       type === TokenType.NUMBER ||
       type === TokenType.MINUS ||

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -46,8 +46,6 @@ const UNSUPPORTED_COMMANDS: Record<string, string> = {
   text: "`text` (3D text) is not supported by this renderer",
   font: "`font` is not supported by this renderer",
   import: "`import` is not supported by this renderer — inline the shapes instead",
-  mesh: "raw `mesh { polygon … }` is not supported by this renderer — build the shape from primitives, paths and builders",
-  polygon: "`polygon { point … }` with explicit points is not supported — use `polygon { sides N }` or a `path`",
   minkowski: "`minkowski` is not supported by this renderer",
   inset: "`inset` is not supported by this renderer",
   svgpath: "`svgpath` is not supported by this renderer — write the outline as a `path`",
@@ -172,6 +170,7 @@ class Lexer {
       fill: TokenType.FILL,
       hull: TokenType.HULL,
       group: TokenType.GROUP,
+      mesh: TokenType.MESH,
       path: TokenType.PATH,
       point: TokenType.POINT,
       curve: TokenType.CURVE,
@@ -583,12 +582,43 @@ const SHAPE_VALUE_TOKENS = new Set([
   TokenType.FILL,
   TokenType.HULL,
   TokenType.GROUP,
+  TokenType.MESH,
   TokenType.PATH,
   TokenType.UNION,
   TokenType.DIFFERENCE,
   TokenType.INTERSECTION,
   TokenType.XOR,
   TokenType.STENCIL,
+]);
+
+/** Tokens that open a statement. Everything a `parseNode` switch or map
+ *  handles, so a function body can tell a shape it builds from the value it
+ *  returns. */
+const STATEMENT_TOKENS = new Set([
+  ...SHAPE_VALUE_TOKENS,
+  TokenType.FOR,
+  TokenType.IF,
+  TokenType.SWITCH,
+  TokenType.DEFINE,
+  TokenType.DETAIL,
+  TokenType.SEED,
+  TokenType.BACKGROUND,
+  TokenType.TEXTURE,
+  TokenType.MATERIAL,
+  TokenType.OPACITY,
+  TokenType.METALLICITY,
+  TokenType.ROUGHNESS,
+  TokenType.GLOW,
+  TokenType.SMOOTHING,
+  TokenType.PRINT,
+  TokenType.ASSERT,
+  TokenType.COLOR,
+  TokenType.ROTATE,
+  TokenType.TRANSLATE,
+  TokenType.SCALE,
+  TokenType.POSITION,
+  TokenType.ORIENTATION,
+  TokenType.SIZE,
 ]);
 
 /** Tokens that open a standard shape property inside a custom block call. */
@@ -642,6 +672,10 @@ export class Parser {
   /** Custom block names, so a user-defined `light` is still invoked rather
    *  than skipped as the upstream light source. */
   private blocks = new Set<string>();
+  /** Names a plain `define` gave a value, so a keyword reused as a symbol
+   *  (`define hull (0.2 0.2 0.2)` then `color hull`) reads as that symbol
+   *  rather than as the shape or builder it spells. */
+  private values = new Set<string>();
 
   private tokens: Token[];
   private pos = 0;
@@ -778,6 +812,13 @@ export class Parser {
    *  so its elements are read as a VALUE LIST: `(1 +2 +3)` is three components,
    *  the same as `1 +2 +3` written without the parens. */
   private parseParenthesized(): Expression {
+    // Line breaks inside parentheses carry no meaning (literals.md), so a
+    // tuple of tuples may be laid out one row per line.
+    this.skipNewlines();
+    if (this.current().type === TokenType.RPAREN) {
+      this.advance();
+      return { type: "tuple", elements: [] };
+    }
     const elements: Expression[] = [this.parseExpression()];
 
     if (this.current().type === TokenType.COMMA) {
@@ -786,6 +827,7 @@ export class Parser {
       this.parseSpaceSeparated(elements);
     }
 
+    this.skipNewlines();
     this.expect(TokenType.RPAREN);
 
     if (elements.length === 1 && elements[0] !== undefined) {
@@ -798,15 +840,19 @@ export class Parser {
   private parseCommaSeparated(elements: Expression[]): void {
     while (this.current().type === TokenType.COMMA) {
       this.advance();
+      this.skipNewlines();
       if (this.current().type === TokenType.RPAREN) break;
       elements.push(this.parseExpression());
+      this.skipNewlines();
     }
   }
 
-  /** `(1 2 3)` — components held apart by nothing but whitespace. */
+  /** `(1 2 3)` — components held apart by whitespace, line breaks included. */
   private parseSpaceSeparated(elements: Expression[]): void {
+    this.skipNewlines();
     while (this.startsValue()) {
       elements.push(this.parseExpression());
+      this.skipNewlines();
     }
   }
 
@@ -852,6 +898,20 @@ export class Parser {
       return hexColorExpression(String(token.value));
     }
 
+    // `for v in … { expr }` and `if c { a } else { b }` as values
+    if (token.type === TokenType.FOR) return this.parseForExpression();
+    if (token.type === TokenType.IF) return this.parseIfExpression();
+
+    // A shape as a value: `define ico icosphere { detail 0 }` — unless the
+    // script gave that keyword a value or a block of its own.
+    const spelled = typeof token.value === "string" ? token.value : "";
+    if (SHAPE_VALUE_TOKENS.has(token.type) && !this.blocks.has(spelled) && !this.values.has(spelled)) {
+      if (token.type === TokenType.PATH) throw new ParseError("A `path` cannot be used as a value here — use it inside a builder", token.line, token.column);
+      const node = this.parseNode();
+      if (!node) throw new ParseError("Expected a shape", token.line, token.column);
+      return { type: "shape", node };
+    }
+
     // `material { … }` — a bundle of material properties as a value
     if (token.type === TokenType.MATERIAL && this.peek().type === TokenType.LBRACE) {
       this.advance();
@@ -877,6 +937,7 @@ export class Parser {
         // the one this plugin always took. Reading both through the tuple
         // rules means a script can be written once for either parser.
         this.withValueList(true, () => {
+          this.skipNewlines();
           if (this.current().type === TokenType.RPAREN) return;
           args.push(this.parseExpression());
           if (this.current().type === TokenType.COMMA) {
@@ -925,6 +986,39 @@ export class Parser {
     }
 
     throw new ParseError(`Unexpected token in expression: ${token.type}`, token.line, token.column);
+  }
+
+  /** `for [name in] iterable { expression }` — the tuple of every result. */
+  private parseForExpression(): Expression {
+    this.advance();
+    const { variable, iterable } = this.parseLoopHeader();
+    const body = this.scoped(() => {
+      this.callable.delete(variable);
+      return this.parseBracedExpression();
+    });
+    return { type: "for", variable, iterable, body };
+  }
+
+  /** `if condition { expression } else { expression }`. */
+  private parseIfExpression(): Expression {
+    this.advance();
+    const condition = this.withValueList(false, () => this.parseExpression());
+    const then = this.parseBracedExpression();
+    this.skipNewlines();
+    if (this.current().type !== TokenType.ELSE) return { type: "if", condition, then };
+    this.advance();
+    this.skipNewlines();
+    const otherwise = this.current().type === TokenType.IF ? this.parseIfExpression() : this.parseBracedExpression();
+    return { type: "if", condition, then, else: otherwise };
+  }
+
+  private parseBracedExpression(): Expression {
+    this.expect(TokenType.LBRACE);
+    this.skipNewlines();
+    const value = this.parseVectorOrExpression();
+    this.skipNewlines();
+    this.expect(TokenType.RBRACE);
+    return value;
   }
 
   private getPrecedence(type: TokenType): number {
@@ -1113,13 +1207,16 @@ export class Parser {
   private scoped<T>(parse: () => T): T {
     const callable = this.callable;
     const blocks = this.blocks;
+    const values = this.values;
     this.callable = new Set(callable);
     this.blocks = new Set(blocks);
+    this.values = new Set(values);
     try {
       return parse();
     } finally {
       this.callable = callable;
       this.blocks = blocks;
+      this.values = values;
     }
   }
 
@@ -1134,10 +1231,22 @@ export class Parser {
     this.advance(); // consume primitive token
 
     let properties: ShapeProperties = {};
+    let points: PathCommand[] | undefined;
 
     if (this.current().type === TokenType.LBRACE) {
       this.expect(TokenType.LBRACE);
-      properties = this.parseProperties();
+      this.scoped(() => {
+        // A polygon block may list its vertices — `point`, `color`, loops and
+        // defines — beside the usual properties.
+        while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+          Object.assign(properties, this.parseProperties());
+          const token = this.current();
+          if (token.type === TokenType.RBRACE || token.type === TokenType.EOF) break;
+          if (primitive !== "polygon") throw new ParseError(`Unexpected token in ${primitive}: ${token.type}`, token.line, token.column);
+          (points ??= []).push(this.parsePathCommand("polygon"));
+          this.skipNewlines();
+        }
+      });
       this.expect(TokenType.RBRACE);
     }
 
@@ -1145,6 +1254,7 @@ export class Parser {
       type: "shape",
       primitive,
       properties,
+      ...(points === undefined ? {} : { points }),
     };
   }
 
@@ -1357,12 +1467,11 @@ export class Parser {
       };
     }
 
-    // Parse the value - could be a single expression or space-separated tuple
-    this.refuseShapeValue(
-      `\`define ${name} <shape>\` (a shape as a value) is not supported by this renderer — write \`define ${name} { … }\` for a reusable block`,
-    );
+    // Parse the value - a single expression, a space-separated tuple, or a shape.
+    this.refuseUnsupported();
     const value = this.parseVectorOrExpression();
     this.callable.delete(name);
+    this.values.add(name);
 
     return {
       type: "define",
@@ -1371,20 +1480,26 @@ export class Parser {
     };
   }
 
-  /** Upstream lets a shape be a value (`define s sphere { … }`, a function
-   *  returning a mesh); this renderer has no mesh values, so say so by name
-   *  instead of failing on the brace that follows. */
-  private refuseShapeValue(message: string): void {
+  /** An upstream command this renderer lacks, named instead of failing on
+   *  the brace that follows it. */
+  private refuseUnsupported(): void {
     const token = this.current();
-    const name = typeof token.value === "string" ? token.value : "";
-    const unsupported = token.type === TokenType.IDENTIFIER ? unsupportedMessage(name) : undefined;
+    const unsupported = token.type === TokenType.IDENTIFIER ? unsupportedMessage(String(token.value)) : undefined;
     if (unsupported !== undefined) throw new ParseError(unsupported, token.line, token.column);
-    if (SHAPE_VALUE_TOKENS.has(token.type)) throw new ParseError(message, token.line, token.column);
   }
 
-  /** The body may hold `define`s and must end in the expression it returns.
-   *  Upstream also allows shapes there (a function returning a mesh); this
-   *  renderer has no mesh values, so that form is refused by name. */
+  /** Whether `token` opens a statement rather than an expression — used where
+   *  either may appear, such as a function body. */
+  private startsStatement(token: Token): boolean {
+    if (STATEMENT_TOKENS.has(token.type)) return !(token.type === TokenType.MATERIAL && this.peek().type === TokenType.LBRACE);
+    if (token.type !== TokenType.IDENTIFIER) return false;
+    const name = String(token.value);
+    return this.blocks.has(name) || IGNORED_BLOCKS.has(name) || unsupportedMessage(name) !== undefined;
+  }
+
+  /** The body holds statements — `define`s, and shapes the function builds —
+   *  and may end in the expression it returns. A function with no result
+   *  expression returns what its statements built. */
   private parseFunctionDefine(name: string): DefineNode {
     this.expect(TokenType.LPAREN);
     const params: string[] = [];
@@ -1403,22 +1518,29 @@ export class Parser {
     const { body, value } = this.scoped(() => {
       for (const param of params) this.callable.delete(param);
       this.skipNewlines();
-      const defines: DefineNode[] = [];
-      while (this.current().type === TokenType.DEFINE) {
-        defines.push(this.parseDefine());
+      const statements: SceneNode[] = [];
+      let result: Expression | undefined;
+      while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
+        const token = this.current();
+        if (this.startsStatement(token)) {
+          const node = this.parseNode();
+          if (node) statements.push(node);
+        } else {
+          result = this.parseVectorOrExpression();
+          this.skipNewlines();
+          if (this.current().type !== TokenType.RBRACE) {
+            throw new ParseError(`Function \`${name}\`: the expression it returns must be its last line`, this.current().line, this.current().column);
+          }
+        }
         this.skipNewlines();
       }
-      const token = this.current();
-      if (token.type === TokenType.RBRACE) throw new ParseError(`Function \`${name}\` must end with the expression it returns`, token.line, token.column);
-      this.refuseShapeValue(
-        `Function \`${name}\` builds a shape — functions here may only compute values (numbers, tuples, strings); use \`define ${name} { … }\` with options for a reusable shape`,
-      );
-      const result = this.parseVectorOrExpression();
-      this.skipNewlines();
-      return { body: defines, value: result };
+      if (statements.length === 0 && result === undefined) {
+        throw new ParseError(`Function \`${name}\` must build a shape or end with the expression it returns`, this.current().line, this.current().column);
+      }
+      return { body: statements, value: result };
     });
     this.expect(TokenType.RBRACE);
-    return { type: "define", name, params, body, value };
+    return { type: "define", name, params, body, ...(value === undefined ? {} : { value }) };
   }
 
   private parseDetail(): DetailNode {
@@ -1622,6 +1744,10 @@ export class Parser {
         return this.parsePathPoint(token.type === TokenType.POINT ? "point" : "curve");
       case TokenType.ARC:
         return this.parseArc();
+      case TokenType.COLOR: {
+        this.advance();
+        return { type: "color", value: this.parseVectorOrExpression() };
+      }
       case TokenType.ROTATE: {
         this.advance();
         return { type: "rotate", angle: this.parseExpression() };
@@ -1827,6 +1953,10 @@ export class Parser {
       case TokenType.PATH:
         return this.parsePath();
 
+      case TokenType.MESH:
+        this.advance();
+        return { type: "mesh", children: this.parseBlock() };
+
       case TokenType.RBRACE:
       case TokenType.EOF:
         return null;
@@ -1838,6 +1968,9 @@ export class Parser {
           if (IGNORED_BLOCKS.has(name)) return this.skipIgnoredBlock(name);
           const unsupported = unsupportedMessage(name);
           if (unsupported !== undefined) throw new ParseError(unsupported, token.line, token.column);
+          // A function called as a statement (`face data`), whose result is a
+          // shape to place — or, inside `mesh`, a polygon to add.
+          if (this.callable.has(name)) return { type: "expression", value: this.parseVectorOrExpression() };
         }
         this.advance();
         return this.parseCustomShapeCall(name);

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -31,12 +31,15 @@ import {
   ScaleNode,
   MaterialNode,
   MaterialProperties,
+  MeshNode,
+  ExpressionStatementNode,
   Expression,
   Vector3,
   Color,
   ShapeProperties,
 } from "./types";
-import { Evaluator, SymbolTable, Value, RGBA, MaterialValue, iterationValues, rgbaOf, valuesEqual } from "./evaluator";
+import { Evaluator, SymbolTable, Value, RGBA, MaterialValue, FunctionValue, isObjectValue, iterationValues, rgbaOf, valuesEqual } from "./evaluator";
+import { type MeshValue, type PolygonValue, type Point3, geometryFromPolygons, icosphereGeometry } from "./meshValues";
 import { disposeObject3D, disposeScratch } from "./dispose";
 
 /** What a conversion reports besides geometry. Stored on the root group's
@@ -268,6 +271,10 @@ export class Converter {
   private readonly logs: string[] = [];
   private background: RGBA | undefined;
   private sceneDepth = 0;
+  /** While set, polygons and shape values produced by statements are
+   *  collected here instead of entering the scene: the body of `mesh { }`,
+   *  and a function body whose result is what it built. */
+  private valueSink: Value[] | null = null;
 
   constructor(options: ConversionOptions = {}) {
     this.options = options;
@@ -275,6 +282,8 @@ export class Converter {
     this.evaluator = new Evaluator(this.symbols, options.randomSeed);
     // `detail` is readable as a symbol before any `detail` command runs.
     this.symbols.set("detail", this.detailLevel);
+    // Shapes as values and shape-building functions are built here.
+    this.evaluator.hooks = { shape: (node) => this.shapeValue(node), call: (fn, args) => this.callShapeFunction(fn, args) };
     // Initialize with identity transform
     this.pushTransform();
   }
@@ -418,6 +427,10 @@ export class Converter {
       case "ignored":
         this.warn(`\`${node.command}\` is not rendered by this viewer and was skipped`);
         return null;
+      case "expression":
+        return this.convertExpressionStatement(node);
+      case "mesh":
+        return this.convertMesh(node);
       case "rotate":
         this.handleRotateCommand(node);
         return null;
@@ -596,8 +609,223 @@ export class Converter {
     }
   }
 
-  private convertShape(node: ShapeNode): THREE.Mesh {
+  private convertShape(node: ShapeNode): THREE.Mesh | null {
+    if (node.points !== undefined) return this.placeValue(this.polygonValue(node));
     return this.withShapeOptions(node.properties, () => this.finishMesh(this.createGeometry(node), node, false));
+  }
+
+  /** Run `build` with produced values going to `sink` rather than the scene. */
+  private captureValues<T>(sink: Value[], build: () => T): T {
+    const previous = this.valueSink;
+    this.valueSink = sink;
+    try {
+      return build();
+    } finally {
+      this.valueSink = previous;
+    }
+  }
+
+  /** A value a statement produced: collected when a sink is open, otherwise
+   *  a shape is placed in the scene and anything else is an error, as
+   *  upstream's "unused value" is. */
+  private placeValue(value: Value): THREE.Mesh | null {
+    if (this.valueSink) {
+      this.valueSink.push(value);
+      return null;
+    }
+    if (isObjectValue(value) && value.kind === "mesh") return this.placeMesh(value);
+    if (isObjectValue(value) && value.kind === "polygon") return this.placePolygons([value]);
+    if (Array.isArray(value) && value.length > 0 && value.every((item) => isObjectValue(item) && (item.kind === "mesh" || item.kind === "polygon"))) {
+      const meshes = value.filter((item): item is MeshValue => isObjectValue(item) && item.kind === "mesh");
+      const polygons = value.filter((item): item is PolygonValue => isObjectValue(item) && item.kind === "polygon");
+      return this.placeMesh({
+        kind: "mesh",
+        geometry: mergeMeshGeometries([
+          ...meshes.map((mesh) => mesh.geometry),
+          ...(polygons.length
+            ? [
+                geometryFromPolygons(
+                  polygons,
+                  polygons.some((p) => p.colors),
+                ),
+              ]
+            : []),
+        ]),
+      });
+    }
+    throw new Error("Unused value — a statement that is not a shape does nothing here; use `define` or `print`");
+  }
+
+  private convertExpressionStatement(node: ExpressionStatementNode): THREE.Mesh | null {
+    return this.placeValue(this.evaluator.evaluate(node.value));
+  }
+
+  /** Place a mesh value in the scene with the current material and frame.
+   *  Its own vertex colours win over the material colour, as upstream. */
+  private placeMesh(value: MeshValue): THREE.Mesh {
+    const geometry = value.geometry.clone();
+    const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, geometry.hasAttribute("color")));
+    if (value.name !== undefined) mesh.name = value.name;
+    this.applyCurrentTransform(mesh);
+    return mesh;
+  }
+
+  private placePolygons(polygons: readonly PolygonValue[]): THREE.Mesh {
+    const colored = polygons.some((polygon) => polygon.colors !== undefined);
+    const geometry = geometryFromPolygons(polygons, colored);
+    this.chargeEstimate(geometry.getAttribute("position").count);
+    const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, colored));
+    this.applyCurrentTransform(mesh);
+    return mesh;
+  }
+
+  /** `mesh { … }`: every polygon its body produces, and every mesh it builds,
+   *  merged into one mesh in the current frame. */
+  private convertMesh(node: MeshNode): THREE.Mesh {
+    const temporary = new THREE.Group();
+    const captured: Value[] = [];
+    const charged = this.vertexCount;
+    let geometry: THREE.BufferGeometry;
+    try {
+      this.captureValues(captured, () =>
+        this.inScope(temporary, () => {
+          this.currentTransform().matrix.identity();
+          this.addChildren(temporary, node.children);
+        }),
+      );
+      const polygons = flattenShapeValues(captured).filter((value): value is PolygonValue => value.kind === "polygon");
+      const meshes = flattenShapeValues(captured).filter((value): value is MeshValue => value.kind === "mesh");
+      const built = this.meshesIn(temporary).map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld));
+      const colored = polygons.some((polygon) => polygon.colors !== undefined);
+      const parts = [...(polygons.length ? [geometryFromPolygons(polygons, colored)] : []), ...meshes.map((mesh) => mesh.geometry), ...built];
+      if (parts.length === 0) throw new Error("`mesh` needs at least one polygon");
+      geometry = mergeMeshGeometries(parts);
+    } finally {
+      disposeObject3D(temporary);
+      this.vertexCount = charged;
+    }
+    const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, geometry.hasAttribute("color")));
+    this.applyCurrentTransform(mesh);
+    return mesh;
+  }
+
+  /** `polygon { point … }`: one face from explicit 3D vertices, with `color`
+   *  per vertex, loops and defines, as in a path block. */
+  private polygonValue(node: ShapeNode): PolygonValue {
+    const points: Point3[] = [];
+    const colors: RGBA[] = [];
+    let color: RGBA | undefined = node.properties.color === undefined ? undefined : this.evaluateRGBA(node.properties.color);
+    let colored = color !== undefined;
+    const run = (command: PathCommand) => {
+      if (++this.pathCommandCount > this.maxLoopIterations) throw new ShapeScriptLimitError(`ShapeScript polygon exceeds ${this.maxLoopIterations} commands`);
+      switch (command.type) {
+        case "define":
+          this.handleDefine(command);
+          break;
+        case "color":
+          color = this.evaluateRGBA(command.value);
+          colored = true;
+          break;
+        case "point":
+        case "curve": {
+          points.push(this.pointCoordinates(command));
+          colors.push(color ?? [0.8, 0.8, 0.8, 1]);
+          break;
+        }
+        case "for":
+          this.runPathLoop(command, run);
+          break;
+        case "detail":
+          break;
+        default:
+          throw new Error(`\`${command.type}\` is not supported inside a polygon — list its points`);
+      }
+    };
+    this.symbols.pushScope();
+    try {
+      for (const command of node.points ?? []) run(command);
+    } finally {
+      this.symbols.popScope();
+    }
+    if (points.length < 3) throw new Error("`polygon` needs at least three points");
+    return { kind: "polygon", points, ...(colored ? { colors } : {}) };
+  }
+
+  /** `point 1 2 3`, or `point v` where `v` is a tuple. */
+  private pointCoordinates(command: PointCommand | CurveCommand): Point3 {
+    const first = this.evaluator.evaluate(command.x as Expression);
+    const numbers = Array.isArray(first)
+      ? first.map((component) => (typeof component === "number" ? component : Number.NaN))
+      : [this.evaluateNumber(command.x), this.evaluateNumber(command.y), command.z === undefined ? 0 : this.evaluateNumber(command.z)];
+    const [x = 0, y = 0, z = 0] = numbers;
+    if (![x, y, z].every(Number.isFinite)) throw new Error("Expected finite point coordinates");
+    return [x, y, z];
+  }
+
+  private meshesIn(root: THREE.Object3D): THREE.Mesh[] {
+    root.updateMatrixWorld(true);
+    const meshes: THREE.Mesh[] = [];
+    root.traverse((object) => {
+      if ((object as THREE.Mesh).isMesh) meshes.push(object as THREE.Mesh);
+    });
+    return meshes;
+  }
+
+  /** A shape as a value: built at the origin in a scratch group, its meshes
+   *  merged into one geometry the script can read members of and place. A
+   *  polygon block or a function that returned one is that value itself. */
+  private shapeValue(node: SceneNode): Value {
+    const temporary = new THREE.Group();
+    const captured: Value[] = [];
+    const charged = this.vertexCount;
+    try {
+      this.captureValues(captured, () =>
+        this.inScope(temporary, () => {
+          this.currentTransform().matrix.identity();
+          this.addChildren(temporary, [node]);
+        }),
+      );
+      const meshes = this.meshesIn(temporary);
+      if (meshes.length === 0) {
+        if (captured.length === 1) return captured[0]!;
+        if (captured.length > 1) return captured;
+        throw new Error("The shape used as a value produced nothing");
+      }
+      const geometry = mergeMeshGeometries(meshes.map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld)));
+      this.chargeEstimate(geometry.getAttribute("position").count);
+      return { kind: "mesh", geometry, ...(meshes.length === 1 && meshes[0]!.name ? { name: meshes[0]!.name } : {}) };
+    } finally {
+      disposeObject3D(temporary);
+      this.vertexCount = charged;
+    }
+  }
+
+  /** A function whose body builds shapes: run it at the origin with its
+   *  parameters bound, and return what it built — one value, or a tuple. */
+  private callShapeFunction(fn: FunctionValue, args: Value[]): Value {
+    const { params = [], body = [], value, name } = fn.definition;
+    return this.evaluator.withArguments(params, args, () => {
+      const temporary = new THREE.Group();
+      const captured: Value[] = [];
+      const charged = this.vertexCount;
+      try {
+        this.captureValues(captured, () =>
+          this.inScope(temporary, () => {
+            this.currentTransform().matrix.identity();
+            this.addChildren(temporary, body);
+            if (value !== undefined) captured.push(this.evaluator.evaluate(value));
+          }),
+        );
+        for (const mesh of this.meshesIn(temporary)) {
+          captured.push({ kind: "mesh", geometry: mesh.geometry.clone().applyMatrix4(mesh.matrixWorld) });
+        }
+      } finally {
+        disposeObject3D(temporary);
+        this.vertexCount = charged;
+      }
+      if (captured.length === 0) throw new Error(`Function \`${name}\` produced no value`);
+      return captured.length === 1 ? captured[0]! : captured;
+    });
   }
 
   /** A solid whose extent is zero in any dimension draws nothing.
@@ -629,7 +857,8 @@ export class Converter {
 
       case "icosphere":
         this.requireExtent("icosphere", size);
-        return new THREE.IcosahedronGeometry(0.5, icosphereSubdivisions(this.detailLevel)).scale(...size);
+        // Euclid's construction, face for face, so `.polygons` indexes as upstream.
+        return icosphereGeometry(0.5, icosphereSubdivisions(this.detailLevel)).geometry.scale(...size);
 
       case "cylinder": {
         const radiusTop = node.properties.radiusTop ? this.evaluateNumber(node.properties.radiusTop) : size[0] / 2;
@@ -758,13 +987,15 @@ export class Converter {
     if (material.texture !== undefined) this.warnTexture(material.texture);
   }
 
-  private createMaterial(node: { properties: ShapeProperties }, base?: MaterialState): THREE.Material {
+  private createMaterial(node: { properties: ShapeProperties }, base?: MaterialState, vertexColors = false): THREE.Material {
     // A per-shape property wins; otherwise the enclosing scope's commands
     // apply. Opacity is the colour's alpha times every `opacity` in scope.
     const state = this.materialFor(node.properties, base ?? this.currentTransform().material);
     const opacity = Math.max(0, state.alpha * state.opacity);
     return new THREE.MeshStandardMaterial({
-      color: state.color?.clone() ?? new THREE.Color(0.8, 0.8, 0.8),
+      // Vertex colours multiply the material colour, so a coloured mesh keeps its own.
+      color: vertexColors ? new THREE.Color(1, 1, 1) : (state.color?.clone() ?? new THREE.Color(0.8, 0.8, 0.8)),
+      vertexColors,
       opacity: Math.min(1, opacity),
       transparent: opacity < 1,
       ...(state.metallicity === undefined ? {} : { metalness: Math.min(1, Math.max(0, state.metallicity)) }),
@@ -1022,6 +1253,17 @@ export class Converter {
   private convertCustomShape(node: CustomShapeNode): THREE.Object3D | null {
     // Look up the custom shape definition
     const definition = this.symbols.get(node.name);
+
+    // A symbol holding a shape value (`define ico icosphere { … }` then `ico`)
+    // is placed, with the call's options as its placement.
+    if (definition !== undefined && isShapeValue(definition)) {
+      const group = new THREE.Group();
+      return this.inScope(group, () => {
+        this.applyPlacement(this.currentTransform().matrix, node.properties as ShapeProperties);
+        const placed = this.placeValue(definition);
+        if (placed) group.add(placed);
+      });
+    }
 
     if (!definition || typeof definition !== "object" || !("type" in definition)) {
       throw new Error(`Unknown shape: ${node.name}`);
@@ -1345,6 +1587,11 @@ export class Converter {
         }
         case "for":
           this.runPathLoop(command, processCommand);
+          break;
+        case "color":
+          // Path point colours are not drawn here; the value is checked so a
+          // bad one is still an error.
+          this.evaluateRGBA(command.value);
           break;
       }
     };
@@ -1708,6 +1955,43 @@ const STANDARD_KEYS: Record<string, true> = {
   detail: true,
   smoothing: true,
 };
+
+/** Mesh and polygon values, at any depth of tuple. */
+function flattenShapeValues(values: readonly Value[]): (MeshValue | PolygonValue)[] {
+  const shapes: (MeshValue | PolygonValue)[] = [];
+  for (const value of values) {
+    if (Array.isArray(value)) shapes.push(...flattenShapeValues(value));
+    else if (isShapeValue(value)) shapes.push(value);
+  }
+  return shapes;
+}
+
+function isShapeValue(value: Value): value is MeshValue | PolygonValue {
+  return isObjectValue(value) && (value.kind === "mesh" || value.kind === "polygon");
+}
+
+/** Merge geometries into one non-indexed geometry carrying position, normal,
+ *  uv and — when any part has it — colour, so parts from different sources
+ *  (a lathe, a polygon list, a CSG result) combine. */
+function mergeMeshGeometries(parts: readonly THREE.BufferGeometry[]): THREE.BufferGeometry {
+  const colored = parts.some((part) => part.hasAttribute("color"));
+  const prepared = parts.map((part) => {
+    const flat = part.index ? part.toNonIndexed() : part.clone();
+    if (!flat.hasAttribute("normal")) flat.computeVertexNormals();
+    const count = flat.getAttribute("position").count;
+    if (!flat.hasAttribute("uv")) flat.setAttribute("uv", new THREE.Float32BufferAttribute(new Float32Array(count * 2), 2));
+    if (colored && !flat.hasAttribute("color")) flat.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(count * 3).fill(0.8), 3));
+    for (const name of Object.keys(flat.attributes)) {
+      if (!["position", "normal", "uv", "color"].includes(name)) flat.deleteAttribute(name);
+    }
+    flat.clearGroups();
+    return flat;
+  });
+  const merged = prepared.length === 1 ? prepared[0]! : mergeGeometries(prepared);
+  if (!merged) throw new Error("Could not combine the shapes into one mesh");
+  if (prepared.length > 1) prepared.forEach((part) => part.dispose());
+  return merged;
+}
 
 /** `print` output, one value per space, tuples in parentheses. */
 function printable(value: Value): string {

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -679,31 +679,44 @@ export class Converter {
     return mesh;
   }
 
-  /** `mesh { … }`: every polygon its body produces, and every mesh it builds,
-   *  merged into one mesh in the current frame. */
-  private convertMesh(node: MeshNode): THREE.Mesh {
+  /** Build `nodes` at the origin in a throwaway group, collecting the values
+   *  their statements produced and the geometry of every mesh they built (in
+   *  the group's frame). The group is disposed and its vertex charge refunded;
+   *  what is returned is the caller's to charge. */
+  private buildScratch(
+    nodes: readonly SceneNode[],
+    after?: (captured: Value[]) => void,
+  ): { captured: Value[]; geometries: THREE.BufferGeometry[]; name: string | undefined } {
     const temporary = new THREE.Group();
     const captured: Value[] = [];
     const charged = this.vertexCount;
-    let geometry: THREE.BufferGeometry;
     try {
       this.captureValues(captured, () =>
         this.inScope(temporary, () => {
           this.currentTransform().matrix.identity();
-          this.addChildren(temporary, node.children);
+          this.addChildren(temporary, nodes);
+          after?.(captured);
         }),
       );
-      const polygons = flattenShapeValues(captured).filter((value): value is PolygonValue => value.kind === "polygon");
-      const meshes = flattenShapeValues(captured).filter((value): value is MeshValue => value.kind === "mesh");
-      const built = this.meshesIn(temporary).map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld));
-      const colored = polygons.some((polygon) => polygon.colors !== undefined);
-      const parts = [...(polygons.length ? [geometryFromPolygons(polygons, colored)] : []), ...meshes.map((mesh) => mesh.geometry), ...built];
-      if (parts.length === 0) throw new Error("`mesh` needs at least one polygon");
-      geometry = mergeMeshGeometries(parts);
+      const meshes = this.meshesIn(temporary);
+      const geometries = meshes.map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld));
+      return { captured, geometries, name: meshes.length === 1 && meshes[0]!.name ? meshes[0]!.name : undefined };
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = charged;
     }
+  }
+
+  /** `mesh { … }`: every polygon its body produces, and every mesh it builds,
+   *  merged into one mesh in the current frame. */
+  private convertMesh(node: MeshNode): THREE.Mesh {
+    const { captured, geometries } = this.buildScratch(node.children);
+    const polygons = flattenShapeValues(captured).filter((value): value is PolygonValue => value.kind === "polygon");
+    const meshes = flattenShapeValues(captured).filter((value): value is MeshValue => value.kind === "mesh");
+    const colored = polygons.some((polygon) => polygon.colors !== undefined);
+    const parts = [...(polygons.length ? [geometryFromPolygons(polygons, colored)] : []), ...meshes.map((mesh) => mesh.geometry), ...geometries];
+    if (parts.length === 0) throw new Error("`mesh` needs at least one polygon");
+    const geometry = mergeMeshGeometries(parts);
     const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, geometry.hasAttribute("color")));
     this.applyCurrentTransform(mesh);
     return mesh;
@@ -775,29 +788,15 @@ export class Converter {
    *  merged into one geometry the script can read members of and place. A
    *  polygon block or a function that returned one is that value itself. */
   private shapeValue(node: SceneNode): Value {
-    const temporary = new THREE.Group();
-    const captured: Value[] = [];
-    const charged = this.vertexCount;
-    try {
-      this.captureValues(captured, () =>
-        this.inScope(temporary, () => {
-          this.currentTransform().matrix.identity();
-          this.addChildren(temporary, [node]);
-        }),
-      );
-      const meshes = this.meshesIn(temporary);
-      if (meshes.length === 0) {
-        if (captured.length === 1) return captured[0]!;
-        if (captured.length > 1) return captured;
-        throw new Error("The shape used as a value produced nothing");
-      }
-      const geometry = mergeMeshGeometries(meshes.map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld)));
-      this.chargeEstimate(geometry.getAttribute("position").count);
-      return { kind: "mesh", geometry, ...(meshes.length === 1 && meshes[0]!.name ? { name: meshes[0]!.name } : {}) };
-    } finally {
-      disposeObject3D(temporary);
-      this.vertexCount = charged;
+    const { captured, geometries, name } = this.buildScratch([node]);
+    if (geometries.length === 0) {
+      if (captured.length === 1) return captured[0]!;
+      if (captured.length > 1) return captured;
+      throw new Error("The shape used as a value produced nothing");
     }
+    const geometry = mergeMeshGeometries(geometries);
+    this.chargeEstimate(geometry.getAttribute("position").count);
+    return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }) };
   }
 
   /** A function whose body builds shapes: run it at the origin with its
@@ -805,24 +804,10 @@ export class Converter {
   private callShapeFunction(fn: FunctionValue, args: Value[]): Value {
     const { params = [], body = [], value, name } = fn.definition;
     return this.evaluator.withArguments(params, args, () => {
-      const temporary = new THREE.Group();
-      const captured: Value[] = [];
-      const charged = this.vertexCount;
-      try {
-        this.captureValues(captured, () =>
-          this.inScope(temporary, () => {
-            this.currentTransform().matrix.identity();
-            this.addChildren(temporary, body);
-            if (value !== undefined) captured.push(this.evaluator.evaluate(value));
-          }),
-        );
-        for (const mesh of this.meshesIn(temporary)) {
-          captured.push({ kind: "mesh", geometry: mesh.geometry.clone().applyMatrix4(mesh.matrixWorld) });
-        }
-      } finally {
-        disposeObject3D(temporary);
-        this.vertexCount = charged;
-      }
+      const { captured, geometries } = this.buildScratch(body, (values) => {
+        if (value !== undefined) values.push(this.evaluator.evaluate(value));
+      });
+      for (const geometry of geometries) captured.push({ kind: "mesh", geometry });
       if (captured.length === 0) throw new Error(`Function \`${name}\` produced no value`);
       return captured.length === 1 ? captured[0]! : captured;
     });

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -631,7 +631,10 @@ export class Converter {
    *  upstream's "unused value" is. */
   private placeValue(value: Value): THREE.Mesh | null {
     if (this.valueSink) {
-      this.valueSink.push(value);
+      // Captured in the current frame, as a placed shape would be: a
+      // `translate` before a polygon inside `mesh { }` moves that polygon.
+      // A copy, so a symbol's value is not moved by using it.
+      this.valueSink.push(this.transformedForCapture(value));
       return null;
     }
     if (isObjectValue(value) && value.kind === "mesh") return this.placeMesh(value);
@@ -655,6 +658,21 @@ export class Converter {
     throw new Error("Unused value — a statement that is not a shape does nothing here; use `define` or `print`");
   }
 
+  private transformedForCapture(value: Value): Value {
+    const matrix = this.currentTransform().matrix;
+    const identity = matrix.equals(new THREE.Matrix4());
+    if (Array.isArray(value)) return identity ? value : value.map((item) => this.transformedForCapture(item));
+    if (!isShapeValue(value) || identity) return value;
+    if (value.kind === "polygon") {
+      return { ...value, points: value.points.map((point) => new THREE.Vector3(...point).applyMatrix4(matrix).toArray() as Point3) };
+    }
+    return {
+      ...value,
+      geometry: value.geometry.clone().applyMatrix4(matrix),
+      ...(value.polygons ? { polygons: value.polygons.map((polygon) => this.transformedForCapture(polygon) as PolygonValue) } : {}),
+    };
+  }
+
   private convertExpressionStatement(node: ExpressionStatementNode): THREE.Mesh | null {
     return this.placeValue(this.evaluator.evaluate(node.value));
   }
@@ -676,6 +694,15 @@ export class Converter {
     const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, colored));
     this.applyCurrentTransform(mesh);
     return mesh;
+  }
+
+  /** A geometry that stays alive as a value (a `define`d shape, a function's
+   *  result) counts against the vertex budget for good, since a script can
+   *  keep making them: refuse when it would overflow, then count it. */
+  private chargeRetained(geometry: THREE.BufferGeometry): void {
+    const count = geometry.getAttribute("position").count;
+    this.chargeEstimate(count);
+    this.vertexCount += count;
   }
 
   /** Build `nodes` at the origin in a throwaway group, collecting the values
@@ -819,7 +846,7 @@ export class Converter {
     }
     const geometry = mergeMeshGeometries(geometries);
     geometries.forEach((part) => part.dispose());
-    this.chargeEstimate(geometry.getAttribute("position").count);
+    this.chargeRetained(geometry);
     return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }), ...(polygons === undefined ? {} : { polygons }) };
   }
 
@@ -831,7 +858,10 @@ export class Converter {
       const { captured, geometries } = this.buildScratch(body, (values) => {
         if (value !== undefined) values.push(this.evaluator.evaluate(value));
       });
-      for (const geometry of geometries) captured.push({ kind: "mesh", geometry });
+      for (const geometry of geometries) {
+        this.chargeRetained(geometry);
+        captured.push({ kind: "mesh", geometry });
+      }
       if (captured.length === 0) throw new Error(`Function \`${name}\` produced no value`);
       return captured.length === 1 ? captured[0]! : captured;
     });

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -639,20 +639,18 @@ export class Converter {
     if (Array.isArray(value) && value.length > 0 && value.every((item) => isObjectValue(item) && (item.kind === "mesh" || item.kind === "polygon"))) {
       const meshes = value.filter((item): item is MeshValue => isObjectValue(item) && item.kind === "mesh");
       const polygons = value.filter((item): item is PolygonValue => isObjectValue(item) && item.kind === "polygon");
-      return this.placeMesh({
-        kind: "mesh",
-        geometry: mergeMeshGeometries([
-          ...meshes.map((mesh) => mesh.geometry),
-          ...(polygons.length
-            ? [
-                geometryFromPolygons(
-                  polygons,
-                  polygons.some((p) => p.colors),
-                ),
-              ]
-            : []),
-        ]),
-      });
+      const faces = polygons.length
+        ? geometryFromPolygons(
+            polygons,
+            polygons.some((p) => p.colors),
+          )
+        : undefined;
+      const geometry = mergeMeshGeometries([...meshes.map((mesh) => mesh.geometry), ...(faces ? [faces] : [])]);
+      faces?.dispose();
+      // `placeMesh` clones, so the merged geometry is an intermediate too.
+      const placed = this.placeMesh({ kind: "mesh", geometry });
+      geometry.dispose();
+      return placed;
     }
     throw new Error("Unused value — a statement that is not a shape does nothing here; use `define` or `print`");
   }
@@ -724,9 +722,13 @@ export class Converter {
     const polygons = flattenShapeValues(captured).filter((value): value is PolygonValue => value.kind === "polygon");
     const meshes = flattenShapeValues(captured).filter((value): value is MeshValue => value.kind === "mesh");
     const colored = polygons.some((polygon) => polygon.colors !== undefined);
-    const parts = [...(polygons.length ? [geometryFromPolygons(polygons, colored)] : []), ...meshes.map((mesh) => mesh.geometry), ...geometries];
+    // Owned here: the face geometry and the scratch clones. Not owned: a mesh
+    // value's geometry, which its symbol keeps.
+    const owned = [...(polygons.length ? [geometryFromPolygons(polygons, colored)] : []), ...geometries];
+    const parts = [...owned, ...meshes.map((mesh) => mesh.geometry)];
     if (parts.length === 0) throw new Error("`mesh` needs at least one polygon");
     const geometry = mergeMeshGeometries(parts);
+    owned.forEach((part) => part.dispose());
     // The faces as written, so `.polygons` on this mesh as a value returns
     // them rather than their triangles.
     if (meshes.length === 0 && geometries.length === 0) geometry.userData = { polygons };
@@ -786,10 +788,11 @@ export class Converter {
 
   /** `point 1 2 3`, or `point v` where `v` is a tuple. */
   private pointCoordinates(command: PointCommand | CurveCommand): Point3 {
-    const first = this.evaluator.evaluate(command.x as Expression);
+    // Evaluated once: `point rnd 0 0` must draw a single random number.
+    const first = typeof command.x === "number" ? command.x : this.evaluator.evaluate(command.x);
     const numbers = Array.isArray(first)
       ? first.map((component) => (typeof component === "number" ? component : Number.NaN))
-      : [this.evaluateNumber(command.x), this.evaluateNumber(command.y), command.z === undefined ? 0 : this.evaluateNumber(command.z)];
+      : [typeof first === "number" ? first : Number.NaN, this.evaluateNumber(command.y), command.z === undefined ? 0 : this.evaluateNumber(command.z)];
     const [x = 0, y = 0, z = 0] = numbers;
     if (![x, y, z].every(Number.isFinite)) throw new Error("Expected finite point coordinates");
     return [x, y, z];
@@ -815,6 +818,7 @@ export class Converter {
       throw new Error("The shape used as a value produced nothing");
     }
     const geometry = mergeMeshGeometries(geometries);
+    geometries.forEach((part) => part.dispose());
     this.chargeEstimate(geometry.getAttribute("position").count);
     return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }), ...(polygons === undefined ? {} : { polygons }) };
   }
@@ -1978,7 +1982,9 @@ function isShapeValue(value: Value): value is MeshValue | PolygonValue {
 
 /** Merge geometries into one non-indexed geometry carrying position, normal,
  *  uv and — when any part has it — colour, so parts from different sources
- *  (a lathe, a polygon list, a CSG result) combine. */
+ *  (a lathe, a polygon list, a CSG result) combine. The inputs are not
+ *  touched (each is cloned first), so the caller disposes the ones it owns;
+ *  the result is always a new geometry. */
 function mergeMeshGeometries(parts: readonly THREE.BufferGeometry[]): THREE.BufferGeometry {
   const colored = parts.some((part) => part.hasAttribute("color"));
   const prepared = parts.map((part) => {

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -284,6 +284,7 @@ export class Converter {
     this.symbols.set("detail", this.detailLevel);
     // Shapes as values and shape-building functions are built here.
     this.evaluator.hooks = { shape: (node) => this.shapeValue(node), call: (fn, args) => this.callShapeFunction(fn, args) };
+    this.evaluator.maxLoopIterations = this.maxLoopIterations;
     // Initialize with identity transform
     this.pushTransform();
   }
@@ -686,7 +687,7 @@ export class Converter {
   private buildScratch(
     nodes: readonly SceneNode[],
     after?: (captured: Value[]) => void,
-  ): { captured: Value[]; geometries: THREE.BufferGeometry[]; name: string | undefined } {
+  ): { captured: Value[]; geometries: THREE.BufferGeometry[]; name: string | undefined; polygons: PolygonValue[] | undefined } {
     const temporary = new THREE.Group();
     const captured: Value[] = [];
     const charged = this.vertexCount;
@@ -700,7 +701,16 @@ export class Converter {
       );
       const meshes = this.meshesIn(temporary);
       const geometries = meshes.map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld));
-      return { captured, geometries, name: meshes.length === 1 && meshes[0]!.name ? meshes[0]!.name : undefined };
+      const single = meshes.length === 1 ? meshes[0] : undefined;
+      const faces = single?.geometry.userData.polygons as PolygonValue[] | undefined;
+      const polygons =
+        single && faces
+          ? faces.map((face) => ({
+              ...face,
+              points: face.points.map((point) => new THREE.Vector3(...point).applyMatrix4(single.matrixWorld).toArray() as Point3),
+            }))
+          : undefined;
+      return { captured, geometries, name: single?.name || undefined, polygons };
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = charged;
@@ -717,6 +727,9 @@ export class Converter {
     const parts = [...(polygons.length ? [geometryFromPolygons(polygons, colored)] : []), ...meshes.map((mesh) => mesh.geometry), ...geometries];
     if (parts.length === 0) throw new Error("`mesh` needs at least one polygon");
     const geometry = mergeMeshGeometries(parts);
+    // The faces as written, so `.polygons` on this mesh as a value returns
+    // them rather than their triangles.
+    if (meshes.length === 0 && geometries.length === 0) geometry.userData = { polygons };
     const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, geometry.hasAttribute("color")));
     this.applyCurrentTransform(mesh);
     return mesh;
@@ -761,6 +774,13 @@ export class Converter {
       this.symbols.popScope();
     }
     if (points.length < 3) throw new Error("`polygon` needs at least three points");
+    // The block's own position / orientation / size place its points.
+    const { position, orientation, rotation, size } = node.properties;
+    if (position || orientation || rotation || size) {
+      const frame = new THREE.Matrix4();
+      this.applyPlacement(frame, node.properties);
+      for (const point of points) new THREE.Vector3(...point).applyMatrix4(frame).toArray(point);
+    }
     return { kind: "polygon", points, ...(colored ? { colors } : {}) };
   }
 
@@ -788,7 +808,7 @@ export class Converter {
    *  merged into one geometry the script can read members of and place. A
    *  polygon block or a function that returned one is that value itself. */
   private shapeValue(node: SceneNode): Value {
-    const { captured, geometries, name } = this.buildScratch([node]);
+    const { captured, geometries, name, polygons } = this.buildScratch([node]);
     if (geometries.length === 0) {
       if (captured.length === 1) return captured[0]!;
       if (captured.length > 1) return captured;
@@ -796,7 +816,7 @@ export class Converter {
     }
     const geometry = mergeMeshGeometries(geometries);
     this.chargeEstimate(geometry.getAttribute("position").count);
-    return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }) };
+    return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }), ...(polygons === undefined ? {} : { polygons }) };
   }
 
   /** A function whose body builds shapes: run it at the origin with its
@@ -1250,9 +1270,10 @@ export class Converter {
       });
     }
 
-    if (!definition || typeof definition !== "object" || !("type" in definition)) {
-      throw new Error(`Unknown shape: ${node.name}`);
-    }
+    if (definition === undefined) throw new Error(`Unknown shape: ${node.name}`);
+    // A plain value named as a statement: the result a function body ends
+    // with, collected there; anywhere else an unused value.
+    if (typeof definition !== "object" || Array.isArray(definition) || !("type" in definition)) return this.placeValue(definition);
 
     const defineNode = definition as unknown as DefineNode;
 

--- a/packages/plugins/shapescript-plugin/src/shapescript/types.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/types.ts
@@ -5,7 +5,43 @@ export type Color = [number, number, number];
 
 // Expression types
 export type Expression =
-  NumberLiteral | StringLiteral | IdentifierExpr | BinaryExpr | UnaryExpr | FunctionCall | MemberAccess | SubscriptExpr | TupleExpr | RangeExpr | MaterialExpr;
+  | NumberLiteral
+  | StringLiteral
+  | IdentifierExpr
+  | BinaryExpr
+  | UnaryExpr
+  | FunctionCall
+  | MemberAccess
+  | SubscriptExpr
+  | TupleExpr
+  | RangeExpr
+  | MaterialExpr
+  | ShapeExpr
+  | ForExpr
+  | IfExpr;
+
+/** A shape used as a value: `define ico icosphere { detail 0 }`. Built by the
+ *  converter into a mesh value the script can read members of and place. */
+export interface ShapeExpr {
+  type: "shape";
+  node: SceneNode;
+}
+
+/** `for v in iterable { expr }` as a value: the tuple of every iteration's result. */
+export interface ForExpr {
+  type: "for";
+  variable: string;
+  iterable: Expression;
+  body: Expression;
+}
+
+/** `if cond { a } else { b }` as a value. */
+export interface IfExpr {
+  type: "if";
+  condition: Expression;
+  then: Expression;
+  else?: Expression;
+}
 
 export interface NumberLiteral {
   type: "number";
@@ -106,6 +142,8 @@ export type SceneNode =
   | PrintNode
   | AssertNode
   | IgnoredNode
+  | MeshNode
+  | ExpressionStatementNode
   | ColorNode
   | RotateNode
   | OrientationNode
@@ -118,6 +156,22 @@ export interface ShapeNode {
   primitive: ShapePrimitive;
   properties: ShapeProperties;
   children?: SceneNode[];
+  /** `polygon { point … }`: explicit vertices (3D), with `color` and loops,
+   *  making a single face rather than a regular polygon. */
+  points?: PathCommand[];
+}
+
+/** `mesh { polygon { … } … }` — a mesh assembled from polygon values. */
+export interface MeshNode {
+  type: "mesh";
+  children: SceneNode[];
+}
+
+/** A bare expression as a statement: a call that returns a shape (`face data`
+ *  inside `mesh`), or the value a function body ends with. */
+export interface ExpressionStatementNode {
+  type: "expression";
+  value: Expression;
 }
 
 export type ShapePrimitive = "cube" | "sphere" | "icosphere" | "cylinder" | "cone" | "torus" | "circle" | "square" | "roundrect" | "polygon";
@@ -193,8 +247,9 @@ export interface DefineNode {
   value?: Expression; // For variable definitions, or a function's result expression
   options?: OptionNode[]; // For custom shape definitions
   body?: SceneNode[]; // For custom shape definitions, or a function's leading `define`s
-  /** `define name(a b) { … }` — a function. `body` holds its `define`s and
-   *  `value` the expression it returns. */
+  /** `define name(a b) { … }` — a function. `body` holds its statements
+   *  (defines, or shapes it builds) and `value` the expression it ends with,
+   *  if any; a function with no final expression returns what it built. */
   params?: string[];
 }
 
@@ -330,7 +385,22 @@ export interface PathNode {
 }
 
 export type PathCommand =
-  DefineNode | PointCommand | CurveCommand | ArcCommand | RotateCommand | TranslateCommand | ScaleCommand | DetailPathCommand | ForLoopPathCommand;
+  | DefineNode
+  | PointCommand
+  | CurveCommand
+  | ArcCommand
+  | RotateCommand
+  | TranslateCommand
+  | ScaleCommand
+  | DetailPathCommand
+  | ColorPathCommand
+  | ForLoopPathCommand;
+
+/** `color …` inside a path or polygon block: the colour of the points that follow. */
+export interface ColorPathCommand {
+  type: "color";
+  value: Expression;
+}
 
 export interface PointCommand {
   type: "point";
@@ -414,6 +484,7 @@ export enum TokenType {
   FILL = "FILL",
   HULL = "HULL",
   GROUP = "GROUP",
+  MESH = "MESH",
   PATH = "PATH",
   POINT = "POINT",
   CURVE = "CURVE",

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -117,7 +117,9 @@ Constants: pi, true, false (avoid tau, upstream lacks it; write 2 * pi). Tuple/s
 Ranges are values (define r 1 to 5 step 2; for i in r; if 3 in r). A bare path draws as a line; fill/extrude it for a surface.
 Polygon supports sides (3–256). String literals and join/split/trim are supported. print records output for you.
 Use the tool schema for exact syntax and builder limits. This is a modeling subset of upstream ShapeScript;
-imports, text/fonts, raw meshes, minkowski/inset/svgpath/along and shapes as values are refused by name;
+imports, text/fonts, minkowski/inset/svgpath/along and object values are refused by name;
+shapes are values (define ico icosphere { detail 0 }; ico.polygons, .bounds, .volume), for/if work as expressions,
+functions may build shapes, and mesh { polygon { point … } } builds a mesh from explicit faces;
 textures, cameras and lights are accepted but not drawn (the result reports them).
 If presentShapeScript returns an error diagnostic, correct the script and retry; no visualization was created.
 

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -56,7 +56,7 @@ Switch statements for multiple cases
 
 Calls: C-like max(0 (j - 1)) with NO space before the parenthesis, or bare max 0 (j - 1) / sqrt 9 as upstream.
 Separate arguments with spaces. Commas work here but not in the upstream app.
-Custom functions compute values: define hyp(a b) { sqrt(a * a + b * b) }
+Custom functions return a value (define hyp(a b) { sqrt(a * a + b * b) }) or the shapes they build (define face(d) { polygon { … } }).
 One statement per line; the upstream app rejects two statements on one line.
 
 ### Best Practices:

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -847,7 +847,27 @@ describe("shapes as values", () => {
     );
     assert.throws(() => objectsOf("define nothing(a) { define b a }\nnothing 1"), /returns nothing|produced no value/);
   });
+  it("keeps a mesh block's faces as its polygons, places a point polygon, and bounds `for` expressions", () => {
+    withMesh(
+      "define s mesh {\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 1 1 0\n  point 0 1 0\n }\n}\ncube { size s.polygons.count s.triangles.count 1 }",
+      (mesh) => near(extent(mesh).toArray(), [1, 2, 1]),
+    );
+    withMesh("polygon {\n position 5 0 0\n size 2\n point 0 0\n point 1 0\n point 0 1\n}", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x, box.max.x, box.max.y], [5, 7, 2]);
+    });
+    assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript("define v for i in 1 to 3 { i }\ncube"), { maxLoopIterations: 2 })), /iterations/);
+  });
+  it("lets a function end in `if`, `for` or a bare symbol, and treats keyword-named bindings as values", () => {
+    withMesh("define choose(x) { if x { 1 } else { 2 } }\ncube { size choose(true) choose(false) 1 }", (mesh) => near(extent(mesh).toArray(), [1, 2, 1]));
+    withMesh("define sc(n) { for i in 1 to n { i / n } }\ncube { size sc(2) }", (mesh) => near(extent(mesh).toArray(), [0.5, 1, 0.5]));
+    withMesh("define last(v) {\n define l v.last\n l\n}\ncube { size last((1 2 3)) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
+    withMesh("define f(cube) { cube }\ncube { size f(3) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
+    withMesh("define b {\n option sphere 2\n cube { size sphere }\n}\nb", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    withMesh("for cone in 2 to 2 { cube { size cone } }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+  });
   it("accepts line breaks inside parentheses", () => {
+    withMesh("cube { size (1\n + 2) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
     withMesh("define rows (\n (1 2 3)\n (4 5 6)\n)\ncube { position rows.first size rows.last }", (mesh) => {
       near(mesh.position.toArray(), [1, 2, 3]);
       near(extent(mesh).toArray(), [4, 5, 6]);

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -833,6 +833,14 @@ describe("shapes as values", () => {
       "define s mesh {\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 0 1 0\n }\n}\ncube { size s.polygons.count s.polygons.first.center.x 1 }",
       (mesh) => near(extent(mesh).toArray(), [1, 1 / 3, 1]),
     );
+    // A transform inside the block moves the polygons that follow it.
+    withMesh("mesh {\n translate 1 0 0\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 0 1 0\n }\n}", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x, box.max.x], [1, 2]);
+    });
+    withMesh("define tri {\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 0 1 0\n }\n}\nmesh {\n translate 0 0 3\n tri\n}", (mesh) =>
+      near([new THREE.Box3().setFromObject(mesh).min.z], [3]),
+    );
     assert.throws(() => objectsOf("polygon { point 0 0 point 1 0 }"), /three points/);
     assert.throws(() => objectsOf("mesh { }"), /at least one polygon/);
   });
@@ -870,6 +878,12 @@ describe("shapes as values", () => {
     withMesh("define f(cube) { cube }\ncube { size f(3) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
     withMesh("define b {\n option sphere 2\n cube { size sphere }\n}\nb", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
     withMesh("for cone in 2 to 2 { cube { size cone } }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    withMesh("define f(if) { if }\nfor point in 1 to 1 { cube { size f(3) point 1 } }", (mesh) => near(extent(mesh).toArray(), [3, 1, 1]));
+    // Retained shape values count against the vertex budget.
+    assert.throws(
+      () => disposeObject3D(astToThreeJS(parseShapeScript("for i in 1 to 100 { define s sphere { detail 64 } }\ncube"), { maxVertices: 50000 })),
+      /vertices/,
+    );
   });
   it("accepts line breaks inside parentheses", () => {
     withMesh("cube { size (1\n + 2) }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -567,7 +567,8 @@ describe("upstream shapes and paths", () => {
   });
   it("builds an icosphere of the requested diameter", () => {
     withMesh("icosphere { size 2 detail 16 }", (mesh) => {
-      assert.equal(mesh.geometry.type, "IcosahedronGeometry");
+      // Twenty faces at detail 0 → 20 · 4² triangles at detail 16 (two subdivisions).
+      assert.equal(mesh.geometry.getAttribute("position").count, 20 * 16 * 3);
       const size = extent(mesh);
       assert.ok(size.x > 1.9 && size.x <= 2.001 && size.y > 1.9 && size.z > 1.9, size.toArray().join(","));
     });
@@ -722,7 +723,7 @@ describe("control flow, ranges and functions", () => {
     withMesh("define vec(a) { a 0 a }\ncube { position vec(2) }", (mesh) => near(mesh.position.toArray(), [2, 0, 2]));
     assert.throws(() => objectsOf("define sq(a) { a * a }\ncube { size sq(1 2) }"), /takes 1 argument/);
     assert.throws(() => objectsOf("define f(a) { f(a) }\ncube { size f(1) }"), /recursed/);
-    assert.throws(() => objectsOf("define f(a) { cube }\nf(1)"), /builds a shape/);
+    withMesh("define f(a) { cube { size a } }\nf(2)", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
     assert.throws(() => objectsOf("define f(a) { minkowski { cube } }\nf(1)"), /minkowski/);
   });
   it("collects `print` output and stops on a failed `assert`", () => {
@@ -743,11 +744,114 @@ describe("control flow, ranges and functions", () => {
     for (const [script, message] of [
       ['text "hi"', /text/],
       ['import "other.shape"', /import/],
-      ["define s sphere { size 2 }", /shape as a value/],
+      ["define p path { point 0 0 point 1 1 }", /path.*value/],
       ["extrude { square along path { point 0 0 point 1 1 } }", /along/],
       ['fill svgpath "M 0 0 L 1 0 L 0 1 z"', /svgpath/],
     ] as const) {
       assert.throws(() => objectsOf(script), message, script);
     }
+  });
+});
+
+describe("shapes as values", () => {
+  it("defines a shape as a value, reads its members and places it", () => {
+    withMesh("define s sphere { size 2 }\ns", (mesh) => near(extent(mesh).toArray(), [2, 2, 2], 0.01));
+    withMesh("define s cube { size 1 2 3 }\ncube { size s.bounds.size }", (mesh) => near(extent(mesh).toArray(), [1, 2, 3]));
+    withMesh("define s cube { size 1 2 3 }\ncube { position s.bounds.center size s.bounds.width s.bounds.height s.bounds.depth }", (mesh) =>
+      near(extent(mesh).toArray(), [1, 2, 3]),
+    );
+    withMesh("define s cube\ncube { size s.volume s.triangles.count s.polygons.count }", (mesh) => near(extent(mesh).toArray(), [1, 12, 12]));
+    withMesh("define s cube { position 1 0 0 }\ns { position 0 2 0 }", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x, box.min.y], [0.5, 1.5]);
+    });
+    assert.throws(() => objectsOf("define f(a) { a }\nf 1"), /Unused value/);
+    // A keyword the script has given a value keeps reading as that value.
+    materialOf("define hull (0 0 1)\nsphere { color hull }", (m) => near(m.color.toArray(), [0, 0, 1]));
+  });
+  it("builds an icosphere in Euclid's face order, so face indices match upstream", () => {
+    // Euclid's first face is v0, v11, v5 of its icosahedron; its centre lies
+    // in the +Y half, tilted by the pitch Euclid applies.
+    const t = 1 + Math.SQRT2 / 2;
+    const scale = 1 / Math.sqrt(t * t + 1);
+    const rotate = (p: [number, number, number]) => new THREE.Vector3(...p).multiplyScalar(scale).applyAxisAngle(new THREE.Vector3(1, 0, 0), -Math.atan(t));
+    const expected = [rotate([-1, t, 0]), rotate([-t, 0, 1]), rotate([0, 1, t])].reduce((sum, v) => sum.add(v), new THREE.Vector3()).multiplyScalar(0.5 / 3);
+    withMesh("define ico icosphere { detail 0 }\ndefine c ico.polygons.first.center\ncube { position c size ico.polygons.count 1 1 }", (mesh) => {
+      near(mesh.position.toArray(), expected.toArray(), 1e-6);
+      near(extent(mesh).toArray(), [20, 1, 1]);
+    });
+  });
+  it("evaluates `for` and `if` as expressions", () => {
+    withMesh("define scales for i in 1 to 3 { i / 3 }\ncube { size scales }", (mesh) => near(extent(mesh).toArray(), [1 / 3, 2 / 3, 1]));
+    withMesh("define pts for p in ((1 2) (3 4)) { p.x + p.y }\ncube { size pts.first pts.last 1 }", (mesh) => near(extent(mesh).toArray(), [3, 7, 1]));
+    withMesh("define big true\ndefine s if big { 3 } else { 1 }\ncube { size s }", (mesh) => near(extent(mesh).toArray(), [3, 3, 3]));
+    withMesh("define n 2\ndefine s if n = 1 { 1 } else if n = 2 { 2 } else { 3 }\ncube { size s }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    assert.throws(() => objectsOf("define s if false { 1 }\ncube { size s }"), /needs an `else`/);
+  });
+  it("makes a face from `polygon { point … }` and a mesh from `mesh { … }`", () => {
+    withMesh("polygon {\n point 0 0 0\n point 1 0 0\n point 1 1 0\n point 0 1 0\n}", (mesh) => {
+      near(extent(mesh).toArray(), [1, 1, 0]);
+      assert.equal(mesh.geometry.getAttribute("position").count, 6);
+    });
+    // A tetrahedron from four coloured faces, one vertex-coloured mesh.
+    const tetra = `mesh {
+  define a (0 0 0)
+  define b (1 0 0)
+  define c (0 1 0)
+  define d (0 0 1)
+  polygon {
+    color red
+    point a
+    point c
+    point b
+  }
+  polygon {
+    color green
+    point a
+    point b
+    point d
+  }
+  polygon {
+    color blue
+    point a
+    point d
+    point c
+  }
+  polygon {
+    point b
+    point c
+    point d
+  }
+}`;
+    materialOf(tetra, (m, mesh) => {
+      assert.equal(mesh.geometry.getAttribute("position").count, 12);
+      assert.ok(mesh.geometry.hasAttribute("color"));
+      assert.equal(m.vertexColors, true);
+      near([Math.abs(volume(mesh))], [1 / 6], 1e-6);
+    });
+    withMesh(
+      "define s mesh {\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 0 1 0\n }\n}\ncube { size s.polygons.count s.polygons.first.center.x 1 }",
+      (mesh) => near(extent(mesh).toArray(), [1, 1 / 3, 1]),
+    );
+    assert.throws(() => objectsOf("polygon { point 0 0 point 1 0 }"), /three points/);
+    assert.throws(() => objectsOf("mesh { }"), /at least one polygon/);
+  });
+  it("lets a function build shapes, and a bare call place or contribute them", () => {
+    withMesh("define box(s) { cube { size s } }\nbox 2", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+    withMesh("define tri(z) {\n polygon {\n  point 0 0 z\n  point 1 0 z\n  point 0 1 z\n }\n}\nmesh {\n for z in 0 to 1 {\n  tri z\n }\n}", (mesh) => {
+      near(extent(mesh).toArray(), [1, 1, 1]);
+      assert.equal(mesh.geometry.getAttribute("position").count, 6);
+    });
+    withMesh("define pair { cube { position -1 } cube { position 1 } }\ndefine both(s) { pair }\ncube { size both(1).count 1 1 }", (mesh) =>
+      near(extent(mesh).toArray(), [2, 1, 1]),
+    );
+    assert.throws(() => objectsOf("define nothing(a) { define b a }\nnothing 1"), /returns nothing|produced no value/);
+  });
+  it("accepts line breaks inside parentheses", () => {
+    withMesh("define rows (\n (1 2 3)\n (4 5 6)\n)\ncube { position rows.first size rows.last }", (mesh) => {
+      near(mesh.position.toArray(), [1, 2, 3]);
+      near(extent(mesh).toArray(), [4, 5, 6]);
+    });
+    withMesh("cube { size max(\n 1\n 2\n) }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
   });
 });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -849,9 +849,14 @@ describe("shapes as values", () => {
   });
   it("keeps a mesh block's faces as its polygons, places a point polygon, and bounds `for` expressions", () => {
     withMesh(
-      "define s mesh {\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 1 1 0\n  point 0 1 0\n }\n}\ncube { size s.polygons.count s.triangles.count 1 }",
-      (mesh) => near(extent(mesh).toArray(), [1, 2, 1]),
+      "define s mesh {\n polygon {\n  point 0 0 0\n  point 1 0 0\n  point 1 1 0\n  point 0 1 0\n }\n}\ncube { size s.polygons.count s.triangles.count s.polygons.first.triangles.count }",
+      (mesh) => near(extent(mesh).toArray(), [1, 2, 2]),
     );
+    // A point's first coordinate is evaluated once, so `rnd` advances once per point.
+    withMesh("seed 1\npolygon {\n point rnd 0 0\n point 1 0 0\n point 0 1 0\n}", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x], [0]);
+    });
     withMesh("polygon {\n position 5 0 0\n size 2\n point 0 0\n point 1 0\n point 0 1\n}", (mesh) => {
       const box = new THREE.Box3().setFromObject(mesh);
       near([box.min.x, box.max.x, box.max.y], [5, 7, 2]);

--- a/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
+++ b/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
@@ -32,10 +32,13 @@ const RENDERS: Record<string, Rendered> = {
   "Earth.shape": { objects: 1, bounds: { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] }, warnings: [/background image "Stars.jpg"/, /texture "Earth.png"/] },
   "Spring.shape": { objects: 1, bounds: { min: [-0.55, -0.65, -0.55], max: [0.55, 0.65, 0.55] }, warnings: [] },
   "Train.shape": { objects: 14, bounds: { min: [-0.6, -0.42, -1.12], max: [0.6, 1.53, 1.15] }, warnings: [/camera/] },
+  // Twelve pentagons built from the icosphere's face centres — which only
+  // works when `icosphere.polygons` comes out in Euclid's face order — as one
+  // vertex-coloured mesh, flat-shaded by `smoothing 0`.
+  "Dodecahedron.shape": { objects: 1, bounds: { min: [-0.7, -0.604, -0.74], max: [0.7, 0.604, 0.74] }, warnings: [] },
 };
 
 const REFUSED: Record<string, RegExp> = {
-  "Dodecahedron.shape": /a shape as a value.*not supported/,
   "Fillet.shape": /minkowski.*not supported/,
   "Spirals.shape": /along.*not supported/,
 };

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -1,6 +1,6 @@
 # ShapeScript plugin: upstream parity tracker
 
-**Status**: phase 1 shipped in 2.0.0 (#3069); phase 2 and the first phase-3 batch in 2.1.0
+**Status**: phase 1 shipped in 2.0.0 (#3069); phase 2 and the first phase-3 batch in 2.1.0 (#3072); mesh values in 2.2.0
 **Upstream**: [nicklockwood/ShapeScript](https://github.com/nicklockwood/ShapeScript) 1.11.4 (2026-09-04)
 **Ours**: `packages/plugins/shapescript-plugin` (ported from `@gui-chat-plugin/present3d`)
 **Last updated**: 2026-09-11
@@ -65,7 +65,7 @@ Found while running the upstream examples (fixed in 2.1.0, also phase-1 class):
 ## Phase 3 — missing language features (by likely impact on generated scripts)
 
 Test fixtures: the upstream `Examples/` directory (`test/fixtures/upstream-examples/`, MIT).
-Ball, Chessboard, Cog, Earth, Spring and Train render; Dodecahedron, Fillet and Spirals are
+Ball, Chessboard, Cog, Dodecahedron, Earth, Spring and Train render; Fillet and Spirals are
 refused by name (see "open" below).
 
 Done in 2.1.0:
@@ -83,13 +83,19 @@ Done in 2.1.0:
   `camera` / `light` skipped with a warning; `import`, `text`, `font`, `mesh`, `minkowski`,
   `inset`, `svgpath`, `along`, `object`, `normals`, `focus`, `debug` refused by name.
 
+Done in 2.2.0 (Dodecahedron):
+
+- **Values**: shapes as values with `polygons` / `triangles` / `bounds` / `volume` members and
+  polygon `center` / `points` / `bounds`; `for` and `if` as expressions; functions that build
+  shapes, called bare as statements; `polygon { point … }` faces with colours; `mesh { … }`;
+  the icosphere in Euclid's face order; line breaks inside parentheses.
+
 Open:
 
 - **Builders**: `minkowski`; `extrude` options `along`, `twist`, `axisAligned`, `miterLimit`;
   `inset` (Fillet, Spirals).
-- **Values**: shapes as values (`define s sphere { … }`, functions returning meshes, mesh
-  members `polygons` / `triangles` / `bounds` / `volume`, `for` as an expression) — Dodecahedron.
-  Would need a mesh value type in the evaluator; the largest remaining item.
+- **Values**: paths as values (`define p path { … }`, `path.points`), per-vertex colours between
+  a polygon's points (a polygon takes one colour), `object` values.
 - **Paths**: `svgpath`, nested / compound paths with holes, `path.color` gradients, 3D path
   points with z ≠ 0, `arc` outside a path.
 - **Materials**: texture images (`texture`, `opacity` / `metallicity` / `roughness` textures,


### PR DESCRIPTION
## Summary

The last upstream example that needed language work, `Dodecahedron.shape`, now renders. Follow-up to #3072.

- **Shapes as values**: `define ico icosphere { detail 0 }` keeps its mesh; `ico` (with optional `position` / `orientation` / `size` on the call) places it; members `polygons` and `triangles` (each with `.center`, `.points`, `.bounds`), `bounds` (`.min` `.max` `.center` `.size` `.width` `.height` `.depth`) and `volume`.
- **Icosphere in Euclid's order**: built vertex for vertex and face for face as `Mesh.icosahedron` + `subdivide()` upstream, so a script that indexes `ico.polygons` (the dodecahedron's face table) gets the same faces. Test pins the first face's centre to the formula.
- **`for` / `if` as expressions**: `define scales for i in 1 to 3 { i / 3 }`, `define c if big { red } else { white }` (with `else if`).
- **Shape-building functions**: `define face(data) { polygon { … } }` runs in the converter and returns what it built (one value, or a tuple); a function called bare as a statement (`face data`) places its result, or contributes it inside `mesh`.
- **`polygon { point … }`** with 3D points (a tuple per point allowed), a colour per face, loops and defines; **`mesh { … }`** assembles the polygons and meshes its body produces into one flat-shaded, vertex-coloured mesh.
- Line breaks inside parentheses and call arguments; a keyword a script `define`s as a value (`define hull (…)` then `color hull`) keeps reading as that value (a workspace script relied on it).
- A value a statement produces that is not a shape is an "unused value" error, as upstream.

### Implementation
`meshValues.ts` holds the value types, Euclid's icosphere, triangulation and polygon → geometry. The evaluator gains the value family and two hooks the converter provides (`shape`: build a node as a value; `call`: run a shape-building function). The converter collects produced values through a sink while building `mesh { }` and function bodies, and places mesh/polygon values in the scene otherwise.

### Versioning
`@mulmoclaude/shapescript-plugin` 2.1.0 → 2.2.0 (additive), launcher range `^2.2.0`, changelog + Ships line, plan file updated.

## Test plan
- [x] Plugin tests: 154 pass (new "shapes as values" suite; Dodecahedron now in the rendering fixtures with bounds asserted)
- [x] Dodecahedron rendered to PNG: twelve coloured pentagons, flat-shaded
- [x] All 70 workspace `.shape` files: same pass/fail set as before this PR
- [x] `yarn format`, `yarn lint` (no new warnings), `yarn typecheck`, `yarn build`, `yarn check:launcher-sync`, changelog Ships check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz

work in mulmoclaude

## Summary by Sourcery

Extend ShapeScript with mesh-valued shapes and polygon-based mesh construction so the Dodecahedron example renders successfully.

New Features:
- Support shapes as values with geometry members including polygons, triangles, bounds, and volume.
- Add polygon faces, mesh blocks, and shape-building functions for constructing and composing meshes.
- Add for and if expressions, multiline parenthesized expressions, and keyword-named value bindings in ShapeScript.
- Render the Dodecahedron upstream example using Euclid-compatible icosphere face ordering.

Enhancements:
- Preserve flat shading and per-face vertex colours when assembling polygon meshes.
- Expose retained shape values for placement and geometry inspection while enforcing unused-value and vertex limits.

Build:
- Bump @mulmoclaude/shapescript-plugin to 2.2.0 and update the launcher dependency range.

Documentation:
- Document ShapeScript mesh values, polygon construction, mesh blocks, and the newly supported Dodecahedron example.
- Update the changelog and upstream parity plan with the completed mesh-value support and remaining unsupported features.

Tests:
- Expand language coverage for shape values, geometry members, expressions, polygon and mesh construction, shape-building functions, multiline syntax, limits, and keyword bindings.
- Add Dodecahedron rendering coverage with bounds assertions and update icosphere geometry expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shapes can now be stored, placed, and inspected through polygons, triangles, bounds, and volume.
  - Added mesh and polygon construction with explicit faces and optional vertex colors.
  - Added shape-building functions, bare function calls, and `for`/`if` expressions.
  - Line breaks are supported inside parentheses.
  - Dodecahedron examples now render successfully.

- **Documentation**
  - Updated compatibility guidance and examples for newly supported ShapeScript capabilities.
  - Clarified features that remain unsupported, including paths as values and object values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->