### PR TITLE
fix(shapescript): loft takes path sections only, and lofts open paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Fixed
+
+#### `@mulmoclaude/shapescript-plugin@2.5.1` — `loft` takes path sections only, and lofts open paths (PR #3094)
+
+Two mismatches with the upstream app, both in `loft`. A `fill { path … }` as a section rendered
+here but is refused upstream ("A mesh value was not expected in this context"): the builder built
+every child into a mesh and read the outline back, so a filled face passed for the path it was
+made from, and a generated F-22 that previewed fine failed in the app. `loft` now refuses a mesh
+section with a message naming the fix, checked on the evaluated value so a `define`d `fill` is
+refused too, while `fill` on its own and inside `hull` stay legal. And a section whose last point
+did not repeat its first was dropped as an open stroke, so a two-section loft failed with "requires
+at least two cross-sections"; upstream closes such a section implicitly and so does this builder
+now. Sections keep their written order when open and closed ones mix.
+
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.8.0`, `@mulmoclaude/shapescript-plugin@2.5.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+
 ## [1.16.0] - 2026-09-12
 
 **3D models became a first-class canvas view, and a MulmoScript deck can now live in a registered stories root instead of only the workspace.**

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -45,7 +45,7 @@
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "@mulmoclaude/mulmoscript-plugin": "^4.8.0",
-    "@mulmoclaude/shapescript-plugin": "^2.5.0",
+    "@mulmoclaude/shapescript-plugin": "^2.5.1",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",
     "@receptron/task-scheduler": "^1.0.3",

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/shapescript-plugin",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "presentShapeScript \u2014 interactive 3D visualizations authored in the ShapeScript language (parser + Three.js renderer). Core (tool definition + execute) on `.`, Vue View/Preview on `./vue`.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugins/shapescript-plugin/src/shapescript/meshValues.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/meshValues.ts
@@ -23,6 +23,10 @@ export interface MeshValue {
    *  in the order the script (or Euclid) produced them. */
   polygons?: PolygonValue[];
   name?: string;
+  /** Set when every mesh the value was built from stands in for a `path`
+   *  (a `path` block, a flat primitive, `text`), so a `define`d or returned
+   *  profile is still a path where a builder such as `loft` demands one. */
+  path?: true;
 }
 
 /** `shape.bounds` / `polygon.bounds`. */

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -108,10 +108,12 @@ function linePoints(line: THREE.Line): THREE.Vector3[] {
  *  `square` / `circle` / `roundrect` / `polygon`, `text`) are marked, and
  *  `loft` refuses anything else. */
 const PATH_VALUE_KEY = "pathValue";
+/** Mark `object` as standing in for a path value, and hand it back. */
 function markPathValue<T extends THREE.Object3D>(object: T): T {
   object.userData[PATH_VALUE_KEY] = true;
   return object;
 }
+/** Whether `object` stands in for a path value (see `markPathValue`). */
 function isPathValue(object: THREE.Object3D): boolean {
   return object.userData[PATH_VALUE_KEY] === true;
 }
@@ -737,8 +739,10 @@ export class Converter {
         : undefined;
       const geometry = mergeMeshGeometries([...meshes.map((mesh) => mesh.geometry), ...(faces ? [faces] : [])]);
       faces?.dispose();
-      // `placeMesh` clones, so the merged geometry is an intermediate too.
-      const placed = this.placeMesh({ kind: "mesh", geometry });
+      // `placeMesh` clones, so the merged geometry is an intermediate too. A
+      // tuple of paths alone is still a path (a builder then judges its outline).
+      const path = polygons.length === 0 && meshes.every((mesh) => mesh.path);
+      const placed = this.placeMesh({ kind: "mesh", geometry, ...(path ? { path } : {}) });
       geometry.dispose();
       return placed;
     }

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -777,6 +777,7 @@ export class Converter {
     const geometry = value.geometry.clone();
     const mesh = this.makeMesh(geometry, this.createMaterial({ properties: {} }, undefined, geometry.hasAttribute("color")));
     if (value.name !== undefined) mesh.name = value.name;
+    if (value.path) markPathValue(mesh);
     this.applyCurrentTransform(mesh);
     return mesh;
   }
