### PR TITLE
fix(remote-host): re-key a parked session blob to the app it is restored into

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,14 @@ Seeding now re-keys the blob to the app about to be opened, so a parked session 
 depends on the sequence number it happened to be saved under. Sessions already parked under a
 later name restore without a new sign-in.
 
+The re-key refuses to guess. A blob can carry two app names — `open` keeps the previous app
+alive until the fresh one has validated, and both share one store, so a token refresh in that
+window writes the old name back beside the new one. Collapsing both onto one target would pick
+a winner by JSON order, and the stale app is the one that writes last, so a restart could come
+back as the account the user had just signed out of. An ambiguous target is dropped instead:
+the restore finds no user and the client is asked to sign in once, which is what happened
+before re-keying existed.
+
 #### `@mulmoclaude/shapescript-plugin@2.5.1` — `loft` takes path sections only, and lofts open paths (PR #3094)
 
 Two mismatches with the upstream app, both in `loft`. A `fill { path … }` as a section rendered

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 
+#### A phone-link session parked under a later Firebase app survives a host restart (#3089)
+
+Firebase Auth namespaces every persistence key with the app that wrote it
+(`firebase:<key>:<apiKey>:<appName>`), and `createRemoteHostSession` opens a fresh
+`remote-host-${appSeq}` app on each connect, counting from zero in every new process. So a
+session the browser parked while `remote-host-2` was live was invisible to the `remote-host-1`
+app a restarted host opens first: the SDK looked up its own key, missed, and settled with no
+user. The host answered 401, the browser dropped the parked session, and the user signed in
+through the Google popup again — and because the failed restore had already advanced the
+counter, the new session was saved under `remote-host-2` too, so it came back on the next
+restart. The same mismatch broke in-process reconnect, where the app name always moves on.
+
+Seeding now re-keys the blob to the app about to be opened, so a parked session no longer
+depends on the sequence number it happened to be saved under. Sessions already parked under a
+later name restore without a new sign-in.
+
 #### `@mulmoclaude/shapescript-plugin@2.5.1` — `loft` takes path sections only, and lofts open paths (PR #3094)
 
 Two mismatches with the upstream app, both in `loft`. A `fill { path … }` as a section rendered

--- a/packages/core/src/remote-host/server/firebase.ts
+++ b/packages/core/src/remote-host/server/firebase.ts
@@ -134,15 +134,22 @@ export const createRemoteHostSession = (config: FirebaseOptions): RemoteHostSess
     const previousApp = app;
     const previousBlob = store.exportBlob();
     appSeq += 1;
