### PR TITLE
feat(shapescript): minkowski, inset and extrude along — Fillet and Spirals render (2.3.0)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -52,7 +52,8 @@ and together they round edges as upstream's Fillet does. `extrude { section alon
 a section along a path, mitred at corners and capped at the ends of an open path; an open path
 extrudes to a two-sided wall; `detail` reads as a value and `detail 0` inside a path draws its
 curve points as corners; a `detail` inside a path no longer leaks past it. A shape kept as a
-value keeps the colour it was given (the filleted cone stays blue). **Behaviour change** toward
+value keeps the one colour it was given (the filleted cone stays blue); a mesh whose vertices
+differ in colour gives an uncoloured `minkowski` result. **Behaviour change** toward
 upstream: `extrude` no longer closes an open path for you — repeat the first point to get a
 solid, otherwise the path extrudes to a wall.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,7 +55,9 @@ curve points as corners; a `detail` inside a path no longer leaks past it. A sha
 value keeps the one colour it was given (the filleted cone stays blue); a mesh whose vertices
 differ in colour gives an uncoloured `minkowski` result. **Behaviour change** toward
 upstream: `extrude` no longer closes an open path for you — repeat the first point to get a
-solid, otherwise the path extrudes to a wall.
+solid, otherwise the path extrudes to a wall; and a lone `position` value is X alone
+(`position 1` is `1 0 0`, as `translate 1` already was — it padded to `1 1 1`, which laid the
+Spirals out diagonally and hung Fillet's cylinder off a cube corner).
 
 #### `@mulmoclaude/shapescript-plugin@2.2.0` — shapes as values, meshes from polygons, Dodecahedron
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Added
 
+#### `@mulmoclaude/shapescript-plugin@2.3.0` — minkowski, inset, extrude along; Fillet and Spirals
+
+The last two upstream examples render, so all nine do. `minkowski { a b }` sums shapes (one hull
+for convex operands, merged per-face hulls for a non-convex one), `inset(mesh distance)` moves a
+mesh value's faces inward (each vertex to where its faces' offset planes meet, exact at corners),
+and together they round edges as upstream's Fillet does. `extrude { section along path }` sweeps
+a section along a path, mitred at corners and capped at the ends of an open path; an open path
+extrudes to a two-sided wall; `detail` reads as a value and `detail 0` inside a path draws its
+curve points as corners; a `detail` inside a path no longer leaks past it. A shape kept as a
+value keeps the colour it was given (the filleted cone stays blue). **Behaviour change** toward
+upstream: `extrude` no longer closes an open path for you — repeat the first point to get a
+solid, otherwise the path extrudes to a wall.
+
 #### `@mulmoclaude/shapescript-plugin@2.2.0` — shapes as values, meshes from polygons, Dodecahedron
 
 The last upstream example that needed language work. A shape is now a value
@@ -212,7 +225,7 @@ the same way.
 An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
 diagnostic `presentShapeScript` returns.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.2.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.6.0`, `@mulmoclaude/shapescript-plugin@2.3.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.6.0",
-    "@mulmoclaude/shapescript-plugin": "^2.2.0",
+    "@mulmoclaude/shapescript-plugin": "^2.3.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/README.md
+++ b/packages/plugins/shapescript-plugin/README.md
@@ -267,17 +267,22 @@ upstream ShapeScript**.
 Loft accepts ordered, closed planar sections with one perimeter each, resamples differing
 vertex counts, interpolates linearly, and triangulates the end caps. Sections must enclose
 a volume. Hull accepts geometry from child meshes and filled paths. Primitive profiles
-for fill/extrude must lie in XY; holes, swept/twisted extrusion (`along`, `twist`), and
-arbitrary 3D path commands are not implemented. `import`, `text` / `font`, `minkowski`, `inset`,
-`svgpath`, `object` values and paths as values are refused with a message naming the feature. Textures,
+for fill/extrude must lie in XY; holes, twisted extrusion (`twist`) and arbitrary 3D path
+commands are not implemented. `extrude … along` sweeps a section along a path (mitred at
+corners, capped at the ends of an open path); an open path extrudes to a two-sided wall, as
+upstream. `minkowski { a b }` is the hull of two convex solids' vertex sums, and for a
+non-convex operand the merged per-face hulls (overlapping shells, not a boolean union — fine to
+draw, not to feed to another boolean); `inset(mesh d)` slides every vertex to where its faces'
+offset planes meet. `import`, `text` / `font`, `svgpath`, `object` values and paths as values
+are refused with a message naming the feature. Textures,
 normal maps, `camera` and `light` blocks are accepted and skipped with a warning that the
 tool result and the View both report. Unsupported commands and failed CSG operations return
 errors instead of silently substituting different geometry. As with other polygonal CSG
 engines, degenerate or self-intersecting inputs may fail.
 
 The upstream project's own example scripts are test fixtures
-(`test/fixtures/upstream-examples/`, MIT): Ball, Chessboard, Cog, Dodecahedron, Earth, Spring and
-Train render; Fillet (`minkowski` / `inset`) and Spirals (`along`) are refused by name.
+(`test/fixtures/upstream-examples/`, MIT): all nine — Ball, Chessboard, Cog, Dodecahedron, Earth,
+Fillet, Spirals, Spring and Train — render.
 
 ## Shapes as values, meshes and polygons
 

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "presentShapeScript \u2014 interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -165,9 +165,24 @@ A bare path draws as a LINE (stroke), as upstream; use fill / extrude / lathe / 
       cube { position 1 0 0 }
   }
 - stencil preserves the first shape and paints its surface with later shapes' materials.
+- minkowski (the Minkowski sum; with inset it rounds edges, as upstream's Fillet example does):
+  define fillet(source radius) {
+      minkowski {
+          inset(source radius)
+          sphere { size radius * 2 }
+      }
+  }
+  fillet(cone { color red } 0.1)
+- extrude … along (a section swept along a path, capped at the ends of an open path):
+  extrude {
+      circle { size 0.1 }
+      along path { for i in 0 to 20 { curve 0 1 - i / 20 rotate 0.2 } }
+  }
 Loft sections must each have one perimeter and enclose an area; extrude/fill primitive profiles must lie in XY.
+An extrude path is a solid only when it is closed (its last point repeats its first); an open path extrudes
+to a wall, as upstream. inset(mesh distance) moves a mesh value's faces inward (outward when negative).
 A material command inside a builder block (extrude { color red … }) colours the result; size on a builder or
-group scales it. Not supported: extrude along/twist, minkowski, inset, svgpath, text.
+group scales it. Not supported: extrude twist, svgpath, text.
 - mesh { polygon { point x y z … } … }: a mesh from explicit faces; polygon { color red point a point b point c }
   takes 3D points (a tuple works: point v) and a colour per face. Faces may come from a function: mesh { for f in faces { face f } }.
 
@@ -196,9 +211,8 @@ post { height 3 }
 ### Compatibility:
 This plugin implements the documented modeling subset, not all upstream ShapeScript syntax; units, scoping,
 materials and path semantics follow upstream, so a script written against the upstream docs renders the
-same here. Not supported (each is refused by name): import, text/font, minkowski, inset, svgpath,
-extrude along/twist, object values and paths as values. Textures, cameras and lights are accepted but
-not drawn.
+same here. Not supported (each is refused by name): import, text/font, svgpath, extrude twist,
+object values and paths as values. Textures, cameras and lights are accepted but not drawn.
 
 ### Comments:
 // Single-line comment

--- a/packages/plugins/shapescript-plugin/src/core/definition.ts
+++ b/packages/plugins/shapescript-plugin/src/core/definition.ts
@@ -188,6 +188,7 @@ group scales it. Not supported: extrude twist, svgpath, text.
 
 ### Additional Expressions:
 - Constants: pi, true, false (tau exists here but NOT in the upstream app; write 2 * pi)
+- A lone position / translate value is X alone (position 1 = 1 0 0); a lone size is uniform; a lone orientation is a roll.
 - Scientific notation and unary plus: 1e-3, +2
 - Ranges as values: define loops 1 to 5 step 2, then for i in loops { … }, for i in loops step 1, and
   "if 3 in loops"; the in operator also tests tuples (2 in (1 2 3)) and strings.

--- a/packages/plugins/shapescript-plugin/src/shapescript/builders.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/builders.ts
@@ -1,4 +1,5 @@
 import * as THREE from "three";
+import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
 
 /** Read an ordered perimeter from a triangulated planar profile. Interior
  * vertices (e.g. the centre of CircleGeometry) must never enter a loft ring. */
@@ -93,21 +94,24 @@ function alignWinding(rings: THREE.Vector3[][]): void {
   }
 }
 
-/** Straight interpolation between successive rings, with triangulated end caps. */
-export function loftGeometry(profiles: THREE.Vector3[][]): THREE.BufferGeometry {
+/** Straight interpolation between successive rings, with triangulated end
+ *  caps — or, for a `closed` chain (a section swept around a loop), the last
+ *  ring joined back to the first and no caps at all. */
+export function loftGeometry(profiles: THREE.Vector3[][], closed = false): THREE.BufferGeometry {
   if (profiles.length < 2) throw new Error("Loft requires at least two cross-sections");
   const count = Math.max(...profiles.map((ring) => ring.length));
   const rings = profiles.map((ring) => resample(ring, count));
   alignWinding(rings);
   const indices: number[] = [];
-  for (let r = 0; r < rings.length - 1; r++) {
+  const total = rings.length * count;
+  for (let r = 0; r < (closed ? rings.length : rings.length - 1); r++) {
     for (let i = 0; i < count; i++) {
       const a = r * count + i,
         b = r * count + ((i + 1) % count);
-      indices.push(a, b, b + count, a, b + count, a + count);
+      indices.push(a, b, (b + count) % total, a, (b + count) % total, (a + count) % total);
     }
   }
-  for (const end of [0, rings.length - 1]) {
+  for (const end of closed ? [] : [0, rings.length - 1]) {
     const ring = rings[end]!;
     const origin = ring[0]!;
     const u = ring[1]!.clone().sub(origin).normalize();
@@ -162,4 +166,68 @@ export function loftGeometry(profiles: THREE.Vector3[][]): THREE.BufferGeometry 
   }
   geometry.computeVertexNormals();
   return geometry;
+}
+
+/** A section ring (in the XY plane, its normal +Z) placed at every point of a
+ *  path, the way `extrude … along` sweeps it: +Z turns to the path tangent
+ *  (mitred at corners, and the ring widened there so the walls meet), +Y to
+ *  the path's plane normal. A `closed` path wraps the first corner too. */
+export function sweepRings(section: THREE.Vector3[], path: THREE.Vector3[], closed: boolean): THREE.Vector3[][] {
+  const up = pathUp(path);
+  return path.map((origin, i) => {
+    const before = closed || i > 0 ? path[(i - 1 + path.length) % path.length]! : undefined;
+    const after = closed || i < path.length - 1 ? path[(i + 1) % path.length]! : undefined;
+    const incoming = before ? origin.clone().sub(before).normalize() : after!.clone().sub(origin).normalize();
+    const outgoing = after ? after.clone().sub(origin).normalize() : incoming;
+    const tangent = incoming.clone().add(outgoing);
+    if (tangent.lengthSq() < 1e-12) tangent.copy(incoming);
+    tangent.normalize();
+    // The section is widened across the mitre so the walls on either side of
+    // the corner meet: by 1 / cos(θ / 2), capped like a miter limit.
+    const widen = Math.min(SWEEP_MITER_LIMIT, 1 / Math.max(1e-6, Math.sqrt(Math.max(0, (1 + incoming.dot(outgoing)) / 2))));
+    const binormal = up.clone().cross(tangent);
+    if (binormal.lengthSq() < 1e-12) binormal.copy(perpendicularTo(tangent));
+    binormal.normalize();
+    const normal = tangent.clone().cross(binormal).normalize();
+    return section.map((point) => origin.clone().addScaledVector(binormal, point.x * widen).addScaledVector(normal, point.y));
+  });
+}
+
+const SWEEP_MITER_LIMIT = 4;
+
+/** The plane normal of the path, or for a straight path any direction across it. */
+function pathUp(path: THREE.Vector3[]): THREE.Vector3 {
+  const normal = ringNormal(path);
+  if (normal.lengthSq() > 1e-12) return normal.normalize();
+  return perpendicularTo(path[path.length - 1]!.clone().sub(path[0]!).normalize());
+}
+
+function perpendicularTo(direction: THREE.Vector3): THREE.Vector3 {
+  const axis = Math.abs(direction.z) < 0.9 ? new THREE.Vector3(0, 0, 1) : new THREE.Vector3(1, 0, 0);
+  return axis.cross(direction).normalize();
+}
+
+/** An OPEN path extruded: a wall of `depth` along the path with no caps, faced
+ *  both ways as upstream draws an open surface. */
+export function ribbonGeometry(points: THREE.Vector3[], depth: number): THREE.BufferGeometry {
+  if (points.length < 2) throw new Error("Extruding a path needs at least two points");
+  const positions = points.flatMap((point) => [point.x, point.y, point.z - depth / 2, point.x, point.y, point.z + depth / 2]);
+  const indices: number[] = [];
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = i * 2;
+    indices.push(a, a + 2, a + 3, a, a + 3, a + 1);
+  }
+  const front = new THREE.BufferGeometry();
+  front.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+  front.setAttribute("uv", new THREE.Float32BufferAttribute(points.flatMap((_, i) => [i / (points.length - 1), 0, i / (points.length - 1), 1]), 2));
+  front.setIndex(indices);
+  front.computeVertexNormals();
+  const back = front.clone();
+  back.setIndex(indices.map((_, i) => indices[i - (i % 3) + ((3 - (i % 3)) % 3)]!));
+  back.computeVertexNormals();
+  const both = mergeGeometries([front, back]);
+  front.dispose();
+  back.dispose();
+  if (!both) throw new Error("Could not build the extruded path");
+  return both;
 }

--- a/packages/plugins/shapescript-plugin/src/shapescript/builders.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/builders.ts
@@ -189,7 +189,12 @@ export function sweepRings(section: THREE.Vector3[], path: THREE.Vector3[], clos
     if (binormal.lengthSq() < 1e-12) binormal.copy(perpendicularTo(tangent));
     binormal.normalize();
     const normal = tangent.clone().cross(binormal).normalize();
-    return section.map((point) => origin.clone().addScaledVector(binormal, point.x * widen).addScaledVector(normal, point.y));
+    return section.map((point) =>
+      origin
+        .clone()
+        .addScaledVector(binormal, point.x * widen)
+        .addScaledVector(normal, point.y),
+    );
   });
 }
 
@@ -219,7 +224,13 @@ export function ribbonGeometry(points: THREE.Vector3[], depth: number): THREE.Bu
   }
   const front = new THREE.BufferGeometry();
   front.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
-  front.setAttribute("uv", new THREE.Float32BufferAttribute(points.flatMap((_, i) => [i / (points.length - 1), 0, i / (points.length - 1), 1]), 2));
+  front.setAttribute(
+    "uv",
+    new THREE.Float32BufferAttribute(
+      points.flatMap((_, i) => [i / (points.length - 1), 0, i / (points.length - 1), 1]),
+      2,
+    ),
+  );
   front.setIndex(indices);
   front.computeVertexNormals();
   const back = front.clone();

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -12,6 +12,7 @@ import {
   trianglesOf,
   triangulatePolygon,
 } from "./meshValues";