@@ -807,7 +808,7 @@ export class Converter {
   private buildScratch(
     nodes: readonly SceneNode[],
     after?: (captured: Value[]) => void,
-  ): { captured: Value[]; geometries: THREE.BufferGeometry[]; name: string | undefined; polygons: PolygonValue[] | undefined } {
+  ): { captured: Value[]; geometries: THREE.BufferGeometry[]; name: string | undefined; polygons: PolygonValue[] | undefined; path: boolean } {
     const temporary = new THREE.Group();
     const captured: Value[] = [];
     const charged = this.vertexCount;
@@ -831,7 +832,8 @@ export class Converter {
               points: face.points.map((point) => new THREE.Vector3(...point).applyMatrix4(single.matrixWorld).toArray() as Point3),
             }))
           : undefined;
-      return { captured, geometries, name: single?.name || undefined, polygons };
+      const path = meshes.length > 0 && meshes.every(isPathValue);
+      return { captured, geometries, name: single?.name || undefined, polygons, path };
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = charged;
@@ -938,7 +940,7 @@ export class Converter {
    *  merged into one geometry the script can read members of and place. A
    *  polygon block or a function that returned one is that value itself. */
   private shapeValue(node: SceneNode): Value {
-    const { captured, geometries, name, polygons } = this.buildScratch([node]);
+    const { captured, geometries, name, polygons, path } = this.buildScratch([node]);
     if (geometries.length === 0) {
       if (captured.length === 1) return captured[0]!;
       if (captured.length > 1) return captured;
@@ -947,7 +949,7 @@ export class Converter {
     const geometry = mergeMeshGeometries(geometries);
     geometries.forEach((part) => part.dispose());
     this.chargeRetained(geometry);
-    return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }), ...(polygons === undefined ? {} : { polygons }) };
+    return { kind: "mesh", geometry, ...(name === undefined ? {} : { name }), ...(polygons === undefined ? {} : { polygons }), ...(path ? { path } : {}) };
   }
 
   /** A function whose body builds shapes: run it at the origin with its
@@ -955,14 +957,14 @@ export class Converter {
   private callShapeFunction(fn: FunctionValue, args: Value[]): Value {
     const { params = [], body = [], value, name } = fn.definition;
     return this.evaluator.withArguments(params, args, () => {
-      const { captured, geometries } = this.buildScratch(body, (values) => {
+      const { captured, geometries, path } = this.buildScratch(body, (values) => {
         // A shape the body ends with is placed where the body's transforms
         // left the frame, as a statement there would be.
         if (value !== undefined) values.push(this.transformedForCapture(this.evaluator.evaluate(value)));
       });
       for (const geometry of geometries) {
         this.chargeRetained(geometry);
-        captured.push({ kind: "mesh", geometry });
+        captured.push({ kind: "mesh", geometry, ...(path ? { path } : {}) });
       }
       if (captured.length === 0) throw new Error(`Function \`${name}\` produced no value`);
       return captured.length === 1 ? captured[0]! : captured;

--- a/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
+++ b/packages/plugins/shapescript-plugin/src/shapescript/toThreeJS.ts
@@ -27,6 +27,7 @@ import {
   ArcCommand,
   ForLoopPathCommand,
   CustomShapeNode,
+  ShapePrimitive,
   ColorNode,
   RotateNode,
   OrientationNode,
@@ -98,6 +99,32 @@ function linePoints(line: THREE.Line): THREE.Vector3[] {
     const previous = points[points.length - 1];
     if (previous === undefined || previous.distanceToSquared(point) > PATH_POINT_EPSILON ** 2) points.push(point);
   }
+  return points;
+}
+
+/** Upstream's `loft` takes `path` values only — a `fill` is a mesh there and
+ *  is refused. This evaluator builds every operand into a mesh or a line first,
+ *  so the ones that stand in for a path (a `path` block, the flat primitives
+ *  `square` / `circle` / `roundrect` / `polygon`, `text`) are marked, and
+ *  `loft` refuses anything else. */
+const PATH_VALUE_KEY = "pathValue";
+function markPathValue<T extends THREE.Object3D>(object: T): T {
+  object.userData[PATH_VALUE_KEY] = true;
+  return object;
+}
+function isPathValue(object: THREE.Object3D): boolean {
+  return object.userData[PATH_VALUE_KEY] === true;
+}
+const FLAT_PRIMITIVES: ReadonlySet<ShapePrimitive> = new Set(["circle", "square", "roundrect", "polygon"]);
+
+/** A `loft` operand's ring. An open path reaches the builder as a line and is
+ *  closed implicitly, as upstream lofts it (its `loft` of four unrepeated
+ *  square corners is a watertight box). */
+function loftSection(operand: THREE.Mesh | THREE.Line): THREE.Vector3[] {
+  if (!isPathValue(operand)) throw new Error("`loft` expects `path` cross-sections, not meshes — pass the path itself rather than a `fill` of it");
+  if ((operand as THREE.Mesh).isMesh) return profileOf(operand as THREE.Mesh);
+  const points = linePoints(operand as THREE.Line);
+  if (points.length < 3) throw new Error("A `loft` cross-section needs at least three points");
   return points;
 }
 
