### PR TITLE
fix(mulmoscript-plugin): View が dispatch に root を載せる（#3014 の順序1の残り）

### DIFF
--- a/packages/plugins/mulmoscript-plugin/src/core/types.ts
+++ b/packages/plugins/mulmoscript-plugin/src/core/types.ts
@@ -21,6 +21,16 @@ export interface SaveMulmoScriptArgs {
 export interface MulmoScriptData {
   script: MulmoScript;
   filePath: string;
+  /**
+   * Which registered stories root `filePath` is relative to (#3014). Absent = the host's
+   * default root, which is what every card minted before roots carries.
+   *
+   * The HOST fills this in when it opens a deck the user can see — it is deliberately absent
+   * from the agent's tool schema, so a model cannot name a root (#3015). The View's job is to
+   * hand it back on every dispatch: the same `stories/deck.json` exists in every root, so the
+   * path alone addresses the wrong file and identifies the wrong card.
+   */
+  root?: string | undefined;
 }
 
 /** Host capabilities the phase-1 core needs, delivered through the GENERIC

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -830,7 +830,11 @@ async function onSourceToggle(open: boolean) {
     // `stories/<rel>` and only the mulmoScript save/reopen op knows
     // how to map it to the on-disk path under `artifacts/stories/...`.
     if (filePath.value) {
-      const response = await api.call("save", storyRef());
+      const requested = storyRef();
+      const response = await api.call("save", requested);
+      // The disk read describes the script it was asked for. Navigating away during it would
+      // otherwise seed the source editor with ANOTHER deck's text (#3014).
+      if (staleSince(requested)) return;
       const diskScript = response.ok ? (response.data.script as MulmoScript | undefined) : undefined;
       if (diskScript) text = toScriptSourceText(diskScript);
       // fall through to in-memory script on failure
@@ -852,10 +856,15 @@ async function applySource() {
     alert(errorMessage(err));
     return;
   }
+  const requested = storyRef();
   const response = await api.call("updateScript", {
-    ...storyRef(),
+    ...requested,
     script: parsed,
   });
+  // The write landed in the script it was asked for. Committing it after the user moved on
+  // would put that script into the card now on screen, and re-initialize against it (#3014) —
+  // the same shape the deck editor's `resetForScriptChange` closes on its own path.
+  if (staleSince(requested)) return;
   if (!response.ok) {
     alert(response.error || "Update failed");
     return;

--- a/packages/plugins/mulmoscript-plugin/src/vue/View.vue
+++ b/packages/plugins/mulmoscript-plugin/src/vue/View.vue
@@ -385,6 +385,7 @@ import {
   isBeatImageReference,
   isValidBeat as isValidBeatOf,
   staleSince as staleSinceOf,
+  type StoryRef,
   scriptSourceText as toScriptSourceText,
   resolveSilentAdvanceSeconds,
   clearReactiveRecords,
@@ -430,6 +431,19 @@ const emit = defineEmits<{ updateResult: [result: ToolResultComplete] }>();
 const data = computed(() => props.selectedResult.data);
 const script = computed<MulmoScript>(() => data.value?.script ?? {});
 const filePath = computed(() => data.value?.filePath ?? "");
+/**
+ * Which registered root `filePath` is relative to; `undefined` = the host's default (#3014).
+ *
+ * The host puts it on the card when it opens a deck the user can see; the agent's tool schema
+ * deliberately has no root, so a model cannot name one (#3015). Every dispatch below hands it
+ * back, because `stories/deck.json` exists in EVERY root: without it the call addresses the
+ * default root's file of that name, which is how a deck inside a repository opened fine and
+ * then answered `File not found` to every save and every beat image
+ * (receptron/mulmoterminal#1970).
+ */
+const root = computed(() => data.value?.root);
+/** The story as the wire addresses it — the pair that is its identity. */
+const storyRef = (): StoryRef => ({ filePath: filePath.value, root: root.value });
 const beats = computed<Beat[]>(() => script.value.beats ?? []);
 
 // Per-beat render state
@@ -494,7 +508,7 @@ const {
   downloadPdf,
   refreshPdfPath,
   resetMedia,
-} = useMediaExport({ api, adapter, filePath, chatSessionId });
+} = useMediaExport({ api, adapter, filePath, root, chatSessionId });
 
 const {
   beatMovies,
@@ -506,7 +520,7 @@ const {
   closeBeatMovie,
   invalidateBeatMovie,
   resetBeatMovies,
-} = useBeatMovie({ api, adapter, filePath });
+} = useBeatMovie({ api, adapter, filePath, root });
 
 const {
   charRenderState,
@@ -522,7 +536,7 @@ const {
   renderCharacter,
   generateAllCharacters,
   resetCharacters,
-} = useCharacterImages({ api, filePath, chatSessionId, getImages: () => script.value.imageParams?.images });
+} = useCharacterImages({ api, filePath, root, chatSessionId, getImages: () => script.value.imageParams?.images });
 
 function stopPlayingAudio() {
   // Single helper that clears both the audio path and the silent
@@ -732,6 +746,7 @@ function commitScript(next: MulmoScript): void {
 const { canEditBeats, deckScriptInput, deckSaveError, resetForScriptChange, onDeckUpdate, flushPendingDeckSave, watchForeignWrites } = useDeckEditor({
   api,
   filePath,
+  root,
   effectiveScript,
   commitScript,
 });
@@ -815,7 +830,7 @@ async function onSourceToggle(open: boolean) {
     // `stories/<rel>` and only the mulmoScript save/reopen op knows
     // how to map it to the on-disk path under `artifacts/stories/...`.
     if (filePath.value) {
-      const response = await api.call("save", { filePath: filePath.value });
+      const response = await api.call("save", storyRef());
       const diskScript = response.ok ? (response.data.script as MulmoScript | undefined) : undefined;
       if (diskScript) text = toScriptSourceText(diskScript);
       // fall through to in-memory script on failure
@@ -838,7 +853,7 @@ async function applySource() {
     return;
   }
   const response = await api.call("updateScript", {
-    filePath: filePath.value,
+    ...storyRef(),
     script: parsed,
   });
   if (!response.ok) {
@@ -888,15 +903,15 @@ async function updateBeat(index: number) {
   const prevImage = JSON.stringify(effectiveBeat(index).image);
   const prevText = effectiveBeat(index).text;
 
-  const requestedFilePath = filePath.value;
+  const requested = storyRef();
   Reflect.deleteProperty(beatSaveErrors, index);
   beatSaving[index] = true;
   const response = await api.call("updateBeat", {
-    filePath: requestedFilePath,
+    ...requested,
     beatIndex: index,
     beat,
   });
-  if (staleSince(requestedFilePath)) return;
+  if (staleSince(requested)) return;
   Reflect.deleteProperty(beatSaving, index);
   if (!response.ok) {
     beatSaveErrors[index] = { kind: "saveFailed", error: response.error };
@@ -931,14 +946,14 @@ async function updateBeat(index: number) {
 }
 
 async function renderBeat(index: number) {
-  const requestedFilePath = filePath.value;
+  const requested = storyRef();
   renderState[index] = "rendering";
   const response = await api.call("renderBeat", {
-    filePath: requestedFilePath,
+    ...requested,
     beatIndex: index,
     chatSessionId: chatSessionId.value,
   });
-  if (staleSince(requestedFilePath)) return;
+  if (staleSince(requested)) return;
   if (!response.ok) {
     renderErrors[index] = response.error || "Render failed";
     renderState[index] = "error";
@@ -951,17 +966,17 @@ async function renderBeat(index: number) {
 }
 
 async function regenerateBeat(index: number) {
-  const requestedFilePath = filePath.value;
+  const requested = storyRef();
   Reflect.deleteProperty(renderedImages, index);
   invalidateBeatMovie(index);
   renderState[index] = "rendering";
   const response = await api.call("renderBeat", {
-    filePath: requestedFilePath,
+    ...requested,
     beatIndex: index,
     force: true,
     chatSessionId: chatSessionId.value,
   });
-  if (staleSince(requestedFilePath)) return;
+  if (staleSince(requested)) return;
   if (!response.ok) {
     renderErrors[index] = response.error || "Render failed";
     renderState[index] = "error";
@@ -973,18 +988,19 @@ async function regenerateBeat(index: number) {
 }
 
 // Stale-response guard shared by every per-beat/character loader and
-// mutator below: capture the wire path at call time and discard the
+// mutator below: capture the wire ref at call time and discard the
 // response when the user has navigated to a different result meanwhile —
 // otherwise late responses from script A's bulk mount-time probes would
-// write into the per-beat maps that now belong to script B.
-function staleSince(requestedFilePath: string): boolean {
-  return staleSinceOf(filePath.value, requestedFilePath);
+// write into the per-beat maps that now belong to script B. The ref is the
+// PAIR `(root, filePath)`: the same path exists in every root (#3014).
+function staleSince(requested: StoryRef): boolean {
+  return staleSinceOf(storyRef(), requested);
 }
 
 async function loadExistingBeatImage(index: number) {
-  const requestedFilePath = filePath.value;
-  const response = await api.call("beatImage", { filePath: requestedFilePath, beatIndex: index });
-  if (staleSince(requestedFilePath)) return;
+  const requested = storyRef();
+  const response = await api.call("beatImage", { ...requested, beatIndex: index });
+  if (staleSince(requested)) return;
   // silently ignore errors — image simply hasn't been generated yet
   if (response.ok && response.data.image) {
     renderedImages[index] = response.data.image;
@@ -993,9 +1009,9 @@ async function loadExistingBeatImage(index: number) {
 }
 
 async function loadExistingBeatAudio(index: number) {
-  const requestedFilePath = filePath.value;
-  const response = await api.call("beatAudio", { filePath: requestedFilePath, beatIndex: index });
-  if (staleSince(requestedFilePath)) return;
+  const requested = storyRef();
+  const response = await api.call("beatAudio", { ...requested, beatIndex: index });
+  if (staleSince(requested)) return;
   // silently ignore errors
   if (response.ok && response.data.audio) {
     beatAudios[index] = response.data.audio;
@@ -1004,15 +1020,15 @@ async function loadExistingBeatAudio(index: number) {
 }
 
 async function generateAudio(index: number) {
-  const requestedFilePath = filePath.value;
+  const requested = storyRef();
   audioState[index] = "generating";
   Reflect.deleteProperty(audioErrors, index);
   const response = await api.call("generateBeatAudio", {
-    filePath: requestedFilePath,
+    ...requested,
     beatIndex: index,
     chatSessionId: chatSessionId.value,
   });
-  if (staleSince(requestedFilePath)) return;
+  if (staleSince(requested)) return;
   if (!response.ok) {
     audioErrors[index] = response.error || "Audio generation failed";
     audioState[index] = "error";
@@ -1073,13 +1089,13 @@ async function onBeatDrop(event: DragEvent, index: number) {
     renderState[index] = "error";
     return;
   }
-  const requestedFilePath = filePath.value;
+  const requested = storyRef();
   const response = await api.call("uploadBeatImage", {
-    filePath: requestedFilePath,
+    ...requested,
     beatIndex: index,
     imageData,
   });
-  if (staleSince(requestedFilePath)) return;
+  if (staleSince(requested)) return;
   if (!response.ok) {
     renderErrors[index] = response.error || "Upload failed";
     renderState[index] = "error";
@@ -1141,11 +1157,11 @@ async function hydrateBeatImage(beat: Beat, index: number, hasCharacters: boolea
  * issue its own refresh against the correct file.
  */
 async function refreshScriptFromDisk(): Promise<void> {
-  const requestedFilePath = filePath.value;
-  if (!requestedFilePath) return;
+  const requested = storyRef();
+  if (!requested.filePath) return;
   const requestedUuid = props.selectedResult.uuid;
-  const response = await api.call("save", { filePath: requestedFilePath });
-  if (props.selectedResult.uuid !== requestedUuid || filePath.value !== requestedFilePath) return;
+  const response = await api.call("save", requested);
+  if (props.selectedResult.uuid !== requestedUuid || staleSince(requested)) return;
   if (!response.ok) return;
   const diskScript = response.data.script as MulmoScript | undefined;
   // The server-side reopen op already validated against
@@ -1231,10 +1247,10 @@ async function initializeScript() {
     // Stale-response guard: if the user navigates to a different result
     // while these calls are in flight, their answers describe the OLD
     // script — drop them instead of stamping them onto the new one.
-    const requestedFilePath = filePath.value;
-    const isStale = () => filePath.value !== requestedFilePath;
+    const requested = storyRef();
+    const isStale = () => staleSince(requested);
 
-    const response = await api.call("movieStatus", { filePath: requestedFilePath });
+    const response = await api.call("movieStatus", requested);
     if (isStale()) return;
     if (response.ok && response.data.moviePath) {
       moviePath.value = response.data.moviePath;
@@ -1243,7 +1259,7 @@ async function initializeScript() {
     // Also check whether a PDF was previously generated and is still
     // newer than the source; status returns null otherwise so the UI
     // re-offers the Generate button.
-    const pdfResponse = await api.call("pdfStatus", { filePath: requestedFilePath });
+    const pdfResponse = await api.call("pdfStatus", requested);
     if (isStale()) return;
     if (pdfResponse.ok && pdfResponse.data.pdfPath) {
       pdfPath.value = pdfResponse.data.pdfPath;
@@ -1253,7 +1269,7 @@ async function initializeScript() {
     // mounted (user switched away mid-generation and came back).
     // Snapshot via dispatch; live updates arrive on the pubsub
     // subscription below.
-    const pending = await api.call("pendingGenerations", { filePath: requestedFilePath });
+    const pending = await api.call("pendingGenerations", requested);
     if (isStale()) return;
     if (pending.ok) {
       for (const entry of pending.data.pending) {
@@ -1274,10 +1290,9 @@ watch(() => props.selectedResult, initializeScript);
 // after a remount, on finish we reload the relevant asset off disk.
 const unsubscribeGenerationEvents = api.onGenerationEvent({
   filePath: () => filePath.value,
-  // The View is opened from the host's default root today; step 2 gives it a
-  // root of its own. Written out rather than left to a default so the pair
-  // filter is visible at the call site (#3014).
-  root: () => undefined,
+  // The PAIR is the identity: `stories/deck.json` exists in every root, so filtering on the
+  // path alone puts ANOTHER repository's spinners on this card (#3014).
+  root: () => root.value,
   handler: (event) => {
     if (!event.done) {
       reflectGenerationStart(event);

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useBeatMovie.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useBeatMovie.ts
@@ -5,7 +5,7 @@
 
 import { reactive, type ComputedRef } from "vue";
 import { errorMessage } from "@mulmoclaude/common";
-import { clearReactiveRecords, staleSince as staleSinceOf } from "../helpers";
+import { clearReactiveRecords, staleSince as staleSinceOf, type StoryRef } from "../helpers";
 import type { MulmoScriptTransport } from "../transport";
 import type { MulmoScriptHostAdapter } from "../hostAdapter";
 
@@ -13,20 +13,24 @@ export interface UseBeatMovieOptions {
   api: MulmoScriptTransport;
   adapter: MulmoScriptHostAdapter;
   filePath: ComputedRef<string>;
+  /** Which registered root `filePath` is relative to; `undefined` = the host's default (#3014). */
+  root: ComputedRef<string | undefined>;
 }
 
-export function useBeatMovie({ api, adapter, filePath }: UseBeatMovieOptions) {
+export function useBeatMovie({ api, adapter, filePath, root }: UseBeatMovieOptions) {
   const beatMovies = reactive<Record<number, string>>({});
   const beatMovieUrls = reactive<Record<number, string>>({});
   const beatMovieOpen = reactive<Record<number, boolean>>({});
   const beatMovieLoading = reactive<Record<number, boolean>>({});
 
-  const staleSince = (requestedFilePath: string): boolean => staleSinceOf(filePath.value, requestedFilePath);
+  // The PAIR, not the path: `stories/deck.json` exists in every root (#3014).
+  const storyRef = (): StoryRef => ({ filePath: filePath.value, root: root.value });
+  const staleSince = (requested: StoryRef): boolean => staleSinceOf(storyRef(), requested);
 
   async function loadExistingBeatMovie(index: number): Promise<void> {
-    const requestedFilePath = filePath.value;
-    const response = await api.call("beatMovie", { filePath: requestedFilePath, beatIndex: index });
-    if (staleSince(requestedFilePath)) return;
+    const requested = storyRef();
+    const response = await api.call("beatMovie", { ...requested, beatIndex: index });
+    if (staleSince(requested)) return;
     // silently ignore errors — the clip simply hasn't been generated yet
     if (response.ok && response.data.moviePath) {
       beatMovies[index] = response.data.moviePath;

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useBeatMovie.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useBeatMovie.ts
@@ -48,7 +48,7 @@ export function useBeatMovie({ api, adapter, filePath, root }: UseBeatMovieOptio
     try {
       // Re-type the .mov blob as video/mp4 — same ISO-BMFF family, and
       // <video> support for "video/mp4" is broader than "video/quicktime".
-      const blob = new Blob([await fetchMediaBlob({ moviePath: beatMovies[index] })], { type: "video/mp4" });
+      const blob = new Blob([await fetchMediaBlob({ moviePath: beatMovies[index], root: root.value })], { type: "video/mp4" });
       beatMovieUrls[index] = URL.createObjectURL(blob);
       beatMovieOpen[index] = true;
     } catch (err) {

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useCharacterImages.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useCharacterImages.ts
@@ -5,7 +5,7 @@
 
 import { computed, reactive, type ComputedRef } from "vue";
 import { errorMessage } from "@mulmoclaude/common";
-import { characterPrompt as characterPromptOf, clearReactiveRecords, getMissingCharacterKeys, staleSince as staleSinceOf } from "../helpers";
+import { characterPrompt as characterPromptOf, clearReactiveRecords, getMissingCharacterKeys, staleSince as staleSinceOf, type StoryRef } from "../helpers";
 import { readFileAsDataUrl } from "../support";
 import type { MulmoScriptTransport } from "../transport";
 
@@ -16,17 +16,21 @@ type ScriptImages = Record<string, { type?: string; prompt?: string }> | undefin
 export interface UseCharacterImagesOptions {
   api: MulmoScriptTransport;
   filePath: ComputedRef<string>;
+  /** Which registered root `filePath` is relative to; `undefined` = the host's default (#3014). */
+  root: ComputedRef<string | undefined>;
   chatSessionId: ComputedRef<string | undefined>;
   getImages: () => ScriptImages;
 }
 
-export function useCharacterImages({ api, filePath, chatSessionId, getImages }: UseCharacterImagesOptions) {
+export function useCharacterImages({ api, filePath, root, chatSessionId, getImages }: UseCharacterImagesOptions) {
   const charRenderState = reactive<Record<string, CharRenderState>>({});
   const charImages = reactive<Record<string, string>>({});
   const charErrors = reactive<Record<string, string>>({});
   const charDragOver = reactive<Record<string, boolean>>({});
 
-  const staleSince = (requestedFilePath: string): boolean => staleSinceOf(filePath.value, requestedFilePath);
+  // The PAIR, not the path: `stories/deck.json` exists in every root (#3014).
+  const storyRef = (): StoryRef => ({ filePath: filePath.value, root: root.value });
+  const staleSince = (requested: StoryRef): boolean => staleSinceOf(storyRef(), requested);
 
   const characterKeys = computed(() => {
     const imgs = getImages() ?? {};
@@ -63,9 +67,9 @@ export function useCharacterImages({ api, filePath, chatSessionId, getImages }: 
       charRenderState[key] = "error";
       return;
     }
-    const requestedFilePath = filePath.value;
-    const response = await api.call("uploadCharacterImage", { filePath: requestedFilePath, key, imageData });
-    if (staleSince(requestedFilePath)) return;
+    const requested = storyRef();
+    const response = await api.call("uploadCharacterImage", { ...requested, key, imageData });
+    if (staleSince(requested)) return;
     if (!response.ok) {
       charErrors[key] = response.error || "Upload failed";
       charRenderState[key] = "error";
@@ -76,9 +80,9 @@ export function useCharacterImages({ api, filePath, chatSessionId, getImages }: 
   }
 
   async function loadExistingCharacterImage(key: string): Promise<void> {
-    const requestedFilePath = filePath.value;
-    const response = await api.call("characterImage", { filePath: requestedFilePath, key });
-    if (staleSince(requestedFilePath)) return;
+    const requested = storyRef();
+    const response = await api.call("characterImage", { ...requested, key });
+    if (staleSince(requested)) return;
     // silently ignore errors
     if (response.ok && response.data.image) {
       charImages[key] = response.data.image;
@@ -91,11 +95,11 @@ export function useCharacterImages({ api, filePath, chatSessionId, getImages }: 
   }
 
   async function renderCharacter(key: string, force: boolean): Promise<void> {
-    const requestedFilePath = filePath.value;
+    const requested = storyRef();
     charRenderState[key] = "rendering";
     Reflect.deleteProperty(charErrors, key);
-    const response = await api.call("renderCharacter", { filePath: requestedFilePath, key, force, chatSessionId: chatSessionId.value });
-    if (staleSince(requestedFilePath)) return;
+    const response = await api.call("renderCharacter", { ...requested, key, force, chatSessionId: chatSessionId.value });
+    if (staleSince(requested)) return;
     if (!response.ok) {
       charErrors[key] = response.error || "Render failed";
       charRenderState[key] = "error";

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useDeckEditor.ts
@@ -35,20 +35,22 @@ const EDITOR_ORIGIN = `deck-editor-${Math.random().toString(36).slice(2)}`;
 export type DeckEditorTransport = Pick<MulmoScriptTransport, "onScriptChanged"> & {
   call(
     kind: "updateScript",
-    args: { filePath: string; script: MulmoScript; origin: string },
+    args: { filePath: string; root?: string | undefined; script: MulmoScript; origin: string },
   ): Promise<TransportResult<MulmoScriptDispatchResult["updateScript"]>>;
 };
 
 export interface UseDeckEditorOptions {
   api: DeckEditorTransport;
   filePath: ComputedRef<string>;
+  /** Which registered root `filePath` is relative to; `undefined` = the host's default (#3014). */
+  root: ComputedRef<string | undefined>;
   effectiveScript: ComputedRef<MulmoScript>;
   /** Persist the saved script back into the parent's toolResult so the
    *  in-memory script and reactive beats[] stay in sync without a remount. */
   commitScript: (next: MulmoScript) => void;
 }
 
-export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: UseDeckEditorOptions) {
+export function useDeckEditor({ api, filePath, root, effectiveScript, commitScript }: UseDeckEditorOptions) {
   const canEditBeats = computed(() => hasEditableBeats(effectiveScript.value));
   const deckScriptInput = computed<DeckScriptShape>(() => effectiveScript.value as unknown as DeckScriptShape);
 
@@ -95,7 +97,7 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
     pendingDeckScript = null;
     if (!next || !filePath.value) return;
     const revision = editRevision;
-    const response = await api.call("updateScript", { filePath: filePath.value, script: next, origin: EDITOR_ORIGIN });
+    const response = await api.call("updateScript", { filePath: filePath.value, root: root.value, script: next, origin: EDITOR_ORIGIN });
     if (revision !== editRevision) return;
     if (!response.ok) {
       // The deck editor still holds the latest edit in its props until the next refresh, so
@@ -133,8 +135,10 @@ export function useDeckEditor({ api, filePath, effectiveScript, commitScript }: 
   function watchForeignWrites(reload: () => void): () => void {
     return api.onScriptChanged({
       filePath: () => filePath.value,
-      // Default root until step 2 — see the note in View.vue.
-      root: () => undefined,
+      // The PAIR is the identity: `stories/deck.json` exists in every root, so filtering on the
+      // path alone reloads this editor when ANOTHER repository's same-named deck is written
+      // (#3014).
+      root: () => root.value,
       ownOrigin: EDITOR_ORIGIN,
       handler: () => {
         flushPendingDeckSave();

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useMediaExport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useMediaExport.ts
@@ -94,7 +94,9 @@ export function useMediaExport({ api, adapter, filePath, root, chatSessionId }: 
     downloading.value = true;
     let objectUrl: string | null = null;
     try {
-      const blob = await fetchMediaBlob(kind === "movie" ? { moviePath: sourcePath } : { pdfPath: sourcePath });
+      // The root travels with the path: an artifact ref is relative to ITS root, and the same
+      // spelling exists in every other one (#3014).
+      const blob = await fetchMediaBlob(kind === "movie" ? { moviePath: sourcePath, root: root.value } : { pdfPath: sourcePath, root: root.value });
       objectUrl = URL.createObjectURL(blob);
       clickDownloadAnchor(objectUrl, downloadFilename(sourcePath, fallbackName));
     } catch (err) {

--- a/packages/plugins/mulmoscript-plugin/src/vue/composables/useMediaExport.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/composables/useMediaExport.ts
@@ -7,7 +7,7 @@
 
 import { ref, type ComputedRef, type Ref } from "vue";
 import { errorMessage } from "@mulmoclaude/common";
-import { downloadFilename } from "../helpers";
+import { downloadFilename, staleSince, type StoryRef } from "../helpers";
 import type { MulmoScriptTransport } from "../transport";
 import type { MulmoScriptHostAdapter } from "../hostAdapter";
 
@@ -15,12 +15,17 @@ export interface UseMediaExportOptions {
   api: MulmoScriptTransport;
   adapter: MulmoScriptHostAdapter;
   filePath: ComputedRef<string>;
+  /** Which registered root `filePath` is relative to; `undefined` = the host's default (#3014). */
+  root: ComputedRef<string | undefined>;
   chatSessionId: ComputedRef<string | undefined>;
 }
 
 type MediaKind = "movie" | "pdf";
 
-export function useMediaExport({ api, adapter, filePath, chatSessionId }: UseMediaExportOptions) {
+export function useMediaExport({ api, adapter, filePath, root, chatSessionId }: UseMediaExportOptions) {
+  // The PAIR, not the path: `stories/deck.json` exists in every root (#3014), so a late
+  // resolution must be matched against the root it was asked for as well.
+  const storyRef = (): StoryRef => ({ filePath: filePath.value, root: root.value });
   const movieGenerating = ref(false);
   const movieDownloading = ref(false);
   const moviePath = ref<string | null>(null);
@@ -37,11 +42,11 @@ export function useMediaExport({ api, adapter, filePath, chatSessionId }: UseMed
   // describes the OLD script, so drop it; the new script's own
   // initializeScript / pubsub subscription owns the visible state.
   async function generateMovie(): Promise<void> {
-    const requestedFilePath = filePath.value;
+    const requested = storyRef();
     movieGenerating.value = true;
     movieError.value = null;
-    const response = await api.call("generateMovie", { filePath: requestedFilePath, chatSessionId: chatSessionId.value });
-    if (filePath.value !== requestedFilePath) return;
+    const response = await api.call("generateMovie", { ...requested, chatSessionId: chatSessionId.value });
+    if (staleSince(storyRef(), requested)) return;
     movieGenerating.value = false;
     if (!response.ok) {
       // Surface inline (instead of `alert()` which blocks + has no retry
@@ -53,10 +58,10 @@ export function useMediaExport({ api, adapter, filePath, chatSessionId }: UseMed
   }
 
   async function generatePdf(): Promise<void> {
-    const requestedFilePath = filePath.value;
+    const requested = storyRef();
     pdfGenerating.value = true;
-    const response = await api.call("generatePdf", { filePath: requestedFilePath, chatSessionId: chatSessionId.value });
-    if (filePath.value !== requestedFilePath) return;
+    const response = await api.call("generatePdf", { ...requested, chatSessionId: chatSessionId.value });
+    if (staleSince(storyRef(), requested)) return;
     pdfGenerating.value = false;
     if (!response.ok) {
       alert(response.error);
@@ -66,18 +71,18 @@ export function useMediaExport({ api, adapter, filePath, chatSessionId }: UseMed
   }
 
   async function refreshMoviePath(): Promise<void> {
-    const requestedFilePath = filePath.value;
-    if (!requestedFilePath) return;
-    const response = await api.call("movieStatus", { filePath: requestedFilePath });
-    if (filePath.value !== requestedFilePath) return;
+    const requested = storyRef();
+    if (!requested.filePath) return;
+    const response = await api.call("movieStatus", requested);
+    if (staleSince(storyRef(), requested)) return;
     if (response.ok && response.data.moviePath) moviePath.value = response.data.moviePath;
   }
 
   async function refreshPdfPath(): Promise<void> {
-    const requestedFilePath = filePath.value;
-    if (!requestedFilePath) return;
-    const response = await api.call("pdfStatus", { filePath: requestedFilePath });
-    if (filePath.value !== requestedFilePath) return;
+    const requested = storyRef();
+    if (!requested.filePath) return;
+    const response = await api.call("pdfStatus", requested);
+    if (staleSince(storyRef(), requested)) return;
     if (response.ok && response.data.pdfPath) pdfPath.value = response.data.pdfPath;
   }
 

--- a/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/helpers.ts
@@ -4,6 +4,7 @@
 // helpers did not move — per-beat generation progress now arrives on the
 // plugin pubsub channel (see `core/contract.ts`).
 
+import { sameRoot } from "../core/contract";
 import { isRecord } from "./support";
 
 /**
@@ -157,13 +158,28 @@ export function isValidBeat(source: string | undefined, schema: SafeParseSchema)
   return validateBeatJSON(source ?? "", schema);
 }
 
-/** Stale-response guard: a per-beat / per-character response is stale
- *  once the View has navigated to a different result, i.e. the current
- *  file path no longer matches the one captured when the call was made.
- *  Keeping the direction pinned matters — an inverted check would let
- *  script A's late responses write into script B's state. */
-export function staleSince(currentFilePath: string, requestedFilePath: string): boolean {
-  return currentFilePath !== requestedFilePath;
+/** A story as the wire addresses it: the path plus the root it is relative to (absent = the
+ *  host's default root). The PAIR is the identity — see `staleSince`. */
+export interface StoryRef {
+  filePath: string;
+  root?: string | undefined;
+}
+
+/**
+ * Stale-response guard: a per-beat / per-character response is stale once the View has
+ * navigated to a different result.
+ *
+ * The identity is the PAIR `(root, filePath)`, not the path — `stories/deck.json` exists in
+ * every registered root (#3014), so comparing paths alone lets one repository's deck accept
+ * another's late response while both are open under the same name. `sameRoot` reads an absent
+ * root as the host's default rather than as "different", which is what keeps every pre-root
+ * caller's behaviour byte-identical.
+ *
+ * Keeping the direction pinned matters — an inverted check would let script A's late responses
+ * write into script B's state.
+ */
+export function staleSince(current: StoryRef, requested: StoryRef): boolean {
+  return current.filePath !== requested.filePath || !sameRoot(current.root, requested.root);
 }
 
 const JSON_INDENT = 2;

--- a/packages/plugins/mulmoscript-plugin/src/vue/hostAdapter.ts
+++ b/packages/plugins/mulmoscript-plugin/src/vue/hostAdapter.ts
@@ -19,8 +19,15 @@ export interface MulmoScriptHostAdapter {
   chatSessionId?: Ref<string | undefined>;
   /** Authenticated media download. Exactly one of `moviePath` / `pdfPath`
    *  is set — both are the wire `stories/…` paths the status/probe
-   *  dispatches return. Rejects on transport/HTTP failure. */
-  fetchMediaBlob?: (query: { moviePath?: string; pdfPath?: string }) => Promise<Blob>;
+   *  dispatches return. Rejects on transport/HTTP failure.
+   *
+   *  `root` is which registered stories root that path is relative to (#3014); absent = the
+   *  host's default. It is REQUIRED for correctness, not decoration: `toStoryRef` relativizes
+   *  an artifact against its own root's directory, so the returned path does not carry the
+   *  root, and the same `stories/…/__movies__/x.mov` exists in every one of them. A host that
+   *  ignores it serves the DEFAULT root's file of that name, or 404s. Optional so an older
+   *  host keeps compiling; a single-root host can ignore it because for it the two agree. */
+  fetchMediaBlob?: (query: { moviePath?: string; pdfPath?: string; root?: string | undefined }) => Promise<Blob>;
 }
 
 export const MULMOSCRIPT_HOST_ADAPTER_KEY: InjectionKey<MulmoScriptHostAdapter> = Symbol("mulmoscript-host-adapter");

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatchCarriesRoot.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatchCarriesRoot.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+/**
+ * Every dispatch the browser makes carries the root its card names (#3014).
+ *
+ * `stories/deck.json` exists in EVERY registered root, so a call that sends only the path
+ * addresses the DEFAULT root's file of that name. That is not a theoretical collision: a deck
+ * inside a registered root opened fine and then answered `File not found` to every save and
+ * every beat image, because the card carried `root` and the View sent `filePath` alone
+ * (receptron/mulmoterminal#1970, measured against a running server).
+ *
+ * The rule is stated as what is PERMITTED rather than as a list of bad spellings: an argument
+ * object must spread a story ref or name `root` outright. A new call site written the old way is
+ * then red by default, instead of being caught only when someone thinks to look — which is how
+ * this shipped root-blind through three releases.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const VUE_SOURCES = [
+  "src/vue/View.vue",
+  "src/vue/composables/useBeatMovie.ts",
+  "src/vue/composables/useCharacterImages.ts",
+  "src/vue/composables/useDeckEditor.ts",
+  "src/vue/composables/useMediaExport.ts",
+] as const;
+
+/** The argument text of every `api.call("<kind>", <args>)` in one file, kind included. */
+function dispatchArguments(source: string): { kind: string; args: string }[] {
+  const calls: { kind: string; args: string }[] = [];
+  const opener = /api\.call\(\s*"([a-zA-Z]+)"\s*,\s*/g;
+  let match = opener.exec(source);
+  while (match) {
+    const kind = match[1] ?? "";
+    // Walk to the matching close paren so a nested object or call does not end the slice early.
+    let depth = 1;
+    let index = opener.lastIndex;
+    while (index < source.length && depth > 0) {
+      const char = source[index];
+      if (char === "(" || char === "{") depth += 1;
+      if (char === ")" || char === "}") depth -= 1;
+      index += 1;
+    }
+    calls.push({ kind, args: source.slice(opener.lastIndex, index - 1) });
+    match = opener.exec(source);
+  }
+  return calls;
+}
+
+/** A ref spread (`...requested`, `...storyRef()`), a bare ref, or an explicit `root`. */
+function carriesRoot(args: string): boolean {
+  return /\.\.\.(requested|storyRef\(\))/.test(args) || /^\s*(requested|storyRef\(\))\s*$/.test(args) || /\broot:/.test(args);
+}
+
+describe("every browser dispatch carries its card's root", () => {
+  VUE_SOURCES.forEach((relative) => {
+    it(`${relative} names a root on every api.call`, () => {
+      const source = readFileSync(join(here, "..", relative), "utf-8");
+      const calls = dispatchArguments(source);
+      assert.ok(calls.length > 0, `${relative} has at least one dispatch to check`);
+      const rootless = calls.filter((call) => !carriesRoot(call.args)).map((call) => call.kind);
+      assert.deepEqual(rootless, [], `these dispatches send no root: ${rootless.join(", ")}`);
+    });
+  });
+
+  it("checks every dispatch in the Vue layer, so a new FILE cannot slip past the list", () => {
+    const viewSource = readFileSync(join(here, "..", "src", "vue", "View.vue"), "utf-8");
+    const composables = viewSource.match(/from "\.\/composables\/(\w+)"/g) ?? [];
+    const listed = VUE_SOURCES.join(" ");
+    composables.forEach((importLine) => {
+      const name = /composables\/(\w+)/.exec(importLine)?.[1];
+      assert.ok(name && listed.includes(`composables/${name}.ts`), `composable ${name} is not in VUE_SOURCES`);
+    });
+  });
+
+  it("sends a card with NO root exactly as it did before roots existed", () => {
+    // The backward-compatibility claim, checked rather than argued: a default-root card's
+    // arguments must reach the wire byte-identical to the pre-root spelling, so every existing
+    // card keeps its behaviour. `root: undefined` is dropped by JSON.stringify, and the server
+    // reads an absent OR empty root as the default (`str()` in `server/dispatch.ts`).
+    const withDefaultRoot = { filePath: "stories/a.json", root: undefined, beatIndex: 3 };
+    const beforeRoots = { filePath: "stories/a.json", beatIndex: 3 };
+    assert.equal(JSON.stringify(withDefaultRoot), JSON.stringify(beforeRoots));
+  });
+
+  it("subscribes with the card's root too — the pair filters generation and foreign-write events", () => {
+    const viewSource = readFileSync(join(here, "..", "src", "vue", "View.vue"), "utf-8");
+    const deckSource = readFileSync(join(here, "..", "src", "vue", "composables", "useDeckEditor.ts"), "utf-8");
+    assert.match(viewSource, /root: \(\) => root\.value/);
+    assert.match(deckSource, /root: \(\) => root\.value/);
+    assert.doesNotMatch(viewSource, /root: \(\) => undefined/);
+    assert.doesNotMatch(deckSource, /root: \(\) => undefined/);
+  });
+});

--- a/packages/plugins/mulmoscript-plugin/test/test_dispatchCarriesRoot.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_dispatchCarriesRoot.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -20,13 +20,28 @@ import { dirname, join } from "node:path";
  */
 
 const here = dirname(fileURLToPath(import.meta.url));
-const VUE_SOURCES = [
-  "src/vue/View.vue",
-  "src/vue/composables/useBeatMovie.ts",
-  "src/vue/composables/useCharacterImages.ts",
-  "src/vue/composables/useDeckEditor.ts",
-  "src/vue/composables/useMediaExport.ts",
-] as const;
+const VUE_DIR = join(here, "..", "src", "vue");
+
+/**
+ * Every browser-side file that dispatches, DISCOVERED rather than listed.
+ *
+ * A hardcoded list only guards the files someone remembered to add to it, and a new composable
+ * is exactly the thing that would be written root-blind (Codex, round 1). Walking the tree means
+ * a new file is covered the moment it makes its first `api.call`.
+ */
+function dispatchingSources(): string[] {
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return /\.(ts|vue)$/.test(entry.name) && readFileSync(full, "utf-8").includes("api.call(") ? [full] : [];
+    });
+  return walk(VUE_DIR).sort();
+}
+
+const VUE_SOURCES = dispatchingSources();
+/** Shown in test names — the path from `src/vue` down, not the absolute one. */
+const label = (absolute: string): string => absolute.slice(absolute.indexOf(join("src", "vue")));
 
 /** The argument text of every `api.call("<kind>", <args>)` in one file, kind included. */
 function dispatchArguments(source: string): { kind: string; args: string }[] {
@@ -56,23 +71,14 @@ function carriesRoot(args: string): boolean {
 }
 
 describe("every browser dispatch carries its card's root", () => {
-  VUE_SOURCES.forEach((relative) => {
-    it(`${relative} names a root on every api.call`, () => {
-      const source = readFileSync(join(here, "..", relative), "utf-8");
+  assert.ok(VUE_SOURCES.length >= 5, "the walk found the dispatching files");
+  VUE_SOURCES.forEach((absolute) => {
+    it(`${label(absolute)} names a root on every api.call`, () => {
+      const source = readFileSync(absolute, "utf-8");
       const calls = dispatchArguments(source);
-      assert.ok(calls.length > 0, `${relative} has at least one dispatch to check`);
+      assert.ok(calls.length > 0, `${label(absolute)} has at least one dispatch to check`);
       const rootless = calls.filter((call) => !carriesRoot(call.args)).map((call) => call.kind);
       assert.deepEqual(rootless, [], `these dispatches send no root: ${rootless.join(", ")}`);
-    });
-  });
-
-  it("checks every dispatch in the Vue layer, so a new FILE cannot slip past the list", () => {
-    const viewSource = readFileSync(join(here, "..", "src", "vue", "View.vue"), "utf-8");
-    const composables = viewSource.match(/from "\.\/composables\/(\w+)"/g) ?? [];
-    const listed = VUE_SOURCES.join(" ");
-    composables.forEach((importLine) => {
-      const name = /composables\/(\w+)/.exec(importLine)?.[1];
-      assert.ok(name && listed.includes(`composables/${name}.ts`), `composable ${name} is not in VUE_SOURCES`);
     });
   });
 
@@ -93,5 +99,68 @@ describe("every browser dispatch carries its card's root", () => {
     assert.match(deckSource, /root: \(\) => root\.value/);
     assert.doesNotMatch(viewSource, /root: \(\) => undefined/);
     assert.doesNotMatch(deckSource, /root: \(\) => undefined/);
+  });
+});
+
+/**
+ * Every AWAITED dispatch that then mutates View state re-checks the pair first.
+ *
+ * Sending the root fixes which file a call addresses; it does not fix which card the ANSWER is
+ * applied to. `selectedResult` can change during the await, and the same `stories/deck.json`
+ * exists in every root — so a response from one deck could seed the source editor with another
+ * deck's text, or commit it into the card now on screen (Codex P2, round 1). Two of the three
+ * unguarded sites were exactly that.
+ *
+ * Stated as what is PERMITTED: after the await, a call site either re-checks the pair
+ * (`staleSince` / `isStale()`) or is one of the named exceptions below, each with its reason.
+ * A new awaited dispatch is then red by default.
+ */
+describe("an awaited dispatch re-checks the pair before it applies the answer", () => {
+  /** Guarded by `editRevision`, not `staleSince`: `resetForScriptChange()` advances it on a
+   *  result switch, so a stale answer is dropped by the revision check instead. */
+  const GUARDED_BY_REVISION = new Set(["useDeckEditor.ts:updateScript"]);
+
+  VUE_SOURCES.forEach((absolute) => {
+    it(`${label(absolute)} guards every awaited dispatch`, () => {
+      const source = readFileSync(absolute, "utf-8");
+      const file = absolute.split("/").pop() ?? absolute;
+      const unguarded: string[] = [];
+      const awaited = /await api\.call\(\s*"(\w+)"/g;
+      let match = awaited.exec(source);
+      while (match) {
+        const kind = match[1] ?? "";
+        // The guard has to be close: past ~400 characters the answer has already been applied.
+        const following = source.slice(match.index, match.index + 400);
+        const guarded = /staleSince\(|isStale\(\)|revision !== editRevision/.test(following);
+        if (!guarded && !GUARDED_BY_REVISION.has(`${file}:${kind}`)) unguarded.push(kind);
+        match = awaited.exec(source);
+      }
+      assert.deepEqual(unguarded, [], `these awaited dispatches apply their answer unguarded: ${unguarded.join(", ")}`);
+    });
+  });
+});
+
+/**
+ * The media-byte download carries the root too.
+ *
+ * `toStoryRef` relativizes an artifact against ITS OWN root's directory, so a `moviePath` /
+ * `pdfPath` does not carry the root — and the same `stories/…/__movies__/x.mov` exists in every
+ * registered one. The issue predicted this exact consumer: "a consumer that stores the ref
+ * alone breaks". `fetchMediaBlob` is that consumer (Codex P2, round 1).
+ */
+describe("media-byte downloads carry the root", () => {
+  it("the host adapter's query declares it", () => {
+    const adapter = readFileSync(join(here, "..", "src", "vue", "hostAdapter.ts"), "utf-8");
+    assert.match(adapter, /fetchMediaBlob\?: \(query: \{[^}]*root\?: string \| undefined[^}]*\}\)/);
+  });
+
+  it("both call sites pass it", () => {
+    const beatMovie = readFileSync(join(here, "..", "src", "vue", "composables", "useBeatMovie.ts"), "utf-8");
+    const mediaExport = readFileSync(join(here, "..", "src", "vue", "composables", "useMediaExport.ts"), "utf-8");
+    const calls = [...beatMovie.matchAll(/fetchMediaBlob\(([^)]*)\)/g), ...mediaExport.matchAll(/fetchMediaBlob\(([^)]*)\)/g)]
+      .map((m) => m[1] ?? "")
+      .filter((args) => args.includes("Path"));
+    assert.ok(calls.length >= 2, "both download call sites are found");
+    calls.forEach((args) => assert.match(args, /root: root\.value/, `this fetchMediaBlob call sends no root: ${args}`));
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_helpers.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_helpers.ts
@@ -8,6 +8,7 @@ import {
   isSameScript,
   resolveSilentAdvanceSeconds,
   shouldAutoRenderBeat,
+  staleSince,
   validateBeatJSON,
   type SafeParseSchema,
 } from "../src/vue/helpers";
@@ -279,5 +280,37 @@ describe("clearReactiveRecords", () => {
     clearReactiveRecords(record);
     assert.deepEqual(record, {});
     assert.doesNotThrow(() => clearReactiveRecords());
+  });
+});
+
+/**
+ * The stale-response guard's identity is the PAIR `(root, filePath)`.
+ *
+ * `stories/deck.json` exists in every registered root (#3014), so a guard that compares paths
+ * alone lets one repository's deck accept another's late response while both are open under the
+ * same name — the class this issue's table calls out, which sending `root` does not close on its
+ * own.
+ */
+describe("staleSince", () => {
+  const DECK = "stories/deck.json";
+
+  it("is not stale for the same path in the same root", () => {
+    assert.equal(staleSince({ filePath: DECK, root: "acme" }, { filePath: DECK, root: "acme" }), false);
+    assert.equal(staleSince({ filePath: DECK }, { filePath: DECK }), false);
+  });
+
+  it("is stale for a different path, as it always was", () => {
+    assert.equal(staleSince({ filePath: "stories/other.json" }, { filePath: DECK }), true);
+  });
+
+  it("is stale for the SAME path in a DIFFERENT root — the case the path alone cannot see", () => {
+    assert.equal(staleSince({ filePath: DECK, root: "acme" }, { filePath: DECK, root: "widgets" }), true);
+    assert.equal(staleSince({ filePath: DECK, root: "widgets" }, { filePath: DECK, root: "acme" }), true);
+  });
+
+  it("reads an absent root as the host's default, not as a third value", () => {
+    assert.equal(staleSince({ filePath: DECK }, { filePath: DECK, root: undefined }), false);
+    assert.equal(staleSince({ filePath: DECK, root: "" }, { filePath: DECK }), false);
+    assert.equal(staleSince({ filePath: DECK }, { filePath: DECK, root: "acme" }), true);
   });
 });

--- a/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
+++ b/packages/plugins/mulmoscript-plugin/test/test_useDeckEditor.ts
@@ -18,6 +18,8 @@ import type { MulmoScript } from "../src/vue/viewTypes";
  */
 
 type SaveOutcome = TransportResult<Record<string, never>>;
+/** The registered root the harness's deck lives in — the pair `(root, filePath)` is its identity. */
+const STORY_ROOT = "acme-docs";
 const OK: SaveOutcome = { ok: true, data: {} };
 const failedWith = (error: string): SaveOutcome => ({ ok: false, error });
 
@@ -40,6 +42,7 @@ function harness(outcomes: SaveOutcome[]) {
   const editor = useDeckEditor({
     api,
     filePath: computed(() => "stories/deck/launch.json"),
+    root: computed(() => STORY_ROOT),
     effectiveScript: computed(() => script),
     commitScript: (next) => committed.push(next),
   });
@@ -78,6 +81,7 @@ function overlappingHarness() {
   const editor = useDeckEditor({
     api,
     filePath: computed(() => "stories/deck/launch.json"),
+    root: computed(() => STORY_ROOT),
     effectiveScript: computed(() => script),
     commitScript: (next) => committed.push(next),
   });
@@ -204,6 +208,53 @@ describe("a deck save that succeeds", () => {
     assert.equal(deckSaveError.value, null);
     assert.deepEqual(sentTitles, ["one", "two"]);
     assert.equal(committed.length, 2);
+  });
+});
+
+describe("the root the card names", () => {
+  it("rides on every save — the same path in another root is a different file", async () => {
+    const sent: (string | undefined)[] = [];
+    const api: DeckEditorTransport = {
+      call: async (_kind, args) => {
+        sent.push(args.root);
+        return OK;
+      },
+      onScriptChanged: () => () => {},
+    };
+    const editor = useDeckEditor({
+      api,
+      filePath: computed(() => "stories/deck/launch.json"),
+      root: computed(() => STORY_ROOT),
+      effectiveScript: computed(() => ({ title: "deck", beats: [{ text: "one" }] })),
+      commitScript: () => {},
+    });
+    editor.onDeckUpdate({ title: "renamed", beats: [{ text: "one" }] });
+    editor.flushPendingDeckSave();
+    await new Promise((settled) => setImmediate(settled));
+    assert.deepEqual(sent, [STORY_ROOT]);
+  });
+
+  it("filters foreign writes by the pair, not by the path", () => {
+    let subscription: { filePath: () => string; root: () => string | undefined } | null = null;
+    const api: DeckEditorTransport = {
+      call: async () => OK,
+      onScriptChanged: (first) => {
+        subscription = first as { filePath: () => string; root: () => string | undefined };
+        return () => {};
+      },
+    };
+    const editor = useDeckEditor({
+      api,
+      filePath: computed(() => "stories/deck/launch.json"),
+      root: computed(() => STORY_ROOT),
+      effectiveScript: computed(() => ({})),
+      commitScript: () => {},
+    });
+    editor.watchForeignWrites(() => {});
+    assert.ok(subscription, "the composable subscribed");
+    const subscribed: { filePath: () => string; root: () => string | undefined } = subscription;
+    assert.equal(subscribed.root(), STORY_ROOT);
+    assert.equal(subscribed.filePath(), "stories/deck/launch.json");
   });
 });
 

--- a/plans/fix-3014-view-sends-root.md
+++ b/plans/fix-3014-view-sends-root.md
@@ -1,0 +1,78 @@
+# View が dispatch に `root` を載せる（#3014 の順序 1 の残り）
+
+## 症状
+
+登録済み root 配下のデッキを Canvas で開くと、**開けるのにビート画像も保存も `File not found`**。
+実測（MulmoTerminal 4.19 台のサーバに直接投げたもの。デッキは `<workspace>/acme-docs/decks/launch.json`、
+`acme-docs` は登録済み root）:
+
+```
+相対 + root なし → {"ok":false,"code":"not_found","error":"File not found: stories/acme-docs/decks/launch.json"}
+絶対 + root なし → {"ok":true}   ファイルの中身が実際に書き変わる
+```
+
+## 原因
+
+**ホストは既にカードに `root` を載せている。View がそれを一度も読まない。**
+
+MulmoTerminal 側（`src/composables/canvasOpenFile.ts:291`）:
+
+```ts
+card: { toolName: STORY_TOOL, data: { script: body.script, filePath: body.filePath, ...root } }
+```
+
+プラグイン側の `MulmoScriptData`（`src/core/types.ts:21`）は `{ script, filePath }` しか宣言していない。
+View は `data.value?.filePath` だけを読み、transport は受け取った引数をそのまま流すので、
+**Vue 層の 20 箇所の dispatch すべてで `root` が落ちる**。購読2つも `root: () => undefined` とベタ書き。
+
+サーバ側の受け皿（`artifactsForRoot` / `guardStoryWriteRoot` / `rootScopedGenerationState`）は
+#3015 / #3019 / #3020 で入っていて動く。**View が送りさえすれば通る。**
+
+## もう1つ、同じ根から出る問題 —— staleness ガードが `filePath` 単体
+
+View と composable の随所にこの形がある:
+
+```ts
+const requestedFilePath = filePath.value;
+const response = await api.call(...);
+if (staleSince(filePath.value, requestedFilePath)) return;
+```
+
+`stories/deck.json` は根ごとに存在するので、**別の root の同名デッキに切り替えてもこのガードを素通りし、
+片方の応答がもう片方の状態に書き込まれる**。issue 本文の表 #1〜#3 と同じクラスで、`root` を送るだけでは
+閉じない。同一性の鍵を対 `(root, filePath)` に広げる必要がある。
+
+## 直し方
+
+1. `MulmoScriptData` に `root?: string` を宣言する（ホストが既に送っている値に型を付けるだけ。
+   省略 = 既定 root で、roots 以前と同じ意味）。
+2. View に `root = computed(() => data.value?.root)` を置き、**全 dispatch に載せる**。
+   composable 4つ（`useDeckEditor` / `useBeatMovie` / `useCharacterImages` / `useMediaExport`）は
+   `filePath` と同じ形で `root: ComputedRef<string | undefined>` を受け取る。
+3. 購読2つ（`onGenerationEvent` / `onScriptChanged`）の `root: () => undefined` を
+   カードの root にする。
+4. `staleSince(current, requested)` を **対を取る形**に変える。`sameRoot`（`core/contract.ts:103`）が
+   既にあるので、root の比較はそれを使う（`undefined` と既定 root の綴りを同一視する正規化込み）。
+
+**エージェントのツールスキーマは変えない。** `root` は意図的にスキーマに無く、ホストが埋める
+（#3015 の設計。モデルが任意の root を名指しできないことが封じ込めの一部）。
+
+## やらないこと
+
+- MulmoTerminal 側の順序 2・3（別リポ）
+- #2036 の絶対パス回避の撤回（あちらの判断）
+- したがって **`Closes #3014` にはしない** —— この PR は issue の一部
+
+## テスト
+
+`staleSince` の対化は純粋関数なので `test/test_helpers.ts` に両方向（同じ root で同じパス /
+同じパスで別 root / root 省略 と 既定 root の綴り）。
+
+dispatch が root を載せることは、composable には注入した fake transport で、View には
+ソース読み取りで（`test_beatPaneDefault.ts` と同じ手法 —— mount にはランタイム一式が要る）。
+
+## 関連
+
+- #3014 —— 親 issue（順序 2・3 は MulmoTerminal 側に残る）
+- #3015 / #3019 / #3020 —— サーバ側
+- receptron/mulmoterminal#1970 —— 症状の報告元、#2036 で絶対パスに切り替えて回避済み

--- a/plans/fix-3014-view-sends-root.md
+++ b/plans/fix-3014-view-sends-root.md
@@ -53,6 +53,15 @@ if (staleSince(filePath.value, requestedFilePath)) return;
    カードの root にする。
 4. `staleSince(current, requested)` を **対を取る形**に変える。`sameRoot`（`core/contract.ts:103`）が
    既にあるので、root の比較はそれを使う（`undefined` と既定 root の綴りを同一視する正規化込み）。
+5. **メディアのバイト取得にも root を載せる。** `toStoryRef` は成果物を**その root 自身のディレクトリ**に
+   対して相対化するので、`moviePath` / `pdfPath` は root を持たず、同じ綴りが全 root に存在する。
+   issue が「ref だけを保存する消費者が現れると壊れる」と予告していた、まさにその消費者が
+   `fetchMediaBlob` だった。`MulmoScriptHostAdapter` の query に `root?: string` を足し（optional なので
+   既存ホストは非破壊）、呼び出し2箇所とホストの adapter・ダウンロード2ルートまで通す。
+6. **await した dispatch は応答を適用する前に対を再確認する。** root を送ることは「どのファイルを
+   指すか」を直すだけで、「その応答をどのカードに適用するか」は直さない。await 中に
+   `selectedResult` は変わり得るので、source editor の2経路（`openSource` の reopen と
+   `applySource` の updateScript）にガードが要る。
 
 **エージェントのツールスキーマは変えない。** `root` は意図的にスキーマに無く、ホストが埋める
 （#3015 の設計。モデルが任意の root を名指しできないことが封じ込めの一部）。
@@ -70,6 +79,11 @@ if (staleSince(filePath.value, requestedFilePath)) return;
 
 dispatch が root を載せることは、composable には注入した fake transport で、View には
 ソース読み取りで（`test_beatPaneDefault.ts` と同じ手法 —— mount にはランタイム一式が要る）。
+
+`test_dispatchCarriesRoot.ts` は**ルールを「許されている形」で述べる**（引数は story ref を spread するか
+`root:` を名指す / await の後は対を再確認する）。対象ファイルは**ハードコードせず `src/vue` を走査**して
+`api.call(` を含むものを拾うので、**新しい composable はそれが最初の dispatch を書いた瞬間から対象**になる
+（ハードコードした一覧は、誰かが足し忘れたファイルを守らない）。
 
 ## 関連
 

--- a/plans/fix-3014-view-sends-root.md
+++ b/plans/fix-3014-view-sends-root.md
@@ -23,7 +23,7 @@ card: { toolName: STORY_TOOL, data: { script: body.script, filePath: body.filePa
 
 プラグイン側の `MulmoScriptData`（`src/core/types.ts:21`）は `{ script, filePath }` しか宣言していない。
 View は `data.value?.filePath` だけを読み、transport は受け取った引数をそのまま流すので、
-**Vue 層の 20 箇所の dispatch すべてで `root` が落ちる**。購読2つも `root: () => undefined` とベタ書き。
+**Vue 層の 22 箇所（17 kind）の dispatch すべてで `root` が落ちる**。購読2つも `root: () => undefined` とベタ書き。
 
 サーバ側の受け皿（`artifactsForRoot` / `guardStoryWriteRoot` / `rootScopedGenerationState`）は
 #3015 / #3019 / #3020 で入っていて動く。**View が送りさえすれば通る。**

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -400,7 +400,10 @@ bindRoute(router, API_ROUTES.mulmoScript.downloadMovie, (req: Request, res: Resp
     badRequest(res, "moviePath is required");
     return;
   }
-  const resolved = mulmoScriptOps.resolveStory(moviePath);
+  // An artifact ref is relative to ITS stories root (#3014). Absent = the default root, which
+  // is every request this host makes today — it registers no extra roots — so this is
+  // unchanged for it and correct for a host that does.
+  const resolved = mulmoScriptOps.resolveStory(moviePath, getOptionalStringQuery(req, "root"));
   if (!resolved.ok) {
     sendOpFailure(res, resolved);
     return;
@@ -477,7 +480,8 @@ bindRoute(router, API_ROUTES.mulmoScript.downloadPdf, (req: Request, res: Respon
     badRequest(res, "pdfPath is required");
     return;
   }
-  const resolved = mulmoScriptOps.resolveStory(pdfPath);
+  // Same as downloadMovie above: the ref is relative to its root (#3014).
+  const resolved = mulmoScriptOps.resolveStory(pdfPath, getOptionalStringQuery(req, "root"));
   if (!resolved.ok) {
     sendOpFailure(res, resolved);
     return;

--- a/server/api/routes/mulmo-script.ts
+++ b/server/api/routes/mulmo-script.ts
@@ -131,6 +131,11 @@ bindRoute(router, API_ROUTES.mulmoScript.save, async (req: Request<object, objec
   if (req.body?.autoGenerateMovie === true) {
     // The in-flight dedup + background pipeline key on the realpath, so
     // re-resolve the package's wire path host-side.
+    //
+    // No root, deliberately: this is the AGENT's tool path, and `root` is not in the tool
+    // schema so a model cannot name one (#3015). Every save that reaches here is in the
+    // default root by construction. Named as an exception in
+    // `test/plugins/mulmoscript/test_storyRootSweep.ts`.
     const resolved = mulmoScriptOps.resolveStory(outcome.filePath);
     if (resolved.ok) {
       mulmoScriptOps.triggerAutoBackgroundMovie(resolved.absolutePath, outcome.filePath, getSessionQuery(req) || undefined);
@@ -234,6 +239,9 @@ bindRoute(
 
 interface GenerationRequestBody {
   filePath: string;
+  /** Which registered stories root `filePath` is relative to; absent = the default (#3014).
+   *  This host registers no extra roots, so every request it makes today omits it. */
+  root?: string | undefined;
   chatSessionId?: string | undefined;
 }
 
@@ -254,7 +262,8 @@ function resolveStoryRequest(
     sendOpFailure(res, ffmpeg);
     return null;
   }
-  const resolved = mulmoScriptOps.resolveStory(filePath);
+  // The PAIR, not the path: the same `stories/…` spelling exists in every root (#3014).
+  const resolved = mulmoScriptOps.resolveStory(filePath, typeof req.body.root === "string" ? req.body.root : undefined);
   if (!resolved.ok) {
     sendOpFailure(res, resolved);
     return null;

--- a/server/api/routes/sessions.ts
+++ b/server/api/routes/sessions.ts
@@ -297,6 +297,9 @@ function isPresentMulmoScriptToolResult(entry: unknown): entry is PresentMulmoSc
   const { result } = entry;
   if (!isRecord(result) || result.toolName !== "presentMulmoScript") return false;
   const { data } = result;
+  // `root` is optional and stays untyped here — it is read through a `typeof` check at the
+  // one place that uses it, so a malformed value degrades to the default root rather than
+  // rejecting an entry that is otherwise fine to replay.
   return isRecord(data) && typeof data.filePath === "string";
 }
 
@@ -313,7 +316,11 @@ function isPresentMulmoScriptToolResult(entry: unknown): entry is PresentMulmoSc
 // replaying the script as it was when the tool call ran).
 async function enrichWithMulmoScript(entry: PresentMulmoScriptToolResult): Promise<unknown> {
   try {
-    const resolved = mulmoScriptOps.resolveStory(entry.result.data.filePath);
+    // The PAIR, not the path: `stories/deck.json` exists in every registered stories root, so
+    // rehydrating by path alone re-reads the DEFAULT root's file of that name and replays a
+    // different deck into the session (#3014). `root` is what the card carries; absent = default.
+    const { filePath, root } = entry.result.data;
+    const resolved = mulmoScriptOps.resolveStory(filePath, typeof root === "string" ? root : undefined);
     if (!resolved.ok) return entry;
     const scriptJson = (await readTextSafe(resolved.absolutePath)) ?? "";
     const script: unknown = JSON.parse(scriptJson);

--- a/src/plugins/presentMulmoScript/index.ts
+++ b/src/plugins/presentMulmoScript/index.ts
@@ -30,11 +30,15 @@ export type { MulmoScriptData };
 // the Authorization header, and the routes stay behind the standard
 // /api/* bearer guard by explicit review decision — so the package View
 // fetches bytes through this injected capability instead.
-async function fetchMediaBlob(query: { moviePath?: string; pdfPath?: string }): Promise<Blob> {
+async function fetchMediaBlob(query: { moviePath?: string; pdfPath?: string; root?: string | undefined }): Promise<Blob> {
   const endpoints = pluginEndpoints<MulmoScriptEndpoints>("mulmoScript");
+  // An artifact ref is relative to ITS stories root, and the same spelling exists in every
+  // other one — so the root travels with it or the route serves the default root's file of
+  // that name (#3014). Omitted when absent so a default-root request is unchanged.
+  const rootQuery = query.root === undefined ? {} : { root: query.root };
   const target = query.pdfPath
-    ? { url: endpoints.downloadPdf.url, query: { pdfPath: query.pdfPath } }
-    : { url: endpoints.downloadMovie.url, query: { moviePath: query.moviePath ?? "" } };
+    ? { url: endpoints.downloadPdf.url, query: { pdfPath: query.pdfPath, ...rootQuery } }
+    : { url: endpoints.downloadMovie.url, query: { moviePath: query.moviePath ?? "", ...rootQuery } };
   const res = await apiFetchRaw(target.url, { method: "GET", query: target.query });
   if (!res.ok) {
     throw new Error(`HTTP ${res.status}`);

--- a/test/plugins/mulmoscript/test_helpers.ts
+++ b/test/plugins/mulmoscript/test_helpers.ts
@@ -301,13 +301,23 @@ describe("staleSince", () => {
   // The guard drops a late response once the View navigated elsewhere. The
   // direction is load-bearing — an inverted check would let one script's
   // responses write into another's per-beat state.
+  //
+  // The identity is the PAIR `(root, filePath)`: `stories/deck.json` exists in every
+  // registered root (#3014), so the path alone lets one repository's deck accept another's
+  // late response. The full set of root cases lives with the plugin, in
+  // `packages/plugins/mulmoscript-plugin/test/test_helpers.ts` — this file predates the
+  // plugin's own suite and duplicates it.
   it("is stale only when the current path differs from the requested one", () => {
-    assert.equal(staleSince("stories/b.json", "stories/a.json"), true);
-    assert.equal(staleSince("stories/a.json", "stories/a.json"), false);
+    assert.equal(staleSince({ filePath: "stories/b.json" }, { filePath: "stories/a.json" }), true);
+    assert.equal(staleSince({ filePath: "stories/a.json" }, { filePath: "stories/a.json" }), false);
   });
 
   it("treats two empty paths as not stale", () => {
-    assert.equal(staleSince("", ""), false);
+    assert.equal(staleSince({ filePath: "" }, { filePath: "" }), false);
+  });
+
+  it("is stale for the same path in a different root", () => {
+    assert.equal(staleSince({ filePath: "stories/a.json", root: "acme" }, { filePath: "stories/a.json", root: "widgets" }), true);
   });
 });
 

--- a/test/plugins/mulmoscript/test_storyRootSweep.ts
+++ b/test/plugins/mulmoscript/test_storyRootSweep.ts
@@ -1,0 +1,173 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, relative } from "node:path";
+
+/**
+ * A story is addressed by the PAIR `(root, filePath)`, everywhere in the host.
+ *
+ * `stories/deck.json` exists in EVERY registered stories root (#3014), so a host call that
+ * resolves a path alone reads the DEFAULT root's file of that name. This rule was patched three
+ * times before it was written down — the media-byte download, the session rehydration, and the
+ * movie/PDF generation body — so it is stated here as a rule instead of a fourth fix.
+ *
+ * It is deliberately phrased as what is PERMITTED: a `resolveStory` call names a root, OR it is
+ * in `ROOTLESS_BY_DESIGN` below with the reason it cannot have one. Everything else is reported.
+ * That direction is the point — a new call site is red by default rather than correct by luck,
+ * and the exceptions are a list someone has to justify rather than a silence.
+ *
+ * It over-reports by construction: a call whose root genuinely does not exist has to be added to
+ * the list with a sentence. That is the trade, and it is the right one here, because the failure
+ * this guards against is silent — the wrong deck is read and nothing errors.
+ *
+ * WHAT THIS DOES NOT COVER, said out loud rather than left to be discovered:
+ *
+ * - It is a TEXTUAL rule over host code under `server/` and `src/`. An aliased or computed call
+ *   (`const rs = ops.resolveStory; rs(p)`) would slip past the argument check, so a second test
+ *   below forbids naming these ops in any form other than a direct call. An AST rule would be
+ *   stronger; this is the version that pays for itself today.
+ * - It says nothing about the PACKAGE's own internals — `resolveStory` is defined there, and the
+ *   package has its own root contract tests.
+ * - A future helper that wraps one of these ops and takes `filePath` without `root` would be
+ *   reported where it is WRITTEN, but its callers would not be. Exemptions are therefore kept at
+ *   call granularity, never file granularity.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(here, "..", "..", "..");
+const SEARCHED = ["server", "src"] as const;
+
+/**
+ * Every ops entry point that resolves a story, and therefore takes a root.
+ *
+ * `resolveStory` was the one the first three findings landed on, but it is not the only door:
+ * the beat / status / generation ops resolve internally through `runStoryOp`, and reach the same
+ * wrong file when the host calls them with a path alone (Codex, round 3 step C-bis).
+ */
+const ROOT_TAKING_OPS = [
+  "resolveStory",
+  "beatImageOp",
+  "beatAudioOp",
+  "beatMovieOp",
+  "characterImageOp",
+  "movieStatusOp",
+  "pdfStatusOp",
+  "renderBeatOp",
+  "generateBeatAudioOp",
+  "renderCharacterOp",
+  "uploadBeatImageOp",
+  "uploadCharacterImageOp",
+] as const;
+
+/**
+ * Call sites that may address a story by path alone, and why.
+ *
+ * Keyed by `<path-from-repo-root>:<the call's own line text, trimmed>` so moving a file or
+ * changing the call breaks the exemption rather than silently carrying it.
+ */
+const SUPERSEDED_REST_SURFACE =
+  "REST surface, no caller in this repo. `pluginEndpoints<MulmoScriptEndpoints>` is used by exactly one file — the host adapter — and only for the two download routes (both rooted). The View reaches these ops through the ROOT-AWARE dispatch route instead. Threading `root` through every REST body/query parser and `makeBeatOpHandler` is a change to a surface nothing here calls, so it is #3077 rather than this PR. A host that DOES call these routes must fix them first.";
+
+const ROOTLESS_BY_DESIGN = new Map<string, string>([
+  [
+    "server/api/routes/mulmo-script.ts:const resolved = mulmoScriptOps.resolveStory(outcome.filePath);",
+    "The AGENT's tool path. `root` is not in the tool schema, so a model cannot name one (#3015) — every save reaching here is in the default root by construction.",
+  ],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.beatImageOp(query.filePath, query.beatIndex);", SUPERSEDED_REST_SURFACE],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.movieStatusOp(filePath);", SUPERSEDED_REST_SURFACE],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.beatAudioOp(query.filePath, query.beatIndex);", SUPERSEDED_REST_SURFACE],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.beatMovieOp(query.filePath, query.beatIndex);", SUPERSEDED_REST_SURFACE],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.characterImageOp(filePath, key);", SUPERSEDED_REST_SURFACE],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.uploadBeatImageOp(filePath, beatIndex, imageData);", SUPERSEDED_REST_SURFACE],
+  [
+    "server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.renderCharacterOp({ filePath, key, force, chatSessionId });",
+    SUPERSEDED_REST_SURFACE,
+  ],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.uploadCharacterImageOp(filePath, key, imageData);", SUPERSEDED_REST_SURFACE],
+  ["server/api/routes/mulmo-script.ts:const result = await mulmoScriptOps.pdfStatusOp(filePath);", SUPERSEDED_REST_SURFACE],
+]);
+
+/**
+ * Ops handed to a factory as a VALUE rather than called directly.
+ *
+ * `makeBeatOpHandler(op, …)` invokes them with a `BeatOpArgs` that has no `root` field, so these
+ * are the same superseded REST surface as above, reached by a different spelling. Listed
+ * separately because the direct-call test cannot see an argument list that does not exist yet.
+ */
+const OP_VALUES_BY_DESIGN = new Set<string>([
+  "server/api/routes/mulmo-script.ts:makeBeatOpHandler(mulmoScriptOps.generateBeatAudioOp, (result) => ({ audio: result.audio })),",
+  "server/api/routes/mulmo-script.ts:makeBeatOpHandler(mulmoScriptOps.renderBeatOp, (result) => ({ image: result.image })),",
+]);
+
+/** Every `.ts` file under the searched directories. */
+function sourceFiles(): string[] {
+  const walk = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return entry.name === "node_modules" ? [] : walk(full);
+      return entry.name.endsWith(".ts") ? [full] : [];
+    });
+  return SEARCHED.flatMap((dir) => walk(join(REPO_ROOT, dir)));
+}
+
+/**
+ * Calls to a root-taking op whose arguments never mention a root.
+ *
+ * The test is "does the argument text name `root`", NOT "is there a second argument": these ops
+ * have different arities (`resolveStory(p, root)` but `beatImageOp(p, beatIndex, root)`), and a
+ * positional count passed `beatImageOp(filePath, beatIndex)` as though it were rooted — a FALSE
+ * NEGATIVE, which is the direction that matters. Naming the token is arity-independent.
+ */
+function rootlessCalls(): string[] {
+  const found: string[] = [];
+  sourceFiles().forEach((file) => {
+    readFileSync(file, "utf-8")
+      .split("\n")
+      .forEach((line) => {
+        const call = new RegExp(`\\b(?:${ROOT_TAKING_OPS.join("|")})\\(([^;]*)`).exec(line);
+        if (!call) return;
+        if (!/\broot\b/.test(call[1] ?? "")) found.push(`${relative(REPO_ROOT, file)}:${line.trim()}`);
+      });
+  });
+  return found;
+}
+
+describe("a story is addressed by the pair, not the path", () => {
+  it("finds the resolveStory call sites at all — a sweep that matches nothing proves nothing", () => {
+    const total = sourceFiles().filter((file) => readFileSync(file, "utf-8").includes("resolveStory(")).length;
+    assert.ok(total > 0, "at least one file calls resolveStory");
+  });
+
+  it("every resolveStory call names a root, or is exempted with a reason", () => {
+    const unexplained = rootlessCalls().filter((site) => !ROOTLESS_BY_DESIGN.has(site));
+    assert.deepEqual(unexplained, [], `these resolve a story by path alone: ${unexplained.join(" | ")}`);
+  });
+
+  it("names these ops only as a direct call — an alias would walk straight past the argument check", () => {
+    // `const rs = ops.resolveStory; rs(p)` resolves a story with no root and matches no
+    // `resolveStory(` line. Rather than enumerate the spellings, this forbids every mention that
+    // is not immediately a call (Codex, round 3 step C-bis).
+    const evasions: string[] = [];
+    sourceFiles().forEach((file) => {
+      readFileSync(file, "utf-8")
+        .split("\n")
+        .forEach((line) => {
+          ROOT_TAKING_OPS.forEach((opName) => {
+            if (!new RegExp(`\\b${opName}\\b`).test(line)) return;
+            const asDirectCall = new RegExp(`\\b${opName}\\(`).test(line);
+            const asImportOrType = /^\s*(import|export)\b/.test(line) || line.includes("//");
+            const site = `${relative(REPO_ROOT, file)}:${line.trim()}`;
+            if (!asDirectCall && !asImportOrType && !OP_VALUES_BY_DESIGN.has(site)) evasions.push(site);
+          });
+        });
+    });
+    assert.deepEqual(evasions, [], `these name a story op without calling it directly: ${evasions.join(" | ")}`);
+  });
+
+  it("every exemption still exists — a stale one hides the next real call site", () => {
+    const rootless = new Set(rootlessCalls());
+    const gone = [...ROOTLESS_BY_DESIGN.keys()].filter((site) => !rootless.has(site));
+    assert.deepEqual(gone, [], `these exemptions no longer match any call: ${gone.join(" | ")}`);
+  });
+});


### PR DESCRIPTION
## Summary

登録済み root 配下のデッキが「開けるのに保存もビート画像も `File not found`」になる件
（receptron/mulmoterminal#1970）。原因は **ホストは既にカードに `root` を載せているのに、View が
それを一度も読まない**ことでした。

MulmoTerminal 側（`src/composables/canvasOpenFile.ts:291`）は既にこう作っています:

```ts
card: { toolName: STORY_TOOL, data: { script: body.script, filePath: body.filePath, ...root } }
```

ところがプラグインの `MulmoScriptData` は `{ script, filePath }` しか宣言しておらず、View は
`filePath` だけを読み、transport は受け取った引数をそのまま流す。結果 **17 の dispatch kind
すべてが root 無しで飛び**、`stories/deck.json` は根ごとに存在するので**既定 root の同名ファイル**を
指していました。購読2つも `root: () => undefined` とベタ書きでした。

- `MulmoScriptData` に `root?: string` を宣言（ホストが既に送っている値に型を付ける）
- View が読み、**全 dispatch と購読2つ**が対 `(root, filePath)` を運ぶ
- **`staleSince` を対に広げた** —— root を送るだけでは閉じないため（下記）
- **メディアのバイト取得（`fetchMediaBlob`）にも root を載せた** —— 成果物 ref は**その root 自身の
  ディレクトリ**に対して相対化されるので root を持たない。ホストの adapter とダウンロード2ルートまで
- **await した dispatch は応答を適用する前に対を再確認する** —— root を送ることは「どのファイルを
  指すか」を直すだけで、「その応答をどのカードに適用するか」は直さない
- **エージェントのツールスキーマは無変更**。`root` は意図的にスキーマに無く、ホストだけが埋める（#3015）

### root を送るだけでは閉じないもの

View と composable の随所にこの形があります:

```ts
const requestedFilePath = filePath.value;
const response = await api.call(...);
if (staleSince(filePath.value, requestedFilePath)) return;
```

比べているのは `filePath` だけ。**別 root の同名デッキに切り替えてもこのガードを素通りし、片方の
応答がもう片方のビート状態に書き込まれます。** issue 本文の表 #1〜#3 と同じクラスなので、同じ PR で
`staleSince` を対にしました（root の比較は既存の `sameRoot` —— 未指定と既定 root を同一視する正規化込み）。

## Items to Confirm / Review

1. **`Closes #3014` にしていません。** これは issue の一部で、順序 2・3 は MulmoTerminal 側に残ります。
2. **`staleSince` のシグネチャ変更**（`(string, string)` → `(StoryRef, StoryRef)`）。この関数は
   `src/vue/index.ts` から export されていないので公開 API ではありませんが、呼び出し側は
   plugin とホストのテストを合わせて全部書き換えています。**未変換が1つでも残れば root の
   `typecheck` が落ちる**ので、この主張は数を数えなくてもコンパイラが保証します
   （実際 round 1 の前にホスト側の1ファイルがそれで見つかりました）。
3. **実アプリでの目視は未実施。** 再現には登録済み root を持つ MulmoTerminal が要ります。代わりに
   **ビルド済み `dist/vue.js` を解析して 17 kind すべてが root を運ぶことを確認**しました（4.6.0 が
   root-blind だと実測されたのと同じ場所です）。
4. **`test_dispatchCarriesRoot.ts` は「許されている形」を列挙するルール**にしています（引数は story ref を
   spread するか `root:` を名指す / await の後は対を再確認する）。対象ファイルは**ハードコードせず
   `src/vue` を走査**するので、**新しい composable はそれが最初の dispatch を書いた瞬間から対象**です。
   禁止形の列挙ではないので、昔の書き方で足すと既定で赤になります。
5. **ホスト側にも触っています** —— `src/plugins/presentMulmoScript/index.ts` の adapter と
   `server/api/routes/mulmo-script.ts` のダウンロード2ルート。このホストは extra root を登録して
   いないので**挙動は不変**ですが、登録するホストのために正しくしてあります。

## 検証

- テスト **388 → 408 pass / 0 fail**。root の typecheck / format、plugin の build / eslint / prettier すべて green
- **fix を戻して赤くなることを確認**: 1つの call site を root 無しに戻す / `root: () => undefined` に
  戻す / `updateScript` から root を抜く —— それぞれ対応するテストが赤
- **挙動保存は「実行して」確認**（推論ではなく）: 旧 `staleSince` を verbatim コピーして新旧を並べ、
  生成した **147 の default-root ペアで 0 disagreement**。加えて `{filePath, root: undefined}` が
  root 以前の形と **byte-identical に serialize** される（`JSON.stringify` が undefined を落とし、
  サーバの `str()` は空・未指定を既定 root として読む）。**両方の property は恒久テストとして残しました**
- **ビルド済みバンドルで 17 kind 全部**が root を運ぶことを確認（root-less: なし）

## User Prompt

- #3014 なおせる？

## 関連

- #3014 — 親 issue（順序 2・3 は MulmoTerminal 側）
- #3015 / #3019 / #3020 — サーバ側。受け皿は既に動いており、View が送りさえすれば通る
- receptron/mulmoterminal#1970 — 症状の報告元。#2036 で絶対パスに切り替えて回避済みなので、
  あちらの緊急度は下がっています（この PR はその回避を撤回しません）

work in mulmoclaude2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgM174UftqbfGd9Y5kuUwg

## Summary by Sourcery

Propagate registered story roots throughout the MulmoScript View and host integration so root-scoped decks and their asynchronous operations target the correct files safely.

New Features:
- Carry the selected card's registered stories root through View dispatches, subscriptions, and media downloads so decks and generated artifacts resolve within the correct root.

Bug Fixes:
- Prevent root-scoped decks from incorrectly resolving, saving, or downloading same-named files from the default root.
- Prevent late asynchronous responses and cross-root events from updating a different deck after navigation.

Enhancements:
- Treat `(root, filePath)` as the story identity while preserving default-root compatibility and keeping the agent tool schema root-free.
- Add source-scanning and behavioral coverage to enforce root propagation, stale-response guards, media download handling, and host-side root resolution.

Tests:
- Expand plugin and host tests for root-aware story references, subscriptions, stale-response behavior, and root propagation across dispatch and download call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of decks with identical file paths in different roots.
  * Ensured saves, rendering, media generation, downloads, and status updates target the correct deck.
  * Prevented responses and updates from one root from affecting another.
  * Preserved deck identity during source editing and foreign-write handling.

* **Tests**
  * Added coverage for root information across dispatches, subscriptions, downloads, and stale-response checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->