### PR TITLE
chore(release): @mulmoclaude/core@4.9.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,7 +46,7 @@ did not repeat its first was dropped as an open stroke, so a two-section loft fa
 at least two cross-sections"; upstream closes such a section implicitly and so does this builder
 now. Sections keep their written order when open and closed ones mix.
 
-Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.8.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.8.0`, `@mulmoclaude/shapescript-plugin@2.5.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
+Ships `@mulmoclaude/accounting-plugin@3.0.0`, `@mulmoclaude/chart-plugin@3.0.0`, `@mulmoclaude/collection-plugin@4.6.0`, `@mulmoclaude/common@1.2.0`, `@mulmoclaude/core@4.9.0`, `@mulmoclaude/form-plugin@2.0.0`, `@mulmoclaude/google-plugin@3.0.0`, `@mulmoclaude/html-plugin@4.0.0`, `@mulmoclaude/markdown-plugin@4.1.0`, `@mulmoclaude/markdown-utils@2.2.0`, `@mulmoclaude/mulmoscript-plugin@4.8.0`, `@mulmoclaude/shapescript-plugin@2.5.1`, `@mulmoclaude/spotify-plugin@2.0.0`, `@mulmoclaude/x-plugin@1.0.3`.
 
 #### A bridge no longer has to be restarted every time the server is (#3078)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmoclaude/core",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Shared server-side core for MulmoClaude and MulmoTerminal — the always-shipped-together subsystems consolidated behind subpath exports so the two hosts can't drift. Server-only except the browser-safe ./artifacts, ./whisper/client, ./workspace-setup/slug, ./translation/client, ./remote-view, ./remote-host and ./plugin-vue entries. All host specifics are injected.",
   "repository": {
     "type": "git",

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -38,7 +38,7 @@
     "@mulmoclaude/chart-plugin": "^3.0.0",
     "@mulmoclaude/collection-plugin": "^4.6.0",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@mulmoclaude/form-plugin": "^2.0.0",
     "@mulmoclaude/google-plugin": "^3.0.0",
     "@mulmoclaude/html-plugin": "^4.0.0",

--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -40,7 +40,7 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "express": "^5.2.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
@@ -61,7 +61,7 @@
     }
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/express": "^5.0.6",
     "@types/node": "^26.4.1",

--- a/packages/plugins/chart-plugin/package.json
+++ b/packages/plugins/chart-plugin/package.json
@@ -35,14 +35,14 @@
     "test": "echo 'no in-package tests; presentChart logic is covered by host integration tests'"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.70.0",

--- a/packages/plugins/collection-plugin/package.json
+++ b/packages/plugins/collection-plugin/package.json
@@ -41,14 +41,14 @@
     "zod": "^4.6.2"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "echarts": "^6.0.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "vue-i18n": "^11.4.4"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/plugins/google-plugin/package.json
+++ b/packages/plugins/google-plugin/package.json
@@ -31,12 +31,12 @@
     "lint": "eslint src test"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "gui-chat-protocol": "^2.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@types/node": "^26.4.1",
     "tsx": "^4.23.13",
     "typescript": "^6.0.3",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -38,14 +38,14 @@
     "@mulmoclaude/common": "^1.2.0"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@mulmoclaude/common": "^1.2.0",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.70.0",

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -44,13 +44,13 @@
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.70.0",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
     "mulmocast": "^2.9.0",
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.4.1",
     "@typescript-eslint/eslint-plugin": "^8.70.0",

