### PR TITLE
chore(mulmoclaude): bump launcher + root to 1.16.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-09-12
+
+**3D models became a first-class canvas view, and a MulmoScript deck can now live in a registered stories root instead of only the workspace.**
+
 ### Changed
 
 #### `@mulmoclaude/shapescript-plugin@2.5.0` — one statement per line, no `tau`
@@ -42,6 +46,40 @@ Helvetiker (a Helvetica look-alike, licensed for redistribution) scaled to Helve
 warning naming it. Text is capped at 2000 characters before the vertex budget applies.
 
 ### Fixed
+
+#### The mulmoScript REST routes addressed a story by its path alone (#3077, PR #3083)
+
+The host's REST adapter pointed at a story with `filePath` and nothing else. `stories/deck.json`
+exists in EVERY registered root, so a host with more than one read and wrote the DEFAULT root's
+file of that name — silently, because that path is well-formed in both. Thirteen routes were
+affected: the beat image / audio / movie reads, movie and PDF status, character images, the three
+uploads, both beat generation ops behind the handler factory, and the two writes.
+
+A malformed root is now REFUSED with a 400 rather than folded into the default. Folding it is the
+defect #3015 fixed at the dispatch entry: the caller believes it named a root while the write
+lands in another. A repeated `?root=` produces an array, so that shape arrives by accident.
+
+The SSE generation routes (`generateMovie`, `generatePdf`) were bypassing the package's own
+`guardStoryGenerationRoot`, which refuses a named root on a host that cannot tell two roots'
+generations apart (#3020) — so rooted generation had been running unguarded.
+
+#### An unparsed story root no longer compiles (#3086, PR #3090)
+
+The same class of bug appeared four times across #3076 and #3077, and the guard against it was a
+textual sweep that a review spent five rounds on — because a textual rule has infinitely many
+blind spellings. `ParsedStoryRoot` is a branded string that only `parseSuppliedRoot` can mint (via
+a type guard, not `as`), and the host stops exporting the raw ops object: it is seen through a
+type that requires a parsed root on all 26 root-taking members, with no runtime wrapper. The root
+is REQUIRED rather than optional, so a call that omits it — directly, through an alias, or
+destructured — is a compile error.
+
+The package's own signatures are unchanged, so this breaks no published API and MulmoTerminal
+needs no edit.
+
+#### Shared `shortcuts.json` dropped keys the running build did not know (#3055, PR #3057)
+
+A shortcuts file written by a newer build lost its unrecognised keys the moment an older one saved
+over it. Unknown keys are now preserved through a read-modify-write.
 
 #### `@mulmoclaude/mulmoscript-plugin@4.8.0` — the View sends the root its card names (#3014, PR #3076)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude-monorepo",
   "private": true,
-  "version": "1.15.1",
+  "version": "1.16.0",
   "type": "module",
   "author": "snakajima",
   "license": "MIT",

--- a/packages/mulmoclaude/README.md
+++ b/packages/mulmoclaude/README.md
@@ -32,6 +32,7 @@ Your browser opens to `http://localhost:3001`. That's it.
 | "Add this to my calendar"       | Event in your Google Calendar (sign in, no setup)     |
 | "Put that on my task list"      | Task in Google Tasks, with notes and a due date       |
 | "Subscribe to this RSS feed"    | Data feed on `/feeds`, fetched on a schedule          |
+| "Model a chess piece in 3D"     | Interactive ShapeScript scene, exportable to USDZ     |
 
 **Pages you can visit directly**: `/wiki` (browse + lint), `/feeds` (data feeds), `/collections` (data apps — Discover tab to import community collections, Contribute to share your own), `/automations` (recurring tasks), `/files` (drop files onto a folder row to save them straight into it), `/skills`, `/roles`. Each page has its own chat composer that spawns a fresh chat already aware of the page context.
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoclaude",
-  "version": "1.15.1",
-  "description": "MulmoClaude — GUI-chat with Claude Code + long-term memory. One command to start.",
+  "version": "1.16.0",
+  "description": "MulmoClaude \u2014 GUI-chat with Claude Code + long-term memory. One command to start.",
   "type": "module",
   "bin": {
     "mulmoclaude": "bin/mulmoclaude.js"


### PR DESCRIPTION
## Summary

`mulmoclaude` launcher を **1.15.1 → 1.16.0** に上げ、npm に publish するためのバンプです。

**なぜ必要か**: launcher の `files` は `server/` と `src/` を含むので、**アプリ本体のコードは
launcher publish でしか npm 利用者に届きません**。1.15.1 の publish 以降、そこに
**32ファイル / 約920行**のドリフトが溜まっていました。

出荷内容:

- **ShapeScript プラグイン一式**（2.0.0 → 2.5.0）—— `presentShapeScript`、USDZ エクスポート、
  `text`、マテリアル、メッシュ、upstream の単位・パス意味論への追従。今回の目玉
- **mulmoScript の複数 root 対応**（#3014 の実装順序1。ホスト側が今回で完了）
- デッキ編集の保存失敗バナー（#3070）
- bridge が `.server-port` に追従する修正（#3078）
- 共有 `shortcuts.json` が知らないキーを保持する（#3055）

## Items to Confirm / Review

1. **root と launcher を同じコミットで 1.16.0 に揃えています**（skill の §5.5）。
   `v1.16.0` タグと `mulmoclaude@1.16.0` がずれないための規則で、`check:launcher-sync` は OK。
2. **CHANGELOG の節の切り方**。`[Unreleased]` をそのまま `## [1.16.0] - 2026-09-12` にし、
   空の `[Unreleased]` を上に新設しました。`check-changelog-ships` は
   「`[Unreleased]` に `Ships` 行があればそれ、無ければ launcher の version 節」を見る作りなので、
   いまは `[1.16.0]` を見て OK になっています。
3. **アプリレベルの3項目を追記しました** —— パッケージ節が無く、どこにも載っていなかったものです:
   REST ルートが story をパス単体で指していた件（#3077, PR #3083）、story root の branded type 化
   （#3086, PR #3090）、shortcuts が未知のキーを落としていた件（#3055, PR #3057）。
4. **README に ShapeScript の行を1つ追加**。npm のランディングページに今回の目玉への言及が
   ゼロだったためです（skill §3.5）。Options ブロックは `bin/mulmoclaude.js` と突き合わせ済みで、
   5フラグすべてカバーされていました。

## 検証

ルートで**終了コード判定**: `yarn lint` 0 / `yarn typecheck` 0 / `yarn build` 0 /
`yarn test` 0（**12953 pass / 0 fail**）。`yarn check:launcher-sync` OK、
`yarn check:changelog-ships` OK、`node scripts/mulmoclaude/deps.mjs` OK、
`node scripts/mulmoclaude/drift.mjs` OK。

**§6 の依存解決チェックが本物のブロッカーを1件出しました**: `@mulmobridge/client` が
ローカル 1.1.0 / npm 1.0.2 で、launcher は `^1.1.0` を宣言していました。過去の bump
（`4ae76ba9f`）が publish されていなかったもので、このままだと `npx mulmoclaude@1.16.0` が
ETARGET で落ちます。**1.1.0 を先に publish して解消済み**（タグ・GH release も作成）。
未公開なのは飾りではなく、1.1.0 は `resolveApiUrl` と `tokenFilePath` を新たに export し、
公開中だった 1.0.2 の dist には `resolveApiUrl` が入っていませんでした。

> **ローカルの §4 タールボール smoke はこの環境では回りません** —— `xlsx` が
> `https://cdn.sheetjs.com/...` の remote URL 依存（sheetjs が npm 公開をやめたため）で、
> このサンドボックスの npm が `EALLOWREMOTE` で取得を拒否します。パッケージ側の問題ではなく、
> **CI の `MulmoClaude publish smoke` が go/no-go** です（skill の規定どおり）。
> このブランチの結果を待って publish します。

`origin/main` の #3096（macOS の lint heap 修正）を取り込んだ上で全ゲートを回し直しています。

## User Prompt

- こっちでの残課題なし？
- まず3 として、1,2かな
- あ、必要ならこっちでpublishするよ
- publishした

（3 = `mulmoclaude@1.15.1` のタグ遡り打ち、1 = `@mulmoclaude/mulmoscript-plugin` の publish、
2 = この launcher publish。3 と 1 は完了済み。`@mulmobridge/client@1.1.0` は 2 の前提として
ユーザーが publish。）

## 関連

- #3014 / #3070 / #3055 / #3078 —— このリリースが届ける修正

work in mulmoclaude2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KgM174UftqbfGd9Y5kuUwg

## Summary by Sourcery

Release MulmoClaude 1.16.0 with root-aware MulmoScript decks, an upgraded ShapeScript experience, and fixes for story routing and shortcut compatibility.

New Features:
- Add support for MulmoScript decks rooted in registered story locations.
- Promote ShapeScript 3D scenes to a documented first-class canvas experience with USDZ export.

Bug Fixes:
- Ensure story-rooted REST operations target and validate the requested root instead of defaulting silently.
- Preserve unknown entries when updating shared shortcut configuration files.

Enhancements:
- Enforce parsed story roots across host operations at compile time and complete the root-aware deck editing flow.

Build:
- Bump the monorepo and mulmoclaude launcher packages to version 1.16.0.

Documentation:
- Document the 1.16.0 release, including the ShapeScript and story-root capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 3D models are now supported as a first-class canvas view.
  - MulmoScript decks now live in a registered stories root.
  - Added an example for modeling a chess piece in 3D with export to USDZ.

- **Bug Fixes**
  - Improved story-root validation and REST route handling.
  - Prevented malformed roots from compiling or triggering generation errors.
  - Preserved unknown settings in shared shortcut configurations.

- **Documentation**
  - Updated release documentation and examples for version 1.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->