### PR TITLE
fix(bridges): 常駐プロセスとしての堅牢化 — unhandledRejection / SIGINT (#3084)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,13 @@ flush are now the `onShutdown` they pass, and telegram gains `SIGTERM`, which it
 `cli` is deliberately out of scope — it is an interactive readline REPL, not a resident process,
 and Ctrl-C there belongs to readline.
 
+`@mulmobridge/client` goes to 1.2.0 with the new export, and all 28 declared ranges on it are swept
+to `^1.2.0`. That is not tidiness: `scripts/mulmoclaude/drift.mjs` (the `smoke` job's drift stage)
+counts value-export lines in `src/index.ts` against the published tarball's, and a new export at an
+unchanged version is exactly the failure it exists to catch — npm still ships the old dist, so a
+consumer would crash with "does not provide an export named installProcessGuards". A bumped version
+reads as `pending-publish` instead, which is the honest state until the cascade publish lands.
+
 No restart logic: a supervisor belongs to whatever started the bridge (#3080), and two would fight.
 Verified on a running bridge process — `SIGINT` and `SIGTERM` each print their line and exit 0, and
 a stray rejection prints the transport-named line where Node alone printed an anonymous stack.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 
+#### A bridge that crashed said nothing about which bridge it was, and Ctrl-C dropped work in flight (#3084)
+
+Counting all 25 packages under `packages/bridges/`: none had an `unhandledRejection` handler, none
+had `uncaughtException`, and only `telegram` and `nostr` handled `SIGINT` / `SIGTERM`. A bridge is a
+process a user starts in a terminal and leaves running, so both gaps show up as the same report —
+"the bot just stopped answering". Node 15+ terminates on an unhandled rejection, so ONE missed
+`await` anywhere took the bot down leaving a stack trace that named no transport; and Ctrl-C killed
+the other 23 mid-flight, dropping a webhook that was being handled or updates already fetched.
+
+`installProcessGuards({ name, onShutdown })` in `@mulmobridge/client` — which all 25 already
+depend on — is now called once from each of the 24 resident bridges. A crash prints
+`[<transport>] unhandled rejection — exiting: <reason>` and then the stack, and still exits 1:
+installing a handler SUPPRESSES Node's own exit, so it re-exits explicitly. The aim is a legible
+message, not a survivable error. A signal prints `[<transport>] SIGINT — shutting down`, runs the
+bridge's shutdown work, and exits 0; a second signal skips the wait and exits 1, because someone
+pressing Ctrl-C twice means it. A shutdown task that hangs is capped at 5s.
+
+`telegram` and `nostr` were the two that already did this correctly, so their work was folded in
+rather than replaced: telegram's `AbortController` + socket close and nostr's debounced-cursor
+flush are now the `onShutdown` they pass, and telegram gains `SIGTERM`, which it did not handle.
+`cli` is deliberately out of scope — it is an interactive readline REPL, not a resident process,
+and Ctrl-C there belongs to readline.
+
+No restart logic: a supervisor belongs to whatever started the bridge (#3080), and two would fight.
+Verified on a running bridge process — `SIGINT` and `SIGTERM` each print their line and exit 0, and
+a stray rejection prints the transport-named line where Node alone printed an anonymous stack.
+
 #### A webhook bridge read its port with `Number(env) || N`, and a busy port killed it unexplained (#3084)
 
 The nine bridges that receive events over an inbound webhook (`line`, `line-works`, `google-chat`,

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@gui-chat-plugin/google-map": "^2.0.0",
     "@gui-chat-plugin/mindmap": "^2.0.0",
     "@marp-team/marp-core": "^4.4.0",
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/deck": "^2.0.2",
     "@mulmocast/types": "^2.11.0",

--- a/packages/bridges/bluesky/package.json
+++ b/packages/bridges/bluesky/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/bluesky/src/index.ts
+++ b/packages/bridges/bluesky/src/index.ts
@@ -18,10 +18,12 @@
 //   BLUESKY_ALLOWED_DIDS  — CSV of DIDs allowed to converse (empty = all)
 
 import "dotenv/config";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "bluesky";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_DM_LEN = 10_000;
 const POLL_INTERVAL_MS = 3_000;
 const FETCH_TIMEOUT_MS = 15_000;

--- a/packages/bridges/chatwork/package.json
+++ b/packages/bridges/chatwork/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/chatwork/src/index.ts
+++ b/packages/bridges/chatwork/src/index.ts
@@ -24,10 +24,12 @@
 //     at 60s) and honours Retry-After when the server supplies it.
 
 import "dotenv/config";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "chatwork";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const API_BASE = "https://api.chatwork.com/v2";
 const MAX_MSG_LEN = 40_000; // Chatwork's practical limit is generous; chunk conservatively
 const FETCH_TIMEOUT_MS = 15_000;

--- a/packages/bridges/cli/package.json
+++ b/packages/bridges/cli/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "dotenv": "^17.0.0"
   },
   "devDependencies": {

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "discord.js": "^14.27.0",

--- a/packages/bridges/discord/src/index.ts
+++ b/packages/bridges/discord/src/index.ts
@@ -12,11 +12,13 @@
 
 import "dotenv/config";
 import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { collectAttachments, resolveMessageText, type DiscordAttachmentLike } from "./attachments.js";
 
 const TRANSPORT_ID = "discord";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_DISCORD_LENGTH = 2000;
 
 const token = process.env.DISCORD_BOT_TOKEN;

--- a/packages/bridges/email/package.json
+++ b/packages/bridges/email/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/email/src/index.ts
+++ b/packages/bridges/email/src/index.ts
@@ -21,10 +21,12 @@ import "dotenv/config";
 import { ImapFlow } from "imapflow";
 import { simpleParser, type ParsedMail } from "mailparser";
 import nodemailer from "nodemailer";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "email";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_BODY_LEN = 100_000; // truncate inbound email text before forwarding to MulmoClaude
 const MAX_REPLY_LEN = 100_000; // truncate outbound reply so SMTP servers don't bounce
 const DEFAULT_POLL_SEC = 30;

--- a/packages/bridges/google-chat/package.json
+++ b/packages/bridges/google-chat/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/google-chat/src/index.ts
+++ b/packages/bridges/google-chat/src/index.ts
@@ -19,10 +19,12 @@ import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
 import { configureTrustProxy, createWebhookRateLimit, listenWebhook } from "@mulmobridge/webhook-runtime";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, splitJwtSegments } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "google-chat";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 const projectNumber = process.env.GOOGLE_CHAT_PROJECT_NUMBER;
 if (!projectNumber) {

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "dotenv": "^17.0.0",
     "irc-framework": "^4.14.0"

--- a/packages/bridges/irc/src/index.ts
+++ b/packages/bridges/irc/src/index.ts
@@ -13,9 +13,11 @@
 
 import "dotenv/config";
 import { Client as IrcClient } from "irc-framework";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 
 const TRANSPORT_ID = "irc";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 const server = process.env.IRC_SERVER;
 const nick = process.env.IRC_NICK;

--- a/packages/bridges/line-works/package.json
+++ b/packages/bridges/line-works/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/line-works/src/index.ts
+++ b/packages/bridges/line-works/src/index.ts
@@ -26,11 +26,13 @@ import "dotenv/config";
 import crypto from "crypto";
 import { readFileSync } from "fs";
 import type { Request, Response as ExpressResponse } from "express";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "line-works";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_TEXT = 1_000;
 const FETCH_TIMEOUT_MS = 15_000;
 const JWT_TTL_SEC = 3_600;

--- a/packages/bridges/line/package.json
+++ b/packages/bridges/line/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/line/src/index.ts
+++ b/packages/bridges/line/src/index.ts
@@ -16,11 +16,13 @@
 
 import "dotenv/config";
 import type { Request, Response } from "express";
-import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply, installProcessGuards } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { extractIncomingLineMessage, parseLineWebhookBody } from "./parse.js";
 
 const TRANSPORT_ID = "line";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 function readRequiredEnv(): { channelSecret: string; channelAccessToken: string } {
   const channelSecret = process.env.LINE_CHANNEL_SECRET;

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -22,13 +22,15 @@
 
 import "dotenv/config";
 import WebSocket from "ws";
-import { createBridgeClient, chunkText, formatAckReply, frameText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply, frameText, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 import { parseNotificationRaw, parseFrame, type JsonRecord, type ParsedStatus } from "./parse.js";
 import { fitBudget, hasRelayableContent, imageMediaEntries, isLostImagesOnly, resolveMessageText, type ImageMedia } from "./media.js";
 import { resolvePublicUrl } from "./urlGuard.js";
 
 const TRANSPORT_ID = "mastodon";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_STATUS_LEN = 500; // Mastodon's default soft limit; many instances raise to 1000+
 const FETCH_TIMEOUT_MS = 15_000;
 /** Cap on one fetched attachment. Without it a remote sender could point the

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/matrix/src/index.ts
+++ b/packages/bridges/matrix/src/index.ts
@@ -14,10 +14,12 @@
 
 import "dotenv/config";
 import { createClient, RoomEvent, type MatrixClient, type MatrixEvent, type Room } from "matrix-js-sdk";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "matrix";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 const homeserverUrl = process.env.MATRIX_HOMESERVER_URL;
 const accessToken = process.env.MATRIX_ACCESS_TOKEN;

--- a/packages/bridges/mattermost/package.json
+++ b/packages/bridges/mattermost/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/mattermost/src/index.ts
+++ b/packages/bridges/mattermost/src/index.ts
@@ -12,10 +12,12 @@
 
 import "dotenv/config";
 import WebSocket from "ws";
-import { createBridgeClient, chunkText, asJsonRecord } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, asJsonRecord, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "mattermost";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 function readRequiredEnv(): { mmUrl: string; botToken: string } {
   const mmUrl = process.env.MATTERMOST_URL;

--- a/packages/bridges/messenger/package.json
+++ b/packages/bridges/messenger/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/messenger/src/index.ts
+++ b/packages/bridges/messenger/src/index.ts
@@ -13,10 +13,12 @@
 
 import "dotenv/config";
 import { createWebhookApp, registerMetaWebhook, listenWebhook } from "@mulmobridge/webhook-runtime";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { extractMessengerMessages, type MessengerTextMessage } from "@mulmoclaude/common/meta-webhook";
 
 const TRANSPORT_ID = "messenger";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 function readRequiredEnv(): { pageAccessToken: string; verifyToken: string; appSecret: string } {
   const pageAccessToken = process.env.MESSENGER_PAGE_ACCESS_TOKEN;

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/nostr/src/index.ts
+++ b/packages/bridges/nostr/src/index.ts
@@ -28,7 +28,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { SimplePool, finalizeEvent, getPublicKey, nip04, nip19, type Event } from "nostr-tools";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { isErrorWithCode, parseCsvList, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "nostr";
@@ -246,13 +246,7 @@ function installShutdownFlush(): void {
       await cursorWriteInFlight;
     }
   };
-  for (const signal of ["SIGINT", "SIGTERM"] as const) {
-    process.once(signal, () => {
-      flush()
-        .catch(() => {})
-        .finally(() => process.exit(0));
-    });
-  }
+  installProcessGuards({ name: TRANSPORT_ID, onShutdown: flush });
 }
 
 // ── Subscription ────────────────────────────────────────────────

--- a/packages/bridges/rocketchat/package.json
+++ b/packages/bridges/rocketchat/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/rocketchat/src/index.ts
+++ b/packages/bridges/rocketchat/src/index.ts
@@ -17,10 +17,12 @@
 //   ROCKETCHAT_POLL_INTERVAL_SEC  — poll interval seconds (default 5)
 
 import "dotenv/config";
-import { createBridgeClient, chunkText, fetchJsonRecord, type JsonRecord } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, fetchJsonRecord, type JsonRecord, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "rocketchat";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_MSG_LEN = 4_000;
 const FETCH_TIMEOUT_MS = 15_000;
 

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0",

--- a/packages/bridges/signal/src/index.ts
+++ b/packages/bridges/signal/src/index.ts
@@ -17,10 +17,12 @@
 
 import "dotenv/config";
 import WebSocket from "ws";
-import { createBridgeClient, chunkText, frameText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, frameText, installProcessGuards } from "@mulmobridge/client";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "signal";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_SIGNAL_TEXT = 4_000;
 const FETCH_TIMEOUT_MS = 15_000;
 const RECONNECT_BASE_MS = 1_000;

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "@slack/socket-mode": "^3.0.1",

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -23,13 +23,15 @@
 import "dotenv/config";
 import { SocketModeClient } from "@slack/socket-mode";
 import { WebClient } from "@slack/web-api";
-import { createBridgeClient, formatAckReply } from "@mulmobridge/client";
+import { createBridgeClient, formatAckReply, installProcessGuards } from "@mulmobridge/client";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { buildExternalChatId, effectiveThreadTs, parseExternalChatId, parseGranularity } from "./sessionId.js";
 import { parseAckReaction } from "./ackReaction.js";
 import { redactUser } from "./redactUser.js";
 
 const TRANSPORT_ID = "slack";
+
+installProcessGuards({ name: TRANSPORT_ID });
 
 const botToken = process.env.SLACK_BOT_TOKEN;
 const appToken = process.env.SLACK_APP_TOKEN;

--- a/packages/bridges/teams/package.json
+++ b/packages/bridges/teams/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/teams/src/index.ts
+++ b/packages/bridges/teams/src/index.ts
@@ -20,12 +20,14 @@
 import "dotenv/config";
 import express, { type Request, type Response } from "express";
 import { CloudAdapter, ConfigurationBotFrameworkAuthentication, TurnContext, type Activity } from "botbuilder";
-import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply, installProcessGuards } from "@mulmobridge/client";
 import { listenWebhook } from "@mulmobridge/webhook-runtime";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { extractIncomingMessage } from "./parse.js";
 
 const TRANSPORT_ID = "teams";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_TEAMS_TEXT = 28_000; // Teams message limit is 40k; leave headroom for formatting
 
 function readRequiredEnv(): { appId: string; appPassword: string } {

--- a/packages/bridges/telegram/package.json
+++ b/packages/bridges/telegram/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "dotenv": "^17.0.0"
   },

--- a/packages/bridges/telegram/src/index.ts
+++ b/packages/bridges/telegram/src/index.ts
@@ -13,7 +13,7 @@
 //   TELEGRAM_POLL_TIMEOUT_SEC   — optional, default 25
 
 import "dotenv/config";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { createTelegramApi, type TelegramApi } from "./api.js";
 import { parseAllowlist, type Allowlist } from "./allowlist.js";
 import { createMessageRouter, type MessageRouter } from "./router.js";
@@ -102,11 +102,15 @@ async function main(): Promise<void> {
   });
 
   const abortController = new AbortController();
-  process.on("SIGINT", () => {
-    console.log("\nShutting down...");
-    abortController.abort();
-    client.close();
-    process.exit(0);
+  // Installed here rather than at module level because the shutdown work needs
+  // the controller and the socket. `main().catch` still covers the awaited
+  // startup path above, so nothing is unguarded in between.
+  installProcessGuards({
+    name: TRANSPORT_ID,
+    onShutdown: () => {
+      abortController.abort();
+      client.close();
+    },
   });
 
   await pollLoop(api, router, {

--- a/packages/bridges/twilio-sms/package.json
+++ b/packages/bridges/twilio-sms/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/twilio-sms/src/index.ts
+++ b/packages/bridges/twilio-sms/src/index.ts
@@ -27,11 +27,13 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response as ExpressResponse } from "express";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "twilio-sms";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_SMS_LEN = 1_600; // Twilio concatenates segments up to 1600 chars
 const FETCH_TIMEOUT_MS = 15_000;
 

--- a/packages/bridges/viber/package.json
+++ b/packages/bridges/viber/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/viber/src/index.ts
+++ b/packages/bridges/viber/src/index.ts
@@ -17,11 +17,13 @@
 
 import "dotenv/config";
 import type { Request, Response as ExpressResponse } from "express";
-import { createBridgeClient, chunkText } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, installProcessGuards } from "@mulmobridge/client";
 import { createWebhookApp, createWebhookRateLimit, verifyHmacSignature, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord, parseCsvSet } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "viber";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_VIBER_TEXT = 7_000;
 const FETCH_TIMEOUT_MS = 15_000;
 const VIBER_API = "https://chatapi.viber.com/pa";

--- a/packages/bridges/webhook/package.json
+++ b/packages/bridges/webhook/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/webhook/src/index.ts
+++ b/packages/bridges/webhook/src/index.ts
@@ -26,11 +26,13 @@
 import "dotenv/config";
 import crypto from "crypto";
 import express, { type Request, type Response } from "express";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { listenWebhook } from "@mulmobridge/webhook-runtime";
 import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "webhook";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const ENDPOINT = process.env.WEBHOOK_PATH ?? "/webhook";
 const secret = process.env.WEBHOOK_SECRET ?? "";
 const allowOpen = process.env.WEBHOOK_ALLOW_OPEN === "1";

--- a/packages/bridges/whatsapp/package.json
+++ b/packages/bridges/whatsapp/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/webhook-runtime": "^1.1.0",
     "@mulmoclaude/common": "^1.2.0",

--- a/packages/bridges/whatsapp/src/index.ts
+++ b/packages/bridges/whatsapp/src/index.ts
@@ -14,12 +14,14 @@
 //   WHATSAPP_ALLOWED_NUMBERS  — CSV of phone numbers (empty = all)
 
 import "dotenv/config";
-import { createBridgeClient } from "@mulmobridge/client";
+import { createBridgeClient, installProcessGuards } from "@mulmobridge/client";
 import { createWebhookApp, registerMetaWebhook, listenWebhook } from "@mulmobridge/webhook-runtime";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { extractWhatsAppMessages, type WhatsAppTextMessage } from "@mulmoclaude/common/meta-webhook";
 
 const TRANSPORT_ID = "whatsapp";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const FETCH_TIMEOUT_MS = 30_000;
 
 function readRequiredEnv(): { accessToken: string; phoneNumberId: string; verifyToken: string; appSecret: string } {

--- a/packages/bridges/xmpp/package.json
+++ b/packages/bridges/xmpp/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "@xmpp/client": "^0.14.0",

--- a/packages/bridges/xmpp/src/index.ts
+++ b/packages/bridges/xmpp/src/index.ts
@@ -26,13 +26,15 @@
 
 import "dotenv/config";
 import xmppPkg, { type XmlElement } from "@xmpp/client";
-import { createBridgeClient, chunkText, formatAckReply } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, formatAckReply, installProcessGuards } from "@mulmobridge/client";
 import { parseCsvSet } from "@mulmoclaude/common";
 import { splitJid, parseStanzaFields } from "./parse.js";
 
 const { client, xml } = xmppPkg;
 
 const TRANSPORT_ID = "xmpp";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const MAX_BODY_LEN = 10_000;
 
 const jid = process.env.XMPP_JID;

--- a/packages/bridges/zulip/package.json
+++ b/packages/bridges/zulip/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "author": "Receptron Team",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmoclaude/common": "^1.2.0",
     "dotenv": "^17.0.0"

--- a/packages/bridges/zulip/src/index.ts
+++ b/packages/bridges/zulip/src/index.ts
@@ -9,10 +9,12 @@
 //   ZULIP_API_KEY   — Bot API key
 
 import "dotenv/config";
-import { createBridgeClient, chunkText, fetchJsonRecord, type JsonRecord } from "@mulmobridge/client";
+import { createBridgeClient, chunkText, fetchJsonRecord, type JsonRecord, installProcessGuards } from "@mulmobridge/client";
 import { isRecord } from "@mulmoclaude/common";
 
 const TRANSPORT_ID = "zulip";
+
+installProcessGuards({ name: TRANSPORT_ID });
 const POLL_TIMEOUT_SEC = 30;
 
 const zulipUrl = process.env.ZULIP_URL;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmobridge/client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Socket.io client library for MulmoBridge — shared by all bridge implementations",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -26,3 +26,5 @@ export {
   buildDataUrl,
   type ParsedDataUrl,
 } from "./mime.js";
+
+export { installProcessGuards, SHUTDOWN_GRACE_MS, type ProcessGuardOptions, type ShutdownTask } from "./processGuards.js";

--- a/packages/client/src/processGuards.ts
+++ b/packages/client/src/processGuards.ts
@@ -27,6 +27,9 @@ export interface ProcessGuardOptions {
   onShutdown?: ShutdownTask;
   /** Test seam; production ends the process. */
   exit?: (code: number) => void;
+  /** How long a shutdown task may take before the process leaves anyway.
+   *  Defaults to `SHUTDOWN_GRACE_MS`; tests shorten it. */
+  graceMs?: number;
 }
 
 /** A shutdown task that hangs must not hold the terminal hostage. */
@@ -63,26 +66,34 @@ function installSignalGuards(opts: ProcessGuardOptions, exit: (code: number) => 
     }
     shuttingDown = true;
     console.log(`[${opts.name}] ${signal} — shutting down`);
-    void runShutdown(opts.name, opts.onShutdown).then(() => exit(0));
+    void runShutdown(opts.name, opts.onShutdown, opts.graceMs ?? SHUTDOWN_GRACE_MS).then(() => exit(0));
   };
   (["SIGINT", "SIGTERM"] as const).forEach((signal) => process.on(signal, () => handle(signal)));
 }
 
-async function runShutdown(name: string, task: ShutdownTask | undefined): Promise<void> {
+async function runShutdown(name: string, task: ShutdownTask | undefined, graceMs: number): Promise<void> {
   if (task === undefined) return;
+  // The deadline timer stays REFERENCED, and is cleared once the race settles.
+  // An `unref`ed one looks tidier and silently breaks the guarantee: a shutdown
+  // task that hangs after the last other handle closed lets Node empty its loop
+  // and exit before the timer fires, so neither the message below nor the
+  // `exit(0)` that follows this call ever runs. Keeping it referenced is what
+  // holds the process open for exactly as long as the grace period.
+  let deadline: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([Promise.resolve(task()), graceExpiry(name)]);
+    await Promise.race([
+      Promise.resolve(task()),
+      new Promise<void>((resolve) => {
+        deadline = setTimeout(() => {
+          console.error(`[${name}] shutdown did not finish within ${graceMs}ms — exiting anyway`);
+          resolve();
+        }, graceMs);
+      }),
+    ]);
   } catch (err) {
     console.error(`[${name}] shutdown task failed: ${errorMessage(err)}`);
+  } finally {
+    // A fast shutdown must not wait out the rest of the grace period.
+    if (deadline !== undefined) clearTimeout(deadline);
   }
-}
-
-function graceExpiry(name: string): Promise<void> {
-  return new Promise<void>((resolve) => {
-    // `unref` so a shutdown that finishes early is not held open by this timer.
-    setTimeout(() => {
-      console.error(`[${name}] shutdown did not finish within ${SHUTDOWN_GRACE_MS}ms — exiting anyway`);
-      resolve();
-    }, SHUTDOWN_GRACE_MS).unref();
-  });
 }

--- a/packages/client/src/processGuards.ts
+++ b/packages/client/src/processGuards.ts
@@ -1,0 +1,88 @@
+// Process-level guards for a bridge (#3084).
+//
+// A bridge is a long-lived process a user starts in a terminal and leaves
+// running, and none of the 25 had any of these:
+//
+//   - `unhandledRejection` — Node 15+ terminates the process, so ONE missed
+//     `await` anywhere took the bot down leaving a bare stack trace that names
+//     no bridge. From the outside that is "the bot just stopped answering".
+//   - `uncaughtException` — the same, for a throw off the call stack.
+//   - `SIGINT` / `SIGTERM` — Ctrl-C killed the process mid-flight, dropping a
+//     webhook that was being handled or updates already fetched and unprocessed.
+//
+// Installing a handler for the first two SUPPRESSES Node's own exit, so both
+// re-exit explicitly: the aim is a legible message, not a survivable error. No
+// restart logic lives here — a supervisor belongs to whatever started the
+// bridge (#3080), and two of them would fight.
+
+import { errorMessage } from "@mulmoclaude/common";
+
+/** Release resources and stop accepting work. May be async. */
+export type ShutdownTask = () => void | Promise<void>;
+
+export interface ProcessGuardOptions {
+  /** Transport id, used as the log prefix so the line says WHICH bridge died. */
+  name: string;
+  /** Runs once, on the first signal, before the process exits. */
+  onShutdown?: ShutdownTask;
+  /** Test seam; production ends the process. */
+  exit?: (code: number) => void;
+}
+
+/** A shutdown task that hangs must not hold the terminal hostage. */
+export const SHUTDOWN_GRACE_MS = 5_000;
+
+export function installProcessGuards(opts: ProcessGuardOptions): void {
+  const exit = opts.exit ?? ((code: number) => process.exit(code));
+  installCrashGuards(opts.name, exit);
+  installSignalGuards(opts, exit);
+}
+
+function installCrashGuards(name: string, exit: (code: number) => void): void {
+  process.on("unhandledRejection", (reason: unknown) => {
+    console.error(`[${name}] unhandled rejection — exiting: ${errorMessage(reason)}`);
+    if (reason instanceof Error && reason.stack !== undefined) console.error(reason.stack);
+    exit(1);
+  });
+  process.on("uncaughtException", (err: unknown) => {
+    console.error(`[${name}] uncaught exception — exiting: ${errorMessage(err)}`);
+    if (err instanceof Error && err.stack !== undefined) console.error(err.stack);
+    exit(1);
+  });
+}
+
+function installSignalGuards(opts: ProcessGuardOptions, exit: (code: number) => void): void {
+  let shuttingDown = false;
+  const handle = (signal: string): void => {
+    if (shuttingDown) {
+      // Someone pressed Ctrl-C twice because the first one looked stuck. Honour
+      // the impatience rather than waiting out the grace period.
+      console.error(`[${opts.name}] ${signal} again — exiting now`);
+      exit(1);
+      return;
+    }
+    shuttingDown = true;
+    console.log(`[${opts.name}] ${signal} — shutting down`);
+    void runShutdown(opts.name, opts.onShutdown).then(() => exit(0));
+  };
+  (["SIGINT", "SIGTERM"] as const).forEach((signal) => process.on(signal, () => handle(signal)));
+}
+
+async function runShutdown(name: string, task: ShutdownTask | undefined): Promise<void> {
+  if (task === undefined) return;
+  try {
+    await Promise.race([Promise.resolve(task()), graceExpiry(name)]);
+  } catch (err) {
+    console.error(`[${name}] shutdown task failed: ${errorMessage(err)}`);
+  }
+}
+
+function graceExpiry(name: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    // `unref` so a shutdown that finishes early is not held open by this timer.
+    setTimeout(() => {
+      console.error(`[${name}] shutdown did not finish within ${SHUTDOWN_GRACE_MS}ms — exiting anyway`);
+      resolve();
+    }, SHUTDOWN_GRACE_MS).unref();
+  });
+}

--- a/packages/client/test/fixture-hanging-shutdown.ts
+++ b/packages/client/test/fixture-hanging-shutdown.ts
@@ -1,0 +1,30 @@
+// Child-process fixture for the shutdown-deadline regression test.
+//
+// It mirrors what a bridge actually does: hold a referenced handle while
+// running (a server, a socket — here an interval), release it when the signal
+// arrives, and then take too long to finish. At that moment the deadline timer
+// inside `installProcessGuards` is the ONLY thing left holding the event loop —
+// exactly the case an `unref`ed timer got wrong, since Node then drains the loop
+// and exits before the grace period elapses.
+//
+// The handle also has to exist BEFORE the signal: `process.on` does not keep
+// Node alive, so without it this fixture exits on its own between printing
+// `ready` and the parent's `kill`, and the test passes or fails by luck.
+
+import { installProcessGuards } from "../src/processGuards.ts";
+
+const graceMs = Number(process.argv[2]);
+const HEARTBEAT_MS = 1_000;
+
+const whileRunning = setInterval(() => {}, HEARTBEAT_MS);
+
+installProcessGuards({
+  name: "fixture",
+  graceMs,
+  onShutdown: () => {
+    clearInterval(whileRunning);
+    return new Promise<void>(() => {}); // never settles
+  },
+});
+
+console.log("ready");

--- a/packages/client/test/test_processGuards.ts
+++ b/packages/client/test/test_processGuards.ts
@@ -1,0 +1,197 @@
+// Tests for the bridge process guards (#3084).
+//
+// Each case installs the guards, emits the real process event, and asserts on
+// the exit code and the message — the message is the whole point, since what a
+// user had before was a stack trace naming no bridge.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { installProcessGuards, SHUTDOWN_GRACE_MS } from "../src/processGuards.ts";
+
+const EVENTS = ["unhandledRejection", "uncaughtException", "SIGINT", "SIGTERM"] as const;
+const NAME = "line";
+
+// node:test installs its own handlers for some of these; take them out for the
+// duration of a case and put them back, so a guard under test never inherits or
+// clobbers them.
+const saved = new Map<string, ((...args: never[]) => void)[]>();
+
+beforeEach(() => {
+  EVENTS.forEach((event) => {
+    saved.set(event, process.listeners(event) as ((...args: never[]) => void)[]);
+    process.removeAllListeners(event);
+  });
+});
+
+afterEach(() => {
+  EVENTS.forEach((event) => {
+    process.removeAllListeners(event);
+    (saved.get(event) ?? []).forEach((listener) => process.on(event, listener));
+  });
+  saved.clear();
+});
+
+interface Capture {
+  codes: number[];
+  lines: string[];
+  restore: () => void;
+}
+
+const capture = (): Capture => {
+  const lines: string[] = [];
+  const originalError = console.error;
+  const originalLog = console.log;
+  console.error = (...args: unknown[]) => void lines.push(args.map(String).join(" "));
+  console.log = (...args: unknown[]) => void lines.push(args.map(String).join(" "));
+  return {
+    codes: [],
+    lines,
+    restore: () => {
+      console.error = originalError;
+      console.log = originalLog;
+    },
+  };
+};
+
+const withGuards = async (onShutdown: (() => void | Promise<void>) | undefined, run: (cap: Capture) => Promise<void> | void): Promise<void> => {
+  const cap = capture();
+  installProcessGuards({ name: NAME, onShutdown, exit: (code) => void cap.codes.push(code) });
+  try {
+    await run(cap);
+  } finally {
+    cap.restore();
+  }
+};
+
+describe("installProcessGuards — crashes", () => {
+  it("an unhandled rejection names the bridge and exits non-zero", async () => {
+    await withGuards(undefined, (cap) => {
+      process.emit("unhandledRejection", new Error("boom"), Promise.resolve());
+      assert.deepEqual(cap.codes, [1]);
+      assert.ok(
+        cap.lines.some((line) => line.includes("[line] unhandled rejection — exiting: boom")),
+        cap.lines.join(" | "),
+      );
+    });
+  });
+
+  it("a rejection with a non-Error reason does not print [object Object]", async () => {
+    await withGuards(undefined, (cap) => {
+      process.emit("unhandledRejection", { message: "odd" }, Promise.resolve());
+      assert.deepEqual(cap.codes, [1]);
+      assert.ok(
+        cap.lines.some((line) => line.includes("odd")),
+        cap.lines.join(" | "),
+      );
+      assert.ok(!cap.lines.some((line) => line.includes("[object Object]")), cap.lines.join(" | "));
+    });
+  });
+
+  it("an uncaught exception exits non-zero too", async () => {
+    await withGuards(undefined, (cap) => {
+      process.emit("uncaughtException", new Error("thrown"), "uncaughtException");
+      assert.deepEqual(cap.codes, [1]);
+      assert.ok(
+        cap.lines.some((line) => line.includes("[line] uncaught exception — exiting: thrown")),
+        cap.lines.join(" | "),
+      );
+    });
+  });
+});
+
+describe("installProcessGuards — signals", () => {
+  const flush = async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  it("SIGINT runs the shutdown task before exiting 0", async () => {
+    let ran = 0;
+    await withGuards(
+      () => {
+        ran++;
+      },
+      async (cap) => {
+        process.emit("SIGINT", "SIGINT");
+        await flush();
+        assert.equal(ran, 1);
+        assert.deepEqual(cap.codes, [0]);
+        assert.ok(
+          cap.lines.some((line) => line.includes("[line] SIGINT — shutting down")),
+          cap.lines.join(" | "),
+        );
+      },
+    );
+  });
+
+  it("SIGTERM is handled as well — before this only two bridges were", async () => {
+    let ran = 0;
+    await withGuards(
+      () => {
+        ran++;
+      },
+      async (cap) => {
+        process.emit("SIGTERM", "SIGTERM");
+        await flush();
+        assert.equal(ran, 1);
+        assert.deepEqual(cap.codes, [0]);
+      },
+    );
+  });
+
+  it("an async shutdown task is awaited", async () => {
+    const order: string[] = [];
+    await withGuards(
+      async () => {
+        await Promise.resolve();
+        order.push("shutdown");
+      },
+      async (cap) => {
+        process.emit("SIGINT", "SIGINT");
+        await flush();
+        order.push(`exit:${cap.codes.join(",")}`);
+        assert.deepEqual(order, ["shutdown", "exit:0"]);
+      },
+    );
+  });
+
+  it("a shutdown task that throws still exits cleanly, with the failure said out loud", async () => {
+    await withGuards(
+      () => {
+        throw new Error("close failed");
+      },
+      async (cap) => {
+        process.emit("SIGINT", "SIGINT");
+        await flush();
+        assert.deepEqual(cap.codes, [0]);
+        assert.ok(
+          cap.lines.some((line) => line.includes("[line] shutdown task failed: close failed")),
+          cap.lines.join(" | "),
+        );
+      },
+    );
+  });
+
+  it("a second signal exits immediately instead of waiting out the grace period", async () => {
+    await withGuards(
+      () => new Promise<void>(() => {}), // never settles
+      async (cap) => {
+        process.emit("SIGINT", "SIGINT");
+        await flush();
+        assert.deepEqual(cap.codes, [], "the hanging task must still be pending");
+        process.emit("SIGINT", "SIGINT");
+        assert.deepEqual(cap.codes, [1]);
+        assert.ok(
+          cap.lines.some((line) => line.includes("[line] SIGINT again — exiting now")),
+          cap.lines.join(" | "),
+        );
+      },
+    );
+  });
+
+  it("the grace period is bounded, so a hanging task cannot hold the terminal", () => {
+    assert.ok(SHUTDOWN_GRACE_MS > 0 && SHUTDOWN_GRACE_MS <= 30_000, `unreasonable grace: ${SHUTDOWN_GRACE_MS}`);
+  });
+});

--- a/packages/client/test/test_processGuards_deadline.ts
+++ b/packages/client/test/test_processGuards_deadline.ts
@@ -1,0 +1,68 @@
+// Regression: the shutdown deadline must survive an empty event loop.
+//
+// `runShutdown` races the bridge's shutdown task against a timer. The timer was
+// `unref`ed at first, which reads as harmless tidiness and is not: with nothing
+// else referenced, Node empties its loop and exits BEFORE the timer fires, so
+// neither the "did not finish" line nor the `exit(0)` after it ever runs. An
+// in-process test cannot see that — the test runner itself keeps the loop alive
+// — so this one spawns a child whose only remaining handle is that timer.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(HERE, "fixture-hanging-shutdown.ts");
+const GRACE_MS = 200;
+const TEST_TIMEOUT_MS = 30_000;
+
+interface ChildResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  elapsedMs: number;
+}
+
+const runUntilShutdown = async (): Promise<ChildResult> =>
+  new Promise<ChildResult>((resolve, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", FIXTURE, String(GRACE_MS)], {
+      cwd: path.join(HERE, "..", "..", ".."),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let startedAt = 0;
+    const fail = (err: Error): void => {
+      child.kill("SIGKILL");
+      reject(err);
+    };
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      // Signal only once the guards are installed, or the child would die
+      // before it had a handler at all.
+      if (startedAt === 0 && stdout.includes("ready")) {
+        startedAt = Date.now();
+        child.kill("SIGTERM");
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", fail);
+    child.on("exit", (code, signal) => resolve({ code, signal, stdout, stderr, elapsedMs: Date.now() - startedAt }));
+  });
+
+describe("installProcessGuards — the shutdown deadline with no other handles", () => {
+  it("still reports the timeout and exits 0, rather than the loop draining first", { timeout: TEST_TIMEOUT_MS }, async () => {
+    const result = await runUntilShutdown();
+    const detail = `code=${String(result.code)} signal=${String(result.signal)} elapsed=${result.elapsedMs}ms stdout=${JSON.stringify(result.stdout)} stderr=${JSON.stringify(result.stderr)}`;
+    assert.match(result.stderr, /\[fixture\] shutdown did not finish within 200ms — exiting anyway/, detail);
+    assert.equal(result.signal, null, `the child must exit on its own, not die from the signal — ${detail}`);
+    assert.equal(result.code, 0, detail);
+    assert.match(result.stdout, /\[fixture\] SIGTERM — shutting down/);
+    assert.ok(result.elapsedMs >= GRACE_MS, detail);
+  });
+});

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -1392,12 +1392,13 @@ treatment, and the workspace mounted if you want it to follow the port.
 - The platform token (bot token, app token) was revoked or regenerated.
 - The bridge process is not running at all. Check before assuming anything above.
   Since #3084 a bridge that died says why on its last line — `[<transport>]
-unhandled rejection — exiting: …` or `[<transport>] uncaught exception —
-exiting: …`, naming the transport. A bridge killed with Ctrl-C or `kill` says
-  `[<transport>] SIGINT — shutting down` instead. **No such line and the process
-  gone** means either an older npm build (they had no handlers at all, so a
-  missed `await` left only a stack trace) or a kill that no handler can catch
-  (`SIGKILL`, or the OOM killer).
+  unhandled rejection — exiting: …` or `[<transport>] uncaught exception —
+  exiting: …`, naming the transport. A bridge stopped on purpose names the
+  signal: Ctrl-C prints `[<transport>] SIGINT — shutting down`, while a plain
+  `kill <pid>` sends SIGTERM and prints `[<transport>] SIGTERM — shutting down`.
+  **No such line and the process gone** means either an older npm build (they
+  had no handlers at all, so a missed `await` left only a stack trace) or a kill
+  no handler can catch (`kill -9` / SIGKILL, or the OOM killer).
 
 ### What to collect if none of it explains the silence
 

--- a/packages/core/assets/helps/error-recovery.md
+++ b/packages/core/assets/helps/error-recovery.md
@@ -1391,6 +1391,13 @@ treatment, and the workspace mounted if you want it to follow the port.
   message.
 - The platform token (bot token, app token) was revoked or regenerated.
 - The bridge process is not running at all. Check before assuming anything above.
+  Since #3084 a bridge that died says why on its last line — `[<transport>]
+unhandled rejection — exiting: …` or `[<transport>] uncaught exception —
+exiting: …`, naming the transport. A bridge killed with Ctrl-C or `kill` says
+  `[<transport>] SIGINT — shutting down` instead. **No such line and the process
+  gone** means either an older npm build (they had no handlers at all, so a
+  missed `await` left only a stack trace) or a kill that no handler can catch
+  (`SIGKILL`, or the OOM killer).
 
 ### What to collect if none of it explains the silence
 

--- a/packages/mulmoclaude/package.json
+++ b/packages/mulmoclaude/package.json
@@ -28,7 +28,7 @@
     "@gui-chat-plugin/mindmap": "^2.0.0",
     "@marp-team/marp-core": "^4.4.0",
     "@mulmobridge/chat-service": "^1.1.0",
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmobridge/protocol": "^1.0.1",
     "@mulmobridge/web-push": "^1.1.0",
     "@mulmocast/types": "^2.11.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -33,7 +33,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@mulmobridge/client": "^1.1.0",
+    "@mulmobridge/client": "^1.2.0",
     "@mulmoclaude/common": "^1.2.0"
   },
   "homepage": "https://github.com/receptron/mulmoclaude/tree/main/packages/relay#readme",

--- a/plans/fix-3084-bridge-process-guards.md
+++ b/plans/fix-3084-bridge-process-guards.md
@@ -1,0 +1,53 @@
+# fix(bridges): 常駐プロセスとしての堅牢化 — unhandledRejection / SIGINT (#3084 D-4〜D-6)
+
+PR-B。PR-A（受信ポートの読み取りと bind、9 個）とは触るファイルも revert 単位も違うので
+issue の D-4 は **(b) 2 本に割る** を採った。PR-A の上に積む（同じ `index.ts` の import 行を
+両方が触るため）。
+
+## 現状（測った事実 — `packages/bridges/*` 25 個を数えた）
+
+| 観点                 | 持っているブリッジ | 25 個中    |
+| -------------------- | ------------------ | ---------- |
+| `unhandledRejection` | なし               | **0 / 25** |
+| `uncaughtException`  | なし               | **0 / 25** |
+| `SIGINT` / `SIGTERM` | telegram, nostr    | **2 / 25** |
+
+- Node 15 以降、未処理の rejection は**プロセスを落とす**。ハンドラが 1 つも無いので、
+  どこか 1 つの `await` が漏れただけで、**どのブリッジが死んだのかも言わないスタックトレース**
+  だけが残る。外から見ると「bot が急に返事をしなくなった」。
+- 残り 23 個は Ctrl+C で在庫処理の途中でも即死する（受信型なら処理中の webhook、
+  ポーリング型なら取得済みで未処理の update が失われる）。
+
+## 決定（D-5, D-6）
+
+- **D-5 家は `@mulmobridge/client`**。**25 個すべてが依存済み**。
+  `installProcessGuards({ name, onShutdown? })` を 1 つ置き、各 `index.ts` から 1 行呼ぶ。
+  - `unhandledRejection` / `uncaughtException`: ブリッジ名 + 理由を 1 行で出して `exit(1)`。
+    **ハンドラを入れると Node 自身の終了が抑制される**ので、明示的に exit する
+    （狙いは「読めるメッセージ」で、「エラーを生き延びる」ことではない）。
+  - `SIGINT` / `SIGTERM`: 1 行出して `onShutdown` を待ってから `exit(0)`。
+    2 回目のシグナルは grace を待たずに即 `exit(1)`（Ctrl+C を 2 回押す人の意図を尊重）。
+    `onShutdown` が固まった場合の上限は 5 秒。
+- **telegram / nostr は既に正しく書けている唯一の例なので壊さない。**
+  telegram の `AbortController` + `client.close()` と nostr の cursor flush を
+  そのまま `onShutdown` として渡し、各自の `process.on("SIG…")` を消す
+  （telegram は SIGTERM も拾えるようになる）。
+- **D-6 `exit(1)` のみ。supervisor は持ち込まない**（#3080 の責務。2 つあると喧嘩する）。
+- **`cli` は対象外**: 対話型の readline REPL で常駐プロセスではなく、Ctrl+C は readline の
+  持ち物。残り 24 個に入れる。
+
+## 変更
+
+1. `packages/client/src/processGuards.ts`（新規）+ `index.ts` から export。
+2. `packages/client/test/test_processGuards.ts`（新規）— `exit` を seam にして
+   実際に `process.emit` し、終了コードとメッセージを両方向で確認。
+3. 24 個の `index.ts` に 1 行（telegram / nostr は `onShutdown` 付きで、既存ハンドラと置換）。
+
+## 検証（実機）
+
+| 条件                                   | 観測                                                              |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| 起動中の bridge に `SIGINT`            | `[webhook] SIGINT — shutting down`、exit 0                        |
+| 起動中の bridge に `SIGTERM`           | `[webhook] SIGTERM — shutting down`、exit 0（従来: 無言で即死）   |
+| 未処理 rejection（guards なし = 従来） | どのブリッジかを言わないスタックのみ                              |
+| 未処理 rejection（guards あり）        | `[line] unhandled rejection — exiting: <理由>` + スタック、exit 1 |


### PR DESCRIPTION
## Summary

issue #3084 のコメントが数えた **プロセスレベルの穴**（D-4〜D-6）に対応する。本文の D-1〜D-3（受信ポート、9 個）は **#3109** で、こちらはその上に積んでいる（同じ `index.ts` の import 行を両方が触るため）。**#3109 が main に入ったら base は自動で main に切り替わる。**

`packages/bridges/*` の 25 個を数えた結果:

| 観点 | 持っているブリッジ | 25 個中 |
|---|---|---|
| `unhandledRejection` | なし | **0 / 25** |
| `uncaughtException` | なし | **0 / 25** |
| `SIGINT` / `SIGTERM` | telegram, nostr | **2 / 25** |

ブリッジは**ユーザーが端末で起動して放置する常駐プロセス**なので、この 2 つは同じ報告として現れる — 「bot が急に返事をしなくなった」。

- Node 15 以降、未処理の rejection は**プロセスを落とす**。ハンドラが無いので、`await` が 1 つ漏れただけで**どのブリッジが死んだのかも言わない**スタックトレースだけが残る。
- 残り 23 個は Ctrl+C で即死 → 受信型なら処理中の webhook、ポーリング型なら取得済み・未処理の update が失われる。

`@mulmobridge/client`（**25 個すべてが依存済み** = D-5 の答え）に `installProcessGuards({ name, onShutdown })` を 1 つ置き、常駐 24 個から 1 行呼ぶ。

## Items to Confirm / Review

1. **ハンドラを入れると Node 自身の終了が抑制される**ので、`unhandledRejection` / `uncaughtException` は**明示的に `exit(1)`** している。狙いは「読めるメッセージ」で、「エラーを生き延びること」ではない — **この方針でいいか確認してほしい**（生き延びさせると、壊れた状態で黙って動き続けるブリッジになる）。
2. **telegram の表示が変わる。** 従来の `\nShutting down...` が、他 23 個と同じ `[telegram] SIGINT — shutting down` になる。挙動（abort → socket close → exit 0）は同じで、**`SIGTERM` を拾えるようになるのが差分**。
3. **telegram / nostr は「既に正しく書けている唯一の例」なので壊していない。** telegram の `AbortController` + `client.close()`、nostr の debounce された cursor flush を**そのまま `onShutdown` として渡している**（置き換えではなく移設）。nostr の `installShutdownFlush` は関数名ごと残してある。
4. **`cli` は対象外。** 対話型の readline REPL で常駐プロセスではなく、Ctrl+C は readline の持ち物。24/25 になる理由はこれだけ。
5. **2 回目のシグナルで即 `exit(1)`**（grace を待たない）。Ctrl+C を 2 回押す人は「止まってないように見える」から押しているので、待たせないほうがいいという判断。`onShutdown` が固まった場合の上限は 5 秒。
6. **再起動は入れない**（D-6）。supervisor は起動した側（#3080）の責務で、2 つあると喧嘩する。
7. **publish 順**（マージ後の別作業）: `@mulmobridge/client`（新 export のため bump 必須）→ 24 ブリッジ。#3109 の common / webhook-runtime と合わせて 1 回の release にまとめられる。

## 検証

| 検証 | 結果 |
|---|---|
| `packages/client/test/test_processGuards.ts`（新規、9 ケース） | pass |
| client + 全ブリッジ + webhook-runtime + common の全スイート | **489 pass / 0 fail** |
| `tsc --noEmit`（client + 25 ブリッジすべて） | clean |
| eslint（`packages/client`, `packages/bridges`） | clean |
| `check:changelog-ships` / `check:doc-links` | OK |

**実機**（`packages/bridges/webhook/dist/index.js` を実際に起動して kill）:

| 条件 | 観測 |
|---|---|
| 起動中に `SIGINT` | `[webhook] SIGINT — shutting down`、exit 0（従来: 無言で即死） |
| 起動中に `SIGTERM` | `[webhook] SIGTERM — shutting down`、exit 0（従来: 25 個中 2 個だけが処理） |
| 未処理 rejection（guards なし = 従来） | どのブリッジかを言わない匿名のスタックのみ |
| 未処理 rejection（guards あり） | `[line] unhandled rejection — exiting: a missed await deep in a handler` + スタック、exit 1（**終了コードは従来と同じ** — 読めるようにしただけ） |

テストは `exit` を seam にして**実際に `process.emit` し**、終了コードとメッセージの両方を確認している（node:test 自身のハンドラを退避・復元するので相互汚染なし）。非同期 `onShutdown` の await、投げる `onShutdown`、2 回目のシグナル、grace の上限も両方向でカバー。

## 既存ユーザーへの影響

**正常に動いている場合の挙動は変わらない。** 変わるのは「今は無言で落ちている」「今は Ctrl+C で取りこぼす」ケースと、telegram のシャットダウン表示（上記 2）だけ。

`packages/core/assets/helps/error-recovery.md` の既存の「bot が返事をしない」節に、**プロセスが消えていたときに何を探すか**を追記した（新しい節は作らない — 読む人にとっては同じ調査の続き）。npm ユーザーには次の `@mulmoclaude/core` の publish で届く。

Refs #3084, #3109, #3080

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/3084 これって対応できる？
- （確認に対して）スコープは **PR-A と PR-B 両方**、打ち間違いのときは **警告して exit(1)**、**email / irc は含めない**。

## Plan

[`plans/fix-3084-bridge-process-guards.md`](plans/fix-3084-bridge-process-guards.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Leq3Uj4w5Jykheqop7Kcxa

work in mulmoclaude4

## Summary by Sourcery

Harden resident bridges with transport-aware process failure reporting and bounded graceful shutdown handling.

New Features:
- Add shared process guards for resident bridges to report unhandled failures and handle graceful signal shutdown.

Bug Fixes:
- Prevent silent bridge termination on unhandled rejections or uncaught exceptions and reduce in-flight work loss during SIGINT or SIGTERM shutdowns.

Enhancements:
- Apply consistent shutdown behavior across 24 resident bridges while preserving Telegram and Nostr cleanup workflows.
- Bound graceful shutdowns, support immediate exit on repeated signals, and explicitly preserve non-zero exits for fatal process errors.

Build:
- Bump @mulmobridge/client to 1.2.0 and update dependent package ranges for the new public export.

Documentation:
- Document bridge crash and shutdown messages in the changelog and error-recovery guidance.

Tests:
- Add coverage for crash reporting, signal handling, cleanup ordering, shutdown failures, repeated signals, and shutdown deadlines, including a child-process regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent process monitoring across bridge services, including diagnostics for unhandled errors and unexpected exceptions.
  * Added graceful SIGINT and SIGTERM shutdown handling with a five-second completion window.
  * Added escalation when a second shutdown signal is received.
  * Telegram and Nostr now use shared shutdown behavior while preserving bridge-specific cleanup.
  * Exit diagnostics now identify the affected transport and shutdown reason.

* **Documentation**
  * Added guidance for interpreting bridge process exit diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->