@@ -505,12 +532,12 @@ export class Converter {
       const shape = this.shapeFromPathPoints(points);
       // An open path has no face: it reaches the builder as a stroke, which
       // `extrude` walls and `extrude … along` follows.
-      if (!isClosedPath(points)) return this.lineFromPath(node, shape);
+      if (!isClosedPath(points)) return markPathValue(this.lineFromPath(node, shape));
       this.chargePathEstimate(shape, SHAPE_GEOMETRY_CURVE_SEGMENTS);
       this.requireEnclosedArea(shape, "path");
       const mesh = this.makeMesh(this.placePath(new THREE.ShapeGeometry(shape), node), this.createMaterial({ properties: {} }));
       this.applyCurrentTransform(mesh);
-      return mesh;
+      return markPathValue(mesh);
     });
   }
 
@@ -669,7 +696,10 @@ export class Converter {
 
   private convertShape(node: ShapeNode): THREE.Mesh | null {
     if (node.points !== undefined) return this.placeValue(this.polygonValue(node));
-    return this.withShapeOptions(node.properties, () => this.finishMesh(this.createGeometry(node), node, false));
+    return this.withShapeOptions(node.properties, () => {
+      const mesh = this.finishMesh(this.createGeometry(node), node, false);
+      return FLAT_PRIMITIVES.has(node.primitive) ? markPathValue(mesh) : mesh;
+    });
   }
 
   /** Run `build` with produced values going to `sink` rather than the scene. */
@@ -1952,7 +1982,10 @@ export class Converter {
   /** Build `children` into a throwaway group at the block's own origin and hand
    *  back every mesh in it, world matrices already resolved. The group stays
    *  owned by the caller, which disposes it. */
-  private buildOperands(temporary: THREE.Group, children: SceneNode[]): { meshes: THREE.Mesh[]; lines: THREE.Line[]; material: MaterialState } {
+  private buildOperands(
+    temporary: THREE.Group,
+    children: SceneNode[],
+  ): { meshes: THREE.Mesh[]; lines: THREE.Line[]; operands: (THREE.Mesh | THREE.Line)[]; material: MaterialState } {
     let material = this.currentTransform().material;
     this.operandDepth++;
     try {
@@ -1973,16 +2006,21 @@ export class Converter {
     temporary.updateMatrixWorld(true);
     const meshes: THREE.Mesh[] = [];
     const lines: THREE.Line[] = [];
+    // `operands` keeps the source order across both kinds — a loft's sections
+    // must stay in the order they were written.
+    const operands: (THREE.Mesh | THREE.Line)[] = [];
     temporary.traverse((object) => {
       if ((object as THREE.Mesh).isMesh) meshes.push(object as THREE.Mesh);
       else if ((object as THREE.Line).isLine) lines.push(object as THREE.Line);
+      else return;
+      operands.push(object as THREE.Mesh | THREE.Line);
     });
-    return { meshes, lines, material };
+    return { meshes, lines, operands, material };
   }
 
   private buildFromChildren(
     node: { children: SceneNode[]; properties: ShapeProperties },
-    build: (meshes: THREE.Mesh[], lines: THREE.Line[]) => THREE.BufferGeometry,
+    build: (meshes: THREE.Mesh[], lines: THREE.Line[], operands: (THREE.Mesh | THREE.Line)[]) => THREE.BufferGeometry,
   ): THREE.Mesh {
     const temporary = new THREE.Group();
     // The operand meshes are charged as they are built — the budget has to hold
@@ -1996,7 +2034,7 @@ export class Converter {
     try {
       const operands = this.buildOperands(temporary, node.children);
       material = operands.material;
-      geometry = build(operands.meshes, operands.lines);
+      geometry = build(operands.meshes, operands.lines, operands.operands);
     } finally {
       disposeObject3D(temporary);
       this.vertexCount = chargedBeforeOperands;
@@ -2009,8 +2047,8 @@ export class Converter {
   }
 
   private buildLoft(node: LoftNode): THREE.Object3D {
-    return this.buildFromChildren(node, (meshes) => {
-      const profiles = meshes.map(profileOf);
+    return this.buildFromChildren(node, (_meshes, _lines, operands) => {
+      const profiles = operands.map(loftSection);
       const vertices = profiles.length * Math.max(0, ...profiles.map((ring) => ring.length));
       this.chargeEstimate(vertices);
       return loftGeometry(profiles);
@@ -2042,7 +2080,7 @@ export class Converter {
       if (layout.shapes.length === 0) return null;
       if (this.operandDepth > 0 || this.valueSink !== null) {
         this.chargeEstimate(points);
-        return this.finishMesh(new THREE.ShapeGeometry(layout.shapes, 1), node, true);
+        return markPathValue(this.finishMesh(new THREE.ShapeGeometry(layout.shapes, 1), node, true));
       }
       return this.textOutline(node, layout, points);
     });

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -465,6 +465,14 @@ describe("path transform options", () => {
     withMesh(`hull {\n fill { ${square} }\n translate 0 0 2\n fill { ${square} }\n}`, (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
   });
 
+  it("lofts a defined or returned path value — the marker survives capture and placement", () => {
+    withMesh("define sq square\nloft {\n sq\n translate 0 0 1\n sq\n}", (mesh) => near(extent(mesh).toArray(), [1, 1, 1]));
+    withMesh("define sq(s) {\n square { size s }\n}\nloft {\n sq(1)\n translate 0 0 1\n sq(2)\n}", (mesh) => near(extent(mesh).toArray(), [2, 2, 1]));
+    withMesh('define bar text "I"\nloft {\n bar\n translate 0 0 1\n bar\n}', (mesh) => assert.ok(extent(mesh).z > 0.99));
+    // A defined solid is still not a path.
+    assert.throws(() => astToThreeJS(parseShapeScript("define c cube\nloft {\n c\n translate 0 0 1\n c\n}")), /`loft` expects `path`/);
+  });
+
   it("lofts open paths, closing each section implicitly as upstream does", () => {
     // Native 1.11.4 builds a watertight 2×2×2 box from four unrepeated corners per section.
     const open = (z: number) => `path {\n position 0 0 ${z}\n point -1 -1\n point 1 -1\n point 1 1\n point -1 1\n}`;

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -453,6 +453,30 @@ describe("upstream conventions", () => {
 });
 
 describe("path transform options", () => {
+  it("refuses a `fill` as a loft section, as upstream does (a mesh is not a path)", () => {
+    // Native ShapeScript 1.11.4: "A mesh value was not expected in this context."
+    const square = "path {\n point -1 -1\n point 1 -1\n point 1 1\n point -1 1\n point -1 -1\n}";
+    const script = `loft {\nfill {\n position 0 0 0\n ${square}\n}\nfill {\n position 0 0 2\n ${square}\n}\n}`;
+    assert.throws(() => astToThreeJS(parseShapeScript(script)), /`loft` expects `path` cross-sections/);
+    // The same value through a definition is refused too — the check is on the value, not the spelling.
+    assert.throws(() => astToThreeJS(parseShapeScript(`define disc fill { ${square} }\nloft {\n disc\n translate 0 0 2\n disc\n}`)), /`loft` expects `path`/);
+    // A `fill` stays legal where a mesh belongs.
+    withMesh(`fill { ${square} }`, (mesh) => near(extent(mesh).toArray(), [2, 2, 0]));
+    withMesh(`hull {\n fill { ${square} }\n translate 0 0 2\n fill { ${square} }\n}`, (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+  });
+
+  it("lofts open paths, closing each section implicitly as upstream does", () => {
+    // Native 1.11.4 builds a watertight 2×2×2 box from four unrepeated corners per section.
+    const open = (z: number) => `path {\n position 0 0 ${z}\n point -1 -1\n point 1 -1\n point 1 1\n point -1 1\n}`;
+    withMesh(`loft {\n${open(0)}\n${open(2)}\n}`, (mesh) => {
+      near(extent(mesh).toArray(), [2, 2, 2]);
+      assert.ok(Math.abs(volume(mesh) - 8) < 1e-5, `volume ${volume(mesh)}`);
+    });
+    // Sections keep their written order when open and closed paths are mixed.
+    const closed = "path {\n position 0 0 1\n point -0.5 -0.5\n point 0.5 -0.5\n point 0.5 0.5\n point -0.5 0.5\n point -0.5 -0.5\n}";
+    withMesh(`loft {\n${open(0)}\n${closed}\n${open(2)}\n}`, (mesh) => near(extent(mesh).toArray(), [2, 2, 2]));
+  });
+
   it("places a path with its own position/orientation/size, as upstream does for loft sections", () => {
     // Two placed unit squares, 2 apart along Z, loft into a 1×1×2 slab.
     const loft =

--- a/packages/plugins/shapescript-plugin/test/test_language.ts
+++ b/packages/plugins/shapescript-plugin/test/test_language.ts
@@ -471,6 +471,10 @@ describe("path transform options", () => {
     withMesh('define bar text "I"\nloft {\n bar\n translate 0 0 1\n bar\n}', (mesh) => assert.ok(extent(mesh).z > 0.99));
     // A defined solid is still not a path.
     assert.throws(() => astToThreeJS(parseShapeScript("define c cube\nloft {\n c\n translate 0 0 1\n c\n}")), /`loft` expects `path`/);
+    // A function returning a tuple of paths is placed as a path too: the
+    // builder then judges its outline (here two perimeters), not its kind.
+    const two = "define pair() {\n square\n translate 2 0 0\n square\n}\nloft {\n pair()\n translate 0 0 1\n pair()\n}";
+    assert.throws(() => astToThreeJS(parseShapeScript(two)), /multiple perimeters/);
   });
 
   it("lofts open paths, closing each section implicitly as upstream does", () => {


### PR DESCRIPTION
## Summary

Two compatibility mismatches between our ShapeScript preview and native ShapeScript 1.11.4, both in `loft`:

- **A `fill` was accepted as a loft section.** Native refuses it ("A mesh value was not expected in this context"). Our `loft` built every child into a mesh and read the boundary loop back, so a `fill { path … }` was indistinguishable from the path itself and the preview gave a false pass for source the native app rejects.
- **Open paths were dropped, then miscounted.** A path whose last point does not repeat the first became a `THREE.Line`, which `loft` ignored, so a two-section loft failed with "Loft requires at least two cross-sections". Native lofts open paths by closing each section implicitly.

## Changes

- Meshes/lines that stand in for a path value (`path` block, `square` / `circle` / `roundrect` / `polygon`, `text` as an operand) are tagged as path values.
- `loft` refuses any untagged mesh: `` `loft` expects `path` cross-sections, not meshes — pass the path itself rather than a `fill` of it ``. The check is on the evaluated value, so a `define`d fill is refused too.
- Open-path lines are lofted as rings, closed implicitly as upstream does.
- Builders receive their operands in source order across meshes and lines, so mixed open and closed sections keep their written sequence.
- `fill` on its own and `fill` inside `hull` stay legal (pinned by test).
- `@mulmoclaude/shapescript-plugin` bumped to 2.5.1, launcher range in lockstep.

## Verification

Differential check against the official ShapeScript 1.11.4 CLI:

| Source | Native 1.11.4 | Before | After |
|---|---|---|---|
| Two `fill`s inside `loft` | exit 255, mesh not expected | rendered | refused, names the fix |
| Two closed `path`s inside `loft` | 2×2×2 box | 2×2×2 box | 2×2×2 box |
| Same with closing points removed | 2×2×2 box | "at least two cross-sections" | 2×2×2 box |
| Full F-22 model (39 sections, 5 lofts) | 13.563 × 4.0005 × 18.902 | n/a | 13.563 × 4.001 × 18.902 |

- Plugin tests: 175 pass (2 new cases).
- `yarn format` / `lint` / `typecheck` / `build` / `check:launcher-sync` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdnQG4TJH8PhcSDF8cHd97

work in mulmoclaude

## Summary by Sourcery

Align ShapeScript loft behavior with the native implementation by accepting path sections only and implicitly closing open paths.

New Features:
- Support lofting open path sections by implicitly closing each section, matching native ShapeScript behavior.

Bug Fixes:
- Reject mesh values such as filled paths as loft sections while continuing to allow fills in mesh-oriented operations.
- Preserve the written order of mixed open and closed loft sections.

Enhancements:
- Propagate path-value identity through primitives, text, definitions, and returned shape values so loft validates evaluated operands correctly.

Build:
- Bump @mulmoclaude/shapescript-plugin to 2.5.1 and update its consumer dependency.

Documentation:
- Document the loft compatibility fixes and updated package versions in the changelog.

Tests:
- Add coverage for rejecting filled loft sections, preserving path identity through definitions and functions, and lofting open and mixed path sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ShapeScript `loft` behavior with automatic closure of open path sections.
  * Preserved the written order of mixed open and closed sections.
  * Enabled defined or function-returned flat primitives and text to serve as loft sections.

* **Bug Fixes**
  * Rejects solid mesh values as loft cross-sections while retaining valid mesh usage elsewhere.
  * Improved recognition of path-compatible values, including generated text and flat primitives.

* **Chores**
  * Updated the ShapeScript plugin to version 2.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->