### PR TITLE
ci: macOS の lint が eslint heap OOM で落ちる — lint ステップにヒープを与える (#3093)

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -130,7 +130,19 @@ jobs:
       if: steps.pkg-dist-cache.outputs.cache-hit != 'true'
       run: yarn build:packages
     - run: yarn run typecheck
+    # One eslint process covers the whole repo with type-aware rules, which hold
+    # the TypeScript program in memory: measured peak RSS 3.86 GB. Node picks its
+    # default heap from machine RAM, so the ubuntu runners (16 GB → ~4 GB heap)
+    # cleared it by a hair while the macOS arm64 runners (7 GB → ~2 GB) did not —
+    # same command, half the budget, `exit 134` on macOS only (#3093).
+    #
+    # Reproduced locally by capping the heap to the macOS value: 2048 aborts with
+    # the identical FATAL, 4096 and 6144 complete. 4096 is what ubuntu already
+    # had and it was only just enough, so this is 6144 — headroom rather than the
+    # next tipping point. The lint scope only grows.
     - run: yarn run lint
+      env:
+        NODE_OPTIONS: --max-old-space-size=6144
     # Plugin barrel codegen must be in sync — fail the build if a
     # developer added a plugin dir without re-running the codegen.
     # `yarn run build` regenerates them via prebuild, but we want a


### PR DESCRIPTION
## Summary

`lint_test (22.x / 24.x, macos-latest)` が **`main` で赤**でした。lint の指摘ではなく **eslint 自身のヒープ枯渇**です:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
Abort trap: 6 ... exit code 134
```

**ubuntu の leg は通る** — これが手掛かりでした。

### 原因

`yarn lint` は `src server test e2e e2e-live packages scripts batch build-config` を **1 つの eslint プロセス**で、**型情報を使うルール**込みで回します。つまり TypeScript の program 全体が常駐します。**実測ピーク RSS は 3.86 GB。**

Node は既定のヒープ上限を**マシンの RAM から決めます**。したがって:

| runner | RAM | Node の既定ヒープ | 結果 |
|---|---|---|---|
| ubuntu-latest | 16 GB | 約 4 GB | **ぎりぎり通っていた** |
| macos-latest (arm64) | 7 GB | 約 2 GB | **足りない** |

同じコマンドで、**予算が半分**。だから macOS だけが落ちます。

### 推測ではなく再現しました

`main` (`7500a22a`) でヒープを macOS の値に絞ると、同じ FATAL が出ます:

| `--max-old-space-size` | 結果 |
|---|---|
| **2048** | **exit 134、CI と同一の FATAL** |
| 4096 | 完走 |
| 6144 | 完走 |

`#3090`（9 ファイルの refactor）が原因に見えたのは、**4 GB がもともとぎりぎりだった**からです。倒したのは #3090 ですが、倒れる寸前だったのは前からです。

### 変更

lint ステップに `NODE_OPTIONS: --max-old-space-size=6144` を付けるだけ。

**4096 にしない理由**: それは ubuntu が既に持っていた値で、**ぎりぎりだったからこの issue が起きました**。6144 は「次の閾値」ではなく余裕です。V8 は上限を先に確保しないので、3.86 GB のピークは 7 GB の runner に収まります。

## Items to Confirm / Review

1. **これは対症療法だと自覚しています。** 本来のコストは「**プラットフォーム非依存の同じ lint を 4 本の matrix leg で回している**」ことです。lint を ubuntu だけにすれば OOM は消え、CI 時間も減ります。ただしそれは **CI ポリシーの判断**で、CI を解除するための PR に紛れ込ませるべきではないので **#3093 に残しました**。判断をお願いします。
2. **6144 という数字**。上表が根拠です。7 GB の macOS runner で 6 GB のヒープ上限を許すことに懸念があれば 5120 でも通ります（3.86 GB > という条件だけ満たせば）。
3. **lint 対象が増え続けること自体**は変わりません。次に同じことが起きたら、上限をまた上げるのではなく 1 を検討してください。

## User Prompt

- 「OOMってなんでだろう？直せる？」— #3078 / #3082 の作業中に両 PR がこの赤を継承していたため調査し、原因特定と修正を行いました。

## 検証

上の再現表がそのまま検証です（`main` 上で、eslint キャッシュを消してから実行）。CI は `main` が緑に戻るかで判定できます。

Closes #3093

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xGCF24fsL3M3PAHLnVYV8

work in mulmoclaude3

## Summary by Sourcery

Increase the lint step’s Node.js heap limit to prevent platform-specific CI failures during repository-wide linting.

Bug Fixes:
- Prevent macOS lint jobs from failing with JavaScript heap out-of-memory errors by increasing the lint process memory limit.

CI:
- Increase the ESLint heap allowance in the pull request workflow to support the repository-wide, type-aware lint run across macOS and Ubuntu runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of automated code-quality checks by allocating more memory to the linting process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->