+    // `appSeq` restarts at 0 each process and counts failed opens too, so the
+    // name a blob was parked under is meaningless to a later run. `seed` re-keys
+    // the blob to the app we are opening now, which is what makes a parked
+    // session restorable at all (#3089).
+    const appName = `remote-host-${appSeq}`;
     try {
       store.clear();
-      if (seedBlob) store.seed(seedBlob);
-      const { app: nextApp, handles } = await openFreshApp(config, store, `remote-host-${appSeq}`);
+      if (seedBlob) store.seed(seedBlob, appName);
+      const { app: nextApp, handles } = await openFreshApp(config, store, appName);
       await validateOrRollback(nextApp, handles, validate);
       app = nextApp;
       if (previousApp) await deleteApp(previousApp).catch(() => undefined);
       return handles;
     } catch (error) {
+      // Verbatim: the previous app is still live and reads the keys the blob
+      // already carries, so re-keying here would hide its own session from it.
       store.clear();
       if (previousBlob) store.seed(previousBlob);
       throw error;

--- a/packages/core/src/remote-host/server/sessionPersistence.ts
+++ b/packages/core/src/remote-host/server/sessionPersistence.ts
@@ -2,8 +2,9 @@
 // but can be seeded from — and exported back to — an opaque blob, so a host's
 // Firebase session survives a process restart by being parked in the browser's
 // localStorage (mulmoserver#50, "case A'"). The blob is whatever the SDK wrote
-// into persistence, round-tripped through JSON; we NEVER interpret its fields,
-// so we don't couple to the SDK's serialized-user format across versions.
+// into persistence, round-tripped through JSON; we never interpret its VALUES,
+// so we don't couple to the SDK's serialized-user format across versions. Key
+// NAMES we do read, but only their app-name segment — see `seed`.
 //
 // **Persistence is a CLASS, not an instance.** `initializeAuth(app, { persistence })`
 // hands the value to the SDK's `_getInstance(cls)`, which asserts `cls instanceof
@@ -46,8 +47,13 @@ export interface HostAuthPersistenceClass extends Persistence {
 export interface HostSessionPersistence {
   /** Pass to `initializeAuth(app, { persistence })`. It's a class the SDK `new`s. */
   persistence: HostAuthPersistenceClass;
-  /** Load a previously exported blob. Call BEFORE `initializeAuth`. */
-  seed: (blob: string) => void;
+  /**
+   * Load a previously exported blob. Call BEFORE `initializeAuth`. `appName`
+   * re-keys the blob for the app about to be opened (see `rekeyForApp`); omit
+   * it to restore keys verbatim, which is what a rollback to a still-live app
+   * needs.
+   */
+  seed: (blob: string, appName?: string) => void;
   /** Serialize the current contents, or `null` when empty (no session). */
   exportBlob: () => string | null;
   /** Notified with the fresh blob (or `null`) whenever the SDK writes/removes. */
@@ -70,6 +76,25 @@ export const isSeedableBlob = (blob: string): boolean => {
   } catch {
     return false;
   }
+};
+
+// Firebase Auth namespaces every persistence key with the app that wrote it:
+// `firebase:<key>:<apiKey>:<appName>` (@firebase/auth's `_persistenceKeyName`).
+// A host opens a fresh app per connect, so a blob parked while `remote-host-2`
+// was live is invisible to the `remote-host-1` app a restarted host opens first
+// — the SDK looks up its own key, misses, and settles with no user (#3089).
+// Rewriting the app-name segment as the blob is seeded makes a parked session
+// independent of the sequence number it happened to be saved under. Only the key
+// is touched: the serialized user stays opaque, and its own `appName` field is
+// never read back by the SDK (`UserImpl._fromJSON`, @firebase/auth 1.13.3).
+// A key of any other shape is passed through untouched.
+const FIREBASE_KEY_NAMESPACE = "firebase";
+const FIREBASE_KEY_SEGMENTS = 4;
+
+const rekeyForApp = (key: string, appName: string): string => {
+  const segments = key.split(":");
+  if (segments.length !== FIREBASE_KEY_SEGMENTS || segments[0] !== FIREBASE_KEY_NAMESPACE) return key;
+  return [...segments.slice(0, FIREBASE_KEY_SEGMENTS - 1), appName].join(":");
 };
 
 // A class (constructor) so the SDK's `_getInstance` accepts it (it asserts
@@ -123,12 +148,12 @@ export const createHostSessionPersistence = (): HostSessionPersistence => {
 
   const persistence = makeHostPersistenceClass(store, notify);
 
-  const seed = (blob: string): void => {
+  const seed = (blob: string, appName?: string): void => {
     const parsed: unknown = JSON.parse(blob);
     if (!isRecord(parsed)) throw new Error("host session blob must be a JSON object");
     store.clear();
     for (const [key, value] of Object.entries(parsed)) {
-      if (isPersistenceValue(value)) store.set(key, value);
+      if (isPersistenceValue(value)) store.set(appName ? rekeyForApp(key, appName) : key, value);
     }
   };
 

--- a/packages/core/src/remote-host/server/sessionPersistence.ts
+++ b/packages/core/src/remote-host/server/sessionPersistence.ts
@@ -97,6 +97,25 @@ const rekeyForApp = (key: string, appName: string): string => {
   return [...segments.slice(0, FIREBASE_KEY_SEGMENTS - 1), appName].join(":");
 };
 
+// Re-keying is only safe while it is unambiguous, and a blob CAN carry two app
+// names: `open` keeps the previous app alive until the fresh one has validated,
+// and that app shares this store, so a token refresh in the meantime writes its
+// own key back beside the new one. Collapsing both onto one target would pick a
+// winner by JSON order — the stale app writes last — and a host would come back
+// as the account the user had just signed out of. So an ambiguous target is
+// dropped: the restore finds no user, the client is told to sign in again, and
+// that is what happened before re-keying existed.
+const resolveKeys = (keys: string[], appName: string | undefined): Map<string, string> => {
+  if (!appName) return new Map(keys.map((key) => [key, key]));
+  const targets = keys.map((key) => rekeyForApp(key, appName));
+  const contested = new Set(targets.filter((target, index) => targets.indexOf(target) !== index));
+  return keys.reduce((resolved, key, index) => {
+    const target = targets[index];
+    if (target !== undefined && !contested.has(target)) resolved.set(key, target);
+    return resolved;
+  }, new Map<string, string>());
+};
+
 // A class (constructor) so the SDK's `_getInstance` accepts it (it asserts
 // `cls instanceof Function`, then `new cls()`); instances hold the shared
 // `store`/`notify`, so a fresh `new` still sees the seeded/live data. `static
@@ -152,8 +171,10 @@ export const createHostSessionPersistence = (): HostSessionPersistence => {
     const parsed: unknown = JSON.parse(blob);
     if (!isRecord(parsed)) throw new Error("host session blob must be a JSON object");
     store.clear();
+    const resolved = resolveKeys(Object.keys(parsed), appName);
     for (const [key, value] of Object.entries(parsed)) {
-      if (isPersistenceValue(value)) store.set(appName ? rekeyForApp(key, appName) : key, value);
+      const target = resolved.get(key);
+      if (target !== undefined && isPersistenceValue(value)) store.set(target, value);
     }
   };
 

--- a/packages/core/test/remote-host/test_sessionPersistence.ts
+++ b/packages/core/test/remote-host/test_sessionPersistence.ts
@@ -119,6 +119,25 @@ describe("createHostSessionPersistence", () => {
     });
   });
 
+  it("seed drops a re-key target that two source keys claim, rather than picking one", () => {
+    // A blob can carry two app names: `open` keeps the previous app alive until
+    // the fresh one validates, and that app shares this store. Collapsing both
+    // onto one target would pick a winner by JSON order — the stale app writes
+    // last — so the host would come back as the account the user just left.
+    const { seed, exportBlob } = createHostSessionPersistence();
+    seed(
+      JSON.stringify({
+        "firebase:authUser:apiKey:remote-host-3": { uid: "current" },
+        "firebase:authUser:apiKey:remote-host-2": { uid: "stale" },
+        "firebase:persistence:apiKey:remote-host-2": "LOCAL",
+      }),
+      "remote-host-1",
+    );
+
+    // The contested authUser target is dropped; the uncontested one still re-keys.
+    assert.deepEqual(JSON.parse(exportBlob() ?? "null"), { "firebase:persistence:apiKey:remote-host-1": "LOCAL" });
+  });
+
   it("seed without an app name restores keys verbatim (the rollback path)", () => {
     // `open` rolls back to a still-live app, which reads the keys its own blob
     // already carries — re-keying there would hide its session from it.

--- a/packages/core/test/remote-host/test_sessionPersistence.ts
+++ b/packages/core/test/remote-host/test_sessionPersistence.ts
@@ -88,6 +88,46 @@ describe("createHostSessionPersistence", () => {
     assert.deepEqual(JSON.parse(exportBlob() ?? "null"), { [AUTH_KEY]: userValue });
   });
 
+  it("seed re-keys a blob to the app about to be opened (#3089 regression)", async () => {
+    // A blob parked while `remote-host-2` was live must restore into the
+    // `remote-host-1` app a restarted host opens first: the SDK only ever looks
+    // up the key built from ITS OWN app name.
+    const { persistence, seed, exportBlob } = createHostSessionPersistence();
+    seed(JSON.stringify({ "firebase:authUser:apiKey:remote-host-2": userValue }), "remote-host-1");
+
+    assert.deepEqual(await new persistence()._get(AUTH_KEY), userValue);
+    assert.deepEqual(JSON.parse(exportBlob() ?? "null"), { [AUTH_KEY]: userValue });
+  });
+
+  it("seed re-keys every Firebase-shaped key and leaves other keys alone", () => {
+    const { seed, exportBlob } = createHostSessionPersistence();
+    seed(
+      JSON.stringify({
+        "firebase:authUser:apiKey:remote-host-9": userValue,
+        "firebase:persistence:apiKey:remote-host-9": "LOCAL",
+        "not-a-firebase-key": "keep",
+        "firebase:authUser:api:Key:with:colons": "keep", // too many segments to read safely
+      }),
+      "remote-host-1",
+    );
+
+    assert.deepEqual(JSON.parse(exportBlob() ?? "null"), {
+      "firebase:authUser:apiKey:remote-host-1": userValue,
+      "firebase:persistence:apiKey:remote-host-1": "LOCAL",
+      "not-a-firebase-key": "keep",
+      "firebase:authUser:api:Key:with:colons": "keep",
+    });
+  });
+
+  it("seed without an app name restores keys verbatim (the rollback path)", () => {
+    // `open` rolls back to a still-live app, which reads the keys its own blob
+    // already carries — re-keying there would hide its session from it.
+    const { seed, exportBlob } = createHostSessionPersistence();
+    const parked = JSON.stringify({ "firebase:authUser:apiKey:remote-host-2": userValue });
+    seed(parked);
+    assert.equal(exportBlob(), parked);
+  });
+
   it("seed rejects a non-object blob", () => {
     const { seed } = createHostSessionPersistence();
     assert.throws(() => seed("[1,2,3]"), /must be a JSON object/);

--- a/packages/core/test/remote-host/test_sessionRestore.ts
+++ b/packages/core/test/remote-host/test_sessionRestore.ts
@@ -1,0 +1,104 @@
+// Regression test for #3089: a session parked by the browser while a LATER
+// Firebase app was live (`remote-host-2`, …) must still restore on a restarted
+// host, whose first `open` builds `remote-host-1`. Firebase Auth looks the
+// stored user up under `firebase:authUser:<apiKey>:<its own app name>`, so
+// before the fix the lookup missed and `authStateReady()` settled with no user
+// — the host answered 401 and the browser dropped the parked session.
+//
+// This drives the real firebase/auth restore path with no network and no real
+// credentials: `globalThis.fetch` is replaced BEFORE firebase is loaded, because
+// @firebase/auth captures the global in `FetchProvider.initialize(fetch, …)` at
+// module-eval time. Every auth API call then fails as `network-request-failed`,
+// which the SDK treats as "keep the stored user" rather than "sign out". That is
+// why this lives in its own file: `test_session.ts` imports firebase statically,
+// so the stub could not be installed first there.
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const fetchCalls: string[] = [];
+globalThis.fetch = (input: Parameters<typeof fetch>[0]): Promise<Response> => {
+  fetchCalls.push(String(input).split("?")[0] ?? "");
+  return Promise.reject(new TypeError("offline (test stub)"));
+};
+
+const { createRemoteHostSession } = await import("../../src/remote-host/server/firebase.js");
+
+const CONFIG = { apiKey: "test-api-key", authDomain: "test.firebaseapp.com", projectId: "test", appId: "1:0:web:test" };
+const UID = "parked-uid";
+const TOKEN_LIFETIME_MS = 60 * 60 * 1000;
+
+// Shaped like what `UserImpl.toJSON()` writes; `_fromJSON` asserts on these
+// fields. The `appName` INSIDE the user is written by the SDK but never read
+// back, so leaving it stale is deliberate — only the key has to line up.
+const blobFor = (appName: string): string =>
+  JSON.stringify({
+    [`firebase:authUser:${CONFIG.apiKey}:${appName}`]: {
+      uid: UID,
+      emailVerified: false,
+      isAnonymous: false,
+      providerData: [],
+      stsTokenManager: { refreshToken: "parked-refresh", accessToken: "parked-access", expirationTime: Date.now() + TOKEN_LIFETIME_MS },
+      createdAt: "0",
+      lastLoginAt: "0",
+      apiKey: CONFIG.apiKey,
+      appName,
+    },
+  });
+
+describe("createRemoteHostSession.open (restore a parked blob after a restart)", () => {
+  it("restores a blob parked under a later app name on the first open (#3089)", async () => {
+    const session = createRemoteHostSession(CONFIG);
+    try {
+      const opened = await session.open(blobFor("remote-host-2"));
+      assert.equal(opened.uid, UID, "a blob parked under remote-host-2 must restore into the first app of a fresh process");
+      assert.ok(
+        fetchCalls.some((url) => url.endsWith("accounts:lookup")),
+        "the SDK only reloads a user it actually found in persistence",
+      );
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("restores a blob parked under the same app name it reopens with (control)", async () => {
+    const session = createRemoteHostSession(CONFIG);
+    try {
+      const opened = await session.open(blobFor("remote-host-1"));
+      assert.equal(opened.uid, UID);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("restores across an in-process reconnect, where the app name always moves on", async () => {
+    // The self-heal path: a live session hands its own parked blob back to
+    // `open`, which must build a DIFFERENT app (the previous one is still live
+    // and `initializeAuth` runs once per app) — so the blob's app name can never
+    // match there either.
+    const session = createRemoteHostSession(CONFIG);
+    try {
+      const first = await session.open(blobFor("remote-host-1"));
+      assert.equal(first.auth.app.name, "remote-host-1");
+
+      const parked = session.exportSession();
+      assert.ok(parked);
+      const second = await session.open(parked);
+      assert.equal(second.auth.app.name, "remote-host-2", "a reconnect must open a fresh app");
+      assert.equal(second.uid, UID);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("re-exports the restored session under the app that is now live", async () => {
+    const session = createRemoteHostSession(CONFIG);
+    try {
+      await session.open(blobFor("remote-host-2"));
+      const exported: unknown = JSON.parse(session.exportSession() ?? "null");
+      assert.ok(exported && typeof exported === "object");
+      assert.deepEqual(Object.keys(exported), [`firebase:authUser:${CONFIG.apiKey}:remote-host-1`]);
+    } finally {
+      await session.close();
+    }
+  });
+});

--- a/packages/core/test/remote-host/test_sessionRestore.ts
+++ b/packages/core/test/remote-host/test_sessionRestore.ts
@@ -9,19 +9,27 @@
 // credentials: `globalThis.fetch` is replaced BEFORE firebase is loaded, because
 // @firebase/auth captures the global in `FetchProvider.initialize(fetch, …)` at
 // module-eval time. Every auth API call then fails as `network-request-failed`,
-// which the SDK treats as "keep the stored user" rather than "sign out". That is
-// why this lives in its own file: `test_session.ts` imports firebase statically,
-// so the stub could not be installed first there.
+// which is the ONE error the SDK answers by keeping the stored user rather than
+// signing it out (`reloadAndSetCurrentUserOrClear`). That is why this lives in
+// its own file: `test_session.ts` imports firebase statically, so the stub could
+// not be installed first there.
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
+// The stub RESOLVES with an unparsable body rather than rejecting. Both end in
+// `network-request-failed`, but `_performFetchWithErrorHandling` races the fetch
+// against a 30-second `NetworkTimeout` and clears that timer only after the race
+// RESOLVES — a rejecting stub leaves it pending and the test process idles for 30
+// seconds before exiting. Resolving gets the timer cleared, then `response.json()`
+// throws and the SDK reports the network error the restore path needs.
 const fetchCalls: string[] = [];
 globalThis.fetch = (input: Parameters<typeof fetch>[0]): Promise<Response> => {
   fetchCalls.push(String(input).split("?")[0] ?? "");
-  return Promise.reject(new TypeError("offline (test stub)"));
+  return Promise.resolve(new Response("offline (test stub): not json"));
 };
 
 const { createRemoteHostSession } = await import("../../src/remote-host/server/firebase.js");
+const { updateCurrentUser } = await import("firebase/auth");
 
 const CONFIG = { apiKey: "test-api-key", authDomain: "test.firebaseapp.com", projectId: "test", appId: "1:0:web:test" };
 const UID = "parked-uid";
@@ -30,10 +38,10 @@ const TOKEN_LIFETIME_MS = 60 * 60 * 1000;
 // Shaped like what `UserImpl.toJSON()` writes; `_fromJSON` asserts on these
 // fields. The `appName` INSIDE the user is written by the SDK but never read
 // back, so leaving it stale is deliberate — only the key has to line up.
-const blobFor = (appName: string): string =>
+const blobFor = (appName: string, uid: string = UID): string =>
   JSON.stringify({
     [`firebase:authUser:${CONFIG.apiKey}:${appName}`]: {
-      uid: UID,
+      uid,
       emailVerified: false,
       isAnonymous: false,
       providerData: [],
@@ -87,6 +95,34 @@ describe("createRemoteHostSession.open (restore a parked blob after a restart)",
       assert.equal(second.uid, UID);
     } finally {
       await session.close();
+    }
+  });
+
+  it("refuses to restore a blob that carries two app names, instead of adopting the stale one", async () => {
+    // `open` keeps the previous app alive until the fresh one validates, and both
+    // apps share one store — so a write from the previous app during that window
+    // parks a blob holding BOTH names. `validate` runs inside exactly that window,
+    // which is how this drives it without waiting for a real token refresh.
+    const session = createRemoteHostSession(CONFIG);
+    const parked = await (async () => {
+      try {
+        const first = await session.open(blobFor("remote-host-1", "stale-uid"));
+        await session.open(blobFor("remote-host-9", "current-uid"), async () => {
+          if (first.auth.currentUser) await updateCurrentUser(first.auth, first.auth.currentUser);
+        });
+        return session.exportSession();
+      } finally {
+        await session.close();
+      }
+    })();
+    assert.equal(Object.keys(JSON.parse(parked ?? "{}")).length, 2, "the window must actually have produced a two-name blob");
+
+    const restarted = createRemoteHostSession(CONFIG);
+    try {
+      const opened = await restarted.open(parked ?? "{}");
+      assert.equal(opened.uid, null, "an ambiguous blob must restore nobody — never the account the user signed out of");
+    } finally {
+      await restarted.close();
     }
   });
 

--- a/plans/fix-3089-remote-host-session-app-name.md
+++ b/plans/fix-3089-remote-host-session-app-name.md
@@ -1,0 +1,77 @@
+# fix(remote-host): a parked session saved under `remote-host-2` or later cannot be restored
+
+Issue: receptron/mulmoclaude#3089
+
+## Problem
+
+`createRemoteHostSession` (`packages/core/src/remote-host/server/firebase.ts`) opens a FRESH
+Firebase app on every `open`, named `remote-host-${appSeq}` where `appSeq` counts opens within
+the current process (failed ones included) and resets to 0 on restart.
+
+`@firebase/auth` namespaces every persistence key with the app that wrote it —
+`_persistenceKeyName` builds `firebase:<key>:<apiKey>:<appName>`. So the blob the browser parks
+(`exportSession()`) carries the app name that was live when it was written.
+
+`sessionPersistence.seed` stores the blob's keys verbatim. When the parked blob says
+`remote-host-2` and the restarted host's first `open` builds the `remote-host-1` app, the SDK
+looks up its OWN key, misses, and `authStateReady()` settles with `currentUser === null`. The
+host's `restore` then throws `RemoteHostSessionExpiredError` → `/api/remote-host/reconnect`
+answers 401 → the browser drops the parked blob and the user has to sign in with the Google
+popup again.
+
+Once in that state it is self-sustaining: the failed restore has already advanced `appSeq`, so
+the re-sign-in is saved under `remote-host-2` again.
+
+The same mismatch also breaks in-process reconnect (self-heal): `open` #N+1 is always named
+differently from the app whose keys the blob carries.
+
+## Fix
+
+Re-key the blob at seed time to the app that is about to be opened.
+
+- `sessionPersistence.seed(blob, appName?)` — when `appName` is given, rewrite the app-name
+  segment of every key shaped `firebase:<key>:<apiKey>:<appName>` (exactly 4 colon-separated
+  segments, first segment `firebase`). Anything else passes through untouched.
+- `firebase.ts` `openInner` passes the name it is about to open with. The rollback path keeps
+  seeding verbatim — the previous app is still live and reads its own keys.
+
+Only key NAMES are interpreted; the serialized user stays opaque. `UserImpl._fromJSON` does not
+read the `appName` field inside the user JSON, so it needs no rewriting (verified against
+@firebase/auth 1.13.3).
+
+Backwards compatible: blobs already parked under `remote-host-2` restore after the fix without
+the user signing in again.
+
+### Rejected alternative
+
+Wrapping the blob in a core-owned envelope that records the app name, then opening the first app
+under that name. It keeps the "never interpret the blob" rule, but does not fix in-process
+reconnect (the previous app still holds that name) and drops one session for every blob already
+parked in a browser.
+
+## Tests
+
+1. `packages/core/test/remote-host/test_sessionPersistence.ts` — pure: `seed(blob, "remote-host-1")`
+   re-keys `firebase:authUser:<api>:remote-host-2`, leaves non-Firebase-shaped keys alone, and
+   `seed(blob)` (no app name) still restores verbatim.
+2. `packages/core/test/remote-host/test_sessionRestore.ts` (new file) — the regression from the
+   issue, end-to-end through real `firebase/auth`: a blob whose key names `remote-host-2` handed
+   to a fresh `createRemoteHostSession`'s FIRST `open` returns the uid; the control (`remote-host-1`,
+   which worked before); the in-process reconnect; and the re-export carrying the now-live name.
+   `globalThis.fetch` is replaced BEFORE firebase loads (`@firebase/auth` captures the global in
+   `FetchProvider.initialize` at module eval), so no network and no real credentials are touched;
+   the auth API calls fail as `network-request-failed`, which Firebase treats as "keep the stored
+   user". Needs its own file because the existing `test_session.ts` imports firebase statically.
+
+## Verification
+
+- With the two source files stashed, `test_sessionRestore.ts` is 1 pass / 3 fail — the failing
+  one reports exactly the issue's symptom (`uid` null for a `remote-host-2` blob). With the fix,
+  4/4 pass and the whole of `packages/core/test/remote-host` is 163/163.
+- `eslint src/remote-host test/remote-host` → 0 errors (2 pre-existing warnings in
+  `src/remote-host/index.ts`); `tsc --noEmit` clean.
+- Build is left to CI: the host was at load average ~31 and the change adds no import or build
+  input.
+- Real-environment check by the reporter, with a MulmoTerminal carrying the fixed core (needs a
+  `@mulmoclaude/core` publish, which is NOT part of this PR): after a `Disconnect → Connect`
+  within one run, a host restart must stay Online.

--- a/plans/fix-3089-remote-host-session-app-name.md
+++ b/plans/fix-3089-remote-host-session-app-name.md
@@ -42,6 +42,25 @@ read the `appName` field inside the user JSON, so it needs no rewriting (verifie
 Backwards compatible: blobs already parked under `remote-host-2` restore after the fix without
 the user signing in again.
 
+### The re-key must refuse to guess (found in review, not in the issue)
+
+A blob CAN carry two app names. `openInner` calls `store.clear()`, then awaits `openFreshApp`
+AND `validate` — a full Google sign-in round trip on the `signIn` path — and only then deletes
+`previousApp`. Throughout that window the previous app is live, holds a persistence instance
+bound to the SAME store, and writes `firebase:authUser:<apiKey>:remote-host-<prev>` back on any
+token refresh. Re-keying both onto one target picks a winner by JSON order, and the stale app is
+the one that writes last — so a restart could come back as the account the user had just signed
+out of. Reproduced: `open#1` as OLD-account, `open#2` as NEW-account with a write from the
+previous app during `validate`, restart → `uid: OLD-account`. Pre-fix that same blob at a higher
+sequence restores nobody, which is safe, so the re-key would have turned a safe session loss
+into adopting the wrong account, on the auth boundary.
+
+`resolveKeys` therefore drops any target that more than one source key claims: the restore finds
+no user, `restore` throws `RemoteHostSessionExpiredError`, the route answers 401, the client
+drops the blob and the user signs in once — the behaviour that existed before re-keying. The
+underlying window is pre-existing and deliberate (the non-destructive reconnect contract of
+#2076); this PR makes its failure mode safe rather than removing the window.
+
 ### Rejected alternative
 
 Wrapping the blob in a core-owned envelope that records the app name, then opening the first app
@@ -52,12 +71,13 @@ parked in a browser.
 ## Tests
 
 1. `packages/core/test/remote-host/test_sessionPersistence.ts` — pure: `seed(blob, "remote-host-1")`
-   re-keys `firebase:authUser:<api>:remote-host-2`, leaves non-Firebase-shaped keys alone, and
-   `seed(blob)` (no app name) still restores verbatim.
+   re-keys `firebase:authUser:<api>:remote-host-2`, leaves non-Firebase-shaped keys alone, drops a
+   target two source keys claim, and `seed(blob)` (no app name) still restores verbatim.
 2. `packages/core/test/remote-host/test_sessionRestore.ts` (new file) — the regression from the
    issue, end-to-end through real `firebase/auth`: a blob whose key names `remote-host-2` handed
    to a fresh `createRemoteHostSession`'s FIRST `open` returns the uid; the control (`remote-host-1`,
-   which worked before); the in-process reconnect; and the re-export carrying the now-live name.
+   which worked before); the in-process reconnect; the two-app-name blob that must restore
+   nobody rather than the stale account; and the re-export carrying the now-live name.
    `globalThis.fetch` is replaced BEFORE firebase loads (`@firebase/auth` captures the global in
    `FetchProvider.initialize` at module eval), so no network and no real credentials are touched;
    the auth API calls fail as `network-request-failed`, which Firebase treats as "keep the stored
@@ -67,7 +87,9 @@ parked in a browser.
 
 - With the two source files stashed, `test_sessionRestore.ts` is 1 pass / 3 fail — the failing
   one reports exactly the issue's symptom (`uid` null for a `remote-host-2` blob). With the fix,
-  4/4 pass and the whole of `packages/core/test/remote-host` is 163/163.
+  the whole of `packages/core/test/remote-host` is 166/166.
+- The ambiguity guard is break-verified on its own: removing `resolveKeys`' contested-target drop
+  turns exactly the two tests that cover it red (18 pass / 2 fail) and leaves the rest green.
 - `eslint src/remote-host test/remote-host` → 0 errors (2 pre-existing warnings in
   `src/remote-host/index.ts`); `tsc --noEmit` clean.
 - Build is left to CI: the host was at load average ~31 and the change adds no import or build


### PR DESCRIPTION
## Summary

スマホ連携（RemoteHost）のセッションが、ホスト再起動のたびに外れる問題（#3089）を core 側で直します。

`createRemoteHostSession` は `open` のたびに `remote-host-${appSeq}` という名前で新しい Firebase アプリを開き、`appSeq` は起動ごとに 0 から数え直します。一方 Firebase Auth は保存済みユーザーを **そのアプリ名込みのキー** `firebase:<key>:<apiKey>:<appName>`（`_persistenceKeyName`）で探します。

そのため、`remote-host-2` 以降が live だったときにブラウザへ park された blob は、再起動後の最初の `open`（`remote-host-1`）からは見えません。SDK は自分のキーを引いて空振りし、`authStateReady()` の後も `currentUser` が null のまま → `restore` が `RemoteHostSessionExpiredError` → `/api/remote-host/reconnect` が 401 → ブラウザが保存済みセッションを破棄、という流れでサインインし直しになります。しかも失敗した復元で `appSeq` が既に進んでいるので、やり直したサインインはまた `remote-host-2` 以降に保存され、**この状態から自動では抜けられません**。

同じ不一致で、1 回の起動中の再接続（self-heal）も必ず失敗していました。前のアプリが live な以上、次の `open` は必ず別の名前になるためです。

### 変更

- `sessionPersistence.seed(blob, appName?)` — `appName` を渡すと、`firebase:<key>:<apiKey>:<appName>` の形（コロン区切りでちょうど 4 セグメント、先頭が `firebase`）のキーだけ、アプリ名セグメントをこれから開くアプリの名前に書き換えます。それ以外の形のキーは素通し。
- `firebase.ts` の `openInner` は、これから開く名前を `seed` に渡します。**ロールバック経路は今までどおり verbatim** — 戻し先のアプリはまだ live で、blob がすでに持っているキーを読むためです。

解釈するのは **キー名だけ**で、serialized user の中身は不透明なままです。user JSON の中の `appName` フィールドは SDK が読み戻さない（`UserImpl._fromJSON`, @firebase/auth 1.13.3 で確認）ので、書き換え不要です。

すでに `remote-host-2` などで park されている blob も、この修正だけで再サインインなしに復元できます（後方互換）。

### 再キーイングは「当て推量をしない」（レビューで発見、issue には無い P1）

**1つの blob が 2 つのアプリ名を持ち得ます。** `openInner` は `store.clear()` の後、`openFreshApp` と
`validate`（`signIn` 経路では Google サインインの往復まるごと）を await し、`previousApp` を消すのは
**その後**です。その間ずっと前のアプリは live で、同じ store を共有する persistence インスタンスを持ち、
トークン更新のたびに `firebase:authUser:<apiKey>:remote-host-<前>` を書き戻します。

両方を 1 つのターゲットに畳むと勝者は JSON のキー順で決まり、**最後に書くのは stale な方のアプリ**です。
つまり再起動後に「ユーザーが今しがたサインアウトしたアカウント」で復帰し得ます。決定的に再現しました:

```
open#1 -> remote-host-1, uid OLD-account
open#2 -> remote-host-9 の blob, uid NEW-account（validate 中に前のアプリが自分の user を書き戻す）
parked blob keys: ["...:remote-host-2", "...:remote-host-1"]
AFTER RESTART uid: OLD-account      <-- サインアウト済みのアカウント
```

修正前は同じ形の blob（より大きい連番、例 `{remote-host-3: NEW, remote-host-2: OLD}`）は
**誰も復元しない**＝安全側に倒れていました。つまり素朴な再キーイングは「安全なセッション喪失」を
**認証境界での誤アカウント採用**に変えてしまいます。

そこで `resolveKeys` は、**2 つ以上の元キーが奪い合うターゲットを丸ごと捨てます**。復元結果は user なし →
`RemoteHostSessionExpiredError` → 401 → ブラウザが blob を破棄 → サインイン 1 回。再キーイング導入前の
挙動そのものです。同じプローブは修正後 `AFTER RESTART uid: null` を出します。

窓（window）そのものは #2076 の非破壊 reconnect 契約が意図して作ったもので、本 PR は窓を潰すのではなく
**その失敗モードを安全側にします**。

## Items to Confirm / Review

- **曖昧な blob を「捨てる」判断**: 2 つのアプリ名を持つ blob は復元せず、サインインし直しにします。
  信頼できる tie-break が無いためです（JSON のキー順は stale 側を勝たせ、Firebase はどちらが current か
  という権威情報を持たない）。Codex も「dropping is the right call」と判断しました。
  唯一の false positive は **同一ユーザー**の別名が 2 つ入っていた場合で、不要なサインインが 1 回増えます
  （誤アカウント採用は起きません）。このトレードオフでよいかご確認ください。
- **キー形状の決め打ち**: 「コロン区切り 4 セグメント、先頭 `firebase`」で apiKey とアプリ名を切り分けています。Google の API キーにも我々のアプリ名にもコロンは入らないので成立しますが、SDK がキー形式を変えたらここが最初に壊れます。壊れたときに気づけるよう回帰テストを付けています（形が合わないキーは素通しなので、最悪でも現状維持に縮退します）。
- **`seed` の省略可能な第 2 引数**: 「アプリ名あり = 書き換え / なし = verbatim」という非対称が、ロールバックの正しさの肝です。ここを一律に書き換えると、live なままの前アプリが自分のセッションを見失います。この読み分けが十分に伝わるかご確認ください。
- **`packages/core/assets/helps/error-recovery.md` は更新していません。** これはエージェントが実行時に踏む失敗モードではなく、コードで直った不具合のためです（既存の「shared collection が空 / `connect remote-host first`」節がユーザー向けの案内としては既にあります）。この判断でよいかご確認ください。
- **npm publish はこの PR に含めていません。** 起票者の実環境確認には `@mulmoclaude/core` の publish が必要ですが、`chore(release)` は別フローなので分けています。

## 検証

- **修正なしでは red**: `packages/core/src/remote-host/server/{sessionPersistence,firebase}.ts` を stash して `test_sessionRestore.ts` を実行すると **1 pass / 3 fail**。落ちるのは issue の症状そのもの（`remote-host-2` の blob で `uid` が `null`、再 export のキーが `remote-host-2` のまま）。
- **曖昧性ガードも単独で break-verify 済み**: `resolveKeys` の contested-target drop だけを外すと、
  それを覆う 2 本のテストだけが red になります（18 pass / 2 fail）。残りは green のままです。
- `packages/core/test/remote-host` 全体 **166/166 pass**、`packages/core` 全体 **937/937 pass**。
  所要時間は 30 秒台から 1 秒未満へ（手元の計測で `test_sessionRestore.ts` 単体が 30.4 秒 → 0.47 秒、
  Codex の別実行では 0.54 秒。秒数はマシン負荷に依存しますが、**構造的な理由**は固定です:
  firebase の `NetworkTimeout` は race が *resolve* した後にしかタイマーを clear しないため、
  reject する fetch スタブが 30 秒のタイマーを残していました)。
- `eslint src/remote-host test/remote-host` → **0 error**（`src/remote-host/index.ts` の既存 warning 2 件のみ、本 PR は未変更）。`tsc --noEmit` clean、`prettier --check` clean。
- build はこの PR では CI に委ねています（実行時の load average が約 31 で、変更は import もビルド入力も増やさないため）。CI が ground truth です。
- **レビュー**: Codex cross-review（tier C、全 axis 回答つき）と CodeRabbit。CodeRabbit はソース差分
  全体をレビューして actionable コメント 0、pre-merge checks 5/5 pass。**Sourcery は未レビュー**
  （7 日間の diff budget を使い切っており、これは承認ではありません）。
- **未実施**: 実アカウント・実ネットワークでの確認。テストは firebase 読み込み前に `globalThis.fetch` を差し替えており（`@firebase/auth` が `FetchProvider.initialize(fetch, …)` でモジュール評価時に global を捕まえるため）、スタブは **reject ではなく、パースできない body で resolve** します。結果 Auth API は `network-request-failed` になり、Firebase はこれを「保存済みユーザーを保持」として扱うので、実際の復元経路をネットワーク・実認証情報なしで通せます。起票者による実環境確認（`Disconnect → Connect` の後にホスト再起動しても Online のまま）は core の publish 後にお願いしたいです。

## 追加したテスト

- `test/remote-host/test_sessionPersistence.ts` — pure: 再キーイング、Firebase 形以外のキーの素通し、
  **2 つの元キーが奪い合うターゲットの drop**、app 名なし `seed` の verbatim 復元。
- `test/remote-host/test_sessionRestore.ts`（新規、5 本） — 本物の `firebase/auth` を通した end-to-end:
  ①`remote-host-2` の blob が新プロセス最初の `open` で復元される（#3089 回帰）
  ②`remote-host-1` の control ③1 プロセス内の再接続
  ④**2 つのアプリ名を持つ blob は stale を採用せず誰も復元しない**（`validate` が窓の内側で走ることを
  利用して、実トークン更新を待たずに決定的に再現）⑤復元後の re-export が今 live なアプリ名になる。
  既存の `test_session.ts` は firebase を静的 import しているため、`fetch` 差し替えを先に済ませられるよう
  別ファイルにしています。

## User Prompt

> なおせる？？
> https://github.com/receptron/mulmoclaude/issues/3089

Closes #3089

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2cc8GmptJgfyUgdStk51o

work in mulmoclaude5
