### PR TITLE
fix(bridges): 受信ポートの読み取りと bind を安全側に倒す (#3084)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,9 +22,10 @@ it; and a busy port arrived as an unhandled `EADDRINUSE` naming no env var — w
 than rare, since the server's walk-forward band (3002-3021) covers the whole bridge band
 (3002-3013).
 
-The bind now goes through one `listenWebhook` in `@mulmobridge/webhook-runtime`, which every one of
-the nine already depended on for its Express setup, so each bridge names its env var once and the
-rule has a single home. An unusable value stops the bridge with the value, the range and the env var
+The bind now goes through one `listenWebhook` in `@mulmobridge/webhook-runtime`, where six of the
+nine already got their Express setup — `teams`, `twilio-sms` and `webhook` hand-rolled theirs and
+declare the dependency as part of this change. Each bridge names its env var once, and the rule has
+a single home. An unusable value stops the bridge with the value, the range and the env var
 in the message, instead of quietly taking the default (issue decision D-3). `EADDRINUSE` and `EACCES`
 each say which env var to change. The coercion itself is the server's own `asInt` / `PORT_RANGE`,
 moved from `server/utils/envCoerce.ts` into `@mulmoclaude/common` so there is still exactly one copy —

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 
+#### A webhook bridge read its port with `Number(env) || N`, and a busy port killed it unexplained (#3084)
+
+The nine bridges that receive events over an inbound webhook (`line`, `line-works`, `google-chat`,
+`messenger`, `teams`, `twilio-sms`, `viber`, `webhook`, `whatsapp`) each resolved their listen port
+as `Number(process.env.X) || <default>` and then called a bare `app.listen`. Three consequences, all
+silent: a typo (`302a` → `NaN` → falsy) started the bridge **on the default without a word**, so it
+answered somewhere other than where it was told to; `X=0` was impossible for the same falsy reason,
+even though that is the documented way to ask the OS for a free port and the server itself supports
+it; and a busy port arrived as an unhandled `EADDRINUSE` naming no env var — which is routine rather
+than rare, since the server's walk-forward band (3002-3021) covers the whole bridge band
+(3002-3013).
+
+The bind now goes through one `listenWebhook` in `@mulmobridge/webhook-runtime`, which every one of
+the nine already depended on for its Express setup, so each bridge names its env var once and the
+rule has a single home. An unusable value stops the bridge with the value, the range and the env var
+in the message, instead of quietly taking the default (issue decision D-3). `EADDRINUSE` and `EACCES`
+each say which env var to change. The coercion itself is the server's own `asInt` / `PORT_RANGE`,
+moved from `server/utils/envCoerce.ts` into `@mulmoclaude/common` so there is still exactly one copy —
+`server/utils/envCoerce.ts` stays as the door `vite.config.ts` reaches it through, and `DEFAULT_PORT`
+(the host's own 3001) stays behind. The move was verified against a verbatim copy of the pre-move
+function over 620k generated (value, fallback, range) triples: 0 differences.
+
+Two behaviours needed guarding rather than describing. `PORT=0` only helps if you can find out what
+you got, so the startup banner now names the port actually bound — and the banner is printed only
+when `server.address()` confirms a bind, because **Express 5 runs `app.listen`'s callback even when
+the bind failed** (verified on express@5.1: `address()` is `null`, `listening` is `false`, and the
+`error` event lands on the next tick). Without that check a collided bridge printed
+`Webhook listening on http://localhost:3002/webhook` and then the error — the same silence, one step
+later. `packages/webhook-runtime/test/test_port.ts` pins both, including a real `EADDRINUSE` against
+an occupied port.
+
+The matching operator-facing section — both messages, why "already in use" is usually the server, and
+the `=0` way out — is in `packages/core/assets/helps/error-recovery.md`, which the agent reads before
+asking the user anything on a tool failure. It reaches npm users with the next `@mulmoclaude/core`.
+
+Out of scope, deliberately: `email` (`EMAIL_IMAP_PORT`, `EMAIL_SMTP_PORT`) and `irc` (`IRC_PORT`) use
+the same expression, but those are outbound ports where `PORT_RANGE`'s `min: 0` has no meaning. The
+process-level gaps the issue's comment counts (no `unhandledRejection` handler in any of the 25
+bridges, `SIGINT` in only two) are a separate change.
+
 #### `@mulmoclaude/core@4.9.0` — the bundled help stopped telling the agent that the server is on 3001 (#3085)
 
 `assets/helps/*` still described a server pinned to `localhost:3001` after #3081 and #3092 had

--- a/packages/bridges/google-chat/README.md
+++ b/packages/bridges/google-chat/README.md
@@ -42,14 +42,18 @@ In Google Chat, find your app and send it a direct message.
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `GOOGLE_CHAT_PROJECT_NUMBER` | Yes | Google Cloud project number |
-| `GOOGLE_CHAT_BRIDGE_PORT` | No | Webhook port (default: 3005) |
-| `MULMOCLAUDE_API_URL` | No | Default: auto (`.server-port`; waits if nothing is published) |
-| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
-| `GOOGLE_CHAT_BRIDGE_DEFAULT_ROLE` | No | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a google-chat session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
-| `BRIDGE_DEFAULT_ROLE` | No | Same as above but shared across every bridge. Transport-specific `GOOGLE_CHAT_BRIDGE_DEFAULT_ROLE` wins when both are set. |
+| Variable                          | Required | Description                                                                                                                                                                                                                                                                        |
+| --------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_CHAT_PROJECT_NUMBER`      | Yes      | Google Cloud project number                                                                                                                                                                                                                                                        |
+| `GOOGLE_CHAT_BRIDGE_PORT`         | No       | Webhook port (default: 3005; `0` asks the OS for a free port)                                                                                                                                                                                                                      |
+| `MULMOCLAUDE_API_URL`             | No       | Default: auto (`.server-port`; waits if nothing is published)                                                                                                                                                                                                                      |
+| `MULMOCLAUDE_AUTH_TOKEN`          | No       | Bearer token                                                                                                                                                                                                                                                                       |
+| `GOOGLE_CHAT_BRIDGE_DEFAULT_ROLE` | No       | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a google-chat session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
+| `BRIDGE_DEFAULT_ROLE`             | No       | Same as above but shared across every bridge. Transport-specific `GOOGLE_CHAT_BRIDGE_DEFAULT_ROLE` wins when both are set.                                                                                                                                                         |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -109,7 +113,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/cli`](https://www.npmjs.com/package/@mulmobridge/cli) — interactive terminal bridge
 - [`@mulmobridge/discord`](https://www.npmjs.com/package/@mulmobridge/discord) — Discord bot via Gateway
 - [`@mulmobridge/email`](https://www.npmjs.com/package/@mulmobridge/email) — IMAP poll + SMTP reply, threading preserved
-- [`@mulmobridge/google-chat`](https://www.npmjs.com/package/@mulmobridge/google-chat) — Google Chat via MulmoBridge relay  ← **this package**
+- [`@mulmobridge/google-chat`](https://www.npmjs.com/package/@mulmobridge/google-chat) — Google Chat via MulmoBridge relay ← **this package**
 - [`@mulmobridge/irc`](https://www.npmjs.com/package/@mulmobridge/irc) — IRC (Libera, Freenode, custom)
 - [`@mulmobridge/line`](https://www.npmjs.com/package/@mulmobridge/line) — LINE Messaging API via MulmoBridge relay
 - [`@mulmobridge/line-works`](https://www.npmjs.com/package/@mulmobridge/line-works) — LINE Works (enterprise LINE)

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -18,12 +18,11 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import { configureTrustProxy, createWebhookRateLimit } from "@mulmobridge/webhook-runtime";
+import { configureTrustProxy, createWebhookRateLimit, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { createBridgeClient } from "@mulmobridge/client";
 import { isRecord, splitJwtSegments } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "google-chat";
-const PORT = Number(process.env.GOOGLE_CHAT_BRIDGE_PORT) || 3005;
 
 const projectNumber = process.env.GOOGLE_CHAT_PROJECT_NUMBER;
 if (!projectNumber) {
@@ -268,8 +267,8 @@ app.post("/", webhookRateLimit, async (req: Request, res: Response) => {
   }
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "GOOGLE_CHAT_BRIDGE_PORT", fallback: 3005 }, (port) => {
   console.log("MulmoClaude Google Chat bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/`);
+  console.log(`Webhook listening on http://localhost:${port}/`);
   console.log("Configure your Google Chat app endpoint to: <public-url>/");
 });

--- a/packages/bridges/line-works/README.md
+++ b/packages/bridges/line-works/README.md
@@ -46,19 +46,23 @@ Send the bot a direct message in LINE Works — you'll get a reply.
 
 ## Environment variables
 
-| Variable                       | Required | Default | Description |
-|--------------------------------|----------|---------|-------------|
-| `LINEWORKS_CLIENT_ID`          | yes      | —       | App Client ID |
-| `LINEWORKS_CLIENT_SECRET`      | yes      | —       | App Client Secret |
-| `LINEWORKS_SERVICE_ACCOUNT`    | yes      | —       | Service account ID |
-| `LINEWORKS_BOT_ID`             | yes      | —       | Numeric Bot ID |
-| `LINEWORKS_BOT_SECRET`         | yes      | —       | Per-bot secret (used to verify `X-WORKS-Signature` on webhooks) |
-| `LINEWORKS_PRIVATE_KEY`        | either   | —       | PEM string (use `\n` for newlines when putting on a single env line) |
-| `LINEWORKS_PRIVATE_KEY_FILE`   | either   | —       | Path to PEM file (alternative to inline env) |
-| `LINEWORKS_WEBHOOK_PORT`       | no       | `3013`  | HTTP port |
-| `LINEWORKS_ALLOWED_USERS`      | no       | (all)   | CSV of sender `userId`s allowed |
-| `MULMOCLAUDE_AUTH_TOKEN`       | no       | auto    | MulmoClaude bearer token override |
-| `MULMOCLAUDE_API_URL`          | no       | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL |
+| Variable                     | Required | Default                                              | Description                                                          |
+| ---------------------------- | -------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| `LINEWORKS_CLIENT_ID`        | yes      | —                                                    | App Client ID                                                        |
+| `LINEWORKS_CLIENT_SECRET`    | yes      | —                                                    | App Client Secret                                                    |
+| `LINEWORKS_SERVICE_ACCOUNT`  | yes      | —                                                    | Service account ID                                                   |
+| `LINEWORKS_BOT_ID`           | yes      | —                                                    | Numeric Bot ID                                                       |
+| `LINEWORKS_BOT_SECRET`       | yes      | —                                                    | Per-bot secret (used to verify `X-WORKS-Signature` on webhooks)      |
+| `LINEWORKS_PRIVATE_KEY`      | either   | —                                                    | PEM string (use `\n` for newlines when putting on a single env line) |
+| `LINEWORKS_PRIVATE_KEY_FILE` | either   | —                                                    | Path to PEM file (alternative to inline env)                         |
+| `LINEWORKS_WEBHOOK_PORT`     | no       | `3013`                                               | HTTP port (`0` asks the OS for a free port)                          |
+| `LINEWORKS_ALLOWED_USERS`    | no       | (all)                                                | CSV of sender `userId`s allowed                                      |
+| `MULMOCLAUDE_AUTH_TOKEN`     | no       | auto                                                 | MulmoClaude bearer token override                                    |
+| `MULMOCLAUDE_API_URL`        | no       | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL                                               |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -89,12 +93,12 @@ Recommended: at least 32 characters of random data (the server logs a warning at
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `token: 400 invalid_grant` | Private key doesn't match the service account | Re-download the PEM for the exact service account ID |
-| `token: 401 invalid_client` | Client ID / secret wrong | Regenerate in Developer Console |
-| Webhook never arrives | Callback URL not HTTPS or event types unchecked | Set HTTPS URL; enable `Message` event type |
-| `send failed: 403` | Scope missing | Add `bot` + `bot.message` to the app and reauthorize |
+| Symptom                     | Cause                                           | Fix                                                  |
+| --------------------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| `token: 400 invalid_grant`  | Private key doesn't match the service account   | Re-download the PEM for the exact service account ID |
+| `token: 401 invalid_client` | Client ID / secret wrong                        | Regenerate in Developer Console                      |
+| Webhook never arrives       | Callback URL not HTTPS or event types unchecked | Set HTTPS URL; enable `Message` event type           |
+| `send failed: 403`          | Scope missing                                   | Add `bot` + `bot.message` to the app and reauthorize |
 
 ## Security notes
 
@@ -125,7 +129,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/google-chat`](https://www.npmjs.com/package/@mulmobridge/google-chat) — Google Chat via MulmoBridge relay
 - [`@mulmobridge/irc`](https://www.npmjs.com/package/@mulmobridge/irc) — IRC (Libera, Freenode, custom)
 - [`@mulmobridge/line`](https://www.npmjs.com/package/@mulmobridge/line) — LINE Messaging API via MulmoBridge relay
-- [`@mulmobridge/line-works`](https://www.npmjs.com/package/@mulmobridge/line-works) — LINE Works (enterprise LINE)  ← **this package**
+- [`@mulmobridge/line-works`](https://www.npmjs.com/package/@mulmobridge/line-works) — LINE Works (enterprise LINE) ← **this package**
 - [`@mulmobridge/mastodon`](https://www.npmjs.com/package/@mulmobridge/mastodon) — Mastodon DMs + mentions
 - [`@mulmobridge/matrix`](https://www.npmjs.com/package/@mulmobridge/matrix) — Matrix / Element
 - [`@mulmobridge/mattermost`](https://www.npmjs.com/package/@mulmobridge/mattermost) — Mattermost

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -27,7 +27,7 @@ import crypto from "crypto";
 import { readFileSync } from "fs";
 import type { Request, Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
+import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "line-works";
@@ -35,7 +35,6 @@ const MAX_TEXT = 1_000;
 const FETCH_TIMEOUT_MS = 15_000;
 const JWT_TTL_SEC = 3_600;
 const TOKEN_REFRESH_MARGIN_SEC = 60;
-const PORT = Number(process.env.LINEWORKS_WEBHOOK_PORT) || 3013;
 
 function readRequiredEnv(): { clientId: string; clientSecret: string; serviceAccount: string; botId: string; botSecret: string; privateKeyPem: string } {
   const clientId = process.env.LINEWORKS_CLIENT_ID;
@@ -241,9 +240,9 @@ app.post("/callback", callbackRateLimit, async (req: Request, res: ExpressRespon
   }
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "LINEWORKS_WEBHOOK_PORT", fallback: 3013 }, (port) => {
   console.log("MulmoClaude LINE Works bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/callback`);
+  console.log(`Webhook listening on http://localhost:${port}/callback`);
   console.log(`Bot ID: ${botId}`);
   console.log(`Allowlist: ${allowAll ? "(all)" : [...allowedUsers].join(", ")}`);
 });

--- a/packages/bridges/line/README.md
+++ b/packages/bridges/line/README.md
@@ -26,6 +26,7 @@ ngrok http 3002
 ### 3. Configure the webhook
 
 In the LINE Developers Console → Messaging API tab:
+
 - **Webhook URL**: `https://xxxx.ngrok-free.app/webhook` — the trailing `/webhook` is **required** (without it you get 404)
 - **Use webhook**: enabled
 - **Auto-reply messages**: disabled (LINE Official Account settings → Auto-reply messages → OFF, otherwise you get double replies)
@@ -52,15 +53,19 @@ Scan the QR code in the LINE Developers Console → Messaging API tab. Send a me
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `LINE_CHANNEL_SECRET` | Yes | Channel secret for signature verification |
-| `LINE_CHANNEL_ACCESS_TOKEN` | Yes | Long-lived channel access token |
-| `LINE_BRIDGE_PORT` | No | Webhook port (default: 3002) |
-| `MULMOCLAUDE_API_URL` | No | Default: auto (`.server-port`; waits if nothing is published) |
-| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
-| `LINE_BRIDGE_DEFAULT_ROLE` | No | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a line session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
-| `BRIDGE_DEFAULT_ROLE` | No | Same as above but shared across every bridge. Transport-specific `LINE_BRIDGE_DEFAULT_ROLE` wins when both are set. |
+| Variable                    | Required | Description                                                                                                                                                                                                                                                                 |
+| --------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LINE_CHANNEL_SECRET`       | Yes      | Channel secret for signature verification                                                                                                                                                                                                                                   |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Yes      | Long-lived channel access token                                                                                                                                                                                                                                             |
+| `LINE_BRIDGE_PORT`          | No       | Webhook port (default: 3002; `0` asks the OS for a free port)                                                                                                                                                                                                               |
+| `MULMOCLAUDE_API_URL`       | No       | Default: auto (`.server-port`; waits if nothing is published)                                                                                                                                                                                                               |
+| `MULMOCLAUDE_AUTH_TOKEN`    | No       | Bearer token                                                                                                                                                                                                                                                                |
+| `LINE_BRIDGE_DEFAULT_ROLE`  | No       | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a line session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
+| `BRIDGE_DEFAULT_ROLE`       | No       | Same as above but shared across every bridge. Transport-specific `LINE_BRIDGE_DEFAULT_ROLE` wins when both are set.                                                                                                                                                         |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -116,7 +121,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/email`](https://www.npmjs.com/package/@mulmobridge/email) — IMAP poll + SMTP reply, threading preserved
 - [`@mulmobridge/google-chat`](https://www.npmjs.com/package/@mulmobridge/google-chat) — Google Chat via MulmoBridge relay
 - [`@mulmobridge/irc`](https://www.npmjs.com/package/@mulmobridge/irc) — IRC (Libera, Freenode, custom)
-- [`@mulmobridge/line`](https://www.npmjs.com/package/@mulmobridge/line) — LINE Messaging API via MulmoBridge relay  ← **this package**
+- [`@mulmobridge/line`](https://www.npmjs.com/package/@mulmobridge/line) — LINE Messaging API via MulmoBridge relay ← **this package**
 - [`@mulmobridge/line-works`](https://www.npmjs.com/package/@mulmobridge/line-works) — LINE Works (enterprise LINE)
 - [`@mulmobridge/mastodon`](https://www.npmjs.com/package/@mulmobridge/mastodon) — Mastodon DMs + mentions
 - [`@mulmobridge/matrix`](https://www.npmjs.com/package/@mulmobridge/matrix) — Matrix / Element

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -17,11 +17,10 @@
 import "dotenv/config";
 import type { Request, Response } from "express";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
-import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
+import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { extractIncomingLineMessage, parseLineWebhookBody } from "./parse.js";
 
 const TRANSPORT_ID = "line";
-const PORT = Number(process.env.LINE_BRIDGE_PORT) || 3002;
 
 function readRequiredEnv(): { channelSecret: string; channelAccessToken: string } {
   const channelSecret = process.env.LINE_CHANNEL_SECRET;
@@ -158,8 +157,8 @@ app.post("/webhook", webhookRateLimit, async (req: Request, res: Response) => {
   }
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "LINE_BRIDGE_PORT", fallback: 3002 }, (port) => {
   console.log("MulmoClaude LINE bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/webhook`);
+  console.log(`Webhook listening on http://localhost:${port}/webhook`);
   console.log("Set your LINE webhook URL to: <public-url>/webhook");
 });

--- a/packages/bridges/messenger/README.md
+++ b/packages/bridges/messenger/README.md
@@ -22,6 +22,7 @@ ngrok http 3004
 ### 3. Configure webhook
 
 In Meta Dashboard → Messenger → Settings → Webhooks:
+
 - **Callback URL**: `https://xxxx.ngrok-free.app/webhook`
 - **Verify token**: any string (set as `MESSENGER_VERIFY_TOKEN`)
 - Subscribe to: `messages`
@@ -46,16 +47,20 @@ npx @mulmobridge/messenger
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `MESSENGER_PAGE_ACCESS_TOKEN` | Yes | Page access token |
-| `MESSENGER_VERIFY_TOKEN` | Yes | Arbitrary string for webhook verification |
-| `MESSENGER_APP_SECRET` | Yes | App secret for HMAC signature verification |
-| `MESSENGER_BRIDGE_PORT` | No | Webhook port (default: 3004) |
-| `MULMOCLAUDE_API_URL` | No | Default: auto (`.server-port`; waits if nothing is published) |
-| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
-| `MESSENGER_BRIDGE_DEFAULT_ROLE` | No | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a messenger session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
-| `BRIDGE_DEFAULT_ROLE` | No | Same as above but shared across every bridge. Transport-specific `MESSENGER_BRIDGE_DEFAULT_ROLE` wins when both are set. |
+| Variable                        | Required | Description                                                                                                                                                                                                                                                                      |
+| ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MESSENGER_PAGE_ACCESS_TOKEN`   | Yes      | Page access token                                                                                                                                                                                                                                                                |
+| `MESSENGER_VERIFY_TOKEN`        | Yes      | Arbitrary string for webhook verification                                                                                                                                                                                                                                        |
+| `MESSENGER_APP_SECRET`          | Yes      | App secret for HMAC signature verification                                                                                                                                                                                                                                       |
+| `MESSENGER_BRIDGE_PORT`         | No       | Webhook port (default: 3004; `0` asks the OS for a free port)                                                                                                                                                                                                                    |
+| `MULMOCLAUDE_API_URL`           | No       | Default: auto (`.server-port`; waits if nothing is published)                                                                                                                                                                                                                    |
+| `MULMOCLAUDE_AUTH_TOKEN`        | No       | Bearer token                                                                                                                                                                                                                                                                     |
+| `MESSENGER_BRIDGE_DEFAULT_ROLE` | No       | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a messenger session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
+| `BRIDGE_DEFAULT_ROLE`           | No       | Same as above but shared across every bridge. Transport-specific `MESSENGER_BRIDGE_DEFAULT_ROLE` wins when both are set.                                                                                                                                                         |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -103,7 +108,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/mastodon`](https://www.npmjs.com/package/@mulmobridge/mastodon) — Mastodon DMs + mentions
 - [`@mulmobridge/matrix`](https://www.npmjs.com/package/@mulmobridge/matrix) — Matrix / Element
 - [`@mulmobridge/mattermost`](https://www.npmjs.com/package/@mulmobridge/mattermost) — Mattermost
-- [`@mulmobridge/messenger`](https://www.npmjs.com/package/@mulmobridge/messenger) — Facebook Messenger via MulmoBridge relay  ← **this package**
+- [`@mulmobridge/messenger`](https://www.npmjs.com/package/@mulmobridge/messenger) — Facebook Messenger via MulmoBridge relay ← **this package**
 - [`@mulmobridge/nostr`](https://www.npmjs.com/package/@mulmobridge/nostr) — Nostr NIP-04 encrypted DMs
 - [`@mulmobridge/rocketchat`](https://www.npmjs.com/package/@mulmobridge/rocketchat) — Rocket.Chat
 - [`@mulmobridge/signal`](https://www.npmjs.com/package/@mulmobridge/signal) — Signal via signal-cli-rest-api

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -12,12 +12,11 @@
 //   MESSENGER_BRIDGE_PORT — Webhook port (default: 3004)
 
 import "dotenv/config";
-import { createWebhookApp, registerMetaWebhook } from "@mulmobridge/webhook-runtime";
+import { createWebhookApp, registerMetaWebhook, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
 import { extractMessengerMessages, type MessengerTextMessage } from "@mulmoclaude/common/meta-webhook";
 
 const TRANSPORT_ID = "messenger";
-const PORT = Number(process.env.MESSENGER_BRIDGE_PORT) || 3004;
 
 function readRequiredEnv(): { pageAccessToken: string; verifyToken: string; appSecret: string } {
   const pageAccessToken = process.env.MESSENGER_PAGE_ACCESS_TOKEN;
@@ -105,7 +104,7 @@ async function processOneMessage(msg: MessengerTextMessage): Promise<void> {
 
 // ── Start ───────────────────────────────────────────────────────
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "MESSENGER_BRIDGE_PORT", fallback: 3004 }, (port) => {
   console.log("MulmoClaude Messenger bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/webhook`);
+  console.log(`Webhook listening on http://localhost:${port}/webhook`);
 });

--- a/packages/bridges/teams/README.md
+++ b/packages/bridges/teams/README.md
@@ -82,16 +82,20 @@ Message your bot in Teams — DM or @mention in a channel — and you'll get a r
 
 ## Environment variables
 
-| Variable                   | Required    | Default       | Description |
-|----------------------------|-------------|---------------|-------------|
-| `MICROSOFT_APP_ID`         | yes         | —             | Azure Bot App ID (aka MicrosoftAppId) |
-| `MICROSOFT_APP_PASSWORD`   | yes         | —             | Azure Bot client secret |
-| `MICROSOFT_APP_TYPE`       | no          | `MultiTenant` | `MultiTenant` / `SingleTenant` / `UserAssignedMSI` |
-| `MICROSOFT_APP_TENANT_ID`  | conditional | —             | Required when `MICROSOFT_APP_TYPE=SingleTenant` |
-| `TEAMS_BRIDGE_PORT`        | no          | `3006`        | HTTP port to listen on |
-| `TEAMS_ALLOWED_USERS`      | no          | (all)         | CSV of AAD user object IDs — empty = accept everyone in the tenant |
-| `MULMOCLAUDE_AUTH_TOKEN`   | no          | auto          | MulmoClaude bearer token override |
-| `MULMOCLAUDE_API_URL`      | no          | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL |
+| Variable                  | Required    | Default                                              | Description                                                        |
+| ------------------------- | ----------- | ---------------------------------------------------- | ------------------------------------------------------------------ |
+| `MICROSOFT_APP_ID`        | yes         | —                                                    | Azure Bot App ID (aka MicrosoftAppId)                              |
+| `MICROSOFT_APP_PASSWORD`  | yes         | —                                                    | Azure Bot client secret                                            |
+| `MICROSOFT_APP_TYPE`      | no          | `MultiTenant`                                        | `MultiTenant` / `SingleTenant` / `UserAssignedMSI`                 |
+| `MICROSOFT_APP_TENANT_ID` | conditional | —                                                    | Required when `MICROSOFT_APP_TYPE=SingleTenant`                    |
+| `TEAMS_BRIDGE_PORT`       | no          | `3006`                                               | HTTP port to listen on (`0` asks the OS for a free port)           |
+| `TEAMS_ALLOWED_USERS`     | no          | (all)                                                | CSV of AAD user object IDs — empty = accept everyone in the tenant |
+| `MULMOCLAUDE_AUTH_TOKEN`  | no          | auto                                                 | MulmoClaude bearer token override                                  |
+| `MULMOCLAUDE_API_URL`     | no          | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL                                             |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -122,12 +126,12 @@ Recommended: at least 32 characters of random data (the server logs a warning at
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| 401 on `/api/messages` | Wrong app ID / password | Double-check Azure Bot → Configuration |
-| Bot doesn't reply in Teams | Messaging endpoint not set or tunnel URL stale | Update Azure Bot → Configuration → Messaging endpoint |
-| `ngrok` URL changes on restart | Free ngrok plan assigns random URLs | Use a reserved domain, Cloudflare Tunnel, or static ingress |
-| Push messages dropped | No conversation reference yet cached | User must message the bot first — push works from the second turn onward |
+| Symptom                        | Cause                                          | Fix                                                                      |
+| ------------------------------ | ---------------------------------------------- | ------------------------------------------------------------------------ |
+| 401 on `/api/messages`         | Wrong app ID / password                        | Double-check Azure Bot → Configuration                                   |
+| Bot doesn't reply in Teams     | Messaging endpoint not set or tunnel URL stale | Update Azure Bot → Configuration → Messaging endpoint                    |
+| `ngrok` URL changes on restart | Free ngrok plan assigns random URLs            | Use a reserved domain, Cloudflare Tunnel, or static ingress              |
+| Push messages dropped          | No conversation reference yet cached           | User must message the bot first — push works from the second turn onward |
 
 ## Security notes
 
@@ -167,7 +171,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/rocketchat`](https://www.npmjs.com/package/@mulmobridge/rocketchat) — Rocket.Chat
 - [`@mulmobridge/signal`](https://www.npmjs.com/package/@mulmobridge/signal) — Signal via signal-cli-rest-api
 - [`@mulmobridge/slack`](https://www.npmjs.com/package/@mulmobridge/slack) — Slack Socket Mode
-- [`@mulmobridge/teams`](https://www.npmjs.com/package/@mulmobridge/teams) — Microsoft Teams via Bot Framework  ← **this package**
+- [`@mulmobridge/teams`](https://www.npmjs.com/package/@mulmobridge/teams) — Microsoft Teams via Bot Framework ← **this package**
 - [`@mulmobridge/telegram`](https://www.npmjs.com/package/@mulmobridge/telegram) — Telegram bot
 - [`@mulmobridge/twilio-sms`](https://www.npmjs.com/package/@mulmobridge/twilio-sms) — SMS via Twilio Programmable Messaging
 - [`@mulmobridge/viber`](https://www.npmjs.com/package/@mulmobridge/viber) — Viber Public Account bots

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@mulmobridge/client": "^1.1.0",
     "@mulmobridge/protocol": "^1.0.1",
+    "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",
     "botbuilder": "^4.23.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/teams/src/index.ts
+++ b/packages/bridges/teams/src/index.ts
@@ -21,12 +21,12 @@ import "dotenv/config";
 import express, { type Request, type Response } from "express";
 import { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext, type Activity } from "botbuilder";
 import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { listenWebhook } from "@mulmobridge/webhook-runtime";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { extractIncomingMessage } from "./parse.js";
 
 const TRANSPORT_ID = "teams";
 const MAX_TEAMS_TEXT = 28_000; // Teams message limit is 40k; leave headroom for formatting
-const PORT = Number(process.env.TEAMS_BRIDGE_PORT) || 3006;
 
 function readRequiredEnv(): { appId: string; appPassword: string } {
   const appId = process.env.MICROSOFT_APP_ID;
@@ -129,9 +129,9 @@ app.get("/health", (__req: Request, res: Response) => {
   res.json({ status: "ok", transport: TRANSPORT_ID });
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "TEAMS_BRIDGE_PORT", fallback: 3006 }, (port) => {
   console.log("MulmoClaude Teams bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/api/messages`);
+  console.log(`Webhook listening on http://localhost:${port}/api/messages`);
   console.log(`App ID: ${appId}`);
   console.log(`Allowlist: ${allowAll ? "(all)" : [...allowedUsers].join(", ")}`);
 });

--- a/packages/bridges/twilio-sms/README.md
+++ b/packages/bridges/twilio-sms/README.md
@@ -39,17 +39,21 @@ Text the Twilio number — you'll get a reply.
 
 ## Environment variables
 
-| Variable                 | Required    | Default | Description |
-|--------------------------|-------------|---------|-------------|
-| `TWILIO_ACCOUNT_SID`     | yes         | —       | Twilio Account SID |
-| `TWILIO_AUTH_TOKEN`      | yes         | —       | Twilio Auth Token (used for REST + signature verification) |
-| `TWILIO_FROM_NUMBER`     | yes         | —       | Your Twilio number in E.164, e.g. `+15551234567` |
-| `TWILIO_WEBHOOK_PORT`    | no          | `3010`  | HTTP port |
-| `TWILIO_PUBLIC_URL`      | yes (prod)  | —       | Full public URL the bridge is reachable at (e.g. `https://abcd.ngrok-free.app`, including any query string Twilio signs). Required to verify Twilio's `X-Twilio-Signature`. The bridge refuses to start without it unless `TWILIO_ALLOW_UNVERIFIED=1` is also set. |
-| `TWILIO_ALLOW_UNVERIFIED`| no          | —       | Set to `1` to skip signature verification (local testing only). Prints a loud warning and leaves `/sms` wide open. Do **not** set in production. |
-| `TWILIO_ALLOWED_NUMBERS` | no          | (all)   | CSV of sender E.164 numbers allowed (empty = accept every number) |
-| `MULMOCLAUDE_AUTH_TOKEN` | no          | auto    | MulmoClaude bearer token override |
-| `MULMOCLAUDE_API_URL`    | no          | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL |
+| Variable                  | Required   | Default                                              | Description                                                                                                                                                                                                                                                        |
+| ------------------------- | ---------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `TWILIO_ACCOUNT_SID`      | yes        | —                                                    | Twilio Account SID                                                                                                                                                                                                                                                 |
+| `TWILIO_AUTH_TOKEN`       | yes        | —                                                    | Twilio Auth Token (used for REST + signature verification)                                                                                                                                                                                                         |
+| `TWILIO_FROM_NUMBER`      | yes        | —                                                    | Your Twilio number in E.164, e.g. `+15551234567`                                                                                                                                                                                                                   |
+| `TWILIO_WEBHOOK_PORT`     | no         | `3010`                                               | HTTP port (`0` asks the OS for a free port)                                                                                                                                                                                                                        |
+| `TWILIO_PUBLIC_URL`       | yes (prod) | —                                                    | Full public URL the bridge is reachable at (e.g. `https://abcd.ngrok-free.app`, including any query string Twilio signs). Required to verify Twilio's `X-Twilio-Signature`. The bridge refuses to start without it unless `TWILIO_ALLOW_UNVERIFIED=1` is also set. |
+| `TWILIO_ALLOW_UNVERIFIED` | no         | —                                                    | Set to `1` to skip signature verification (local testing only). Prints a loud warning and leaves `/sms` wide open. Do **not** set in production.                                                                                                                   |
+| `TWILIO_ALLOWED_NUMBERS`  | no         | (all)                                                | CSV of sender E.164 numbers allowed (empty = accept every number)                                                                                                                                                                                                  |
+| `MULMOCLAUDE_AUTH_TOKEN`  | no         | auto                                                 | MulmoClaude bearer token override                                                                                                                                                                                                                                  |
+| `MULMOCLAUDE_API_URL`     | no         | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL                                                                                                                                                                                                                                             |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -80,11 +84,11 @@ Recommended: at least 32 characters of random data (the server logs a warning at
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| 401 at Twilio side | Signature verification failed | Verify `TWILIO_PUBLIC_URL` matches the URL Twilio actually hits (scheme + host + path, no trailing `/`) |
+| Symptom            | Cause                             | Fix                                                                                                                                 |
+| ------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| 401 at Twilio side | Signature verification failed     | Verify `TWILIO_PUBLIC_URL` matches the URL Twilio actually hits (scheme + host + path, no trailing `/`)                             |
 | No reply delivered | `Messages.json` REST call failing | `docker logs` / `npx` output will show `[twilio-sms] send failed: …`. Common cause: trial account can only message verified numbers |
-| Duplicate replies | Twilio retried before ACK | Ensure reachable `https://` endpoint (not HTTP) and the bridge responds 2xx under 15 s |
+| Duplicate replies  | Twilio retried before ACK         | Ensure reachable `https://` endpoint (not HTTP) and the bridge responds 2xx under 15 s                                              |
 
 ## Security notes
 
@@ -126,7 +130,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/slack`](https://www.npmjs.com/package/@mulmobridge/slack) — Slack Socket Mode
 - [`@mulmobridge/teams`](https://www.npmjs.com/package/@mulmobridge/teams) — Microsoft Teams via Bot Framework
 - [`@mulmobridge/telegram`](https://www.npmjs.com/package/@mulmobridge/telegram) — Telegram bot
-- [`@mulmobridge/twilio-sms`](https://www.npmjs.com/package/@mulmobridge/twilio-sms) — SMS via Twilio Programmable Messaging  ← **this package**
+- [`@mulmobridge/twilio-sms`](https://www.npmjs.com/package/@mulmobridge/twilio-sms) — SMS via Twilio Programmable Messaging ← **this package**
 - [`@mulmobridge/viber`](https://www.npmjs.com/package/@mulmobridge/viber) — Viber Public Account bots
 - [`@mulmobridge/webhook`](https://www.npmjs.com/package/@mulmobridge/webhook) — generic HTTP webhook bridge
 - [`@mulmobridge/whatsapp`](https://www.npmjs.com/package/@mulmobridge/whatsapp) — WhatsApp Cloud API via MulmoBridge relay

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@mulmobridge/client": "^1.1.0",
     "@mulmobridge/protocol": "^1.0.1",
+    "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"

--- a/packages/bridges/twilio-sms/src/index.ts
+++ b/packages/bridges/twilio-sms/src/index.ts
@@ -28,12 +28,12 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "twilio-sms";
 const MAX_SMS_LEN = 1_600; // Twilio concatenates segments up to 1600 chars
 const FETCH_TIMEOUT_MS = 15_000;
-const PORT = Number(process.env.TWILIO_WEBHOOK_PORT) || 3010;
 
 function readRequiredEnv(): { accountSid: string; authToken: string; fromNumber: string } {
   const accountSid = process.env.TWILIO_ACCOUNT_SID;
@@ -209,9 +209,9 @@ app.post("/sms", async (req: Request, res: ExpressResponse) => {
   }
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "TWILIO_WEBHOOK_PORT", fallback: 3010 }, (port) => {
   console.log("MulmoClaude Twilio SMS bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/sms`);
+  console.log(`Webhook listening on http://localhost:${port}/sms`);
   console.log(`From number: ${fromNumber}`);
   console.log(`Public URL: ${publicUrl ?? "(not set — signature verification OFF)"}`);
   console.log(`Allowlist: ${allowAll ? "(all)" : [...allowedNumbers].join(", ")}`);

--- a/packages/bridges/viber/README.md
+++ b/packages/bridges/viber/README.md
@@ -43,14 +43,18 @@ Send a message to your Public Account from the Viber app — you'll get a reply.
 
 ## Environment variables
 
-| Variable               | Required | Default         | Description |
-|------------------------|----------|-----------------|-------------|
-| `VIBER_AUTH_TOKEN`     | yes      | —               | Public Account auth token from the admin panel |
-| `VIBER_SENDER_NAME`    | no       | `MulmoClaude`   | Display name used on outbound messages |
-| `VIBER_WEBHOOK_PORT`   | no       | `3012`          | HTTP port |
-| `VIBER_ALLOWED_USERS`  | no       | (all)           | CSV of Viber user IDs allowed (empty = everyone who messages the bot) |
-| `MULMOCLAUDE_AUTH_TOKEN` | no     | auto            | MulmoClaude bearer token override |
-| `MULMOCLAUDE_API_URL`  | no       | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL |
+| Variable                 | Required | Default                                              | Description                                                           |
+| ------------------------ | -------- | ---------------------------------------------------- | --------------------------------------------------------------------- |
+| `VIBER_AUTH_TOKEN`       | yes      | —                                                    | Public Account auth token from the admin panel                        |
+| `VIBER_SENDER_NAME`      | no       | `MulmoClaude`                                        | Display name used on outbound messages                                |
+| `VIBER_WEBHOOK_PORT`     | no       | `3012`                                               | HTTP port (`0` asks the OS for a free port)                           |
+| `VIBER_ALLOWED_USERS`    | no       | (all)                                                | CSV of Viber user IDs allowed (empty = everyone who messages the bot) |
+| `MULMOCLAUDE_AUTH_TOKEN` | no       | auto                                                 | MulmoClaude bearer token override                                     |
+| `MULMOCLAUDE_API_URL`    | no       | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL                                                |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -81,11 +85,11 @@ Recommended: at least 32 characters of random data (the server logs a warning at
 
 ## Troubleshooting
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| Webhook registration returns `{"status":10,"status_message":"No URL parameter supplied."}` | Typo in set_webhook call | Re-check JSON body |
-| Invalid signature on all events | Rotation mismatch between `VIBER_AUTH_TOKEN` and the token used to register the webhook | Re-register the webhook using the current token |
-| `send non-zero status: {"status":6,…}` | Receiver hasn't messaged your bot first | Viber requires the user to start the conversation before you can push to them |
+| Symptom                                                                                    | Cause                                                                                   | Fix                                                                           |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Webhook registration returns `{"status":10,"status_message":"No URL parameter supplied."}` | Typo in set_webhook call                                                                | Re-check JSON body                                                            |
+| Invalid signature on all events                                                            | Rotation mismatch between `VIBER_AUTH_TOKEN` and the token used to register the webhook | Re-register the webhook using the current token                               |
+| `send non-zero status: {"status":6,…}`                                                     | Receiver hasn't messaged your bot first                                                 | Viber requires the user to start the conversation before you can push to them |
 
 ## Security notes
 
@@ -127,7 +131,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/teams`](https://www.npmjs.com/package/@mulmobridge/teams) — Microsoft Teams via Bot Framework
 - [`@mulmobridge/telegram`](https://www.npmjs.com/package/@mulmobridge/telegram) — Telegram bot
 - [`@mulmobridge/twilio-sms`](https://www.npmjs.com/package/@mulmobridge/twilio-sms) — SMS via Twilio Programmable Messaging
-- [`@mulmobridge/viber`](https://www.npmjs.com/package/@mulmobridge/viber) — Viber Public Account bots  ← **this package**
+- [`@mulmobridge/viber`](https://www.npmjs.com/package/@mulmobridge/viber) — Viber Public Account bots ← **this package**
 - [`@mulmobridge/webhook`](https://www.npmjs.com/package/@mulmobridge/webhook) — generic HTTP webhook bridge
 - [`@mulmobridge/whatsapp`](https://www.npmjs.com/package/@mulmobridge/whatsapp) — WhatsApp Cloud API via MulmoBridge relay
 - [`@mulmobridge/xmpp`](https://www.npmjs.com/package/@mulmobridge/xmpp) — XMPP / Jabber

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -18,13 +18,12 @@
 import "dotenv/config";
 import type { Request, Response as ExpressResponse } from "express";
 import { createBridgeClient, chunkText } from "@mulmobridge/client";
-import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature } from "@mulmobridge/webhook-runtime";
+import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "viber";
 const MAX_VIBER_TEXT = 7_000;
 const FETCH_TIMEOUT_MS = 15_000;
-const PORT = Number(process.env.VIBER_WEBHOOK_PORT) || 3012;
 const VIBER_API = "https://chatapi.viber.com/pa";
 
 function readRequiredEnv(): { authToken: string } {
@@ -174,9 +173,9 @@ app.post("/viber", webhookRateLimit, async (req: Request, res: ExpressResponse) 
   }
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "VIBER_WEBHOOK_PORT", fallback: 3012 }, (port) => {
   console.log("MulmoClaude Viber bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/viber`);
+  console.log(`Webhook listening on http://localhost:${port}/viber`);
   console.log(`Sender: ${senderName}`);
   console.log(`Allowlist: ${allowAll ? "(all)" : [...allowedUsers].join(", ")}`);
 });

--- a/packages/bridges/webhook/README.md
+++ b/packages/bridges/webhook/README.md
@@ -30,7 +30,7 @@ curl -X POST http://localhost:3009/webhook \
 ```json
 {
   "chatId": "optional-conversation-id",
-  "text":  "what the user said"
+  "text": "what the user said"
 }
 ```
 
@@ -40,6 +40,7 @@ curl -X POST http://localhost:3009/webhook \
 ## Response
 
 **Success (200)**:
+
 ```json
 { "ok": true, "reply": "…AI reply…" }
 ```
@@ -50,14 +51,18 @@ curl -X POST http://localhost:3009/webhook \
 
 ## Environment variables
 
-| Variable            | Required | Default    | Description |
-|---------------------|----------|------------|-------------|
-| `WEBHOOK_PORT`      | no       | `3009`     | HTTP port |
-| `WEBHOOK_PATH`      | no       | `/webhook` | Endpoint path |
-| `WEBHOOK_SECRET`    | yes (prod) | —        | Shared secret. Every request must include `x-webhook-secret: <value>` header (constant-time compared). The bridge refuses to start without a secret unless `WEBHOOK_ALLOW_OPEN=1` is also set. |
-| `WEBHOOK_ALLOW_OPEN`| no       | —          | Set to `1` to run without `WEBHOOK_SECRET` (local testing only). Prints a loud warning and leaves the endpoint unauthenticated — every POST will drive an LLM call. Do **not** expose publicly. |
-| `MULMOCLAUDE_AUTH_TOKEN` | no  | auto       | MulmoClaude bearer token override |
-| `MULMOCLAUDE_API_URL` | no     | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL |
+| Variable                 | Required   | Default                                              | Description                                                                                                                                                                                     |
+| ------------------------ | ---------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WEBHOOK_PORT`           | no         | `3009`                                               | HTTP port (`0` asks the OS for a free port)                                                                                                                                                     |
+| `WEBHOOK_PATH`           | no         | `/webhook`                                           | Endpoint path                                                                                                                                                                                   |
+| `WEBHOOK_SECRET`         | yes (prod) | —                                                    | Shared secret. Every request must include `x-webhook-secret: <value>` header (constant-time compared). The bridge refuses to start without a secret unless `WEBHOOK_ALLOW_OPEN=1` is also set.  |
+| `WEBHOOK_ALLOW_OPEN`     | no         | —                                                    | Set to `1` to run without `WEBHOOK_SECRET` (local testing only). Prints a loud warning and leaves the endpoint unauthenticated — every POST will drive an LLM call. Do **not** expose publicly. |
+| `MULMOCLAUDE_AUTH_TOKEN` | no         | auto                                                 | MulmoClaude bearer token override                                                                                                                                                               |
+| `MULMOCLAUDE_API_URL`    | no         | auto (`.server-port`; waits if nothing is published) | MulmoClaude server URL                                                                                                                                                                          |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -160,7 +165,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/telegram`](https://www.npmjs.com/package/@mulmobridge/telegram) — Telegram bot
 - [`@mulmobridge/twilio-sms`](https://www.npmjs.com/package/@mulmobridge/twilio-sms) — SMS via Twilio Programmable Messaging
 - [`@mulmobridge/viber`](https://www.npmjs.com/package/@mulmobridge/viber) — Viber Public Account bots
-- [`@mulmobridge/webhook`](https://www.npmjs.com/package/@mulmobridge/webhook) — generic HTTP webhook bridge  ← **this package**
+- [`@mulmobridge/webhook`](https://www.npmjs.com/package/@mulmobridge/webhook) — generic HTTP webhook bridge ← **this package**
 - [`@mulmobridge/whatsapp`](https://www.npmjs.com/package/@mulmobridge/whatsapp) — WhatsApp Cloud API via MulmoBridge relay
 - [`@mulmobridge/xmpp`](https://www.npmjs.com/package/@mulmobridge/xmpp) — XMPP / Jabber
 - [`@mulmobridge/zulip`](https://www.npmjs.com/package/@mulmobridge/zulip) — Zulip

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@mulmobridge/client": "^1.1.0",
     "@mulmobridge/protocol": "^1.0.1",
+    "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",
     "express": "^5.0.0"

--- a/packages/bridges/webhook/src/index.ts
+++ b/packages/bridges/webhook/src/index.ts
@@ -27,10 +27,10 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { createBridgeClient } from "@mulmobridge/client";
+import { listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "webhook";
-const PORT = Number(process.env.WEBHOOK_PORT) || 3009;
 const ENDPOINT = process.env.WEBHOOK_PATH ?? "/webhook";
 const secret = process.env.WEBHOOK_SECRET ?? "";
 const allowOpen = process.env.WEBHOOK_ALLOW_OPEN === "1";
@@ -126,8 +126,8 @@ app.post(ENDPOINT, async (req: Request, res: Response) => {
   }
 });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "WEBHOOK_PORT", fallback: 3009 }, (port) => {
   console.log("MulmoClaude Webhook bridge");
-  console.log(`Listening on http://localhost:${PORT}${ENDPOINT}`);
+  console.log(`Listening on http://localhost:${port}${ENDPOINT}`);
   console.log(`Secret: ${secret ? "(set — x-webhook-secret required)" : "(none — open endpoint)"}`);
 });

--- a/packages/bridges/whatsapp/README.md
+++ b/packages/bridges/whatsapp/README.md
@@ -21,6 +21,7 @@ ngrok http 3003
 ### 3. Configure webhook
 
 In Meta Dashboard → WhatsApp → Configuration:
+
 - **Callback URL**: `https://xxxx.ngrok-free.app/webhook`
 - **Verify token**: any string you choose (set as `WHATSAPP_VERIFY_TOKEN`)
 - Subscribe to: `messages`
@@ -45,17 +46,21 @@ npx @mulmobridge/whatsapp
 
 ## Environment Variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `WHATSAPP_ACCESS_TOKEN` | Yes | Permanent access token from Meta dashboard |
-| `WHATSAPP_PHONE_NUMBER_ID` | Yes | Phone number ID |
-| `WHATSAPP_VERIFY_TOKEN` | Yes | Arbitrary string for webhook verification |
-| `WHATSAPP_BRIDGE_PORT` | No | Webhook port (default: 3003) |
-| `WHATSAPP_ALLOWED_NUMBERS` | No | CSV of phone numbers (empty = all) |
-| `MULMOCLAUDE_API_URL` | No | Default: auto (`.server-port`; waits if nothing is published) |
-| `MULMOCLAUDE_AUTH_TOKEN` | No | Bearer token |
-| `WHATSAPP_BRIDGE_DEFAULT_ROLE` | No | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a whatsapp session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
-| `BRIDGE_DEFAULT_ROLE` | No | Same as above but shared across every bridge. Transport-specific `WHATSAPP_BRIDGE_DEFAULT_ROLE` wins when both are set. |
+| Variable                       | Required | Description                                                                                                                                                                                                                                                                     |
+| ------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WHATSAPP_ACCESS_TOKEN`        | Yes      | Permanent access token from Meta dashboard                                                                                                                                                                                                                                      |
+| `WHATSAPP_PHONE_NUMBER_ID`     | Yes      | Phone number ID                                                                                                                                                                                                                                                                 |
+| `WHATSAPP_VERIFY_TOKEN`        | Yes      | Arbitrary string for webhook verification                                                                                                                                                                                                                                       |
+| `WHATSAPP_BRIDGE_PORT`         | No       | Webhook port (default: 3003; `0` asks the OS for a free port)                                                                                                                                                                                                                   |
+| `WHATSAPP_ALLOWED_NUMBERS`     | No       | CSV of phone numbers (empty = all)                                                                                                                                                                                                                                              |
+| `MULMOCLAUDE_API_URL`          | No       | Default: auto (`.server-port`; waits if nothing is published)                                                                                                                                                                                                                   |
+| `MULMOCLAUDE_AUTH_TOKEN`       | No       | Bearer token                                                                                                                                                                                                                                                                    |
+| `WHATSAPP_BRIDGE_DEFAULT_ROLE` | No       | Role id to seed new bridge sessions with (e.g. `coder`, `general`). Applied ONLY when a whatsapp session first appears — once the user switches role via `/role <id>` the session's own role wins. Unknown role ids silently fall back to the server's default with a warn log. |
+| `BRIDGE_DEFAULT_ROLE`          | No       | Same as above but shared across every bridge. Transport-specific `WHATSAPP_BRIDGE_DEFAULT_ROLE` wins when both are set.                                                                                                                                                         |
+
+An unusable value (a typo, a number outside 0-65535) stops the bridge with a message naming
+the variable, rather than silently starting on the default. A port already in use is reported
+the same way (#3084).
 
 ### Auth token persistence across server restarts
 
@@ -118,7 +123,7 @@ Part of the [`@mulmobridge/*`](https://www.npmjs.com/~mulmobridge) package famil
 - [`@mulmobridge/twilio-sms`](https://www.npmjs.com/package/@mulmobridge/twilio-sms) — SMS via Twilio Programmable Messaging
 - [`@mulmobridge/viber`](https://www.npmjs.com/package/@mulmobridge/viber) — Viber Public Account bots
 - [`@mulmobridge/webhook`](https://www.npmjs.com/package/@mulmobridge/webhook) — generic HTTP webhook bridge
-- [`@mulmobridge/whatsapp`](https://www.npmjs.com/package/@mulmobridge/whatsapp) — WhatsApp Cloud API via MulmoBridge relay  ← **this package**
+- [`@mulmobridge/whatsapp`](https://www.npmjs.com/package/@mulmobridge/whatsapp) — WhatsApp Cloud API via MulmoBridge relay ← **this package**
 - [`@mulmobridge/xmpp`](https://www.npmjs.com/package/@mulmobridge/xmpp) — XMPP / Jabber
 - [`@mulmobridge/zulip`](https://www.npmjs.com/package/@mulmobridge/zulip) — Zulip
 

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -15,12 +15,11 @@
 
 import "dotenv/config";
 import { createBridgeClient } from "@mulmobridge/client";
-import { createWebhookApp, registerMetaWebhook } from "@mulmobridge/webhook-runtime";
+import { createWebhookApp, registerMetaWebhook, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { extractWhatsAppMessages, type WhatsAppTextMessage } from "@mulmoclaude/common/meta-webhook";
 
 const TRANSPORT_ID = "whatsapp";
-const PORT = Number(process.env.WHATSAPP_BRIDGE_PORT) || 3003;
 const FETCH_TIMEOUT_MS = 30_000;
 
 function readRequiredEnv(): { accessToken: string; phoneNumberId: string; verifyToken: string; appSecret: string } {
@@ -132,7 +131,7 @@ async function handleWebhookBody(rawBody: string): Promise<void> {
 
 registerMetaWebhook(app, { verifyToken, appSecret, label: "whatsapp", ackBody: "OK", onBody: handleWebhookBody });
 
-app.listen(PORT, () => {
+listenWebhook(app, { envVar: "WHATSAPP_BRIDGE_PORT", fallback: 3003 }, (port) => {
   console.log("MulmoClaude WhatsApp bridge");
-  console.log(`Webhook listening on http://localhost:${PORT}/webhook`);
+  console.log(`Webhook listening on http://localhost:${port}/webhook`);
 });

--- a/packages/common/src/envCoerce.ts
+++ b/packages/common/src/envCoerce.ts
@@ -31,5 +31,9 @@ export function asInt(value: string | undefined, fallback: number, opts: IntRang
 }
 
 /** The port range the backend accepts, so both sides bound the value identically.
- *  `min: 0` is deliberate — 0 asks the OS for an ephemeral port. */
-export const PORT_RANGE: IntRange = Object.freeze({ min: 0, max: 65_535 });
+ *  `min: 0` is deliberate — 0 asks the OS for an ephemeral port.
+ *
+ *  `Required<IntRange>`, not `IntRange`: both bounds are always present here, and
+ *  saying so lets a caller compare against them (`port <= PORT_RANGE.max`) without
+ *  a non-null assertion. Still assignable wherever an `IntRange` is expected. */
+export const PORT_RANGE: Required<IntRange> = Object.freeze({ min: 0, max: 65_535 });

--- a/packages/common/src/envCoerce.ts
+++ b/packages/common/src/envCoerce.ts
@@ -1,0 +1,35 @@
+// Env-var type coercion for ports and other integer settings.
+//
+// It started inside `server/system/env.ts` (#504-era), moved to
+// `server/utils/envCoerce.ts` when #2650 needed the SAME rule for `yarn dev`'s
+// Vite proxy — the proxy has to resolve `PORT` exactly as the backend does, or
+// the two point at different servers — and moved here when #3084 needed it for
+// the messaging bridges too. A second opinion about "is this a port" is that
+// bug one level down, so there is exactly one copy and every tier imports it.
+
+export interface IntRange {
+  min?: number;
+  max?: number;
+}
+
+/**
+ * `Number()`-based integer coercion with an optional range, falling back when the
+ * value is absent, empty, non-integer, or out of range.
+ *
+ * `Number()` — not `parseInt` — on purpose: it is what the server has always used,
+ * so `0x1f`, `1e3`, `+3100` and `3100.0` coerce exactly as they did, and a
+ * whitespace-only value coerces to 0. Anything stricter here would silently
+ * disagree with the backend.
+ */
+export function asInt(value: string | undefined, fallback: number, opts: IntRange = {}): number {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return fallback;
+  if (opts.min !== undefined && parsed < opts.min) return fallback;
+  if (opts.max !== undefined && parsed > opts.max) return fallback;
+  return parsed;
+}
+
+/** The port range the backend accepts, so both sides bound the value identically.
+ *  `min: 0` is deliberate — 0 asks the OS for an ephemeral port. */
+export const PORT_RANGE: IntRange = Object.freeze({ min: 0, max: 65_535 });

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -151,3 +151,4 @@ export function splitJwtSegments(token: string): JwtSegments | null {
 
 export { scanEnvOptions, snakeToLowerCamel, type ScanEnvOptionsConfig } from "./envScan.js";
 export type { MinimalLogger, StructuredLogger } from "./logger.js";
+export { asInt, PORT_RANGE, type IntRange } from "./envCoerce.js";

--- a/packages/common/test/test_env_coerce.ts
+++ b/packages/common/test/test_env_coerce.ts
@@ -1,0 +1,144 @@
+// Tests for the int/port coercion rule, moved here from `server/utils/` when
+// #3084 needed it in the bridges too.
+//
+// The move was verified against a verbatim copy of the pre-move function over
+// 620k generated (value, fallback, range) triples — 0 mismatches. That harness
+// could not survive (half of it was the deleted copy), so what it taught is kept
+// here instead: the GENERATOR (which inputs matter — `Number()`'s odd literals,
+// whitespace, out-of-range, junk) and the PROPERTIES the callers depend on.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { asInt, PORT_RANGE } from "../src/index.ts";
+
+const FALLBACK = 3002;
+
+describe("asInt — absent or empty", () => {
+  it("undefined and empty string take the fallback", () => {
+    assert.equal(asInt(undefined, FALLBACK), FALLBACK);
+    assert.equal(asInt("", FALLBACK), FALLBACK);
+  });
+
+  it("whitespace-only coerces to 0, as `Number()` does", () => {
+    // Deliberate, and load-bearing: callers that must not read blank as
+    // "ephemeral port" reject whitespace BEFORE calling (see
+    // `resolveWebhookPort` in @mulmobridge/webhook-runtime).
+    assert.equal(asInt(" ", FALLBACK), 0);
+    assert.equal(asInt("\t\n", FALLBACK), 0);
+  });
+});
+
+describe("asInt — the literals `Number()` accepts", () => {
+  it("plain integers pass through", () => {
+    assert.equal(asInt("0", FALLBACK), 0);
+    assert.equal(asInt("3100", FALLBACK), 3100);
+    assert.equal(asInt("-1", FALLBACK), -1);
+  });
+
+  it("non-decimal and signed forms coerce the way the backend has always read them", () => {
+    assert.equal(asInt("0x1f", FALLBACK), 31);
+    assert.equal(asInt("0o17", FALLBACK), 15);
+    assert.equal(asInt("0b101", FALLBACK), 5);
+    assert.equal(asInt("1e3", FALLBACK), 1000);
+    assert.equal(asInt("+3100", FALLBACK), 3100);
+    assert.equal(asInt("3100.0", FALLBACK), 3100);
+    assert.equal(asInt(" 3100 ", FALLBACK), 3100);
+  });
+});
+
+describe("asInt — abnormal input falls back", () => {
+  it("junk, partial numbers and non-integers fall back", () => {
+    [
+      "302a",
+      "a302",
+      "NaN",
+      "Infinity",
+      "-Infinity",
+      "null",
+      "undefined",
+      "true",
+      "1_000",
+      "３００２",
+      "3002.5",
+      "1e-3",
+      "1,2",
+      "[]",
+      "{}",
+      "80@attacker.example",
+    ].forEach((raw) => {
+      assert.equal(asInt(raw, FALLBACK), FALLBACK, `expected fallback for ${JSON.stringify(raw)}`);
+    });
+  });
+
+  it("out-of-range falls back at both ends, inclusive bounds pass", () => {
+    assert.equal(asInt("-1", FALLBACK, PORT_RANGE), FALLBACK);
+    assert.equal(asInt("65536", FALLBACK, PORT_RANGE), FALLBACK);
+    assert.equal(asInt("99999", FALLBACK, PORT_RANGE), FALLBACK);
+    assert.equal(asInt("0", FALLBACK, PORT_RANGE), 0);
+    assert.equal(asInt("65535", FALLBACK, PORT_RANGE), 65535);
+  });
+
+  it("min and max apply independently", () => {
+    assert.equal(asInt("5", FALLBACK, { min: 10 }), FALLBACK);
+    assert.equal(asInt("50", FALLBACK, { max: 10 }), FALLBACK);
+    assert.equal(asInt("50", FALLBACK, { min: 10 }), 50);
+  });
+});
+
+describe("asInt — properties over generated input", () => {
+  // Seeded, not `Math.random()`: a property that fails must fail again on the
+  // next run, and the sonarjs/pseudo-random rule is right that an unseeded
+  // generator has no place in a committed test.
+  const SEED = 0x3084;
+  let state = SEED;
+  const nextUnit = (): number => {
+    // xorshift32 — enough spread for input generation, and reproducible.
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0x1_0000_0000;
+  };
+
+  const generated: string[] = [];
+  for (let i = 0; i < 2000; i++) generated.push(String(Math.floor(nextUnit() * 200_000) - 100_000));
+  for (let i = 0; i < 500; i++) generated.push((nextUnit() * 100_000).toFixed(1 + Math.floor(nextUnit() * 3)));
+  for (let i = 0; i < 500; i++) generated.push(nextUnit().toString(36).slice(2, 8));
+
+  it("the result is always an integer inside the range, or exactly the fallback", () => {
+    generated.forEach((raw) => {
+      const got = asInt(raw, FALLBACK, PORT_RANGE);
+      if (got === FALLBACK) return;
+      assert.ok(Number.isInteger(got), `seed ${SEED}: ${JSON.stringify(raw)} produced a non-integer: ${got}`);
+      assert.ok(got >= 0 && got <= 65_535, `seed ${SEED}: ${JSON.stringify(raw)} produced out-of-range: ${got}`);
+    });
+  });
+
+  it("the fallback is returned for exactly the same inputs whatever its value — the sentinel technique rests on this", () => {
+    // `resolveWebhookPort` in @mulmobridge/webhook-runtime detects an unusable
+    // value by passing -1 as the fallback and comparing. That is only sound if
+    // "returned the fallback" means "the input was unusable" and never "the
+    // input happened to equal the fallback".
+    generated.forEach((raw) => {
+      const viaMinusOne = asInt(raw, -1, PORT_RANGE) === -1;
+      const viaMinusTwo = asInt(raw, -2, PORT_RANGE) === -2;
+      assert.equal(viaMinusOne, viaMinusTwo, `seed ${SEED}: ${JSON.stringify(raw)} disagrees between two sentinels`);
+      if (viaMinusOne)
+        assert.equal(asInt(raw, FALLBACK, PORT_RANGE), FALLBACK, `seed ${SEED}: ${JSON.stringify(raw)} fell back for -1 but not for ${FALLBACK}`);
+    });
+  });
+
+  it("a value the sentinel accepts is never negative, so -1 cannot be a real result", () => {
+    generated.concat(["0", "65535", "-1", "-0"]).forEach((raw) => {
+      const got = asInt(raw, -1, PORT_RANGE);
+      if (got !== -1) assert.ok(got >= 0, `seed ${SEED}: ${JSON.stringify(raw)} produced a negative real result: ${got}`);
+    });
+  });
+});
+
+describe("PORT_RANGE", () => {
+  it("admits 0 (ask the OS) through 65535, and is frozen", () => {
+    assert.deepEqual({ ...PORT_RANGE }, { min: 0, max: 65_535 });
+    assert.ok(Object.isFrozen(PORT_RANGE));
+  });
+});

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -124,11 +124,17 @@ Report body:
 
 ```markdown
 ## What happened
+
 ## What I expected
+
 ## Steps to reproduce
+
 1.
+
 ## Environment
+
 (paste the diagnostics report here)
+
 ## Attachments
 ```
 
@@ -280,7 +286,7 @@ naming the file:
   quotes, unquoted key.
 - `role file does not match the role schema, skipping` — the `issues`
   field names each field, e.g. `icon: Invalid input: expected string,
-  received undefined`. All of `id`, `name`, `icon`, `prompt`,
+received undefined`. All of `id`, `name`, `icon`, `prompt`,
   `availablePlugins` are required; `availablePlugins` must be an array
   even for one entry.
 - `role file is empty, skipping` — zero-length or whitespace only.
@@ -328,7 +334,7 @@ it:
     `my role.json`, rejected as `Invalid role id 'my role'.` Neither name
     reaches the role. Renaming is the only fix.
   - `… the id is not a usable role id` — the reverse, e.g. `"id": "my
-    role"` in `designer.json`. `delete designer` still works, and renaming
+role"` in `designer.json`. `delete designer` still works, and renaming
     to `my role.json` would take that away. Change the `id`.
   - `… neither is a usable role id` — pick one id that matches the pattern
     and use it for the file name and the `id` together.
@@ -926,12 +932,12 @@ They are genuinely different failures — a permanent load failure, a startup ra
 and guessing between them is what makes this expensive. Since #2842 the log answers it directly,
 so read these three before forming a theory:
 
-| Log line | What it tells you |
-|---|---|
-| `spawning agent … broker=tsx` | This install is on the SLOW path: the bundle is missing, so the broker is transcoded from source on every spawn (seconds to tens of seconds over a Windows/macOS bind mount). A `broker bundle missing` warn accompanies it once per process. |
-| `[mcp] broker ready bootMs=… initializeMs=…` | The broker DID connect, and how long it took. `broker cold boot is slow` replaces it past 5 s. |
-| `brokerEverReady=false reason=never-ready` on the retry warn | No beacon arrived for that chat, and the host kept looking until the beacon's own delivery budget was spent — the broker did not come up at all. The turn is NOT replayed: a replay would sit out another full connect wait and end in the same error. |
-| `reason=ready-during-wait` on the retry warn | The beacon arrived while the host waited, so the broker lost the race by a moment and IS connected now. The turn is replayed, which is what fixes this one. |
+| Log line                                                      | What it tells you                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spawning agent … broker=tsx`                                 | This install is on the SLOW path: the bundle is missing, so the broker is transcoded from source on every spawn (seconds to tens of seconds over a Windows/macOS bind mount). A `broker bundle missing` warn accompanies it once per process.                                                                                                                                                                                                                                                                                                     |
+| `[mcp] broker ready bootMs=… initializeMs=…`                  | The broker DID connect, and how long it took. `broker cold boot is slow` replaces it past 5 s.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `brokerEverReady=false reason=never-ready` on the retry warn  | No beacon arrived for that chat, and the host kept looking until the beacon's own delivery budget was spent — the broker did not come up at all. The turn is NOT replayed: a replay would sit out another full connect wait and end in the same error.                                                                                                                                                                                                                                                                                            |
+| `reason=ready-during-wait` on the retry warn                  | The beacon arrived while the host waited, so the broker lost the race by a moment and IS connected now. The turn is replayed, which is what fixes this one.                                                                                                                                                                                                                                                                                                                                                                                       |
 | `brokerEverStarted=` on the `MCP tools were unavailable` warn | Whether the broker PROCESS ever existed, which is a different question from whether it answered. `true` with `brokerEverReady=false` means it launched and never finished booting — the boot is the problem (the mount, the `tsx` path). `false` means it never launched — the spawn is the problem. Diagnostic only, and not authenticated: under Docker everything needed to forge it sits in the per-session MCP config inside the workspace mount, so read it as evidence about a healthy install rather than as proof against a hostile one. |
 
 ### Fix
@@ -968,7 +974,7 @@ so read these three before forming a theory:
 
 - The `google` tool (or a `google.calendar.*` remote command) fails with **"Google account not linked on this host"**.
 - **"Google sign-in service unreachable"** or **"Google sign-in service returned HTTP …"**.
-- **"multiple client_secret_*.json files found"**.
+- **"multiple client_secret\_*.json files found"**.
 - **"Google Calendar API: HTTP 403"** with a hint about enabling the API.
 - **"Google Calendar API: HTTP 403 — Request had insufficient authentication scopes"** when pushing
   a collection to a calendar that is NOT in the account's own calendar list.
@@ -1121,8 +1127,7 @@ Pass the file instead. `putItems` accepts **`itemsFile`** — an absolute path t
 a JSON file holding the array of record objects, read by the host:
 
 ```jsonc
-{ "action": "putItems", "slug": "slots", "mode": "create",
-  "itemsFile": "/absolute/path/to/generated-slots.json" }
+{ "action": "putItems", "slug": "slots", "mode": "create", "itemsFile": "/absolute/path/to/generated-slots.json" }
 ```
 
 Write the generated file **under the workspace**. Paths outside it are refused:
@@ -1144,17 +1149,17 @@ Rules that make it fail cleanly rather than silently:
 
 Reading the refusal you got:
 
-| Message | What it means |
-| --- | --- |
-| `must be an ABSOLUTE path` | You passed a relative path. Pass the full one. |
-| `must be inside the workspace` | The file is outside the workspace (or a symlink out of it). Regenerate it under the workspace. |
-| `is a symbolic link` | Symlinks are never followed. Pass the real path. |
-| `changed while it was being opened` | The file was replaced mid-call. Finish writing it, then call putItems. |
-| `grew while it was being read` | The file was still being written. Wait for the script to finish, then call putItems. |
-| `could not read \`itemsFile\`` | The host cannot see that path — the usual cause is a file written to a temp dir outside the mount. Write it under the workspace. |
-| `is not a regular file` | The path is a directory, device, or fifo. |
-| `could not be read as JSON` | The file exists and was read, but does not parse. This is YOUR file's shape, not a host problem — check the script that wrote it (a truncated write, a trailing comma, log output mixed into the file). |
-| `must hold a non-empty JSON array of record objects` | It parsed, but is `[]`, an object, or an array of scalars. The file must be `[{…}, {…}]` — the same row objects you would have passed as `items`. |
+| Message                                              | What it means                                                                                                                                                                                           |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `must be an ABSOLUTE path`                           | You passed a relative path. Pass the full one.                                                                                                                                                          |
+| `must be inside the workspace`                       | The file is outside the workspace (or a symlink out of it). Regenerate it under the workspace.                                                                                                          |
+| `is a symbolic link`                                 | Symlinks are never followed. Pass the real path.                                                                                                                                                        |
+| `changed while it was being opened`                  | The file was replaced mid-call. Finish writing it, then call putItems.                                                                                                                                  |
+| `grew while it was being read`                       | The file was still being written. Wait for the script to finish, then call putItems.                                                                                                                    |
+| `could not read \`itemsFile\``                       | The host cannot see that path — the usual cause is a file written to a temp dir outside the mount. Write it under the workspace.                                                                        |
+| `is not a regular file`                              | The path is a directory, device, or fifo.                                                                                                                                                               |
+| `could not be read as JSON`                          | The file exists and was read, but does not parse. This is YOUR file's shape, not a host problem — check the script that wrote it (a truncated write, a trailing comma, log output mixed into the file). |
+| `must hold a non-empty JSON array of record objects` | It parsed, but is `[]`, an object, or an array of scalars. The file must be `[{…}, {…}]` — the same row objects you would have passed as `items`.                                                       |
 
 Do NOT spawn the MCP bridge yourself. A hand-written JSON-RPC client fails
 invisibly and can leave a partially written collection that nothing reports.
@@ -1196,10 +1201,14 @@ the calendar can place. So format the string, never convert it:
 
 ```js
 // WRONG — appends `Z` and shifts the hours by the generating machine's offset
-{ startAt: new Date(`${day}T08:00`).toISOString() }   // "2026-08-17T15:00:00.000Z"
+{
+  startAt: new Date(`${day}T08:00`).toISOString();
+} // "2026-08-17T15:00:00.000Z"
 
 // RIGHT — the clock you meant, written as the clock
-{ startAt: `${day}T08:00` }                            // "2026-08-17T08:00"
+{
+  startAt: `${day}T08:00`;
+} // "2026-08-17T08:00"
 ```
 
 The conversion is the more expensive half: had the format passed, a Tokyo court's
@@ -1249,7 +1258,7 @@ second line, with the plugin-load errors above it, is what a bug report needs.
 ### Symptoms
 
 - Reading or writing a collection fails with `shared collection unavailable:
-  connect remote-host first`.
+connect remote-host first`.
 - A collection whose `schema.json` declares `"storage": { "type": "firestore" }`
   never appears in the list at all.
 - Reads and writes fail with `permission-denied` from Firestore even though the
@@ -1269,7 +1278,7 @@ The backend deliberately fails loudly instead of returning nothing.
 
 2. **The collection never appears** — discovery REFUSED the schema, and the
    reason is in the server log under `collections` (`schema.json rejected after
-   validation, skipping`). For a shared collection the usual reason is the app
+validation, skipping`). For a shared collection the usual reason is the app
    declaration: `apps/{aid}/collections/{cid}/items` needs an `aid`, which comes
    from `app.json` at the repository root, not from the schema.
 
@@ -1390,6 +1399,54 @@ the server's `[server] listening port=…` line, and whether
 `<workspace>/.server-port` exists. Those three answer "which server, on which
 port, and did the bridge agree" — which is what every one of these turns out to
 be.
+
+## A webhook bridge exits at startup, or never binds its port
+
+### Symptoms
+
+One of the webhook bridges — `line`, `line-works`, `google-chat`, `messenger`,
+`teams`, `twilio-sms`, `viber`, `webhook`, `whatsapp` — exits immediately after
+being started, printing one of:
+
+```text
+Port 3002 is already in use. Set LINE_BRIDGE_PORT to a free port, or LINE_BRIDGE_PORT=0 to let the OS pick one.
+LINE_BRIDGE_PORT="302a" is not a usable port. Set it to an integer from 0 to 65535 (LINE_BRIDGE_PORT=0 asks the OS for a free port), or unset it to use 3002.
+```
+
+Both name the env var to change, and each bridge has its own — `WEBHOOK_PORT`,
+`TWILIO_WEBHOOK_PORT`, `VIBER_WEBHOOK_PORT` and so on. Read the message rather
+than guessing the name.
+
+### "Already in use" is usually the server, not a second bridge
+
+The server's port walk (3002-3021) covers the whole bridge band (3002-3013), so
+a server that found 3001 busy and moved forward can be sitting on a bridge's
+default. Check what the server actually bound before moving the bridge:
+
+```bash
+cat "${MULMOCLAUDE_WORKSPACE_PATH:-$HOME/mulmoclaude}/.server-port"
+lsof -nP -iTCP:3002 -sTCP:LISTEN
+```
+
+Two ways out, both fine:
+
+- Give the bridge a port outside the server's band: `LINE_BRIDGE_PORT=3200`.
+- Let the OS choose: `LINE_BRIDGE_PORT=0`. The startup banner then names the
+  port it actually got — read the banner, not the env var, when tunnelling to it
+  (`Webhook listening on http://localhost:52431/webhook`).
+
+### Before #3084 both of these were silent
+
+A bridge of that vintage reads its port as `Number(process.env.X) || <default>`
+and calls a bare `app.listen`. So a **typo ran on the default without a word**
+(`302a` → `NaN` → falsy → the default), `X=0` was impossible (falsy too), and a
+busy port surfaced as an unhandled `EADDRINUSE` with no mention of which env var
+to change. If neither message above appears and the bridge simply dies, or it is
+answering on a port you did not ask for, that is the old build: reinstall it
+(`npm i -g @mulmobridge/<platform>@latest`).
+
+A bridge that starts but never replies is a different failure — see "A messaging
+bridge's bot does not reply, and nothing errors" above.
 
 ## `renderShapeScript` says Chromium is not installed
 

--- a/packages/webhook-runtime/package.json
+++ b/packages/webhook-runtime/package.json
@@ -27,11 +27,13 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
+    "@mulmoclaude/common": "^1.2.0",
     "express": "^5.1.0",
     "express-rate-limit": "^8.7.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "@types/node": "^26.4.1",
     "tsx": "^4.23.13",
     "typescript": "^6.0.3"
   },

--- a/packages/webhook-runtime/src/index.ts
+++ b/packages/webhook-runtime/src/index.ts
@@ -9,8 +9,11 @@
 // has to be applied six times. This package is the single source.
 
 import crypto from "crypto";
+import type { Server } from "node:http";
 import express, { type Express, type Request, type Response } from "express";
 import rateLimit, { ipKeyGenerator, type RateLimitRequestHandler } from "express-rate-limit";
+import { hasNumberProp } from "@mulmoclaude/common";
+import { describeListenError, resolveWebhookPort } from "./port.js";
 
 // Honour an explicit `trust proxy` setting so `req.ip` (the rate-limit
 // key) reflects the real client IP rather than the load balancer's.
@@ -196,4 +199,51 @@ export function registerMetaWebhook(app: Express, opts: MetaWebhookOptions): voi
     res.status(200).send(opts.ackBody ?? "EVENT_RECEIVED");
     await opts.onBody(rawBody);
   });
+}
+
+export interface ListenWebhookOptions {
+  /** The env var that overrides the port. Every message names it — each bridge
+   *  has a different one, and "which knob do I turn" is the question an
+   *  operator has at exactly the moment this fails. */
+  envVar: string;
+  /** Port used when the env var is unset or blank. */
+  fallback: number;
+  /** Test seam. Production prints the message and exits non-zero. */
+  onFatal?: (message: string) => void;
+}
+
+// Bind a bridge's webhook port, and say something useful when that fails.
+//
+// Before #3084 each bridge did `Number(process.env.X) || N` and a bare
+// `app.listen(PORT, cb)`: a typo ran on the default without a word, `X=0` was
+// impossible, and `EADDRINUSE` surfaced as an unhandled error with no mention
+// of which env var to change. The server's port band (3002-3021) overlaps the
+// bridge band (3002-3013), so that collision is routine, not theoretical
+// (#3079).
+export function listenWebhook(app: Express, opts: ListenWebhookOptions, onReady: (port: number) => void): Server | undefined {
+  const fatal = opts.onFatal ?? exitWithMessage;
+  const resolved = resolveWebhookPort(process.env[opts.envVar], opts.fallback, opts.envVar);
+  if (!resolved.ok) {
+    fatal(resolved.message);
+    return undefined;
+  }
+  const server = app.listen(resolved.port, () => {
+    // `server.address()` is the authority on whether the bind happened, and on
+    // which port it got (it differs from the requested one for `=0`). Express 5
+    // runs this callback even when the bind FAILED — verified against
+    // express@5.1: `address()` is null, `listening` is false, and the 'error'
+    // event arrives on the next tick. Without this guard a bridge prints its
+    // "listening on <port>" banner for a server that never bound, which is the
+    // same silence #3084 is about, one step later.
+    const address = server.address();
+    if (!hasNumberProp(address, "port")) return;
+    onReady(address.port);
+  });
+  server.on("error", (err: unknown) => fatal(describeListenError(err, resolved.port, opts.envVar)));
+  return server;
+}
+
+function exitWithMessage(message: string): void {
+  console.error(message);
+  process.exit(1);
 }

--- a/packages/webhook-runtime/src/port.ts
+++ b/packages/webhook-runtime/src/port.ts
@@ -1,0 +1,45 @@
+// Port resolution and bind diagnostics for the webhook bridges (#3084).
+//
+// Pure on purpose — no `process`, no sockets — so both decisions can be tested
+// directly: WHICH port a bridge binds, and WHAT a human is told when the bind
+// fails. `listenWebhook` in `index.ts` is the only part that touches the world.
+
+import { asInt, errorMessage, isErrorWithCode, PORT_RANGE } from "@mulmoclaude/common";
+
+// A fallback that `asInt` can never produce from a real value, since
+// `PORT_RANGE.min` is 0. Comparing against it turns `asInt`'s "fell back"
+// into "the operator typed something unusable", without changing `asInt`'s
+// contract (it returns the fallback for bad input by design).
+const UNUSABLE = -1;
+
+export type PortResolution = { readonly ok: true; readonly port: number } | { readonly ok: false; readonly message: string };
+
+/** Resolve a bridge's listen port from its env var, or say why it cannot be used.
+ *  `raw` is passed in rather than read here so this stays pure. */
+export function resolveWebhookPort(raw: string | undefined, fallback: number, envVar: string): PortResolution {
+  // A blank value means "not configured", which is what `Number(x) || N` did
+  // for the nine bridges before this — `asInt` alone would read it as 0 and
+  // ask the OS for an ephemeral port.
+  if (raw === undefined || raw.trim() === "") return { ok: true, port: fallback };
+  const port = asInt(raw, UNUSABLE, PORT_RANGE);
+  if (port === UNUSABLE) {
+    return {
+      ok: false,
+      message: `${envVar}="${raw}" is not a usable port. Set it to an integer from ${PORT_RANGE.min} to ${PORT_RANGE.max} (${envVar}=0 asks the OS for a free port), or unset it to use ${fallback}.`,
+    };
+  }
+  return { ok: true, port };
+}
+
+/** What to tell the operator when `listen` fails. Names the env var, because
+ *  every bridge uses a different one and "which knob do I turn" is the whole
+ *  question at that moment. */
+export function describeListenError(err: unknown, port: number, envVar: string): string {
+  if (isErrorWithCode(err) && err.code === "EADDRINUSE") {
+    return `Port ${port} is already in use. Set ${envVar} to a free port, or ${envVar}=0 to let the OS pick one.`;
+  }
+  if (isErrorWithCode(err) && err.code === "EACCES") {
+    return `Port ${port} needs elevated privileges. Set ${envVar} to a port above 1023.`;
+  }
+  return `Failed to listen on port ${port} (set ${envVar} to change it): ${errorMessage(err)}`;
+}

--- a/packages/webhook-runtime/test/test_port.ts
+++ b/packages/webhook-runtime/test/test_port.ts
@@ -1,0 +1,159 @@
+// Tests for the bridge port rules (#3084).
+//
+// Both directions, because the whole point of the change is the abnormal side:
+// before it, a typo ran silently on the default, `=0` was impossible, and
+// EADDRINUSE surfaced as an unhandled error naming no env var.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import express from "express";
+
+import { describeListenError, resolveWebhookPort } from "../src/port.ts";
+import { listenWebhook } from "../src/index.ts";
+
+const ENV_VAR = "LINE_BRIDGE_PORT";
+const FALLBACK = 3002;
+
+const resolve = (raw: string | undefined) => resolveWebhookPort(raw, FALLBACK, ENV_VAR);
+
+describe("resolveWebhookPort — configured", () => {
+  it("a valid port is used as given", () => {
+    assert.deepEqual(resolve("3100"), { ok: true, port: 3100 });
+  });
+
+  it("0 is accepted — it asks the OS for a free port", () => {
+    // The regression that made this issue worth filing: `Number("0") || 3002`
+    // read 0 as falsy, so the documented escape hatch was unreachable.
+    assert.deepEqual(resolve("0"), { ok: true, port: 0 });
+  });
+
+  it("both range bounds are inclusive", () => {
+    assert.deepEqual(resolve("65535"), { ok: true, port: 65535 });
+    assert.equal(resolve("65536").ok, false);
+    assert.equal(resolve("-1").ok, false);
+  });
+});
+
+describe("resolveWebhookPort — unconfigured", () => {
+  it("unset, empty and whitespace-only take the default", () => {
+    [undefined, "", " ", "\t\n"].forEach((raw) => {
+      assert.deepEqual(resolve(raw), { ok: true, port: FALLBACK }, `expected the default for ${JSON.stringify(raw)}`);
+    });
+  });
+});
+
+describe("resolveWebhookPort — unusable", () => {
+  it("a typo is reported, not silently replaced by the default", () => {
+    const result = resolve("302a");
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.message, /LINE_BRIDGE_PORT="302a"/);
+    assert.match(result.message, /0 to 65535/);
+    assert.match(result.message, /unset it to use 3002/);
+  });
+
+  it("every shape of junk is rejected", () => {
+    ["302a", "a302", "99999", "-1", "3002.5", "NaN", "Infinity", "true", "null", "1_000", "３００２", "80@attacker.example", "3002 3003", "[]"].forEach(
+      (raw) => {
+        assert.equal(resolve(raw).ok, false, `expected rejection for ${JSON.stringify(raw)}`);
+      },
+    );
+  });
+
+  it("the message always names the env var — each bridge has its own", () => {
+    ["WHATSAPP_BRIDGE_PORT", "TWILIO_WEBHOOK_PORT", "WEBHOOK_PORT"].forEach((envVar) => {
+      const result = resolveWebhookPort("nope", 3009, envVar);
+      assert.equal(result.ok, false);
+      if (!result.ok) assert.ok(result.message.includes(envVar), `${envVar} missing from: ${result.message}`);
+    });
+  });
+});
+
+describe("describeListenError", () => {
+  it("EADDRINUSE names the port, the env var, and the =0 way out", () => {
+    const message = describeListenError(Object.assign(new Error("listen EADDRINUSE"), { code: "EADDRINUSE" }), 3002, ENV_VAR);
+    assert.match(message, /Port 3002 is already in use/);
+    assert.match(message, /Set LINE_BRIDGE_PORT to a free port/);
+    assert.match(message, /LINE_BRIDGE_PORT=0/);
+  });
+
+  it("EACCES points at the privileged-port rule", () => {
+    const message = describeListenError(Object.assign(new Error("listen EACCES"), { code: "EACCES" }), 80, ENV_VAR);
+    assert.match(message, /Port 80 needs elevated privileges/);
+    assert.match(message, /LINE_BRIDGE_PORT/);
+  });
+
+  it("an unknown failure still names the port and the knob", () => {
+    assert.match(describeListenError(new Error("boom"), 3002, ENV_VAR), /Failed to listen on port 3002 \(set LINE_BRIDGE_PORT to change it\): boom/);
+  });
+
+  it("a non-Error throw does not become [object Object]", () => {
+    assert.match(describeListenError({ message: "weird" }, 3002, ENV_VAR), /weird/);
+    assert.doesNotMatch(describeListenError({ message: "weird" }, 3002, ENV_VAR), /\[object Object\]/);
+  });
+});
+
+describe("listenWebhook", () => {
+  const withEnv = async (value: string | undefined, run: () => Promise<void>): Promise<void> => {
+    const before = process.env[ENV_VAR];
+    if (value === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = value;
+    try {
+      await run();
+    } finally {
+      if (before === undefined) delete process.env[ENV_VAR];
+      else process.env[ENV_VAR] = before;
+    }
+  };
+
+  it("reports the port actually bound, so `=0` prints a usable URL", async () => {
+    await withEnv("0", async () => {
+      let started: ReturnType<typeof listenWebhook>;
+      try {
+        const bound = await new Promise<number>((settle, reject) => {
+          started = listenWebhook(express(), { envVar: ENV_VAR, fallback: FALLBACK, onFatal: reject }, settle);
+        });
+        assert.ok(bound > 0 && bound <= 65535, `expected a real ephemeral port, got ${bound}`);
+      } finally {
+        started?.close();
+      }
+    });
+  });
+
+  it("an unusable value stops the bind — the bridge never listens on the default", async () => {
+    await withEnv("302a", async () => {
+      const messages: string[] = [];
+      const server = listenWebhook(express(), { envVar: ENV_VAR, fallback: FALLBACK, onFatal: (message) => messages.push(message) }, () => {
+        throw new Error("onReady must not run for an unusable port");
+      });
+      assert.equal(server, undefined);
+      assert.equal(messages.length, 1);
+      assert.match(messages[0] ?? "", /not a usable port/);
+    });
+  });
+
+  it("EADDRINUSE is explained instead of crashing unhandled", async () => {
+    // Both servers listen with NO host argument, the way a bridge does: Node
+    // then binds `::` dual-stack. Pinning the first one to "0.0.0.0" instead
+    // does NOT collide on macOS — the second bind succeeds on `::` and the
+    // test proves nothing (it silently did, before this comment existed).
+    const occupied = http.createServer();
+    await new Promise<void>((done) => occupied.listen(0, () => done()));
+    const address = occupied.address();
+    const taken = typeof address === "object" && address !== null ? address.port : 0;
+    let attempted: ReturnType<typeof listenWebhook>;
+    try {
+      await withEnv(String(taken), async () => {
+        const message = await new Promise<string>((settle, reject) => {
+          attempted = listenWebhook(express(), { envVar: ENV_VAR, fallback: FALLBACK, onFatal: settle }, () => reject(new Error("bind should have failed")));
+        });
+        assert.match(message, new RegExp(`Port ${taken} is already in use`));
+        assert.match(message, /LINE_BRIDGE_PORT/);
+      });
+    } finally {
+      attempted?.close();
+      await new Promise<void>((done) => occupied.close(() => done()));
+    }
+  });
+});

--- a/plans/fix-3084-bridge-port-safety.md
+++ b/plans/fix-3084-bridge-port-safety.md
@@ -1,0 +1,99 @@
+# fix(bridges): 受信ポートの読み取りと bind を安全側に倒す (#3084)
+
+PR-A（本プラン）= 受信型 9 個のポート。PR-B（別プラン / 別 PR）= 25 個のプロセス堅牢化。
+issue の D-4 の選択肢 (b) を採る — 触るファイルも revert 単位も違う。
+
+## 現状（測った事実）
+
+| 対象                                          | 件数  | 証跡                                                                                                                       |
+| --------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------- |
+| `Number(process.env.X) \|\| N` で listen する | 9     | `line:23` `whatsapp:23` `messenger:20` `google-chat:26` `teams:29` `webhook:33` `twilio-sms:36` `line-works:38` `viber:27` |
+| `app.listen` の `error` ハンドラ              | 0 / 9 | `grep -n "\.listen(" packages/bridges/*/src/*.ts`                                                                          |
+
+`Number(x) || N` の 3 つの穴:
+
+- `302a` → `NaN` → falsy → 既定で起動（打ち間違いが黙殺される）
+- `0` → falsy → 既定で起動（`PORT=0` = OS に空きを選ばせる、が指定できない）
+- `99999` → 範囲検証なしで `listen` に渡る
+
+## 決定（issue の D-1〜D-3, D-6）
+
+- **D-1 `asInt` の家 = `@mulmoclaude/common`**。依存ゼロの leaf、description が
+  "shared across the MulmoClaude host, bridges, and plugins"、`build:packages` の最初にビルド、
+  そして `@mulmobridge/client` 自身が既に common に依存（族をまたぐ前例あり）。
+  `server/utils/envCoerce.ts` は **パスを残して common から re-export**:
+  `vite.config.ts` → `scripts/lib/devServerPort.ts:23` と `tsconfig.node.json:18` が
+  このパスを直接指しており、動かすと dev プロキシの解決経路を巻き込む。
+  `DEFAULT_PORT`（バックエンドのポート）は共有ルールではないので server 側に残す。
+- **各ブリッジは `asInt` を直接呼ばない**。9 個とも既に `@mulmobridge/webhook-runtime` の
+  `createWebhookApp` を使っているので、そこに `listenWebhook` を 1 つ置く。
+  D-1/D-2/D-3 が 1 箇所に収まり、各ブリッジは環境変数名を 1 回だけ書く。
+- **D-2** `server.on("error")` で `EADDRINUSE` / `EACCES` を環境変数名入りで説明して `exit(1)`。
+- **D-3 打ち間違いは `exit(1)`**（ユーザー判断）。`asInt` の契約は変えない —
+  不正判定は `asInt(raw, -1, PORT_RANGE) === -1` で行う（`PORT_RANGE.min` が 0 なので
+  `-1` は正常値として返り得ない番兵）。
+- **D-6** `exit(1)` のみ。supervisor は持ち込まない（#3080 の責務）。
+- **email / irc の同型パターンは含めない**（発信先ポートで `PORT_RANGE.min: 0` が意味を持たない。別 issue）。
+
+## 変更
+
+1. `packages/common/src/envCoerce.ts`（新規） — `asInt` / `PORT_RANGE` / `IntRange` を
+   `server/utils/envCoerce.ts` から移設（**ロジックは 1 文字も変えない**）。`index.ts` から re-export。
+2. `server/utils/envCoerce.ts` — common から re-export し、`DEFAULT_PORT` だけ残す。
+3. `packages/webhook-runtime/src/port.ts`（新規、純粋・`process` を触らない）
+   - `resolveWebhookPort(raw, fallback, envVar): PortResolution`
+   - `describeListenError(err, port, envVar): string`
+4. `packages/webhook-runtime/src/index.ts` — `listenWebhook(app, { envVar, fallback }, onReady)`。
+   解決失敗 → メッセージ + `exit(1)`（listen しない）。`listen` の `error` → 説明 + `exit(1)`。
+   `onReady` には **実際に bind されたポート**を渡す（`PORT=0` のとき既定ログが `0` になるのを防ぐ）。
+5. 受信型 9 個: `const PORT = Number(...) || N` を削り、`listenWebhook` 呼び出しに置換。
+6. テスト: `packages/webhook-runtime/test/test_port.ts`（純粋関数を両方向）、
+   `packages/common/test/test_env_coerce.ts`（移設したルールの pin）。
+   listen 側は実サーバで `EADDRINUSE` を踏ませて `onFatal` の seam で観測する。
+
+## 既存挙動の保全（検証すること）
+
+- 正常値・未設定のときの解決結果と**ログ 1 バイトも変えない**。
+  → 移設前の `asInt` を throwaway harness にコピーし、生成入力で新旧を比較（`/refactor-safely`）。
+- 空白のみ（`PORT="  "`）: 今日は `Number("  ")=0 → falsy →` 既定。`raw.trim() === ""` を
+  fallback 扱いにすることで**今日の挙動を維持**する（`asInt` 単体だと 0 = ephemeral になる）。
+
+## publish 順（マージ後、別作業）
+
+`@mulmoclaude/common`（新 export → bump 必須）→ `@mulmobridge/webhook-runtime`（range を
+新しい common に sweep）→ 受信型 9 ブリッジ。bottom-up + tag + range sweep は `/publish` に従う。
+**本 PR では range を触らない**（宣言は npm の latest = `^1.2.0` のまま）。
+
+## 実装中に見つかったこと（設計に影響した）
+
+**Express 5 は bind が失敗しても `app.listen` のコールバックを呼ぶ。** `express@5.1` で確認:
+`address()` は `null`、`listening` は `false`、`error` イベントは次の tick。素直に
+`onReady` を呼ぶと、**衝突したブリッジが `Webhook listening on http://localhost:3002/webhook`
+を出した直後にエラーを出す** — #3084 が問題にしている「黙って落ちる」が 1 段後ろにずれるだけ。
+`listenWebhook` は `server.address()` に port があることを確認してからのみ `onReady` を呼ぶ。
+
+## 検証結果
+
+| 検証                                                                                     | 結果                       |
+| ---------------------------------------------------------------------------------------- | -------------------------- |
+| `asInt` 移設の等価性（新旧を生成入力で比較）                                             | 620,368 ケース、差分 **0** |
+| `packages/common/test/test_env_coerce.ts`                                                | 11 pass                    |
+| `packages/webhook-runtime/test/test_port.ts` + 既存                                      | 64 pass                    |
+| `test/scripts/test_devServerPort.ts`（dev プロキシが同じルールを引く）                   | 54 pass                    |
+| `tsc -p server/tsconfig.json` / `test/tsconfig.json` / `tsconfig.node.json` / 各 package | clean                      |
+| eslint（触った全パス）                                                                   | clean                      |
+
+**実機**（`packages/bridges/webhook/dist/index.js` を実際に起動）:
+
+| 条件                    | 結果                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| 未設定                  | `Listening on http://localhost:3009/webhook`（**従来と同一**）                       |
+| `WEBHOOK_PORT=302a`     | exit 1 + 値・範囲・環境変数名を含むメッセージ（従来: 黙って 3009）                   |
+| `WEBHOOK_PORT=99999`    | exit 1 + 同メッセージ（従来: そのまま listen してクラッシュ）                        |
+| `WEBHOOK_PORT=0`        | `Listening on http://localhost:51167/webhook`（従来: 不可能）                        |
+| 3009 を他プロセスが占有 | exit 1 + `Port 3009 is already in use. Set WEBHOOK_PORT to ...`、**banner は出ない** |
+
+サーバ本体の起動（`yarn dev`）は実行していない: 別セッションのテストスイートでこのマシンが飽和
+しており（load average ~50）、2 つ目のサーバはユーザーの workspace の `.server-port` /
+`.session-token` を奪う。サーバ側の差分は re-export のみで、等価性・dev プロキシのテスト・
+実際の import 解決で確認した。

--- a/plans/fix-3084-bridge-port-safety.md
+++ b/plans/fix-3084-bridge-port-safety.md
@@ -25,8 +25,9 @@ issue の D-4 の選択肢 (b) を採る — 触るファイルも revert 単位
   `vite.config.ts` → `scripts/lib/devServerPort.ts:23` と `tsconfig.node.json:18` が
   このパスを直接指しており、動かすと dev プロキシの解決経路を巻き込む。
   `DEFAULT_PORT`（バックエンドのポート）は共有ルールではないので server 側に残す。
-- **各ブリッジは `asInt` を直接呼ばない**。9 個とも既に `@mulmobridge/webhook-runtime` の
-  `createWebhookApp` を使っているので、そこに `listenWebhook` を 1 つ置く。
+- **各ブリッジは `asInt` を直接呼ばない**。9 個のうち 6 個は既に `@mulmobridge/webhook-runtime` の
+  `createWebhookApp` を使っており（`teams` / `twilio-sms` / `webhook` は Express を手組みしていたので
+  依存を追加する）、そこに `listenWebhook` を 1 つ置く。
   D-1/D-2/D-3 が 1 箇所に収まり、各ブリッジは環境変数名を 1 回だけ書く。
 - **D-2** `server.on("error")` で `EADDRINUSE` / `EACCES` を環境変数名入りで説明して `exit(1)`。
 - **D-3 打ち間違いは `exit(1)`**（ユーザー判断）。`asInt` の契約は変えない —

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -81,6 +81,9 @@ async function serverLog(namespace, message, options = {}) {
   await safePost(req, LOG_TIMEOUT_MS);
 }
 
+// packages/common/dist/envCoerce.js
+var PORT_RANGE = Object.freeze({ min: 0, max: 65535 });
+
 // packages/common/dist/index.js
 function isRecord(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -215,7 +218,11 @@ function mirrorSkillDelete(workspaceRoot2, slug) {
   return { dest };
 }
 
-// packages/core/dist/dist-D8zokgGo.js
+// packages/core/dist/dist-BzoA9pDR.js
+Object.freeze({
+  min: 0,
+  max: 65535
+});
 function isRecord2(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/server/build/dispatcher.mjs
+++ b/server/build/dispatcher.mjs
@@ -4,6 +4,14 @@
 import { readFileSync } from "node:fs";
 import path2 from "node:path";
 
+// packages/common/dist/envCoerce.js
+var PORT_RANGE = Object.freeze({ min: 0, max: 65535 });
+
+// packages/common/dist/index.js
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 // server/utils/time.ts
 var ONE_SECOND_MS = 1e3;
 var ONE_MINUTE_MS = 6e4;
@@ -38,7 +46,7 @@ function readPort() {
   const raw = readSidecar(PORT_FILE);
   if (!raw) return null;
   const port = Number.parseInt(raw, 10);
-  return Number.isInteger(port) && port > 0 && port < 65536 ? port : null;
+  return Number.isInteger(port) && port > PORT_RANGE.min && port <= PORT_RANGE.max ? port : null;
 }
 function buildAuthPost(pathname, body) {
   const token = readToken();
@@ -79,14 +87,6 @@ async function serverLog(namespace, message, options = {}) {
   };
   const req = buildAuthPost("/api/hooks/log", body);
   await safePost(req, LOG_TIMEOUT_MS);
-}
-
-// packages/common/dist/envCoerce.js
-var PORT_RANGE = Object.freeze({ min: 0, max: 65535 });
-
-// packages/common/dist/index.js
-function isRecord(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 // server/workspace/hooks/shared/stdin.ts

--- a/server/utils/envCoerce.ts
+++ b/server/utils/envCoerce.ts
@@ -1,42 +1,11 @@
-// Env-var type coercion, shared by the server's env snapshot and by `yarn dev`'s
-// Vite proxy.
-//
-// It lived inside `server/system/env.ts` until #2650 needed the SAME rule for the
-// dev proxy: the proxy has to resolve `PORT` exactly as the backend does, or the
-// two point at different servers — which is the bug #2650 is about. A second
-// opinion about "is this a port" is that bug one level down, so the rule lives
-// here and `server/system/env.ts` consumes it rather than owning it.
-//
-// `vite.config.ts` runs outside the server tsconfig, but it is bundled by esbuild
-// and already imports `scripts/lib/*.ts`, so a plain TS module reaches it fine —
-// and keeps `env.ts` type-checked, which routing this through a `.mjs` did not.
+// The port/int coercion rule now lives in `@mulmoclaude/common` (#3084): the
+// messaging bridges need the same rule, and `@mulmobridge/*` cannot import from
+// `server/`. This module stays as the server-side door to it — `vite.config.ts`
+// reaches it through `scripts/lib/devServerPort.ts`, and `tsconfig.node.json`
+// includes this exact path, so moving the file itself would drag the dev proxy's
+// resolution along with it.
+export { asInt, PORT_RANGE, type IntRange } from "@mulmoclaude/common";
 
-export interface IntRange {
-  min?: number;
-  max?: number;
-}
-
-/**
- * `Number()`-based integer coercion with an optional range, falling back when the
- * value is absent, empty, non-integer, or out of range.
- *
- * `Number()` — not `parseInt` — on purpose: it is what the server has always used,
- * so `0x1f`, `1e3`, `+3100` and `3100.0` coerce exactly as they did, and a
- * whitespace-only value coerces to 0. Anything stricter here would silently
- * disagree with the backend.
- */
-export function asInt(value: string | undefined, fallback: number, opts: IntRange = {}): number {
-  if (value === undefined || value === "") return fallback;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed)) return fallback;
-  if (opts.min !== undefined && parsed < opts.min) return fallback;
-  if (opts.max !== undefined && parsed > opts.max) return fallback;
-  return parsed;
-}
-
-/** The port range the backend accepts, so both sides bound the value identically.
- *  `min: 0` is deliberate — 0 asks the OS for an ephemeral port. */
-export const PORT_RANGE: IntRange = Object.freeze({ min: 0, max: 65_535 });
-
-/** The port the backend binds when `PORT` says nothing usable. */
+/** The port the backend binds when `PORT` says nothing usable. Not shared: it is
+ *  the host's own default, not part of the coercion rule. */
 export const DEFAULT_PORT = 3001;

--- a/server/workspace/hooks/shared/sidecar.ts
+++ b/server/workspace/hooks/shared/sidecar.ts
@@ -10,6 +10,7 @@
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
+import { PORT_RANGE } from "@mulmoclaude/common";
 import { ONE_SECOND_MS } from "../../../utils/time.js";
 import { workspaceRoot } from "./workspace.js";
 
@@ -41,7 +42,10 @@ export function readPort(): number | null {
   const raw = readSidecar(PORT_FILE);
   if (!raw) return null;
   const port = Number.parseInt(raw, 10);
-  return Number.isInteger(port) && port > 0 && port < 65536 ? port : null;
+  // Strictly ABOVE the range floor: 0 is a valid port to BIND (it asks the OS
+  // for an ephemeral one) but never one to connect to, and this value is read
+  // to reach the server.
+  return Number.isInteger(port) && port > PORT_RANGE.min && port <= PORT_RANGE.max ? port : null;
 }
 
 // Build an authenticated POST request against the parent server.

--- a/test/workspace/hooks/shared/test_sidecarPort.ts
+++ b/test/workspace/hooks/shared/test_sidecarPort.ts
@@ -1,0 +1,84 @@
+// The accepted set of `.server-port` values (#3084).
+//
+// `readPort` bounded the value with two hardcoded literals (`> 0 && < 65536`).
+// They now come from `PORT_RANGE` in `@mulmoclaude/common` — the same constant
+// the server, the dev proxy and the bridges bound against — so this pins the
+// accepted set, which must NOT have changed: the hook reads this value to REACH
+// the server, and 0 (valid to bind, "ask the OS") is not a port to connect to.
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { readPort } from "../../../../server/workspace/hooks/shared/sidecar.ts";
+
+const PORT_FILE = ".server-port";
+let workspace = "";
+let savedProjectDir: string | undefined;
+
+before(() => {
+  workspace = mkdtempSync(path.join(tmpdir(), "sidecar-port-"));
+  savedProjectDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = workspace;
+});
+
+after(() => {
+  if (savedProjectDir === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+  else process.env.CLAUDE_PROJECT_DIR = savedProjectDir;
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+const withPortFile = (raw: string | null): number | null => {
+  const file = path.join(workspace, PORT_FILE);
+  if (raw === null) {
+    try {
+      unlinkSync(file);
+    } catch {
+      // already absent — that is the case under test
+    }
+  } else {
+    writeFileSync(file, raw, "utf-8");
+  }
+  return readPort();
+};
+
+describe("readPort — accepted", () => {
+  it("a published port is read as written", () => {
+    assert.equal(withPortFile("3002"), 3002);
+    assert.equal(withPortFile("3021"), 3021);
+  });
+
+  it("surrounding whitespace is trimmed", () => {
+    assert.equal(withPortFile("  3100 \n"), 3100);
+  });
+
+  it("the top of the range is inclusive", () => {
+    assert.equal(withPortFile("65535"), 65535);
+  });
+});
+
+describe("readPort — rejected", () => {
+  it("no file and an empty file both mean 'the server has not published one'", () => {
+    assert.equal(withPortFile(null), null);
+    assert.equal(withPortFile(""), null);
+    assert.equal(withPortFile("   \n"), null);
+  });
+
+  it("0 is refused — valid to bind, never to connect to", () => {
+    assert.equal(withPortFile("0"), null);
+  });
+
+  it("out of range at either end is refused", () => {
+    assert.equal(withPortFile("-1"), null);
+    assert.equal(withPortFile("65536"), null);
+    assert.equal(withPortFile("99999"), null);
+  });
+
+  it("a non-numeric value is refused", () => {
+    ["abc", "port", "NaN", "Infinity", "[]", "{}"].forEach((raw) => {
+      assert.equal(withPortFile(raw), null, `expected null for ${JSON.stringify(raw)}`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

webhook を受ける 9 個のブリッジ（`google-chat` / `line` / `line-works` / `messenger` / `teams` / `twilio-sms` / `viber` / `webhook` / `whatsapp`）が、listen ポートを `Number(process.env.X) || <default>` で読み、素の `app.listen` を呼んでいた。issue #3084 の D-1 / D-2 / D-3 / D-6 に対応する。

| 入力 | 従来 | 本 PR |
|---|---|---|
| 未設定 / 空 / 空白のみ | 既定値 | **既定値（変更なし）** |
| 正常な値 | その値 | **その値（ログも 1 バイト同一）** |
| `302a`（打ち間違い） | `NaN` → falsy → **黙って既定値で起動** | exit 1 + 値・範囲・環境変数名 |
| `99999` | 範囲検証なしで listen → クラッシュ | exit 1 + 同メッセージ |
| `0` | falsy → **指定できない** | OS が選んだポートで起動、banner が実ポートを言う |
| ポートが埋まっている | 未処理の `EADDRINUSE`（環境変数名の説明なし） | exit 1 + `Port N is already in use. Set X to a free port, or X=0 ...` |

- **D-1**: `asInt` / `PORT_RANGE` を `server/utils/envCoerce.ts` → `@mulmoclaude/common` へ移設（依存ゼロの leaf、`@mulmobridge/client` も既に依存しており前例あり）。`server/utils/envCoerce.ts` は door として残す — `vite.config.ts` → `scripts/lib/devServerPort.ts` と `tsconfig.node.json:18` がこのパスを直接指しているため。`DEFAULT_PORT` はホスト自身の値なので移さない。
- **各ブリッジは `asInt` を直接呼ばない**。9 個のうち 6 個が既に依存している `@mulmobridge/webhook-runtime`（残る `teams` / `twilio-sms` / `webhook` は Express を手組みしていたので依存を追加、下記 5）に `listenWebhook` を 1 つ置き、そこに解決・検証・`error` ハンドラを集約。各ブリッジは環境変数名を **1 回だけ**書く（メッセージが名前を言うのが D-2 の肝なので、二重記述で食い違うのを避けた）。
- **D-3**: 打ち間違いは**警告して exit(1)**。`asInt` の契約は変えない — 不正判定は `asInt(raw, -1, PORT_RANGE) === -1`（`PORT_RANGE.min` が 0 なので `-1` は正常値として返り得ない番兵）。
- **D-6**: `exit(1)` のみ。supervisor は持ち込まない（#3080 の責務）。

## Items to Confirm / Review

1. **Express 5 は bind が失敗しても `app.listen` のコールバックを呼ぶ** — `express@5.1` で実測（`address()` は `null`、`listening` は `false`、`error` は次の tick）。素直に書くと**衝突したブリッジが `Webhook listening on http://localhost:3002/webhook` を出した直後にエラーを出す**ので、`server.address()` に port があるときだけ `onReady` を呼ぶガードを入れた（`packages/webhook-runtime/src/index.ts`）。**この挙動の解釈が合っているか見てほしい。**
2. **空白のみ（`X="  "`）を fallback 扱いにした** — `asInt` 単体なら `Number("  ") = 0` で ephemeral になる。従来は `0 || 3009` で既定値だったので、**今日の挙動を維持**する意図。`resolveWebhookPort` 側で `raw.trim() === ""` を先に弾いている（`asInt` は無変更）。
3. **publish 順**（マージ後の別作業）: `@mulmoclaude/common`（新 export のため bump 必須）→ `@mulmobridge/webhook-runtime`（common の range を sweep）→ 9 ブリッジ。本 PR では range を npm の latest（`^1.2.0` / `^1.1.0`）のまま置いている。
4. **`packages/core/assets/helps/error-recovery.md` の節は `@mulmoclaude/core` の republish で初めて npm ユーザーに届く。** 本 PR では core を bump していない（#3100 → #3103 と同じく、bump と 17 range の sweep は `chore(release)` の単位）。
5. `teams` / `twilio-sms` / `webhook` の 3 つは webhook-runtime に依存していなかったので `dependencies` に追加した（Express を手組みしていた 3 つ）。
6. **サーバ本体の起動（`yarn dev`）は実行していない。** 別セッションのテストスイートでこのマシンが飽和しており（load average ~50）、2 つ目のサーバはユーザーの workspace の `.server-port` / `.session-token` を奪う。サーバ側の差分は re-export のみで、下記の等価性検証・dev プロキシのテスト・実 import 解決で確認した。フルビルドは CI が ground truth。

## 検証

| 検証 | 結果 |
|---|---|
| `asInt` 移設の等価性（移設前の関数を逐語コピーし生成入力で新旧比較） | **620,368 ケース、差分 0** |
| `packages/common/test/test_env_coerce.ts`（新規） | 11 pass |
| `packages/webhook-runtime/test/test_port.ts`（新規）+ 既存 | 64 pass |
| `test/scripts/test_devServerPort.ts`（dev プロキシが同じルールを引く既存テスト） | 54 pass |
| `tsc -p server/tsconfig.json` / `test/tsconfig.json` / `tsconfig.node.json` / 触った各 package | clean |
| eslint（触った全パス） | clean |
| `check:launcher-sync` / `check:changelog-ships` / `check:doc-links` | OK |

**実機**（`packages/bridges/webhook/dist/index.js` を実際に起動、5 条件）:

| 条件 | 観測 |
|---|---|
| 未設定 | `Listening on http://localhost:3009/webhook`（**従来と同一**） |
| `WEBHOOK_PORT=302a` | exit 1 + `WEBHOOK_PORT="302a" is not a usable port. Set it to an integer from 0 to 65535 (WEBHOOK_PORT=0 asks the OS for a free port), or unset it to use 3009.` |
| `WEBHOOK_PORT=99999` | exit 1 + 同メッセージ |
| `WEBHOOK_PORT=0` | `Listening on http://localhost:51167/webhook` |
| 3009 を他プロセスが占有 | exit 1 + `Port 3009 is already in use. Set WEBHOOK_PORT to a free port, or WEBHOOK_PORT=0 to let the OS pick one.`、**banner は出ない** |

差分テストの harness は消えるので、そこから**生成器（どの入力が効くか）と性質（旧コード無しで何が成り立つべきか）を収穫**して `test_env_coerce.ts` に残した（seed 固定、`Math.random()` は使わない）。番兵方式の健全性そのものを性質として pin してある（「fallback が返るのは入力が不正なときだけ。fallback の値には依存しない」）。

## 範囲外（意図的）

- `email`（`EMAIL_IMAP_PORT` / `EMAIL_SMTP_PORT`）と `irc`（`IRC_PORT`）は同じ式だが、**発信先**ポートで `PORT_RANGE` の `min: 0` に意味がない。別 issue に切る。
- issue のコメントが数えたプロセスレベルの穴（`unhandledRejection` 0/25、`SIGINT` 2/25）は**別 PR**。触るファイルも revert 単位も違うため、issue の D-4 は (b) を採った。
- 根本原因はサーバの前進（#3079）。本 PR は「負けたときに何が起きるか」を人間に分かる形にするもの。

Refs #3084, #3079

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/3084 これって対応できる？
- （確認に対して）スコープは **PR-A と PR-B 両方**、打ち間違いのときは **警告して exit(1)**、**email / irc は含めない**。

## Plan

[`plans/fix-3084-bridge-port-safety.md`](plans/fix-3084-bridge-port-safety.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Leq3Uj4w5Jykheqop7Kcxa

work in mulmoclaude4

## Summary by Sourcery

Harden inbound webhook bridge port handling so configuration errors and bind failures are reported clearly and safely.

Bug Fixes:
- Make inbound webhook bridges reject invalid or out-of-range listen ports with actionable errors instead of silently falling back or crashing.
- Allow webhook bridges to use port 0 and report the actual OS-assigned port.
- Report port collisions and permission failures with the affected environment variable and remediation guidance.

Enhancements:
- Centralize webhook port resolution and bind error handling across nine inbound bridges.
- Share integer and port-range coercion through @mulmoclaude/common while preserving existing server and development proxy behavior.
- Document webhook port configuration, collision troubleshooting, and ephemeral-port usage.

Documentation:
- Add operator guidance for diagnosing webhook bridge startup and port-binding failures.
- Update bridge README files to document port 0 and invalid-port behavior.

Tests:
- Add coverage for port coercion, validation, bind diagnostics, ephemeral ports, port collisions, and sidecar port handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbound webhook bridges now support port `0` to request an available operating-system port.
  * Startup logs display the actual assigned port.
  * Invalid, unavailable, or permission-restricted ports now produce clear diagnostic errors naming the relevant environment variable.
  * Startup banners are suppressed when binding fails.

* **Documentation**
  * Updated bridge configuration and troubleshooting guidance for port validation, conflicts, and dynamic port assignment.
  * Added guidance for diagnosing bridges that exit during startup or fail to bind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->