+import type * as THREE from "three";
 import { insetGeometry } from "./minkowski";
 
 export type { MeshValue, PolygonValue, BoundsValue, PointValue } from "./meshValues";
@@ -58,6 +59,9 @@ export const isObjectValue = (value: Value | undefined): value is ObjectValue =>
 export interface EvaluatorHooks {
   shape(node: SceneNode): Value;
   call(fn: FunctionValue, args: Value[]): Value;
+  /** A geometry a builtin allocated that stays alive as a value: charged
+   *  against the vertex budget by the converter, or refused. */
+  retain(geometry: THREE.BufferGeometry): void;
 }
 
 /** Upstream's predefined colour constants (materials.md), as RGB tuples. A
@@ -382,13 +386,6 @@ const builtInFunctions: Record<string, (...args: Value[]) => Value> = {
   split: (s: Value, separator: Value) => String(s).split(String(separator ?? "")),
 
   // Colours: `rgb(r g b [a])` passes through, `hsb(h s b [a])` converts.
-  inset: (mesh: Value, distance: Value) => {
-    if (!isObjectValue(mesh) || mesh.kind !== "mesh") throw new Error("`inset` takes a mesh and a distance");
-    const by = toNumber(distance);
-    if (!Number.isFinite(by)) throw new Error("`inset` distance must be a finite number");
-    // The faces move, so the polygons kept from a `mesh { }` block no longer apply.
-    return { kind: "mesh", geometry: insetGeometry(mesh.geometry, by), ...(mesh.name === undefined ? {} : { name: mesh.name }) } as Value;
-  },
   rgb: (...args: Value[]) => args.flat(),
   hsb: (...args: Value[]) => {
     const [h = 0, s = 0, b = 0, a] = args.flat().map(toNumber);
@@ -401,7 +398,8 @@ const builtInFunctions: Record<string, (...args: Value[]) => Value> = {
 };
 
 /** Every built-in a bare call may name (`max 0 1`). */
-export const BUILT_IN_FUNCTION_NAMES: readonly string[] = Object.keys(builtInFunctions);
+// `rand` and `inset` are served by the evaluator itself (see `evaluate`).
+export const BUILT_IN_FUNCTION_NAMES: readonly string[] = [...Object.keys(builtInFunctions), "inset"];
 
 // Accepts `undefined` so callers can index into a `Value[]` under
 // `noUncheckedIndexedAccess` without a guard at every call site; an