--- a/packages/plugins/shapescript-plugin/package.json
+++ b/packages/plugins/shapescript-plugin/package.json
@@ -47,14 +47,14 @@
     "three-mesh-bvh": "0.9.13"
   },
   "peerDependencies": {
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "gui-chat-protocol": "^2.0.0",
     "puppeteer": "^25.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@mulmoclaude/core": "^4.8.0",
+    "@mulmoclaude/core": "^4.9.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",
     "@types/three": "^0.185.1",


### PR DESCRIPTION
## Summary

`@mulmoclaude/core` を **4.9.0** に上げ、宣言されている全 range を `^4.9.0` へ掃きます。
npm publish は**ユーザーが手元で実行**します（この PR は publish しません）。

`@mulmoclaude/core@4.8.0` タグ以降の core の drift は次の2つだけです:

- **#3089 / PR #3102** — RemoteHost の park 済みセッションを、これから開くアプリ名へ再キーイングする修正。
  ホスト再起動後に Google サインインが外れる問題の本体と、レビューで見つかった
  「2つのアプリ名を持つ blob で stale なアカウントを採用しうる」認証境界の P1 ガード。
- **依存の定常更新** — `dompurify ^3.4.13→^3.4.15`、`zod ^4.5.4→^4.6.2`（いずれも runtime）、
  `vite ^8.2.2→^8.3.0`、`vite-plugin-dts ^5.0.3→^5.1.0`（devDependencies）。

### なぜ patch ではなく minor か

`HostSessionPersistence.seed` が **export された interface 上で** optional 引数 `appName` を得ています
（追加のみなので破壊的ではありません）。加えて runtime 依存の range が2つ動いています。
バグ修正だけなら patch ですが、公開 API 形状と runtime 依存が動いたので minor が妥当と判断しました。

### range 掃き（17箇所 / 9ファイル）

| ファイル | フィールド |
|---|---|
| `packages/mulmoclaude` | `dependencies` |
| `accounting` / `chart` / `collection` / `google` / `html` / `markdown` / `mulmoscript` / `shapescript` plugin | `devDependencies` + `peerDependencies` |

`^4.8.0` は1つも残っていません（`grep` で確認）。range 更新は各 consumer の次のリリースで初めてユーザーに届くので、
50個の即時 republish は不要ですが、consumer を次に publish する前にツリーに入っている必要があります。

**launcher 自身の `version` は意図的に触っていません** — あのフィールドは `/publish-mulmoclaude` のものです
（`docs/package-releases.md`）。触ったのは launcher の core への **dep range** だけです。

## Items to Confirm / Review

- **バージョンの刻み（4.9.0）** が意図どおりかご確認ください。patch(4.8.1) を希望される場合は言ってください。
- **`Ships` 行の更新箇所**: `docs/CHANGELOG.md` の `[Unreleased]` 内の1行だけを更新しています
  （454行目・582行目の同じ形の行は**過去リリースの凍結記録**なので触っていません）。
  `check:changelog-ships` が launcher の roster と突き合わせる対象は `[Unreleased]` です。
- **plugin の peer range が上がること**の影響: peer が `^4.9.0` になるので、古い core を持つホストに
  新しい plugin を入れると **loud に失敗**します（これは意図した挙動です。`dependencies` に置いて
  core の2重インストールを許すより安全、という CLAUDE.md の方針どおり）。

## 検証

- `yarn check:changelog-ships` → `OK — [Unreleased] lists all 14 @mulmoclaude/* dependencies.`
- `yarn check:launcher-sync` → `OK — root ↔ launcher ↔ every workspace in sync, no peer-dep violations.`
- `yarn install` → **`yarn.lock` に差分なし**（workspace 内部 range のみのため）
- `packages/core`: `tsc --noEmit` clean / `eslint src test` **0 error**（warning 16 件はすべて既存）/
  `yarn build` 成功 / **937/937 tests pass**
- **ビルド成果物に修正が入っていることを確認**: `dist/remote-host/server/index.js` に `resolveKeys` と
  `contested` が出ています（＝ publish される tarball に入る）
- `npm pack --dry-run` → `@mulmoclaude/core@4.9.0`、452 files、packed 2.1 MB / unpacked 7.0 MB
- publish 前チェック: `file:` 依存なし / `debugger` なし / `console.log`・`console.debug` なし /
  `TODO`・`FIXME` なし（いずれも `packages/core/src`）

## この PR の後

1. マージ
2. マージコミットに `@mulmoclaude/core@4.9.0` タグを打って push（publish される tarball がタグ付きコミットに対応するように、publish の**前**に打ちます）
3. **ユーザーが `npm publish` を実行**
4. publish 後に GitHub release（`--latest=false`。このリポジトリには `v*` のアプリリリースがあるため）

## User Prompt

> publish して npm publishはこっちでおこなう

（直前の依頼: https://github.com/receptron/mulmoclaude/issues/3089 「なおせる？？」→ PR #3102 としてマージ済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2cc8GmptJgfyUgdStk51o

work in mulmoclaude5

## Summary by Sourcery

Release @mulmoclaude/core 4.9.0 and update all declared consumers to require the new minor version.

Enhancements:
- Align the workspace and plugin core dependency ranges with the new 4.9.0 release.

Documentation:
- Update the unreleased changelog entry to list @mulmoclaude/core@4.9.0.

Chores:
- Release @mulmoclaude/core as version 4.9.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core package to version 4.9.0.
  * Updated plugin compatibility and development dependency ranges to support core version 4.9.0.
  * Updated the changelog to reflect the new core version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->