### PR TITLE
@mulmoclaude/mulmoscript-plugin@4.8.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,33 @@ warning naming it. Text is capped at 2000 characters before the vertex budget ap
 
 ### Fixed
 
+#### `@mulmoclaude/mulmoscript-plugin@4.8.0` — the View sends the root its card names (#3014, PR #3076)
+
+A deck under a registered stories root opened fine and then failed every write: saving and beat
+images both answered `File not found` (reported from receptron/mulmoterminal#1970). The host was
+already putting `root` on the card; the View never read it. `MulmoScriptData` declared only
+`{ script, filePath }`, so all **17 dispatch kinds** travelled without a root — and
+`stories/deck.json` exists in EVERY registered root, so each one addressed the DEFAULT root's
+file of that name. Both subscriptions hard-coded `root: () => undefined`.
+
+`MulmoScriptData` now declares `root?: string`, which is a type for a value the host was already
+sending, so this is additive and every pre-root card keeps its exact behaviour: absent means the
+default root.
+
+Sending the root is necessary but not sufficient, and three further defects had to be fixed for
+the pair to actually hold:
+
+- **`staleSince` widened to the pair.** An awaited dispatch is applied to whatever card is on
+  screen when it returns, so the root has to be re-checked on arrival, not only on departure.
+- **Media bytes carry the root too** (`fetchMediaBlob`, the host adapter, and both download
+  routes). An artifact ref is relativised against its own root's directory, so it does not carry
+  one.
+- **Awaited dispatches re-check the pair before applying a response.** Sending the root fixes
+  which file is addressed; it does not fix which card the answer belongs to.
+
+The agent's tool schema is deliberately unchanged: `root` is absent from it so a model cannot
+name a root, and only the host fills it in (#3015).
+
 #### Every bridge connected to port 3001 whether or not the server was on it (#3078, PR #3081)
 
 The shared `@mulmobridge/client` resolved its server address as `opts.apiUrl` → `MULMOCLAUDE_API_URL`
@@ -320,7 +347,7 @@ the same way.
 An unmatched brace is now a `PARSE_ERROR` reported at its own line and column, like every other
 diagnostic `presentShapeScript` returns.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.7.0`, `@mulmoclaude/shapescript-plugin@2.5.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.8.0`, `@mulmoclaude/shapescript-plugin@2.5.0`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 ---
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -44,7 +44,7 @@
     "@mulmoclaude/html-plugin": "^4.0.0",
     "@mulmoclaude/markdown-plugin": "^4.1.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
-    "@mulmoclaude/mulmoscript-plugin": "^4.7.0",
+    "@mulmoclaude/mulmoscript-plugin": "^4.8.0",
     "@mulmoclaude/shapescript-plugin": "^2.5.0",
     "@mulmoclaude/spotify-plugin": "^2.0.0",
     "@mulmoclaude/x-plugin": "^1.0.3",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/mulmoscript-plugin",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "presentMulmoScript — MulmoScript storyboard tool for MulmoClaude and MulmoTerminal. Browser-safe core (tool definition + save/reopen/update logic against the generic gui-chat-protocol files.artifacts capability) on `.`, Vue View/Preview on `./vue`, and the Node-only ops layer (mulmocast render/movie/PDF orchestration + dispatch router, host backends injected) on `./server`.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

`@mulmoclaude/mulmoscript-plugin` を **4.7.0 → 4.8.0** に上げ、npm に publish するためのバージョンバンプです。

**なぜ必要か**: タグ `@mulmoclaude/mulmoscript-plugin@4.7.0` から**ソースが8ファイル分ドリフト**していました。
`version` が npm の最新と一致していても「ソースが一致している」証拠にはならない、というやつです
（`yarn audit:releases --code-only` で `code drift` として検出）。中身は **#3076 の View 側 root 対応**が
まるごと未公開、つまり **npm 経由の利用者には multi-root 修正が1行も届いていません**。

```
src/vue/View.vue                          110 ++---   src/core/types.ts                     10 ++
src/vue/composables/useMediaExport.ts      41 +---    src/vue/helpers.ts                    30 ++-
src/vue/composables/useCharacterImages.ts  28 +--     src/vue/hostAdapter.ts                11 +-
src/vue/composables/useBeatMovie.ts        18 +--     src/vue/composables/useDeckEditor.ts   14 +-
```

**semver が minor である理由**: 公開面の変更は `MulmoScriptData.root?: string | undefined` の追加だけで、
これは**ホストが既に送っていた値に型を付けた**もの。optional なので後方互換で、root 以前のカードは
「absent = 既定 root」で挙動が変わりません。

あわせて:

- `packages/mulmoclaude/package.json` の range を `^4.7.0` → `^4.8.0` に掃き寄せ
  （CLAUDE.md「publish したら同じ PR で consumer の range を揃える」）
- `docs/CHANGELOG.md` の `[Unreleased]` に 4.8.0 のエントリを追加し、`Ships` 行を更新

## Items to Confirm / Review

1. **launcher の OWN version は触っていません**（1.15.1 のまま）。CLAUDE.md の
   「`chore(release)` は launcher の version を先回りで上げてはいけない」規則どおりで、
   あの欄は `/publish-mulmoclaude` のものです。`check:launcher-sync` は OK。
2. **minor の判断**。公開面の追加は optional フィールド1つだけですが、View の挙動は
   「パスだけで指す」→「対 `(root, filePath)` で指す」に変わります。patch ではなく minor にしました。
3. **`docs/CHANGELOG.md` の `Ships` 行**は「この launcher が引き込むバージョン」を答える行なので、
   4.7.0 → 4.8.0 に直しています（`check-changelog-ships.mjs` が強制）。

## 検証

ルートで **終了コード判定**: `yarn lint` 0 / `yarn typecheck` 0 / `yarn build` 0 /
`yarn test` 0（**12953 pass / 0 fail**）。`yarn check:launcher-sync` OK、
`node scripts/packages/check-changelog-ships.mjs` OK。

> 最初の `yarn test` は exit 1 でした。`test_changelogShips.ts` が
> 「version を上げたら `[Unreleased]` の `Ships` 行と一致させる」を強制しており、
> それを直して緑にしています。publish 前に落ちる設計になっているのが効きました。

## User Prompt

- こっちでの残課題なし？
- まず3 として、1,2かな

（1 = `@mulmoclaude/mulmoscript-plugin` の publish、2 = `mulmoclaude` launcher の publish、
3 = `mulmoclaude@1.15.1` のタグ遡り打ち。3 は完了済み。この PR は 1。）

## なぜ PR なのか

`/publish` skill はバージョンバンプの main 直 push を例外的に認めていますが、
このセッションでは auto mode classifier に拒否されたため、**merge commit の PR** に切り替えています。
merge commit ならこのコミットが main の履歴に残るので、リリースタグはそのまま有効です。

## 関連

- #3014 — root 対応の系列。この publish が届けるのは実装順序1の残り（#3076）
- #3076 — View が dispatch に root を載せる

work in mulmoclaude2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgM174UftqbfGd9Y5kuUwg

## Summary by Sourcery

Publish the root-aware MulmoScript View fixes in @mulmoclaude/mulmoscript-plugin 4.8.0 and align its consumer metadata.

New Features:
- Add root-aware View handling so cards and media operations target the correct registered stories root.
- Expose the optional card root in MulmoScriptData while preserving default-root behavior for existing cards.

Bug Fixes:
- Fix saves, beat images, media downloads, and awaited dispatch responses failing or being applied to the wrong card when multiple roots contain the same paths.

Build:
- Bump @mulmoclaude/mulmoscript-plugin from 4.7.0 to 4.8.0 and update the mulmoclaude consumer range.

Documentation:
- Document the root-aware View fix in the changelog and update the shipped plugin version to 4.8.0.