@@ -700,6 +698,7 @@ export class Evaluator {
         // `rand()` shares the seeded generator behind `rnd`, so it cannot be
         // served from the shared function table.
         if (name === "rand") return this.random();
+        if (name === "inset") return this.inset(expr.args.map((arg) => this.evaluate(arg)));
         const func = Object.prototype.hasOwnProperty.call(builtInFunctions, name) ? builtInFunctions[name] : undefined;
         if (!func) {
           throw new Error(`Unknown function: ${expr.name}`);
@@ -801,6 +800,26 @@ export class Evaluator {
     if (roughness !== undefined) material.roughness = this.evaluateToNumber(roughness);
     if (texture) material.texture = String(this.evaluate(texture));
     return material;
+  }
+
+  /** `inset(mesh distance)`: a new mesh value with the faces moved inward.
+   *  Its geometry is a fresh allocation that lives on as a value, so it is
+   *  charged the way a defined shape is. */
+  private inset(args: Value[]): Value {
+    const [mesh, distance] = args;
+    if (args.length !== 2 || !isObjectValue(mesh) || mesh.kind !== "mesh") throw new Error("`inset` takes a mesh and a distance");
+    const by = toNumber(distance);
+    if (!Number.isFinite(by)) throw new Error("`inset` distance must be a finite number");
+    if (!this.hooks) throw new Error("`inset` builds a mesh, which cannot be evaluated here");
+    const geometry = insetGeometry(mesh.geometry, by);
+    try {
+      this.hooks.retain(geometry);
+    } catch (error) {
+      geometry.dispose();
+      throw error;
+    }
+    // The faces move, so the polygons kept from a `mesh { }` block no longer apply.
+    return { kind: "mesh", geometry, ...(mesh.name === undefined ? {} : { name: mesh.name }) };
   }
 
   /** Bind the parameters in a fresh scope, run the body's `define`s, and

--- a/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/evaluator.ts
@@ -12,6 +12,7 @@ import {
   trianglesOf,
   triangulatePolygon,
 } from "./meshValues";
+import { insetGeometry } from "./minkowski";
 
 export type { MeshValue, PolygonValue, BoundsValue, PointValue } from "./meshValues";
 
@@ -381,6 +382,13 @@ const builtInFunctions: Record<string, (...args: Value[]) => Value> = {
   split: (s: Value, separator: Value) => String(s).split(String(separator ?? "")),
 
   // Colours: `rgb(r g b [a])` passes through, `hsb(h s b [a])` converts.
+  inset: (mesh: Value, distance: Value) => {
+    if (!isObjectValue(mesh) || mesh.kind !== "mesh") throw new Error("`inset` takes a mesh and a distance");
+    const by = toNumber(distance);
+    if (!Number.isFinite(by)) throw new Error("`inset` distance must be a finite number");
+    // The faces move, so the polygons kept from a `mesh { }` block no longer apply.
+    return { kind: "mesh", geometry: insetGeometry(mesh.geometry, by), ...(mesh.name === undefined ? {} : { name: mesh.name }) } as Value;
+  },
   rgb: (...args: Value[]) => args.flat(),
   hsb: (...args: Value[]) => {
     const [h = 0, s = 0, b = 0, a] = args.flat().map(toNumber);

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -65,24 +65,27 @@ export function isConvex(triangles: readonly THREE.Vector3[][], points: readonly
   return true;
 }
 
-/** The convex hull of `points`, smooth-shaded: it is the rounded part of a
- *  Minkowski sum, so shared vertices average their face normals. Coplanar
- *  points (two parallel faces summed) give a flat sliver rather than a throw
- *  from `ConvexGeometry`; that is `undefined` here. */
-export function smoothHull(points: THREE.Vector3[]): THREE.BufferGeometry | undefined {
+/** The convex hull of `points`. A whole sum (`smooth`) is the rounded solid
+ *  itself, so shared vertices average their face normals. A per-face PIECE
+ *  keeps flat normals: its rounded sides are interior once the pieces overlap,
+ *  and averaging them into its flat top tilted that face's border — a visible
+ *  bump along every seam of a flat face. Coplanar points (two parallel faces
+ *  summed) give a flat sliver rather than a throw from `ConvexGeometry`; that
+ *  is `undefined` here. */
+export function hullGeometry(points: THREE.Vector3[], smooth: boolean): THREE.BufferGeometry | undefined {
   if (points.length > MAX_HULL_POINTS) throw new Error("`minkowski` operands are too detailed — lower `detail` or simplify the shapes");
   const hull = new ConvexGeometry(points);
   hull.deleteAttribute("normal");
   hull.deleteAttribute("uv");
-  const merged = mergeVertices(hull, 1e-6);
-  hull.dispose();
-  if (!merged.getAttribute("position")?.count || isFlat(merged)) {
-    merged.dispose();
+  const geometry = smooth ? mergeVertices(hull, 1e-6) : hull;
+  if (smooth) hull.dispose();
+  if (!geometry.getAttribute("position")?.count || isFlat(geometry)) {
+    geometry.dispose();
     return undefined;
   }
-  merged.computeVertexNormals();
-  merged.setAttribute("uv", new THREE.Float32BufferAttribute(new Float32Array(merged.getAttribute("position").count * 2), 2));
-  return merged;
+  geometry.computeVertexNormals();
+  geometry.setAttribute("uv", new THREE.Float32BufferAttribute(new Float32Array(geometry.getAttribute("position").count * 2), 2));
+  return geometry;
 }
 
 /** A hull encloses nothing when its volume is negligible AT ITS OWN SCALE: a
@@ -120,7 +123,7 @@ export function minkowskiSum(a: MinkowskiOperand, b: MinkowskiOperand): THREE.Bu
   const convexA = isConvex(facesA, pointsA);
   const convexB = isConvex(facesB, pointsB);
   if (convexA && convexB) {
-    const hull = smoothHull(pairwiseSums(pointsA, pointsB));
+    const hull = hullGeometry(pairwiseSums(pointsA, pointsB), true);
     if (!hull) throw new Error("`minkowski` operands must enclose a volume");
     return hull;
   }
@@ -134,7 +137,7 @@ export function minkowskiSum(a: MinkowskiOperand, b: MinkowskiOperand): THREE.Bu
   const pieces: THREE.BufferGeometry[] = [];
   for (const face of faces)
     for (const corners of other) {
-      const piece = smoothHull(pairwiseSums(face, corners));
+      const piece = hullGeometry(pairwiseSums(face, corners), false);
       if (piece) pieces.push(piece);
     }
   if (pieces.length === 0) throw new Error("`minkowski` operands must enclose a volume");
@@ -156,35 +159,144 @@ function pairwiseSums(a: readonly THREE.Vector3[], b: readonly THREE.Vector3[]):
  *  the planes are consistent, least-squares where more than three meet. */
 export function insetGeometry(geometry: THREE.BufferGeometry, distance: number): THREE.BufferGeometry {
   const position = geometry.getAttribute("position");
-  const normalsAt = new Map<string, THREE.Vector3[]>();
   const triangles = worldTriangles(geometry, new THREE.Matrix4());
-  // Outward whichever way the faces wind, so a mirrored mesh insets inward too.
-  const sign = windingSign(triangles);
-  for (const [a, b, c] of triangles) {
-    const normal = new THREE.Vector3().crossVectors(b!.clone().sub(a!), c!.clone().sub(a!)).multiplyScalar(sign);
-    if (normal.lengthSq() < 1e-18) continue;
-    normal.normalize();
-    for (const corner of [a!, b!, c!]) {
-      const key = keyOf(corner);
-      const normals = normalsAt.get(key) ?? [];
-      if (!normals.some((known) => known.dot(normal) > 1 - 1e-6)) normals.push(normal);
-      normalsAt.set(key, normals);
+  const { normalsAt, onEdge } = faceNormalsAtVertices(triangles);
+  const movedTo = new Map<string, THREE.Vector3>();
+  const cornerMoved = (point: THREE.Vector3): THREE.Vector3 => {
+    const key = keyOf(point);
+    let moved = movedTo.get(key);
+    if (!moved) {
+      moved = point.clone().addScaledVector(offsetDirection(normalsAt.get(key) ?? []), -distance);
+      movedTo.set(key, moved);
     }
-  }
+    return moved;
+  };
+  // A vertex on another face's edge lands on that edge's inset — between its
+  // moved ends, at the same fraction — rather than at its own planes' corner,
+  // which can lie beyond the moved corner when the vertex is nearer to it
+  // than the inset distance.
   const moved = geometry.clone();
   const target = moved.getAttribute("position") as THREE.BufferAttribute;
   const point = new THREE.Vector3();
   for (let i = 0; i < position.count; i++) {
     point.fromBufferAttribute(position, i);
-    const offset = offsetDirection(normalsAt.get(keyOf(point)) ?? []);
-    point.addScaledVector(offset, -distance);
-    target.setXYZ(i, point.x, point.y, point.z);
+    const edge = onEdge.get(keyOf(point));
+    const placed = edge ? cornerMoved(edge.from).clone().lerp(cornerMoved(edge.to), edge.t) : cornerMoved(point);
+    target.setXYZ(i, placed.x, placed.y, placed.z);
   }
   target.needsUpdate = true;
   moved.computeBoundingBox();
   moved.computeBoundingSphere();
   return moved;
 }
+
+/** The distinct face normals meeting at each vertex position. A vertex that
+ *  sits on another triangle's EDGE without being one of its corners — the
+ *  T-junctions a boolean leaves where one face was split by a seam and its
+ *  neighbour was not — belongs to that face too; without it the vertex would
+ *  slide along one face alone and stand proud of the inset surface. */
+interface EdgePlace {
+  from: THREE.Vector3;
+  to: THREE.Vector3;
+  t: number;
+}
+
+function faceNormalsAtVertices(triangles: readonly THREE.Vector3[][]): { normalsAt: Map<string, THREE.Vector3[]>; onEdge: Map<string, EdgePlace> } {
+  const normalsAt = new Map<string, THREE.Vector3[]>();
+  const onEdge = new Map<string, EdgePlace>();
+  const add = (point: THREE.Vector3, normal: THREE.Vector3) => {
+    const key = keyOf(point);
+    const normals = normalsAt.get(key) ?? [];
+    if (!normals.some((known) => known.dot(normal) > 1 - 1e-6)) normals.push(normal);
+    normalsAt.set(key, normals);
+  };
+  // Outward whichever way the faces wind, so a mirrored mesh insets inward too.
+  const sign = windingSign(triangles);
+  const normals = triangles.map(([a, b, c]) => {
+    const normal = new THREE.Vector3().crossVectors(b!.clone().sub(a!), c!.clone().sub(a!)).multiplyScalar(sign);
+    return normal.lengthSq() < 1e-18 ? undefined : normal.normalize();
+  });
+  triangles.forEach((corners, i) => {
+    const normal = normals[i];
+    if (normal) for (const corner of corners) add(corner, normal);
+  });
+  const grid = new VertexGrid(triangles.flat());
+  triangles.forEach((corners, i) => {
+    const normal = normals[i];
+    if (!normal) return;
+    for (let e = 0; e < 3; e++) {
+      const from = corners[e]!,
+        to = corners[(e + 1) % 3]!;
+      for (const point of grid.near(from, to)) {
+        const t = onOpenSegment(point, from, to);
+        if (t === undefined) continue;
+        add(point, normal);
+        if (!onEdge.has(keyOf(point))) onEdge.set(keyOf(point), { from, to, t });
+      }
+    }
+  });
+  return { normalsAt, onEdge };
+}
+
+const ON_EDGE_EPSILON = 1e-6;
+
+/** Where along the segment `point` lies, when it lies strictly between the ends. */
+function onOpenSegment(point: THREE.Vector3, from: THREE.Vector3, to: THREE.Vector3): number | undefined {
+  const edge = to.clone().sub(from);
+  const length = edge.length();
+  if (length < ON_EDGE_EPSILON) return undefined;
+  const t = point.clone().sub(from).dot(edge) / (length * length);
+  if (t <= ON_EDGE_EPSILON || t >= 1 - ON_EDGE_EPSILON) return undefined;
+  return point.distanceTo(from.clone().addScaledVector(edge, t)) < ON_EDGE_EPSILON * Math.max(1, length) ? t : undefined;
+}
+
+/** Distinct vertex positions bucketed on a uniform grid, so an edge is tested
+ *  only against the vertices near it rather than all of them. */
+class VertexGrid {
+  private readonly cells = new Map<string, THREE.Vector3[]>();
+  private readonly cell: number;
+  private readonly origin: THREE.Vector3;
+
+  constructor(points: readonly THREE.Vector3[]) {
+    const box = new THREE.Box3().setFromPoints([...points]);
+    this.origin = box.min.clone();
+    const extent = box.getSize(new THREE.Vector3());
+    this.cell = Math.max(extent.x, extent.y, extent.z, 1e-9) / VERTEX_GRID_DIVISIONS;
+    const seen = new Set<string>();
+    for (const point of points) {
+      const key = keyOf(point);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const cell = this.cellOf(point);
+      const bucket = this.cells.get(cell) ?? [];
+      bucket.push(point);
+      this.cells.set(cell, bucket);
+    }
+  }
+
+  private coordinates(point: THREE.Vector3): [number, number, number] {
+    return [Math.floor((point.x - this.origin.x) / this.cell), Math.floor((point.y - this.origin.y) / this.cell), Math.floor((point.z - this.origin.z) / this.cell)];
+  }
+
+  private cellOf(point: THREE.Vector3): string {
+    return this.coordinates(point).join(",");
+  }
+
+  /** The vertices in every cell the box around `from`–`to` touches. */
+  near(from: THREE.Vector3, to: THREE.Vector3): THREE.Vector3[] {
+    const [ax, ay, az] = this.coordinates(from);
+    const [bx, by, bz] = this.coordinates(to);
+    const found: THREE.Vector3[] = [];
+    for (let x = Math.min(ax, bx); x <= Math.max(ax, bx); x++) {
+      for (let y = Math.min(ay, by); y <= Math.max(ay, by); y++) {
+        for (let z = Math.min(az, bz); z <= Math.max(az, bz); z++) found.push(...(this.cells.get(`${x},${y},${z}`) ?? []));
+      }
+    }
+    return found;
+  }
+}
+
+const VERTEX_GRID_DIVISIONS = 32;
 
 /** Offsets sharper than this are clamped: a needle-like corner would otherwise
  *  shoot its vertex far past the shape. */

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -76,7 +76,7 @@ export function smoothHull(points: THREE.Vector3[]): THREE.BufferGeometry | unde
   hull.deleteAttribute("uv");
   const merged = mergeVertices(hull, 1e-6);
   hull.dispose();
-  if (!merged.getAttribute("position")?.count || Math.abs(enclosedVolume(merged)) < DEGENERATE_VOLUME) {
+  if (!merged.getAttribute("position")?.count || isFlat(merged)) {
     merged.dispose();
     return undefined;
   }
@@ -85,7 +85,17 @@ export function smoothHull(points: THREE.Vector3[]): THREE.BufferGeometry | unde
   return merged;
 }
 
-const DEGENERATE_VOLUME = 1e-12;
+/** A hull encloses nothing when its volume is negligible AT ITS OWN SCALE: a
+ *  sum of two 1e-5 cubes is a solid of 8e-15, a sum of two parallel faces is
+ *  flat however large. */
+const FLAT_VOLUME_RATIO = 1e-9;
+
+function isFlat(geometry: THREE.BufferGeometry): boolean {
+  geometry.computeBoundingBox();
+  const size = geometry.boundingBox!.getSize(new THREE.Vector3());
+  const extent = Math.max(size.x, size.y, size.z);
+  return extent === 0 || Math.abs(enclosedVolume(geometry)) < FLAT_VOLUME_RATIO * extent ** 3;
+}
 
 function enclosedVolume(geometry: THREE.BufferGeometry): number {
   let volume = 0;

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -122,10 +122,11 @@ export function minkowskiSum(a: MinkowskiOperand, b: MinkowskiOperand): THREE.Bu
   }
   // A flat pair (two parallel faces) adds nothing to the union and is skipped.
   const pieces: THREE.BufferGeometry[] = [];
-  for (const face of faces) for (const corners of other) {
-    const piece = smoothHull(pairwiseSums(face, corners));
-    if (piece) pieces.push(piece);
-  }
+  for (const face of faces)
+    for (const corners of other) {
+      const piece = smoothHull(pairwiseSums(face, corners));
+      if (piece) pieces.push(piece);
+    }
   if (pieces.length === 0) throw new Error("`minkowski` operands must enclose a volume");
   const merged = pieces.length === 1 ? pieces[0]! : mergeGeometries(pieces);
   if (pieces.length > 1) pieces.forEach((piece) => piece.dispose());

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -275,7 +275,11 @@ class VertexGrid {
   }
 
   private coordinates(point: THREE.Vector3): [number, number, number] {
-    return [Math.floor((point.x - this.origin.x) / this.cell), Math.floor((point.y - this.origin.y) / this.cell), Math.floor((point.z - this.origin.z) / this.cell)];
+    return [
+      Math.floor((point.x - this.origin.x) / this.cell),
+      Math.floor((point.y - this.origin.y) / this.cell),
+      Math.floor((point.z - this.origin.z) / this.cell),
+    ];
   }
 
   private cellOf(point: THREE.Vector3): string {

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -1,0 +1,168 @@
+import * as THREE from "three";
+import { ConvexGeometry } from "three/examples/jsm/geometries/ConvexGeometry.js";
+import { mergeGeometries, mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+
+/** How far a vertex may sit outside a face plane and the mesh still count as convex. */
+const CONVEX_EPSILON = 1e-6;
+/** Face-plane checks stop at this many comparisons; a bigger mesh is treated as non-convex. */
+const MAX_CONVEXITY_CHECKS = 4_000_000;
+/** The most faces a non-convex operand may contribute pieces for. */
+export const MAX_MINKOWSKI_PIECES = 2048;
+/** The most points one hull may be built from. */
+export const MAX_HULL_POINTS = 400_000;
+
+const keyOf = (point: THREE.Vector3): string => `${Math.round(point.x * 1e6)},${Math.round(point.y * 1e6)},${Math.round(point.z * 1e6)}`;
+
+/** The distinct vertex positions of a geometry, in world space. */
+export function uniquePoints(geometry: THREE.BufferGeometry, matrix: THREE.Matrix4): THREE.Vector3[] {
+  const position = geometry.getAttribute("position");
+  const seen = new Set<string>();
+  const points: THREE.Vector3[] = [];
+  for (let i = 0; i < position.count; i++) {
+    const point = new THREE.Vector3().fromBufferAttribute(position, i).applyMatrix4(matrix);
+    const key = keyOf(point);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    points.push(point);
+  }
+  return points;
+}
+
+/** The triangles of a geometry as world-space corner triples. */
+export function worldTriangles(geometry: THREE.BufferGeometry, matrix: THREE.Matrix4): THREE.Vector3[][] {
+  const position = geometry.getAttribute("position");
+  const index = geometry.index;
+  const count = index?.count ?? position.count;
+  const triangles: THREE.Vector3[][] = [];
+  for (let i = 0; i + 2 < count; i += 3) {
+    triangles.push([0, 1, 2].map((j) => new THREE.Vector3().fromBufferAttribute(position, index ? index.getX(i + j) : i + j).applyMatrix4(matrix)));
+  }
+  return triangles;
+}
+
+/** Whether every vertex lies on or behind every face plane: a convex solid
+ *  (faces wound outward), whose Minkowski sum with another convex solid is the
+ *  hull of their pairwise vertex sums. */
+export function isConvex(triangles: readonly THREE.Vector3[][], points: readonly THREE.Vector3[]): boolean {
+  if (triangles.length * points.length > MAX_CONVEXITY_CHECKS) return false;
+  const normal = new THREE.Vector3();
+  for (const [a, b, c] of triangles) {
+    normal.crossVectors(b!.clone().sub(a!), c!.clone().sub(a!));
+    if (normal.lengthSq() < 1e-18) continue;
+    normal.normalize();
+    const offset = normal.dot(a!);
+    for (const point of points) if (normal.dot(point) - offset > CONVEX_EPSILON) return false;
+  }
+  return true;
+}
+
+/** The convex hull of `points`, smooth-shaded: it is the rounded part of a
+ *  Minkowski sum, so shared vertices average their face normals. */
+export function smoothHull(points: THREE.Vector3[]): THREE.BufferGeometry {
+  if (points.length > MAX_HULL_POINTS) throw new Error("`minkowski` operands are too detailed — lower `detail` or simplify the shapes");
+  const hull = new ConvexGeometry(points);
+  hull.deleteAttribute("normal");
+  hull.deleteAttribute("uv");
+  const merged = mergeVertices(hull, 1e-6);
+  hull.dispose();
+  if (!merged.getAttribute("position")?.count) {
+    merged.dispose();
+    throw new Error("`minkowski` operands must enclose a volume");
+  }
+  merged.computeVertexNormals();
+  merged.setAttribute("uv", new THREE.Float32BufferAttribute(new Float32Array(merged.getAttribute("position").count * 2), 2));
+  return merged;
+}
+
+export interface MinkowskiOperand {
+  geometry: THREE.BufferGeometry;
+  matrix: THREE.Matrix4;
+}
+
+/** `a ⊕ b`. Two convex solids sum to one hull; when one is not convex, every
+ *  face of it is summed with the other on its own and the pieces are merged
+ *  (their union), as upstream decomposes it. */
+export function minkowskiSum(a: MinkowskiOperand, b: MinkowskiOperand): THREE.BufferGeometry {
+  const facesA = worldTriangles(a.geometry, a.matrix);
+  const facesB = worldTriangles(b.geometry, b.matrix);
+  const pointsA = uniquePoints(a.geometry, a.matrix);
+  const pointsB = uniquePoints(b.geometry, b.matrix);
+  if (facesA.length === 0 || facesB.length === 0) throw new Error("`minkowski` needs solid operands");
+  const convexA = isConvex(facesA, pointsA);
+  const convexB = isConvex(facesB, pointsB);
+  if (convexA && convexB) return smoothHull(pairwiseSums(pointsA, pointsB));
+  // Sum the non-convex operand's faces with the whole of the other when that
+  // one is convex; otherwise pair faces with faces.
+  const [faces, other] = convexB ? [facesA, [pointsB]] : convexA ? [facesB, [pointsA]] : [facesA, facesB];
+  if (faces.length * other.length > MAX_MINKOWSKI_PIECES) {
+    throw new Error(`\`minkowski\` of non-convex shapes is limited to ${MAX_MINKOWSKI_PIECES} face pairs — lower \`detail\` or make the operands convex`);
+  }
+  const pieces: THREE.BufferGeometry[] = [];
+  for (const face of faces) for (const corners of other) pieces.push(smoothHull(pairwiseSums(face, corners)));
+  const merged = pieces.length === 1 ? pieces[0]! : mergeGeometries(pieces);
+  if (pieces.length > 1) pieces.forEach((piece) => piece.dispose());
+  if (!merged) throw new Error("Could not combine the `minkowski` pieces");
+  return merged;
+}
+
+function pairwiseSums(a: readonly THREE.Vector3[], b: readonly THREE.Vector3[]): THREE.Vector3[] {
+  if (a.length * b.length > MAX_HULL_POINTS) throw new Error("`minkowski` operands are too detailed — lower `detail` or simplify the shapes");
+  const sums: THREE.Vector3[] = [];
+  for (const p of a) for (const q of b) sums.push(p.clone().add(q));
+  return sums;
+}
+
+/** Every face moved inward by `distance` (outward when negative): each vertex
+ *  slides to where its faces' offset planes meet — exact at any corner where
+ *  the planes are consistent, least-squares where more than three meet. */
+export function insetGeometry(geometry: THREE.BufferGeometry, distance: number): THREE.BufferGeometry {
+  const position = geometry.getAttribute("position");
+  const normalsAt = new Map<string, THREE.Vector3[]>();
+  for (const [a, b, c] of worldTriangles(geometry, new THREE.Matrix4())) {
+    const normal = new THREE.Vector3().crossVectors(b!.clone().sub(a!), c!.clone().sub(a!));
+    if (normal.lengthSq() < 1e-18) continue;
+    normal.normalize();
+    for (const corner of [a!, b!, c!]) {
+      const key = keyOf(corner);
+      const normals = normalsAt.get(key) ?? [];
+      if (!normals.some((known) => known.dot(normal) > 1 - 1e-6)) normals.push(normal);
+      normalsAt.set(key, normals);
+    }
+  }
+  const moved = geometry.clone();
+  const target = moved.getAttribute("position") as THREE.BufferAttribute;
+  const point = new THREE.Vector3();
+  for (let i = 0; i < position.count; i++) {
+    point.fromBufferAttribute(position, i);
+    const offset = offsetDirection(normalsAt.get(keyOf(point)) ?? []);
+    point.addScaledVector(offset, -distance);
+    target.setXYZ(i, point.x, point.y, point.z);
+  }
+  target.needsUpdate = true;
+  moved.computeBoundingBox();
+  moved.computeBoundingSphere();
+  return moved;
+}
+
+/** Offsets sharper than this are clamped: a needle-like corner would otherwise
+ *  shoot its vertex far past the shape. */
+const MAX_OFFSET = 16;
+
+/** The direction `d` with `d · n = 1` for every face normal `n` at a vertex —
+ *  the corner of the unit-offset planes — by ridge-regularised least squares,
+ *  so a single face gives its normal and two faces the point on their bisector. */
+function offsetDirection(normals: readonly THREE.Vector3[]): THREE.Vector3 {
+  if (normals.length === 0) return new THREE.Vector3();
+  const ridge = 1e-9;
+  const m = [ridge, 0, 0, 0, ridge, 0, 0, 0, ridge];
+  const rhs = [0, 0, 0];
+  for (const n of normals) {
+    const c = [n.x, n.y, n.z];
+    for (let r = 0; r < 3; r++) {
+      rhs[r]! += c[r]!;
+      for (let k = 0; k < 3; k++) m[r * 3 + k]! += c[r]! * c[k]!;
+    }
+  }
+  const solved = new THREE.Vector3(...rhs).applyMatrix3(new THREE.Matrix3().fromArray(m).invert());
+  return solved.length() > MAX_OFFSET ? solved.setLength(MAX_OFFSET) : solved;
+}

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -40,14 +40,23 @@ export function worldTriangles(geometry: THREE.BufferGeometry, matrix: THREE.Mat
   return triangles;
 }
 
-/** Whether every vertex lies on or behind every face plane: a convex solid
- *  (faces wound outward), whose Minkowski sum with another convex solid is the
- *  hull of their pairwise vertex sums. */
+/** +1 when the triangles wind outward, −1 when a mirroring `size` or `scale`
+ *  turned them inside out — the sign of the enclosed volume. */
+export function windingSign(triangles: readonly THREE.Vector3[][]): number {
+  let volume = 0;
+  for (const [a, b, c] of triangles) volume += a!.dot(b!.clone().cross(c!));
+  return volume < 0 ? -1 : 1;
+}
+
+/** Whether every vertex lies on or behind every face plane: a convex solid,
+ *  however its faces wind, whose Minkowski sum with another convex solid is
+ *  the hull of their pairwise vertex sums. */
 export function isConvex(triangles: readonly THREE.Vector3[][], points: readonly THREE.Vector3[]): boolean {
   if (triangles.length * points.length > MAX_CONVEXITY_CHECKS) return false;
+  const sign = windingSign(triangles);
   const normal = new THREE.Vector3();
   for (const [a, b, c] of triangles) {
-    normal.crossVectors(b!.clone().sub(a!), c!.clone().sub(a!));
+    normal.crossVectors(b!.clone().sub(a!), c!.clone().sub(a!)).multiplyScalar(sign);
     if (normal.lengthSq() < 1e-18) continue;
     normal.normalize();
     const offset = normal.dot(a!);
@@ -118,8 +127,11 @@ function pairwiseSums(a: readonly THREE.Vector3[], b: readonly THREE.Vector3[]):
 export function insetGeometry(geometry: THREE.BufferGeometry, distance: number): THREE.BufferGeometry {
   const position = geometry.getAttribute("position");
   const normalsAt = new Map<string, THREE.Vector3[]>();
-  for (const [a, b, c] of worldTriangles(geometry, new THREE.Matrix4())) {
-    const normal = new THREE.Vector3().crossVectors(b!.clone().sub(a!), c!.clone().sub(a!));
+  const triangles = worldTriangles(geometry, new THREE.Matrix4());
+  // Outward whichever way the faces wind, so a mirrored mesh insets inward too.
+  const sign = windingSign(triangles);
+  for (const [a, b, c] of triangles) {
+    const normal = new THREE.Vector3().crossVectors(b!.clone().sub(a!), c!.clone().sub(a!)).multiplyScalar(sign);
     if (normal.lengthSq() < 1e-18) continue;
     normal.normalize();
     for (const corner of [a!, b!, c!]) {

--- a/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/minkowski.ts
@@ -66,21 +66,31 @@ export function isConvex(triangles: readonly THREE.Vector3[][], points: readonly
 }
 
 /** The convex hull of `points`, smooth-shaded: it is the rounded part of a
- *  Minkowski sum, so shared vertices average their face normals. */
-export function smoothHull(points: THREE.Vector3[]): THREE.BufferGeometry {
+ *  Minkowski sum, so shared vertices average their face normals. Coplanar
+ *  points (two parallel faces summed) give a flat sliver rather than a throw
+ *  from `ConvexGeometry`; that is `undefined` here. */
+export function smoothHull(points: THREE.Vector3[]): THREE.BufferGeometry | undefined {
   if (points.length > MAX_HULL_POINTS) throw new Error("`minkowski` operands are too detailed — lower `detail` or simplify the shapes");
   const hull = new ConvexGeometry(points);
   hull.deleteAttribute("normal");
   hull.deleteAttribute("uv");
   const merged = mergeVertices(hull, 1e-6);
   hull.dispose();
-  if (!merged.getAttribute("position")?.count) {
+  if (!merged.getAttribute("position")?.count || Math.abs(enclosedVolume(merged)) < DEGENERATE_VOLUME) {
     merged.dispose();
-    throw new Error("`minkowski` operands must enclose a volume");
+    return undefined;
   }
   merged.computeVertexNormals();
   merged.setAttribute("uv", new THREE.Float32BufferAttribute(new Float32Array(merged.getAttribute("position").count * 2), 2));
   return merged;
+}
+
+const DEGENERATE_VOLUME = 1e-12;
+
+function enclosedVolume(geometry: THREE.BufferGeometry): number {
+  let volume = 0;
+  for (const [a, b, c] of worldTriangles(geometry, new THREE.Matrix4())) volume += a!.dot(b!.clone().cross(c!)) / 6;
+  return volume;
 }
 
 export interface MinkowskiOperand {
@@ -99,15 +109,24 @@ export function minkowskiSum(a: MinkowskiOperand, b: MinkowskiOperand): THREE.Bu
   if (facesA.length === 0 || facesB.length === 0) throw new Error("`minkowski` needs solid operands");
   const convexA = isConvex(facesA, pointsA);
   const convexB = isConvex(facesB, pointsB);
-  if (convexA && convexB) return smoothHull(pairwiseSums(pointsA, pointsB));
+  if (convexA && convexB) {
+    const hull = smoothHull(pairwiseSums(pointsA, pointsB));
+    if (!hull) throw new Error("`minkowski` operands must enclose a volume");
+    return hull;
+  }
   // Sum the non-convex operand's faces with the whole of the other when that
   // one is convex; otherwise pair faces with faces.
   const [faces, other] = convexB ? [facesA, [pointsB]] : convexA ? [facesB, [pointsA]] : [facesA, facesB];
   if (faces.length * other.length > MAX_MINKOWSKI_PIECES) {
     throw new Error(`\`minkowski\` of non-convex shapes is limited to ${MAX_MINKOWSKI_PIECES} face pairs — lower \`detail\` or make the operands convex`);
   }
+  // A flat pair (two parallel faces) adds nothing to the union and is skipped.
   const pieces: THREE.BufferGeometry[] = [];
-  for (const face of faces) for (const corners of other) pieces.push(smoothHull(pairwiseSums(face, corners)));
+  for (const face of faces) for (const corners of other) {
+    const piece = smoothHull(pairwiseSums(face, corners));
+    if (piece) pieces.push(piece);
+  }
+  if (pieces.length === 0) throw new Error("`minkowski` operands must enclose a volume");
   const merged = pieces.length === 1 ? pieces[0]! : mergeGeometries(pieces);
   if (pieces.length > 1) pieces.forEach((piece) => piece.dispose());
   if (!merged) throw new Error("Could not combine the `minkowski` pieces");

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -30,6 +30,7 @@ import {
   LatheNode,
   FillNode,
   HullNode,
+  MinkowskiNode,
   ShapeProperties,
   ShapePrimitive,
 } from "./types";
@@ -46,11 +47,8 @@ const UNSUPPORTED_COMMANDS: Record<string, string> = {
   text: "`text` (3D text) is not supported by this renderer",
   font: "`font` is not supported by this renderer",
   import: "`import` is not supported by this renderer — inline the shapes instead",
-  minkowski: "`minkowski` is not supported by this renderer",
-  inset: "`inset` is not supported by this renderer",
   svgpath: "`svgpath` is not supported by this renderer — write the outline as a `path`",
   object: "`object` values are not supported by this renderer — use tuples",
-  along: "`extrude … along` is not supported by this renderer",
   normals: "`normals` (normal maps) are not supported by this renderer",
   focus: "`focus` is not supported by this renderer",
   debug: "`debug` is not supported by this renderer",
@@ -169,6 +167,7 @@ class Lexer {
       lathe: TokenType.LATHE,
       fill: TokenType.FILL,
       hull: TokenType.HULL,
+      minkowski: TokenType.MINKOWSKI,
       group: TokenType.GROUP,
       mesh: TokenType.MESH,
       path: TokenType.PATH,
@@ -581,6 +580,7 @@ const SHAPE_VALUE_TOKENS = new Set([
   TokenType.LATHE,
   TokenType.FILL,
   TokenType.HULL,
+  TokenType.MINKOWSKI,
   TokenType.GROUP,
   TokenType.MESH,
   TokenType.PATH,
@@ -956,6 +956,12 @@ export class Parser {
     if (token.type === TokenType.HEXCOLOR) {
       this.advance();
       return hexColorExpression(String(token.value));
+    }
+
+    // `detail` read as a value: the detail level in force.
+    if (token.type === TokenType.DETAIL) {
+      this.advance();
+      return { type: "identifier", name: "detail" };
     }
 
     // A keyword a binding in scope has claimed is that symbol.
@@ -1683,7 +1689,7 @@ export class Parser {
     };
   }
 
-  private parseBuilder(builderType: "extrude" | "loft" | "lathe" | "fill" | "hull"): ExtrudeNode | LoftNode | LatheNode | FillNode | HullNode {
+  private parseBuilder(builderType: "extrude" | "loft" | "lathe" | "fill" | "hull" | "minkowski"): ExtrudeNode | LoftNode | LatheNode | FillNode | HullNode | MinkowskiNode {
     this.advance(); // consume builder keyword
 
     // Use the same path parser for `lathe path { ... }` and nested paths,
@@ -1703,11 +1709,14 @@ export class Parser {
     this.skipNewlines();
     const properties: ShapeProperties = {};
     const children: SceneNode[] = [];
+    let along: SceneNode | undefined;
     this.scoped(() => {
       while (this.current().type !== TokenType.RBRACE && this.current().type !== TokenType.EOF) {
         const token = this.current();
         if ([TokenType.SIZE, TokenType.COLOR, TokenType.POSITION, TokenType.ROTATION, TokenType.ORIENTATION].includes(token.type)) {
           Object.assign(properties, this.parseProperties());
+        } else if (this.isAlongOption(token)) {
+          along = this.parseAlong(builderType, along);
         } else {
           const node = this.parseNode();
           if (node) children.push(node);
@@ -1716,10 +1725,26 @@ export class Parser {
       }
     });
     this.expect(TokenType.RBRACE);
+    if (builderType === "extrude" && along !== undefined) return { type: "extrude", children, properties, along };
     if (builderType === "extrude" && children.length === 1 && children[0]?.type === "path") {
       return { type: "extrude", path: children[0], properties };
     }
     return { type: builderType, children, properties };
+  }
+
+  private isAlongOption(token: Token): boolean {
+    return token.type === TokenType.IDENTIFIER && token.value === "along" && !this.values.has("along") && !this.blocks.has("along");
+  }
+
+  /** `along <path or shape>` inside `extrude { … }`: the path the sections are swept along. */
+  private parseAlong(builderType: string, previous: SceneNode | undefined): SceneNode {
+    const token = this.current();
+    if (builderType !== "extrude") throw new ParseError("`along` is only valid inside `extrude`", token.line, token.column);
+    if (previous !== undefined) throw new ParseError("`extrude` takes one `along` path", token.line, token.column);
+    this.advance();
+    const path = this.parseNode();
+    if (!path) throw new ParseError("`along` needs a path or shape", token.line, token.column);
+    return path;
   }
 
   /** Run `parse` with the tuple-value break of `isStartOfNewValue` enabled or
@@ -1916,7 +1941,7 @@ export class Parser {
     const token = this.current();
 
     type CSGOperation = "union" | "difference" | "intersection" | "xor" | "stencil";
-    type BuilderType = "extrude" | "loft" | "lathe" | "fill" | "hull";
+    type BuilderType = "extrude" | "loft" | "lathe" | "fill" | "hull" | "minkowski";
     type TransformType = "color" | "rotate" | "translate" | "scale" | "orientation";
 
     // Map token types to shape names
@@ -1949,6 +1974,7 @@ export class Parser {
       [TokenType.LATHE]: "lathe",
       [TokenType.FILL]: "fill",
       [TokenType.HULL]: "hull",
+      [TokenType.MINKOWSKI]: "minkowski",
     };
 
     // Map token types to transform types

--- a/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/parser.ts
@@ -1689,7 +1689,9 @@ export class Parser {
     };
   }
 
-  private parseBuilder(builderType: "extrude" | "loft" | "lathe" | "fill" | "hull" | "minkowski"): ExtrudeNode | LoftNode | LatheNode | FillNode | HullNode | MinkowskiNode {
+  private parseBuilder(
+    builderType: "extrude" | "loft" | "lathe" | "fill" | "hull" | "minkowski",
+  ): ExtrudeNode | LoftNode | LatheNode | FillNode | HullNode | MinkowskiNode {
     this.advance(); // consume builder keyword
 
     // Use the same path parser for `lathe path { ... }` and nested paths,

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -299,6 +299,10 @@ export class Converter {
    *  collected here instead of entering the scene: the body of `mesh { }`,
    *  and a function body whose result is what it built. */
   private valueSink: Value[] | null = null;
+  /** Geometries that live on as values (defined shapes, function results,
+   *  `inset` results). Never in the scene themselves — placing one clones it —
+   *  so they are released together once the conversion is over. */
+  private retained: THREE.BufferGeometry[] = [];
 
   constructor(options: ConversionOptions = {}) {
     this.options = options;
@@ -331,6 +335,10 @@ export class Converter {
       // budget would stay allocated, once per rejected render.
       disposeObject3D(group);
       throw error;
+    } finally {
+      // Every value has been placed (as a clone) by now; the originals go.
+      this.retained.forEach((geometry) => geometry.dispose());
+      this.retained = [];
     }
 
     return group;
@@ -746,6 +754,7 @@ export class Converter {
     const count = geometry.getAttribute("position").count;
     this.chargeEstimate(count);
     this.vertexCount += count;
+    this.retained.push(geometry);
   }
 
   /** Build `nodes` at the origin in a throwaway group, collecting the values

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -2201,11 +2201,19 @@ function coloredClone(mesh: THREE.Mesh): THREE.BufferGeometry {
   return geometry;
 }
 
-/** The colour a mesh was explicitly given, or its first vertex colour. */
+/** The colour a mesh was explicitly given, or the one colour all its vertices
+ *  share; nothing for a mesh whose vertices differ, since a result built from
+ *  new vertices could not carry those. */
 function uniformColorOf(mesh: THREE.Mesh): [number, number, number] | undefined {
   const material = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial | undefined;
   const color = mesh.geometry.getAttribute("color");
-  if (color && color.count > 0) return [color.getX(0), color.getY(0), color.getZ(0)];
+  if (color && color.count > 0) {
+    const first: [number, number, number] = [color.getX(0), color.getY(0), color.getZ(0)];
+    for (let i = 1; i < color.count; i++) {
+      if (Math.abs(color.getX(i) - first[0]) > 1e-6 || Math.abs(color.getY(i) - first[1]) > 1e-6 || Math.abs(color.getZ(i) - first[2]) > 1e-6) return undefined;
+    }
+    return first;
+  }
   if (material?.userData?.colored && material.color) return [material.color.r, material.color.g, material.color.b];
   return undefined;
 }

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -2090,12 +2090,14 @@ export class Converter {
     return result;
   }
 
+  /** A `position`: one value is X alone (`position 1` is `1 0 0`, as
+   *  upstream and as `translate` here), the rest are padded with zeros. */
   private evaluateVector3(value: Vector3 | Expression | undefined): Vector3 {
     if (value === undefined) return [0, 0, 0];
     if (Array.isArray(value) && typeof value[0] === "number") {
       return value as Vector3;
     }
-    const result = this.evaluator.evaluateToVector3(value as Expression);
+    const result = this.evaluateTranslateVector(value as Expression);
     if (!result.every(Number.isFinite)) throw new Error("Expected finite vector components");
     return result;
   }

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -2039,7 +2039,14 @@ export class Converter {
       }
       this.chargeEstimate(geometry.getAttribute("position").count);
       const color = uniformColorOf(first!);
-      if (color) geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(geometry.getAttribute("position").count * 3).map((_, i) => color[i % 3]!), 3));
+      if (color)
+        geometry.setAttribute(
+          "color",
+          new THREE.Float32BufferAttribute(
+            new Float32Array(geometry.getAttribute("position").count * 3).map((_, i) => color[i % 3]!),
+            3,
+          ),
+        );
       return geometry;
     });
   }
@@ -2174,7 +2181,13 @@ function coloredClone(mesh: THREE.Mesh): THREE.BufferGeometry {
   const color = uniformColorOf(mesh);
   if (color && !geometry.hasAttribute("color")) {
     const count = geometry.getAttribute("position").count;
-    geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(count * 3).map((_, i) => color[i % 3]!), 3));
+    geometry.setAttribute(
+      "color",
+      new THREE.Float32BufferAttribute(
+        new Float32Array(count * 3).map((_, i) => color[i % 3]!),
+        3,
+      ),
+    );
   }
   return geometry;
 }

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -717,9 +717,16 @@ export class Converter {
     if (value.kind === "polygon") {
       return { ...value, points: value.points.map((point) => new THREE.Vector3(...point).applyMatrix4(matrix).toArray() as Point3) };
     }
+    const geometry = value.geometry.clone().applyMatrix4(matrix);
+    try {
+      this.chargeRetained(geometry);
+    } catch (error) {
+      geometry.dispose();
+      throw error;
+    }
     return {
       ...value,
-      geometry: value.geometry.clone().applyMatrix4(matrix),
+      geometry,
       ...(value.polygons ? { polygons: value.polygons.map((polygon) => this.transformedForCapture(polygon) as PolygonValue) } : {}),
     };
   }
@@ -768,6 +775,7 @@ export class Converter {
     const temporary = new THREE.Group();
     const captured: Value[] = [];
     const charged = this.vertexCount;
+    const retainedBefore = this.retained.length;
     try {
       this.captureValues(captured, () =>
         this.inScope(temporary, () => {
@@ -791,6 +799,10 @@ export class Converter {
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = charged;
+      // The refund covers the scratch meshes only. A value retained meanwhile
+      // — a transformed capture, an `inset` result, a nested shape value —
+      // outlives the scratch and stays charged.
+      this.vertexCount += this.retained.slice(retainedBefore).reduce((sum, geometry) => sum + geometry.getAttribute("position").count, 0);
     }
   }
 
@@ -908,7 +920,9 @@ export class Converter {
     const { params = [], body = [], value, name } = fn.definition;
     return this.evaluator.withArguments(params, args, () => {
       const { captured, geometries } = this.buildScratch(body, (values) => {
-        if (value !== undefined) values.push(this.evaluator.evaluate(value));
+        // A shape the body ends with is placed where the body's transforms
+        // left the frame, as a statement there would be.
+        if (value !== undefined) values.push(this.transformedForCapture(this.evaluator.evaluate(value)));
       });
       for (const geometry of geometries) {
         this.chargeRetained(geometry);

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 import { ConvexGeometry } from "three/examples/jsm/geometries/ConvexGeometry.js";
 import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
-import { loftGeometry, profileOf } from "./builders";
+import { loftGeometry, profileOf, ribbonGeometry, sweepRings } from "./builders";
 import { Brush, Evaluator as CSGEvaluator, ADDITION, SUBTRACTION, INTERSECTION, HOLLOW_SUBTRACTION, HOLLOW_INTERSECTION } from "three-bvh-csg";
 import {
   SceneNode,
@@ -16,6 +16,7 @@ import {
   LoftNode,
   FillNode,
   HullNode,
+  MinkowskiNode,
   DetailNode,
   PathNode,
   PathCommand,
@@ -41,6 +42,7 @@ import {
 import { Evaluator, SymbolTable, Value, RGBA, MaterialValue, FunctionValue, isObjectValue, iterationValues, rgbaOf, valuesEqual } from "./evaluator";
 import { type MeshValue, type PolygonValue, type Point3, geometryFromPolygons, icosphereGeometry } from "./meshValues";
 import { disposeObject3D, disposeScratch } from "./dispose";
+import { minkowskiSum } from "./minkowski";
 
 /** What a conversion reports besides geometry. Stored on the root group's
  *  `userData` so both viewers and the tool result can read it. */
@@ -66,6 +68,8 @@ interface PathPoint {
 }
 
 const PATH_POINT_EPSILON = 1e-9;
+/** The largest magnitude a Float32 position attribute can hold. */
+const MAX_COORDINATE = 3.4e38;
 
 function samePathPoint(a: PathPoint, b: PathPoint): boolean {
   return Math.abs(a.x - b.x) < PATH_POINT_EPSILON && Math.abs(a.y - b.y) < PATH_POINT_EPSILON;
@@ -73,6 +77,26 @@ function samePathPoint(a: PathPoint, b: PathPoint): boolean {
 
 function midPathPoint(a: PathPoint, b: PathPoint): PathPoint {
   return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2, curved: false };
+}
+
+/** A path whose last point returns to its first encloses a face. */
+function isClosedPath(points: readonly PathPoint[]): boolean {
+  const first = points[0],
+    last = points[points.length - 1];
+  return points.length > 2 && first !== undefined && last !== undefined && samePathPoint(first, last);
+}
+
+/** A stroke's points in its parent's frame, consecutive duplicates dropped. */
+function linePoints(line: THREE.Line): THREE.Vector3[] {
+  line.updateWorldMatrix(true, false);
+  const position = line.geometry.getAttribute("position");
+  const points: THREE.Vector3[] = [];
+  for (let i = 0; i < position.count; i++) {
+    const point = new THREE.Vector3().fromBufferAttribute(position, i).applyMatrix4(line.matrixWorld);
+    const previous = points[points.length - 1];
+    if (previous === undefined || previous.distanceToSquared(point) > PATH_POINT_EPSILON) points.push(point);
+  }
+  return points;
 }
 
 export interface ConversionOptions {
@@ -399,6 +423,8 @@ export class Converter {
         return this.convertFill(node);
       case "hull":
         return this.convertHull(node);
+      case "minkowski":
+        return this.convertMinkowski(node);
       case "group":
         return this.convertBlock(node);
       case "detail":
@@ -455,26 +481,39 @@ export class Converter {
 
   /** A `path` handed to a builder: the flat face it encloses, which `profileOf`
    *  reads the perimeter back from. */
-  private convertPathProfile(node: PathNode): THREE.Mesh {
-    const shape = this.buildPath(node);
-    this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
-    this.requireEnclosedArea(shape, "path");
-    const mesh = this.makeMesh(this.placePath(new THREE.ShapeGeometry(shape), node), this.createMaterial({ properties: {} }));
-    this.applyCurrentTransform(mesh);
-    return mesh;
+  private convertPathProfile(node: PathNode): THREE.Mesh | THREE.Line {
+    return this.withPathDetail(() => {
+      const points = this.collectPathPoints(node);
+      const shape = this.shapeFromPathPoints(points);
+      // An open path has no face: it reaches the builder as a stroke, which
+      // `extrude` walls and `extrude … along` follows.
+      if (!isClosedPath(points)) return this.lineFromPath(node, shape);
+      this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
+      this.requireEnclosedArea(shape, "path");
+      const mesh = this.makeMesh(this.placePath(new THREE.ShapeGeometry(shape), node), this.createMaterial({ properties: {} }));
+      this.applyCurrentTransform(mesh);
+      return mesh;
+    });
+  }
+
+  /** A `detail` inside a path applies to that path alone, as inside any
+   *  block: restore the enclosing level once its points are read. */
+  private withPathDetail<T>(build: () => T): T {
+    return this.withShapeOptions({}, build);
   }
 
   /** A `path` in the scene draws as a stroke, as upstream: `fill` makes a
    *  face of it, and a builder consumes it. Open paths are allowed here. */
   private convertPathLine(node: PathNode): THREE.Line {
-    const shape = this.buildPath(node);
-    const points = shape.getPoints(Math.max(1, Math.floor(this.detailLevel / 4)));
-    if (!points.every((point) => Number.isFinite(point.x) && Number.isFinite(point.y)))
-      throw new Error("`path` needs finite path coordinates — these overflow");
+    return this.withPathDetail(() => this.lineFromPath(node, this.buildPath(node)));
+  }
+
+  private lineFromPath(node: PathNode, shape: THREE.Shape): THREE.Line {
+    const points = this.finitePoints(shape.getPoints(Math.max(1, Math.floor(this.detailLevel / 4))));
     if (points.length < 2) throw new Error("`path` needs at least two points");
     this.chargeEstimate(points.length);
     this.vertexCount += points.length;
-    const geometry = this.placePath(new THREE.BufferGeometry().setFromPoints(points.map((point) => new THREE.Vector3(point.x, point.y, 0))), node);
+    const geometry = this.placePath(new THREE.BufferGeometry().setFromPoints(points), node);
     const material = this.currentTransform().material;
     const opacity = Math.min(1, Math.max(0, material.alpha * material.opacity));
     const line = new THREE.Line(
@@ -583,7 +622,7 @@ export class Converter {
   private finishMesh(geometry: THREE.BufferGeometry, node: { properties: ShapeProperties }, scaleBySize = true, material?: MaterialState): THREE.Mesh {
     let mesh: THREE.Mesh | undefined;
     try {
-      mesh = this.makeMesh(geometry, this.createMaterial(node, material));
+      mesh = this.makeMesh(geometry, this.createMaterial(node, material, geometry.hasAttribute("color")));
       this.applyExplicitTransforms(mesh, node.properties, scaleBySize);
       this.applyCurrentTransform(mesh);
       return mesh;
@@ -616,7 +655,7 @@ export class Converter {
   }
 
   /** Run `build` with produced values going to `sink` rather than the scene. */
-  private captureValues<T>(sink: Value[], build: () => T): T {
+  private captureValues<T>(sink: Value[] | null, build: () => T): T {
     const previous = this.valueSink;
     this.valueSink = sink;
     try {
@@ -725,7 +764,7 @@ export class Converter {
         }),
       );
       const meshes = this.meshesIn(temporary);
-      const geometries = meshes.map((mesh) => mesh.geometry.clone().applyMatrix4(mesh.matrixWorld));
+      const geometries = meshes.map((mesh) => coloredClone(mesh).applyMatrix4(mesh.matrixWorld));
       const single = meshes.length === 1 ? meshes[0] : undefined;
       const faces = single?.geometry.userData.polygons as PolygonValue[] | undefined;
       const polygons =
@@ -1042,6 +1081,8 @@ export class Converter {
       ...(state.glow === undefined ? {} : { emissive: state.glow.clone() }),
       flatShading: state.smoothing !== undefined && state.smoothing <= 0,
       wireframe: this.options.wireframe ?? false,
+      // Remembered so a shape kept as a value can carry the colour it was given.
+      userData: { colored: vertexColors || state.color !== undefined },
     });
   }
 
@@ -1086,7 +1127,8 @@ export class Converter {
           if (child.type === "path") {
             throw new Error("A `path` has no volume and cannot be a CSG operand — wrap it in `extrude`, `lathe` or `fill`");
           }
-          const object = this.convertNode(child);
+          // Operands go to the operation, not to a function's result sink.
+          const object = this.captureValues(null, () => this.convertNode(child));
           // `convertNode` returns null for the commands that only change state
           // (`translate`, `color`, `define`, `detail`, …), so nothing may be
           // read off it before this guard.
@@ -1535,25 +1577,88 @@ export class Converter {
 
   private convertExtrude(node: ExtrudeNode): THREE.Mesh {
     return this.withShapeOptions(node.properties, () => {
+      if (node.along) return this.convertExtrudeAlong(node, node.along);
       const { depth, properties } = this.extrudeProperties(node);
       if (!node.path) {
-        return this.buildFromChildren({ children: node.children ?? [], properties }, (meshes) => {
+        return this.buildFromChildren({ children: node.children ?? [], properties }, (meshes, lines) => {
           const shapes = meshes.map((mesh) => this.planarShape(mesh));
-          if (!shapes.length) throw new Error("Extrude requires a path or planar shape");
+          if (!shapes.length && !lines.length) throw new Error("Extrude requires a path or planar shape");
           for (const shape of shapes) this.chargePathEstimate(shape, 1, 12);
-          return new THREE.ExtrudeGeometry(shapes, { depth, bevelEnabled: false, curveSegments: 1 }).translate(0, 0, -depth / 2);
+          const solids = shapes.length ? [new THREE.ExtrudeGeometry(shapes, { depth, bevelEnabled: false, curveSegments: 1 }).translate(0, 0, -depth / 2)] : [];
+          // An open path extrudes to a wall along it, with no caps.
+          const walls = lines.map((line) => ribbonGeometry(linePoints(line), depth));
+          const parts = [...solids, ...walls];
+          for (const part of parts) this.chargeEstimate(part.getAttribute("position").count);
+          const geometry = parts.length === 1 ? parts[0]! : mergeMeshGeometries(parts);
+          if (parts.length > 1) parts.forEach((part) => part.dispose());
+          return geometry;
         });
       }
-      const shape = this.requireEnclosedArea(this.buildPath(node.path), "extrude");
-
-      // Create extruded geometry
-      const curveSegments = Math.max(1, Math.floor(this.detailLevel / 4));
-      this.chargePathEstimate(shape, curveSegments, EXTRUDE_VERTICES_PER_POINT);
-
-      // Centred on the profile plane (±depth / 2), as upstream extrudes.
-      const geometry = this.placePath(new THREE.ExtrudeGeometry(shape, { depth, bevelEnabled: false, curveSegments }).translate(0, 0, -depth / 2), node.path);
-      return this.finishMesh(geometry, { properties });
+      return this.withPathDetail(() => {
+        const path = node.path!;
+        const points = this.collectPathPoints(path);
+        const shape = this.shapeFromPathPoints(points);
+        const curveSegments = Math.max(1, Math.floor(this.detailLevel / 4));
+        this.chargePathEstimate(shape, curveSegments, EXTRUDE_VERTICES_PER_POINT);
+        // An open path extrudes to a wall along it; a closed one to a solid
+        // centred on the profile plane (±depth / 2), as upstream extrudes.
+        const geometry = isClosedPath(points)
+          ? new THREE.ExtrudeGeometry(this.requireEnclosedArea(shape, "extrude"), { depth, bevelEnabled: false, curveSegments }).translate(0, 0, -depth / 2)
+          : ribbonGeometry(this.finitePoints(shape.getPoints(curveSegments)), depth);
+        return this.finishMesh(this.placePath(geometry, path), { properties });
+      });
     });
+  }
+
+  /** Path samples as 3D points, refused when they would not survive the trip
+   *  into a Float32 position attribute. */
+  private finitePoints(points: readonly THREE.Vector2[]): THREE.Vector3[] {
+    const drawable = (value: number) => Number.isFinite(value) && Math.abs(value) <= MAX_COORDINATE;
+    if (!points.every((point) => drawable(point.x) && drawable(point.y))) throw new Error("`path` needs finite path coordinates — these overflow");
+    return points.map((point) => new THREE.Vector3(point.x, point.y, 0));
+  }
+
+  /** `extrude { section … along path }`: every planar child is a section swept
+   *  along the path — its +Z turned to the path's tangent — and the sections
+   *  are joined into one solid, capped at the ends of an open path. `size`
+   *  scales the result as a whole, as on any shape. */
+  private convertExtrudeAlong(node: ExtrudeNode, along: SceneNode): THREE.Mesh {
+    return this.buildFromChildren({ children: node.children ?? [], properties: node.properties }, (meshes) => {
+      const sections = meshes.map((mesh) => this.sectionOf(mesh));
+      if (!sections.length) throw new Error("`extrude … along` needs a planar section to sweep");
+      const { points, closed } = this.sweepPathOf(along);
+      this.chargeEstimate(sections.reduce((sum, section) => sum + section.length * points.length, 0));
+      const parts = sections.map((section) => loftGeometry(sweepRings(section, points, closed), closed));
+      const geometry = parts.length === 1 ? parts[0]! : mergeMeshGeometries(parts);
+      if (parts.length > 1) parts.forEach((part) => part.dispose());
+      return geometry;
+    });
+  }
+
+  /** A planar child's perimeter as a section in the XY plane, wound
+   *  counter-clockwise so the swept walls face outward. */
+  private sectionOf(mesh: THREE.Mesh): THREE.Vector3[] {
+    const ring = profileOf(mesh);
+    if (ring.some((p) => Math.abs(p.z) > 1e-5)) throw new Error("`extrude … along` sections must lie in the XY plane");
+    return THREE.ShapeUtils.isClockWise(ring.map((p) => new THREE.Vector2(p.x, p.y))) ? ring.reverse() : ring;
+  }
+
+  /** The points of the `along` path — a stroke for an open path, a planar
+   *  shape's perimeter for a closed one — built in a scratch group. */
+  private sweepPathOf(along: SceneNode): { points: THREE.Vector3[]; closed: boolean } {
+    const temporary = new THREE.Group();
+    const charged = this.vertexCount;
+    try {
+      const { meshes, lines } = this.buildOperands(temporary, [along]);
+      if (meshes.length + lines.length !== 1) throw new Error("`along` needs exactly one path");
+      const line = lines[0];
+      const points = line ? linePoints(line) : profileOf(meshes[0]!);
+      if (points.length < 2) throw new Error("`along` needs a path with at least two points");
+      return { points, closed: line === undefined };
+    } finally {
+      disposeObject3D(temporary);
+      this.vertexCount = charged;
+    }
   }
 
   private buildPath(pathNode: PathNode): THREE.Shape {
@@ -1583,12 +1688,13 @@ export class Converter {
   private collectPathPoints(pathNode: PathNode): PathPoint[] {
     const frame = new THREE.Matrix4();
     const points: PathPoint[] = [];
+    let corners = false;
 
     const place = (command: PointCommand | CurveCommand) => {
       if (command.z !== undefined && Math.abs(this.evaluateNumber(command.z)) > PATH_POINT_EPSILON) {
         throw new Error("Paths here are planar — a `point` / `curve` may not have a nonzero third coordinate");
       }
-      this.placePathPoint(frame, points, this.evaluateNumber(command.x), this.evaluateNumber(command.y), command.type === "curve");
+      this.placePathPoint(frame, points, this.evaluateNumber(command.x), this.evaluateNumber(command.y), command.type === "curve" && !corners);
     };
     const move = (step: THREE.Matrix4) => {
       frame.multiply(step);
@@ -1603,9 +1709,14 @@ export class Converter {
         case "define":
           this.handleDefine(command);
           break;
-        case "detail":
-          this.handleDetail(command);
+        case "detail": {
+          // `detail 0` draws the curve points as corners, as upstream's
+          // unsubdivided path does; the level itself is clamped as elsewhere.
+          const requested = this.evaluateNumber(command.value);
+          corners = requested < 1;
+          this.handleDetail({ type: "detail", value: { type: "number", value: requested } });
           break;
+        }
         case "point":
         case "curve":
           place(command);
@@ -1700,8 +1811,7 @@ export class Converter {
     const first = points[0];
     if (first === undefined) return shape;
 
-    const last = points[points.length - 1] as PathPoint;
-    const closed = points.length > 2 && samePathPoint(first, last);
+    const closed = isClosedPath(points);
     const ring = closed ? points.slice(0, -1) : points;
     const at = (index: number): PathPoint => ring[(index + ring.length) % ring.length] as PathPoint;
 
@@ -1809,29 +1919,38 @@ export class Converter {
   /** Build `children` into a throwaway group at the block's own origin and hand
    *  back every mesh in it, world matrices already resolved. The group stays
    *  owned by the caller, which disposes it. */
-  private buildOperands(temporary: THREE.Group, children: SceneNode[]): { meshes: THREE.Mesh[]; material: MaterialState } {
+  private buildOperands(temporary: THREE.Group, children: SceneNode[]): { meshes: THREE.Mesh[]; lines: THREE.Line[]; material: MaterialState } {
     let material = this.currentTransform().material;
     this.operandDepth++;
     try {
-      this.inScope(temporary, () => {
-        this.currentTransform().matrix.identity();
-        this.addChildren(temporary, children);
-        // The material the block ends with is the builder's own — upstream a
-        // `material steel` inside `lathe { … }` colours the lathe.
-        material = cloneMaterialState(this.currentTransform().material);
-      });
+      // A value the operands produce (`inset(source r)` inside `minkowski`) is
+      // an operand here, not part of an enclosing function's result.
+      this.captureValues(null, () =>
+        this.inScope(temporary, () => {
+          this.currentTransform().matrix.identity();
+          this.addChildren(temporary, children);
+          // The material the block ends with is the builder's own — upstream a
+          // `material steel` inside `lathe { … }` colours the lathe.
+          material = cloneMaterialState(this.currentTransform().material);
+        }),
+      );
     } finally {
       this.operandDepth--;
     }
     temporary.updateMatrixWorld(true);
     const meshes: THREE.Mesh[] = [];
+    const lines: THREE.Line[] = [];
     temporary.traverse((object) => {
       if ((object as THREE.Mesh).isMesh) meshes.push(object as THREE.Mesh);
+      else if ((object as THREE.Line).isLine) lines.push(object as THREE.Line);
     });
-    return { meshes, material };
+    return { meshes, lines, material };
   }
 
-  private buildFromChildren(node: { children: SceneNode[]; properties: ShapeProperties }, build: (meshes: THREE.Mesh[]) => THREE.BufferGeometry): THREE.Mesh {
+  private buildFromChildren(
+    node: { children: SceneNode[]; properties: ShapeProperties },
+    build: (meshes: THREE.Mesh[], lines: THREE.Line[]) => THREE.BufferGeometry,
+  ): THREE.Mesh {
     const temporary = new THREE.Group();
     // The operand meshes are charged as they are built — the budget has to hold
     // while they exist — but they are disposed below and never enter the scene,
@@ -1844,7 +1963,7 @@ export class Converter {
     try {
       const operands = this.buildOperands(temporary, node.children);
       material = operands.material;
-      geometry = build(operands.meshes);
+      geometry = build(operands.meshes, operands.lines);
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = chargedBeforeOperands;
@@ -1891,6 +2010,33 @@ export class Converter {
       this.requireEnclosedArea(shape, "fill");
       const geometry = this.placePath(new THREE.ShapeGeometry(shape), pathNode);
       return this.finishMesh(geometry, node);
+    });
+  }
+
+  /** `minkowski { a b … }`: the children summed left to right, each solid
+   *  swept over every point of the next. The result keeps the first child's
+   *  colour, as upstream keeps its material. */
+  private convertMinkowski(node: MinkowskiNode): THREE.Object3D {
+    return this.buildFromChildren(node, (meshes) => {
+      if (meshes.length < 2) throw new Error("`minkowski` needs at least two shapes");
+      const [first, ...rest] = meshes;
+      let geometry = first!.geometry.clone().applyMatrix4(first!.matrixWorld);
+      const identity = new THREE.Matrix4();
+      try {
+        for (const mesh of rest) {
+          this.chargeEstimate(geometry.getAttribute("position").count * mesh.geometry.getAttribute("position").count);
+          const sum = minkowskiSum({ geometry, matrix: identity }, { geometry: mesh.geometry, matrix: mesh.matrixWorld });
+          geometry.dispose();
+          geometry = sum;
+        }
+      } catch (error) {
+        geometry.dispose();
+        throw error;
+      }
+      this.chargeEstimate(geometry.getAttribute("position").count);
+      const color = uniformColorOf(first!);
+      if (color) geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(geometry.getAttribute("position").count * 3).map((_, i) => color[i % 3]!), 3));
+      return geometry;
     });
   }
 
@@ -2015,6 +2161,29 @@ function isShapeValue(value: Value): value is MeshValue | PolygonValue {
  *  (a lathe, a polygon list, a CSG result) combine. The inputs are not
  *  touched (each is cloned first), so the caller disposes the ones it owns;
  *  the result is always a new geometry. */
+/** A mesh's geometry with the colour its material was given baked in as
+ *  vertex colours, so the shape keeps it once it is only a value. A mesh
+ *  drawn in the default colour stays uncoloured and takes the colour in force
+ *  wherever it is placed. */
+function coloredClone(mesh: THREE.Mesh): THREE.BufferGeometry {
+  const geometry = mesh.geometry.clone();
+  const color = uniformColorOf(mesh);
+  if (color && !geometry.hasAttribute("color")) {
+    const count = geometry.getAttribute("position").count;
+    geometry.setAttribute("color", new THREE.Float32BufferAttribute(new Float32Array(count * 3).map((_, i) => color[i % 3]!), 3));
+  }
+  return geometry;
+}
+
+/** The colour a mesh was explicitly given, or its first vertex colour. */
+function uniformColorOf(mesh: THREE.Mesh): [number, number, number] | undefined {
+  const material = (Array.isArray(mesh.material) ? mesh.material[0] : mesh.material) as THREE.MeshStandardMaterial | undefined;
+  const color = mesh.geometry.getAttribute("color");
+  if (color && color.count > 0) return [color.getX(0), color.getY(0), color.getZ(0)];
+  if (material?.userData?.colored && material.color) return [material.color.r, material.color.g, material.color.b];
+  return undefined;
+}
+
 function mergeMeshGeometries(parts: readonly THREE.BufferGeometry[]): THREE.BufferGeometry {
   const colored = parts.some((part) => part.hasAttribute("color"));
   const prepared = parts.map((part) => {

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -94,7 +94,7 @@ function linePoints(line: THREE.Line): THREE.Vector3[] {
   for (let i = 0; i < position.count; i++) {
     const point = new THREE.Vector3().fromBufferAttribute(position, i).applyMatrix4(line.matrixWorld);
     const previous = points[points.length - 1];
-    if (previous === undefined || previous.distanceToSquared(point) > PATH_POINT_EPSILON) points.push(point);
+    if (previous === undefined || previous.distanceToSquared(point) > PATH_POINT_EPSILON ** 2) points.push(point);
   }
   return points;
 }
@@ -307,7 +307,11 @@ export class Converter {
     // `detail` is readable as a symbol before any `detail` command runs.
     this.symbols.set("detail", this.detailLevel);
     // Shapes as values and shape-building functions are built here.
-    this.evaluator.hooks = { shape: (node) => this.shapeValue(node), call: (fn, args) => this.callShapeFunction(fn, args) };
+    this.evaluator.hooks = {
+      shape: (node) => this.shapeValue(node),
+      call: (fn, args) => this.callShapeFunction(fn, args),
+      retain: (geometry) => this.chargeRetained(geometry),
+    };
     this.evaluator.maxLoopIterations = this.maxLoopIterations;
     // Initialize with identity transform
     this.pushTransform();

--- a/packages/plugins/shapescript-plugin/src/shapescript/types.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/types.ts
@@ -132,6 +132,7 @@ export type SceneNode =
   | LatheNode
   | FillNode
   | HullNode
+  | MinkowskiNode
   | GroupNode
   | DetailNode
   | SeedNode
@@ -344,6 +345,8 @@ export interface ExtrudeNode {
   path?: PathNode;
   properties: ShapeProperties;
   children?: SceneNode[];
+  /** `along <path>`: sweep the children (as sections) along this path. */
+  along?: SceneNode;
 }
 
 export interface LoftNode {
@@ -366,6 +369,13 @@ export interface FillNode {
 
 export interface HullNode {
   type: "hull";
+  properties: ShapeProperties;
+  children: SceneNode[];
+}
+
+/** `minkowski { a b … }`: the Minkowski sum of its children, left to right. */
+export interface MinkowskiNode {
+  type: "minkowski";
   properties: ShapeProperties;
   children: SceneNode[];
 }
@@ -483,6 +493,7 @@ export enum TokenType {
   LATHE = "LATHE",
   FILL = "FILL",
   HULL = "HULL",
+  MINKOWSKI = "MINKOWSKI",
   GROUP = "GROUP",
   MESH = "MESH",
   PATH = "PATH",

--- a/packages/plugins/shapescript-plugin/src/vue/index.ts
+++ b/packages/plugins/shapescript-plugin/src/vue/index.ts
@@ -117,7 +117,9 @@ Constants: pi, true, false (avoid tau, upstream lacks it; write 2 * pi). Tuple/s
 Ranges are values (define r 1 to 5 step 2; for i in r; if 3 in r). A bare path draws as a line; fill/extrude it for a surface.
 Polygon supports sides (3–256). String literals and join/split/trim are supported. print records output for you.
 Use the tool schema for exact syntax and builder limits. This is a modeling subset of upstream ShapeScript;
-imports, text/fonts, minkowski/inset/svgpath/along and object values are refused by name;
+imports, text/fonts, svgpath and object values are refused by name;
+minkowski { a b } sums shapes, inset(mesh d) offsets a mesh value's faces (together they round edges),
+extrude { section along path } sweeps a section, and an open extrude path makes a wall (close it for a solid);
 shapes are values (define ico icosphere { detail 0 }; ico.polygons, .bounds, .volume), for/if work as expressions,
 functions may build shapes, and mesh { polygon { point … } } builds a mesh from explicit faces;
 textures, cameras and lights are accepted but not drawn (the result reports them).

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -919,6 +919,15 @@ describe("minkowski, inset and extrude along", () => {
     withMesh("minkowski {\n difference {\n  cube\n  cube { size 0.4 2 0.4 }\n }\n sphere { size 0.2 }\n}", (mesh) => {
       near(extent(mesh).toArray(), [1.2, 1.2, 1.2], 0.01);
     });
+    // Two non-convex operands: an L-shaped prism summed with itself has
+    // parallel faces whose sums are flat; those pairs are skipped, the rest
+    // merge into a solid with finite normals and the expected extent.
+    const L = "extrude path { point 0 0 point 2 0 point 2 1 point 1 1 point 1 2 point 0 2 point 0 0 }";
+    withMesh(`minkowski {\n ${L}\n ${L}\n}`, (mesh) => {
+      near(extent(mesh).toArray(), [4, 4, 2], 1e-4);
+      const normal = mesh.geometry.getAttribute("normal");
+      for (let i = 0; i < normal.count; i++) assert.ok(Number.isFinite(normal.getX(i)) && Number.isFinite(normal.getY(i)), `normal ${i}`);
+    });
     assert.throws(() => objectsOf("minkowski { cube }"), /at least two/);
     assert.throws(() => objectsOf("minkowski { cube path { point 0 0 point 1 0 } }"), /at least two/);
   });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -989,6 +989,17 @@ describe("minkowski, inset and extrude along", () => {
       assert.equal(disposed.has(placed!.geometry), false);
       disposeObject3D(group);
     }
+    // A mesh value captured under a transform is a fresh clone: charged past
+    // the scratch refund and released with the other values.
+    {
+      const script = "define big sphere { detail 16 }\ndefine f() {\n translate 1\n big\n}\nf()";
+      // The body's transform places the shape it ends with.
+      withMesh(script, (mesh) => near([new THREE.Box3().setFromObject(mesh).min.x], [0.5], 0.01));
+      const vertices = 16 * 16 * 6; // one sphere at detail 16, as a value (non-indexed)
+      // The value, its transformed capture and the placed copy: three charges, not two.
+      assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(script), { maxVertices: vertices * 2.5 })), /vertices/);
+      disposeObject3D(astToThreeJS(parseShapeScript(script), { maxVertices: vertices * 3.5 }));
+    }
     // Every inset result is a retained allocation, charged against the budget.
     assert.throws(
       () => disposeObject3D(astToThreeJS(parseShapeScript("define c cube\ndefine d inset(c 0.1)\ndefine e inset(d 0.1)\ncube"), { maxVertices: 60 })),

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -1007,6 +1007,15 @@ describe("minkowski, inset and extrude along", () => {
     withMesh("define w {\n path { point 0 0 point 0 1 }\n}\nextrude {\n size 1 1 0.2\n w\n}", (mesh) => near(extent(mesh).toArray(), [0, 1, 0.2]));
     assert.throws(() => objectsOf("extrude { path { point 0 0 } }"), /at least two/);
   });
+  it("reads a lone `position` value as X alone, on shapes, builders and groups", () => {
+    for (const script of ["cube { position 1 }", "extrude { position 1 square }", "group { position 1\n cube }", "extrude {\n position 1\n square\n along path { point 0 0 point 0 1 }\n}"]) {
+      withMesh(script, (mesh) => {
+        const box = new THREE.Box3().setFromObject(mesh);
+        near([box.min.x, box.max.x], [0.5, 1.5], 0.01);
+        assert.ok(box.max.y <= 1.01 && box.min.y >= -0.51 && box.max.z <= 0.51, `${script}: ${box.min.toArray()} ${box.max.toArray()}`);
+      });
+    }
+  });
   it("reads `detail` as a value, scopes it to a path, and draws curves as corners at `detail 0`", () => {
     withMesh("cube { size detail / 32 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 1]));
     const corners = objectsOf("path {\n detail 0\n curve 0 0\n curve 1 0\n curve 1 1\n}")[0] as THREE.Line;

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -943,6 +943,30 @@ describe("minkowski, inset and extrude along", () => {
     withMesh("define c cube { size -1 1 1 }\ninset(c 0.1)", (mesh) => near(extent(mesh).toArray(), [0.8, 0.8, 0.8], 1e-5));
     assert.throws(() => objectsOf("inset(1 2)"), /mesh/);
     assert.throws(() => objectsOf("define c cube\ninset(c 1 / 0)"), /finite/);
+    // A value's geometry is released once the conversion is over; the scene
+    // holds its own clone.
+    {
+      const disposed = new Set<THREE.BufferGeometry>();
+      const original = THREE.BufferGeometry.prototype.dispose;
+      THREE.BufferGeometry.prototype.dispose = function (this: THREE.BufferGeometry) {
+        disposed.add(this);
+        return original.call(this);
+      };
+      let group: THREE.Group;
+      try {
+        group = astToThreeJS(parseShapeScript("define c cube\ndefine d inset(c 0.1)\nd"));
+      } finally {
+        THREE.BufferGeometry.prototype.dispose = original;
+      }
+      let placed: THREE.Mesh | undefined;
+      group.traverse((object) => {
+        if ((object as THREE.Mesh).isMesh) placed = object as THREE.Mesh;
+      });
+      // The cube value and the inset value were released; the scene's clone was not.
+      assert.ok(disposed.size >= 2, `${disposed.size} disposed`);
+      assert.equal(disposed.has(placed!.geometry), false);
+      disposeObject3D(group);
+    }
     // Every inset result is a retained allocation, charged against the budget.
     assert.throws(
       () => disposeObject3D(astToThreeJS(parseShapeScript("define c cube\ndefine d inset(c 0.1)\ndefine e inset(d 0.1)\ncube"), { maxVertices: 60 })),

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -188,7 +188,7 @@ describe("geometry builders", () => {
     }
   });
   it("refuses a degenerate inline path instead of presenting an empty mesh", () => {
-    for (const script of ["fill path { point 0 0 }", "fill path { point 0 0 point 1 0 }", "extrude path { point 0 0 point 1 0 point 2 0 }"]) {
+    for (const script of ["fill path { point 0 0 }", "fill path { point 0 0 point 1 0 }", "extrude path { point 0 0 point 1 0 point 2 0 point 0 0 }"]) {
       assert.throws(() => disposeObject3D(astToThreeJS(parseShapeScript(script))), /encloses an area/, script);
     }
     // A bare path is a stroke, so it needs a segment rather than an area.
@@ -287,8 +287,8 @@ describe("expressions", () => {
       withMesh(`cube { position ${vector} }`, (mesh) => assert.deepEqual(mesh.position.toArray(), [1, 2, 3]));
     }
     withMesh("cube { position -1 -2 -3 }", (mesh) => assert.deepEqual(mesh.position.toArray(), [-1, -2, -3]));
-    withMesh("extrude path { point +0 +0 point +1 +0 point +0 +1 point -1 +0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 1) < 1e-5));
-    withMesh("extrude path { point 0 0 point (1 + 2 * 3) 0 point 0 1 point -7 0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 7) < 1e-5));
+    withMesh("extrude path { point +0 +0 point +1 +0 point +0 +1 point -1 +0 point +0 +0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 1) < 1e-5));
+    withMesh("extrude path { point 0 0 point (1 + 2 * 3) 0 point 0 1 point -7 0 point 0 0 }", (mesh) => assert.ok(Math.abs(volume(mesh) - 7) < 1e-5));
   });
   it("evaluates `rnd` the same way twice, so validation and rendering agree", () => {
     // The server validates the script and the browser renders it from source;
@@ -405,7 +405,7 @@ describe("upstream conventions", () => {
     withMesh(circle, (mesh) => assert.ok(Math.abs(volume(mesh) - Math.PI) / Math.PI < 0.03, `${volume(mesh)}`));
     // The procedural semicircle from the upstream docs: half a unit disc once
     // filled, give or take the 4% that on-curve midpoints at cos(11.25°) cost.
-    withMesh("extrude path { for 0 to 8 { curve 0 1 rotate 1 / 8 } }", (mesh) =>
+    withMesh("extrude path { point 0 1 for 1 to 7 { rotate 1 / 8 curve 0 1 } rotate 1 / 8 point 0 1 point 0 -1 }", (mesh) =>
       assert.ok(Math.abs(volume(mesh) - Math.PI / 2) / (Math.PI / 2) < 0.05, `${volume(mesh)}`),
     );
     // One control between two corners bows the edge out without passing through the control.
@@ -745,7 +745,6 @@ describe("control flow, ranges and functions", () => {
       ['text "hi"', /text/],
       ['import "other.shape"', /import/],
       ["define p path { point 0 0 point 1 1 }", /path.*value/],
-      ["extrude { square along path { point 0 0 point 1 1 } }", /along/],
       ['fill svgpath "M 0 0 L 1 0 L 0 1 z"', /svgpath/],
     ] as const) {
       assert.throws(() => objectsOf(script), message, script);
@@ -892,5 +891,93 @@ describe("shapes as values", () => {
       near(extent(mesh).toArray(), [4, 5, 6]);
     });
     withMesh("cube { size max(\n 1\n 2\n) }", (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+  });
+});
+
+describe("minkowski, inset and extrude along", () => {
+  it("sums two convex solids into one hull that keeps the first one's colour", () => {
+    withMesh("minkowski {\n cube { color 1 0 0 }\n sphere { size 1 }\n}", (mesh) => {
+      near(extent(mesh).toArray(), [2, 2, 2], 0.01);
+      assert.ok(volume(mesh) > 1 && volume(mesh) < 8, `volume ${volume(mesh)}`);
+      assert.ok(mesh.geometry.hasAttribute("color"));
+      const color = mesh.geometry.getAttribute("color");
+      near([color.getX(0), color.getY(0), color.getZ(0)], [1, 0, 0]);
+      assert.equal((mesh.material as THREE.MeshStandardMaterial).vertexColors, true);
+    });
+    withMesh("minkowski {\n cube\n cube { size 0.5 }\n}", (mesh) => {
+      near(extent(mesh).toArray(), [1.5, 1.5, 1.5], 1e-4);
+      near([volume(mesh)], [1.5 ** 3], 1e-4);
+      assert.equal(mesh.geometry.hasAttribute("color"), false);
+    });
+  });
+  it("sums a non-convex solid face by face", () => {
+    withMesh("minkowski {\n difference {\n  cube\n  cube { size 0.4 2 0.4 }\n }\n sphere { size 0.2 }\n}", (mesh) => {
+      near(extent(mesh).toArray(), [1.2, 1.2, 1.2], 0.01);
+    });
+    assert.throws(() => objectsOf("minkowski { cube }"), /at least two/);
+    assert.throws(() => objectsOf("minkowski { cube path { point 0 0 point 1 0 } }"), /at least two/);
+  });
+  it("insets a mesh value along its faces, exactly at corners", () => {
+    withMesh("define c cube\ninset(c 0.1)", (mesh) => near(extent(mesh).toArray(), [0.8, 0.8, 0.8], 1e-5));
+    withMesh("define c cube\ninset(c -0.1)", (mesh) => near(extent(mesh).toArray(), [1.2, 1.2, 1.2], 1e-5));
+    // A cone's apex slides down to where the inset sides meet: 0.1 / cos(63.4°) below it.
+    withMesh("define k cone\ninset(k 0.1)", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.max.y, box.min.y], [0.5 - 0.1 * Math.sqrt(5), -0.4], 1e-3);
+    });
+    assert.throws(() => objectsOf("inset(1 2)"), /mesh/);
+    assert.throws(() => objectsOf("define c cube\ninset(c 1 / 0)"), /finite/);
+  });
+  it("keeps the colour a shape value was given and takes the scope's colour otherwise", () => {
+    withMesh("define c cone { color 1 0 0 }\ncolor 0 0 1\nc", (mesh) => {
+      const color = mesh.geometry.getAttribute("color");
+      near([color.getX(0), color.getY(0), color.getZ(0)], [1, 0, 0]);
+    });
+    withMesh("define c cone\ncolor 0 0 1\nc", (mesh) => {
+      assert.equal(mesh.geometry.hasAttribute("color"), false);
+      near((mesh.material as THREE.MeshStandardMaterial).color.toArray(), [0, 0, 1]);
+    });
+  });
+  it("extrudes an open path into a two-sided wall", () => {
+    withMesh("extrude { size 1 1 0.5 path { point 0 0 point 2 0 } }", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x, box.max.x, box.min.z, box.max.z], [0, 2, -0.25, 0.25]);
+      assert.equal(mesh.geometry.getAttribute("position").count, 8);
+      near([volume(mesh)], [0]);
+    });
+    withMesh("define w {\n path { point 0 0 point 0 1 }\n}\nextrude {\n size 1 1 0.2\n w\n}", (mesh) => near(extent(mesh).toArray(), [0, 1, 0.2]));
+    assert.throws(() => objectsOf("extrude { path { point 0 0 } }"), /at least two/);
+  });
+  it("reads `detail` as a value, scopes it to a path, and draws curves as corners at `detail 0`", () => {
+    withMesh("cube { size detail / 32 }", (mesh) => near(extent(mesh).toArray(), [1, 1, 1]));
+    const corners = objectsOf("path {\n detail 0\n curve 0 0\n curve 1 0\n curve 1 1\n}")[0] as THREE.Line;
+    assert.equal(corners.geometry.getAttribute("position").count, 3);
+    const smooth = objectsOf("path {\n curve 0 0\n curve 1 0\n curve 1 1\n}")[0] as THREE.Line;
+    assert.ok(smooth.geometry.getAttribute("position").count > 3);
+    const [, sphere] = objectsOf("path {\n detail 4\n point 0 0\n point 1 0\n}\nsphere") as [THREE.Line, THREE.Mesh];
+    const [plain] = objectsOf("sphere") as [THREE.Mesh];
+    assert.equal(sphere.geometry.getAttribute("position").count, plain.geometry.getAttribute("position").count);
+  });
+  it("sweeps a section along a path with `along`", () => {
+    withMesh("extrude {\n circle { size 0.2 }\n along path { point 0 0 point 0 2 }\n}", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x, box.max.x, box.min.y, box.max.y, box.min.z, box.max.z], [-0.1, 0.1, 0, 2, -0.1, 0.1], 1e-5);
+      near([volume(mesh)], [16 * 0.01 * Math.sin(Math.PI / 16) * 2], 1e-4);
+    });
+    // A closed path sweeps a ring with no caps; `size` scales the whole result.
+    withMesh("extrude {\n size 2 1 1\n square { size 0.2 }\n along circle { size 2 }\n}", (mesh) => {
+      near(extent(mesh).toArray(), [4.4, 2.2, 0.2], 0.01);
+      // The geometry itself (before `size`): a 0.2 square around a circumference of 2π.
+      assert.ok(volume(mesh) > 0.24 && volume(mesh) < 0.26, `volume ${volume(mesh)}`);
+    });
+    for (const [script, message] of [
+      ["extrude { square along path { point 0 0 point 1 1 } along circle }", /one `along`/],
+      ["loft { square along circle }", /only valid inside `extrude`/],
+      ["extrude { along circle }", /needs a planar section/],
+      ["extrude { square along }", /needs a path/],
+      ["extrude { square along cube }", /XY plane|exactly one path|closed perimeter/],
+    ] as const) {
+      assert.throws(() => objectsOf(script), message, script);
+    }
   });
 });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -909,6 +909,18 @@ describe("minkowski, inset and extrude along", () => {
       near([volume(mesh)], [1.5 ** 3], 1e-4);
       assert.equal(mesh.geometry.hasAttribute("color"), false);
     });
+    // Per-face colours cannot follow the sum's new vertices: a mesh whose
+    // vertices differ gives an uncoloured result; one colour throughout is kept.
+    const tetra = (colors: readonly string[]) =>
+      `mesh {\n polygon { color ${colors[0]} point 0 0 0 point 1 0 0 point 0 1 0 }\n polygon { color ${colors[1]} point 0 0 0 point 0 0 1 point 1 0 0 }\n polygon { color ${colors[2]} point 0 0 0 point 0 1 0 point 0 0 1 }\n polygon { color ${colors[3]} point 1 0 0 point 0 0 1 point 0 1 0 }\n}`;
+    withMesh(`minkowski {\n ${tetra(["1 0 0", "0 1 0", "0 0 1", "1 1 0"])}\n cube { size 0.5 }\n}`, (mesh) => {
+      near(extent(mesh).toArray(), [1.5, 1.5, 1.5], 1e-4);
+      assert.equal(mesh.geometry.hasAttribute("color"), false);
+    });
+    withMesh(`minkowski {\n ${tetra(["0 1 0", "0 1 0", "0 1 0", "0 1 0"])}\n cube { size 0.5 }\n}`, (mesh) => {
+      const color = mesh.geometry.getAttribute("color");
+      near([color.getX(0), color.getY(0), color.getZ(0)], [0, 1, 0]);
+    });
     // A mirrored operand is still convex: one hull, not per-face pieces.
     withMesh("minkowski {\n cube { size -1 1 1 }\n cube { size 0.5 }\n}", (mesh) => {
       near([volume(mesh)], [1.5 ** 3], 1e-4);

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -909,6 +909,11 @@ describe("minkowski, inset and extrude along", () => {
       near([volume(mesh)], [1.5 ** 3], 1e-4);
       assert.equal(mesh.geometry.hasAttribute("color"), false);
     });
+    // A mirrored operand is still convex: one hull, not per-face pieces.
+    withMesh("minkowski {\n cube { size -1 1 1 }\n cube { size 0.5 }\n}", (mesh) => {
+      near([volume(mesh)], [1.5 ** 3], 1e-4);
+      assert.ok(mesh.geometry.getAttribute("position").count < 100, `${mesh.geometry.getAttribute("position").count} vertices`);
+    });
   });
   it("sums a non-convex solid face by face", () => {
     withMesh("minkowski {\n difference {\n  cube\n  cube { size 0.4 2 0.4 }\n }\n sphere { size 0.2 }\n}", (mesh) => {
@@ -925,8 +930,15 @@ describe("minkowski, inset and extrude along", () => {
       const box = new THREE.Box3().setFromObject(mesh);
       near([box.max.y, box.min.y], [0.5 - 0.1 * Math.sqrt(5), -0.4], 1e-3);
     });
+    // A mirrored mesh winds inward; inset still moves its faces inward.
+    withMesh("define c cube { size -1 1 1 }\ninset(c 0.1)", (mesh) => near(extent(mesh).toArray(), [0.8, 0.8, 0.8], 1e-5));
     assert.throws(() => objectsOf("inset(1 2)"), /mesh/);
     assert.throws(() => objectsOf("define c cube\ninset(c 1 / 0)"), /finite/);
+    // Every inset result is a retained allocation, charged against the budget.
+    assert.throws(
+      () => disposeObject3D(astToThreeJS(parseShapeScript("define c cube\ndefine d inset(c 0.1)\ndefine e inset(d 0.1)\ncube"), { maxVertices: 60 })),
+      /vertices/,
+    );
   });
   it("keeps the colour a shape value was given and takes the scope's colour otherwise", () => {
     withMesh("define c cone { color 1 0 0 }\ncolor 0 0 1\nc", (mesh) => {
@@ -964,6 +976,8 @@ describe("minkowski, inset and extrude along", () => {
       near([box.min.x, box.max.x, box.min.y, box.max.y, box.min.z, box.max.z], [-0.1, 0.1, 0, 2, -0.1, 0.1], 1e-5);
       near([volume(mesh)], [16 * 0.01 * Math.sin(Math.PI / 16) * 2], 1e-4);
     });
+    // Points closer than the coordinate tolerance merge; a short real segment does not.
+    withMesh("extrude {\n square { size 0.1 }\n along path { point 0 0 point 0.00001 0 }\n}", (mesh) => near([extent(mesh).x], [0.00001], 1e-7));
     // A closed path sweeps a ring with no caps; `size` scales the whole result.
     withMesh("extrude {\n size 2 1 1\n square { size 0.2 }\n along circle { size 2 }\n}", (mesh) => {
       near(extent(mesh).toArray(), [4.4, 2.2, 0.2], 0.01);

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -953,6 +953,14 @@ describe("minkowski, inset and extrude along", () => {
       const box = new THREE.Box3().setFromObject(mesh);
       near([box.max.y, box.min.y], [0.5 - 0.1 * Math.sqrt(5), -0.4], 1e-3);
     });
+    // A boolean leaves T-junctions: the face a seam split has vertices along
+    // the cube's edges that the neighbouring face's triangles do not share.
+    // Those vertices belong to both faces and move with both, so the inset
+    // of the union is inset on every axis and nothing stands proud.
+    withMesh("define s union {\n cube\n cylinder { size 0.45 1.2 0.45 orientation 0.5 position 0.45 }\n}\ninset(s 0.06)", (mesh) => {
+      const box = new THREE.Box3().setFromObject(mesh);
+      near([box.min.x, box.min.y, box.min.z, box.max.x, box.max.y, box.max.z], [-0.44, -0.44, -0.44, 0.99, 0.44, 0.44], 1e-3);
+    });
     // A mirrored mesh winds inward; inset still moves its faces inward.
     withMesh("define c cube { size -1 1 1 }\ninset(c 0.1)", (mesh) => near(extent(mesh).toArray(), [0.8, 0.8, 0.8], 1e-5));
     assert.throws(() => objectsOf("inset(1 2)"), /mesh/);
@@ -1008,7 +1016,12 @@ describe("minkowski, inset and extrude along", () => {
     assert.throws(() => objectsOf("extrude { path { point 0 0 } }"), /at least two/);
   });
   it("reads a lone `position` value as X alone, on shapes, builders and groups", () => {
-    for (const script of ["cube { position 1 }", "extrude { position 1 square }", "group { position 1\n cube }", "extrude {\n position 1\n square\n along path { point 0 0 point 0 1 }\n}"]) {
+    for (const script of [
+      "cube { position 1 }",
+      "extrude { position 1 square }",
+      "group { position 1\n cube }",
+      "extrude {\n position 1\n square\n along path { point 0 0 point 0 1 }\n}",
+    ]) {
       withMesh(script, (mesh) => {
         const box = new THREE.Box3().setFromObject(mesh);
         near([box.min.x, box.max.x], [0.5, 1.5], 0.01);

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -921,6 +921,8 @@ describe("minkowski, inset and extrude along", () => {
       const color = mesh.geometry.getAttribute("color");
       near([color.getX(0), color.getY(0), color.getZ(0)], [0, 1, 0]);
     });
+    // Degeneracy is judged at the shapes' own scale: tiny solids still sum.
+    withMesh("minkowski {\n cube { size 0.00001 }\n cube { size 0.00001 }\n}", (mesh) => near(extent(mesh).toArray(), [2e-5, 2e-5, 2e-5], 1e-9));
     // A mirrored operand is still convex: one hull, not per-face pieces.
     withMesh("minkowski {\n cube { size -1 1 1 }\n cube { size 0.5 }\n}", (mesh) => {
       near([volume(mesh)], [1.5 ** 3], 1e-4);

--- a/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
+++ b/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
@@ -39,10 +39,11 @@ const RENDERS: Record<string, Rendered> = {
   // A cone and a cube-plus-cylinder union, each inset and summed with a
   // sphere: the rounded cone is lower than the sharp one (0.4, not 0.5) and
   // narrower at the base, as a true fillet is.
-  "Fillet.shape": { objects: 2, bounds: { min: [-0.949, -0.888, -0.449], max: [1.039, 0.4, 0.539] }, warnings: [] },
+  "Fillet.shape": { objects: 2, bounds: { min: [-0.949, -0.84, -0.449], max: [0.948, 0.4, 0.449] }, warnings: [] },
   // An open spiral path drawn as a line, extruded as a wall 0.1 deep, and
-  // swept with a 0.03 circle: three objects, at positions 0, 1 and 2.
-  "Spirals.shape": { objects: 3, bounds: { min: [-0.375, -0.417, 0], max: [2.488, 2.515, 2.015] }, warnings: [] },
+  // swept with a 0.03 circle: three objects in a row along X (`position 1`
+  // is X alone), all in the XY plane.
+  "Spirals.shape": { objects: 3, bounds: { min: [-0.375, -0.459, -0.05], max: [2.488, 0.515, 0.05] }, warnings: [] },
 };
 
 const REFUSED: Record<string, RegExp> = {};

--- a/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
+++ b/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
@@ -36,12 +36,16 @@ const RENDERS: Record<string, Rendered> = {
   // works when `icosphere.polygons` comes out in Euclid's face order — as one
   // vertex-coloured mesh, flat-shaded by `smoothing 0`.
   "Dodecahedron.shape": { objects: 1, bounds: { min: [-0.7, -0.604, -0.74], max: [0.7, 0.604, 0.74] }, warnings: [] },
+  // A cone and a cube-plus-cylinder union, each inset and summed with a
+  // sphere: the rounded cone is lower than the sharp one (0.4, not 0.5) and
+  // narrower at the base, as a true fillet is.
+  "Fillet.shape": { objects: 2, bounds: { min: [-0.949, -0.888, -0.449], max: [1.039, 0.4, 0.539] }, warnings: [] },
+  // An open spiral path drawn as a line, extruded as a wall 0.1 deep, and
+  // swept with a 0.03 circle: three objects, at positions 0, 1 and 2.
+  "Spirals.shape": { objects: 3, bounds: { min: [-0.375, -0.417, 0], max: [2.488, 2.515, 2.015] }, warnings: [] },
 };
 
-const REFUSED: Record<string, RegExp> = {
-  "Fillet.shape": /minkowski.*not supported/,
-  "Spirals.shape": /along.*not supported/,
-};
+const REFUSED: Record<string, RegExp> = {};
 
 describe("upstream example scripts", () => {
   const files = readdirSync(FIXTURES).filter((file) => file.endsWith(".shape"));

--- a/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
+++ b/packages/plugins/shapescript-plugin/test/test_upstream_examples.ts
@@ -39,7 +39,7 @@ const RENDERS: Record<string, Rendered> = {
   // A cone and a cube-plus-cylinder union, each inset and summed with a
   // sphere: the rounded cone is lower than the sharp one (0.4, not 0.5) and
   // narrower at the base, as a true fillet is.
-  "Fillet.shape": { objects: 2, bounds: { min: [-0.949, -0.84, -0.449], max: [0.948, 0.4, 0.449] }, warnings: [] },
+  "Fillet.shape": { objects: 2, bounds: { min: [-0.949, -0.84, -0.449], max: [0.9, 0.4, 0.449] }, warnings: [] },
   // An open spiral path drawn as a line, extruded as a wall 0.1 deep, and
   // swept with a 0.03 circle: three objects in a row along X (`position 1`
   // is X alone), all in the XY plane.

--- a/plans/feat-shapescript-upstream-parity.md
+++ b/plans/feat-shapescript-upstream-parity.md
@@ -65,8 +65,7 @@ Found while running the upstream examples (fixed in 2.1.0, also phase-1 class):
 ## Phase 3 — missing language features (by likely impact on generated scripts)
 
 Test fixtures: the upstream `Examples/` directory (`test/fixtures/upstream-examples/`, MIT).
-Ball, Chessboard, Cog, Dodecahedron, Earth, Spring and Train render; Fillet and Spirals are
-refused by name (see "open" below).
+All nine (Ball, Chessboard, Cog, Dodecahedron, Earth, Fillet, Spirals, Spring, Train) render.
 
 Done in 2.1.0:
 
@@ -90,10 +89,17 @@ Done in 2.2.0 (Dodecahedron):
   shapes, called bare as statements; `polygon { point … }` faces with colours; `mesh { … }`;
   the icosphere in Euclid's face order; line breaks inside parentheses.
 
+Done in 2.3.0 (Fillet, Spirals):
+
+- **Builders**: `minkowski` (hull of vertex sums for convex operands; merged per-face hulls for a
+  non-convex one — overlapping shells rather than a boolean union), `inset(mesh d)` (offset-plane
+  corners), `extrude … along` (mitred sweep, caps on open paths), open paths extruded to walls,
+  `detail` as a value and `detail 0` in a path, shape values keep their colour.
+
 Open:
 
-- **Builders**: `minkowski`; `extrude` options `along`, `twist`, `axisAligned`, `miterLimit`;
-  `inset` (Fillet, Spirals).
+- **Builders**: `extrude` options `twist`, `axisAligned`, `miterLimit`; a boolean union of
+  `minkowski` pieces for non-convex operands (they are merged shells today).
 - **Values**: paths as values (`define p path { … }`, `path.points`), per-vertex colours between
   a polygon's points (a polygon takes one colour), `object` values.
 - **Paths**: `svgpath`, nested / compound paths with holes, `path.color` gradients, 3D path


### PR DESCRIPTION
## Summary

The last two upstream ShapeScript examples, Fillet and Spirals, now render — so all nine `Examples/` fixtures do. Bumps `@mulmoclaude/shapescript-plugin` to 2.3.0 (launcher range in lockstep).

- **`minkowski { a b … }`** — for two convex operands, one convex hull of the pairwise vertex sums (exact); when an operand is not convex, every face of it is summed with the other and the per-face hulls are merged (overlapping shells, as upstream decomposes it, not a boolean union — documented). Hulls are smooth-shaded since they are the rounded part. Result keeps the first operand's colour. Piece and point caps refuse runaway inputs.
- **`inset(mesh distance)`** — a builtin on mesh values: each vertex slides to where its adjacent faces' offset planes meet (ridge-regularised least squares: exact at any corner where the planes agree, e.g. a cone's apex moves down by `d / cos`), clamped for needle corners. Negative = outward.
- **`extrude { section along path }`** — sections (planar children) swept along the path: +Z turned to the mitred tangent, +Y to the path's plane normal, the section widened across each mitre (limit 4), capped at the ends of an open path, joined round a closed one (`loftGeometry` gained a `closed` mode). `size` scales the whole result.
- **Open paths extrude to walls** — both `extrude path { … }` and a path child (`extrude { spiral { coils 4 } }`), two-sided, no caps. Inside builders an open path now reaches the builder as a stroke instead of being refused. **Behaviour change** toward upstream: `extrude` no longer closes an open path for you; repeat the first point for a solid (three existing tests closed their paths).
- **`detail`** reads as a value (`option steps detail * coils`); `detail 0` inside a path draws curve points as corners (upstream's unsubdivided path); a `detail` inside a path no longer leaks past it.
- **Shape values keep their colour** — a mesh built with an explicit colour bakes it as vertex colours when captured as a value, so `fillet(cone { color #38bdf8 } r)` stays blue; a shape drawn in the default colour still takes the colour in force where it is placed.
- Builder operands and CSG children now run with the function-result sink closed, so `inset(source r)` inside `minkowski { }` inside a function is an operand, not the function's result.

## Test plan

- [x] `yarn test` in the plugin: 163 pass (new suite "minkowski, inset and extrude along": convex/non-convex sums, colour retention, inset exactness on cube and cone apex, wall extrusion, `detail` scoping and `detail 0`, straight and ring sweeps, `along` parse/convert errors)
- [x] `test_upstream_examples.ts`: Fillet (2 objects) and Spirals (3 objects) moved from REFUSED to RENDERS with bounds
- [x] Rendered both fixtures to PNG through the sheet renderer and inspected them: rounded blue cone, rounded purple cube-plus-cylinder, spiral line / wall / tube
- [x] `yarn format`, `yarn lint`, `yarn typecheck`, `yarn build`, `yarn check:launcher-sync`, `check-changelog-ships.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmvrNji65A1oBnF59FXYTz

work in mulmoclaude

## Summary by Sourcery

Bring ShapeScript geometry operations and path extrusion to upstream parity so all bundled examples render.

New Features:
- Add Minkowski sums and mesh inset operations for ShapeScript solids.
- Add section sweeps along paths with mitred corners, closed-loop joining, end caps, and open-path wall extrusion.
- Enable all nine upstream ShapeScript example fixtures, including Fillet and Spirals, to render.

Bug Fixes:
- Align position value semantics with upstream by treating a lone position as an X-only translation.
- Preserve explicit shape colours when shapes are captured and reused as values.
- Scope path detail settings correctly and support detail as a readable value, including unsubdivided curve corners at detail 0.
- Prevent builder operands and CSG children from being captured as enclosing function results.

Enhancements:
- Add geometry retention and vertex-budget accounting for mesh values created by inset and transformed captures.
- Document the new ShapeScript capabilities, open-path extrusion behavior, and remaining unsupported features.

Documentation:
- Document ShapeScript 2.3.0 features and update upstream example support status.

Tests:
- Expand language coverage for Minkowski, inset, along sweeps, open-path walls, detail scoping, color retention, position semantics, validation errors, and geometry budgets.
- Update upstream fixture expectations so Fillet and Spirals are validated as rendered outputs.

Chores:
- Bump the ShapeScript plugin and launcher dependency range to 2.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `minkowski` and `inset` shape operations.
  - Added `extrude … along` for sweeping sections along paths.
  - Open-path extrusion now creates uncapped walls.
  - Added support for `detail` as a value.
  - Fillet and Spirals examples now render successfully.

- **Bug Fixes**
  - Shape values preserve uniform colors.
  - A lone `position` value now applies to X only, correcting placement offsets.

- **Documentation**
  - Updated compatibility guidance, supported features, examples, and release information for version 2.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->