### PR TITLE
fix(e2e): アプリ描画の判定を app-title testid にする（text locator は 5 要素に一致し得る）

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -610,6 +610,8 @@ When a user reports "this failed with no UI feedback" and you can't reproduce it
 
 E2E tests live in `e2e/tests/*.spec.ts`. **No backend runs**; `await mockAllApis(page)` from `e2e/fixtures/api.ts` intercepts every `/api/*` call. Per-test mocks registered AFTER `mockAllApis` win because Playwright walks routes last-registered-first.
 
+Assert "the shell rendered" with `page.getByTestId("app-title")`, never `page.getByText("MulmoClaude")`. The app name also appears in the empty-chat role suggestion chips (`src/config/roles.ts`), so the text locator resolves to five elements whenever those render and Playwright's strict mode fails the assertion — a spec then goes red for a reason unrelated to what it tests, and only on the runs where the chat happened to come up empty.
+
 When to add E2E coverage is documented in [CLAUDE.md](../CLAUDE.md#when-to-add-e2e-coverage).
 
 ---

--- a/e2e/tests/accounting-flow.spec.ts
+++ b/e2e/tests/accounting-flow.spec.ts
@@ -57,7 +57,7 @@ test.describe("accounting plugin — flow", () => {
     });
 
     await page.goto(`/chat/${SESSION_ID}`);
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Production path: <AccountingApp> mounts on the seeded book and
     // shows the regular chrome (header + tabs). The first-run form
@@ -327,7 +327,7 @@ test.describe("accounting plugin — flow", () => {
     await setupSession(page, { envelope: { bookId: null } });
 
     await page.goto(`/chat/${SESSION_ID}`);
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await expect(page.getByTestId("accounting-app")).toBeVisible();
     await expect(page.getByTestId("accounting-new-book-modal")).toBeVisible();

--- a/e2e/tests/accounting-isolation.spec.ts
+++ b/e2e/tests/accounting-isolation.spec.ts
@@ -17,7 +17,7 @@ test.describe("accounting plugin — UI entry point + tool isolation", () => {
   test("PluginLauncher renders an accounting button that navigates to /accounting", async ({ page }) => {
     await page.goto("/chat");
     await page.waitForURL(/\/chat\//);
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // The launcher buttons use plugin-launcher-{key} testids; the
     // accounting plugin registers one in the first group.
     const accountingButton = page.getByTestId("plugin-launcher-accounting");
@@ -29,7 +29,7 @@ test.describe("accounting plugin — UI entry point + tool isolation", () => {
 
   test("/accounting URL resolves to the accounting view", async ({ page }) => {
     await page.goto("/accounting");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     const { pathname } = new URL(page.url());
     expect(pathname).toBe("/accounting");
     await expect(page.getByTestId("accounting-app")).toBeVisible();

--- a/e2e/tests/attachment-chip-filename.spec.ts
+++ b/e2e/tests/attachment-chip-filename.spec.ts
@@ -54,7 +54,7 @@ test.describe("attachment chip filename (#2308)", () => {
 
   test("a turn recorded with an original filename shows it instead of the stored hex id", async ({ page }) => {
     await page.goto(`/chat/${SESSION_ID}`);
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(page.getByTestId("tool-results-scroll").getByText("now this one")).toBeVisible();
 
     await expect(page.getByTestId("sent-attachment-chip").filter({ hasText: ORIGINAL_CSV }).first()).toBeVisible();

--- a/e2e/tests/canvas-plugin.spec.ts
+++ b/e2e/tests/canvas-plugin.spec.ts
@@ -57,7 +57,7 @@ test.describe("canvas plugin", () => {
       { uuid: "canvas-b", imageData: "images/canvas-b.png" },
     ]);
     await page.goto("/chat/canvas-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const canvases = page.locator("canvas[id^='vdc-']");
     await expect(canvases).toHaveCount(2);
@@ -77,7 +77,7 @@ test.describe("canvas plugin", () => {
       (route) => route.fulfill({ status: 500, json: { error: "disk full" } }),
     );
     await page.goto("/chat/canvas-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const canvas = page.locator("canvas[id^='vdc-']").first();
     await expect(canvas).toBeVisible();
@@ -98,7 +98,7 @@ test.describe("canvas plugin", () => {
       },
     );
     await page.goto("/chat/canvas-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const idBefore = await page.locator("canvas[id^='vdc-']").first().getAttribute("id");
     // Clear is the red delete-icon button in the toolbar.

--- a/e2e/tests/chart-plugin.spec.ts
+++ b/e2e/tests/chart-plugin.spec.ts
@@ -82,7 +82,7 @@ test.describe("chart plugin rendering", () => {
 
   test("renders both charts in the canvas", async ({ page }) => {
     await page.goto("/chat/chart-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Click the preview for the chart result to open it in the canvas.
     // The sidebar preview component shows the document title.
@@ -104,7 +104,7 @@ test.describe("chart plugin rendering", () => {
 
   test("PNG export button triggers a download", async ({ page }) => {
     await page.goto("/chat/chart-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("Sales Overview").first().click();
     await expect(page.locator('[data-testid="chart-export-png-0"]')).toBeVisible();
 

--- a/e2e/tests/file-explorer-lazy.spec.ts
+++ b/e2e/tests/file-explorer-lazy.spec.ts
@@ -141,7 +141,7 @@ test.describe("file explorer lazy expand (#200 phase 2)", () => {
   test("deep link auto-expands ancestors", async ({ page }) => {
     const mock = await mockLazyDirs(page);
     await page.goto("/files/wiki/pages/foo.md");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Both `wiki` and `wiki/pages` should have been fetched so the
     // tree can reveal the selection.

--- a/e2e/tests/file-explorer.spec.ts
+++ b/e2e/tests/file-explorer.spec.ts
@@ -69,7 +69,7 @@ test.beforeEach(async ({ page }) => {
 test.describe("file explorer path in URL", () => {
   test("selecting a file pushes /files/<path> onto the URL", async ({ page }) => {
     await page.goto("/files");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Wait for the root dir's shallow listing to land — with lazy
     // expand (#200 phase 2), the tree only renders children after
@@ -93,7 +93,7 @@ test.describe("file explorer path in URL", () => {
 
   test("direct URL /files/<path> opens the file", async ({ page }) => {
     await page.goto("/files/wiki/hello.md");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // The file content should be visible
     await expect(page.getByText("This is a test.")).toBeVisible({
@@ -120,7 +120,7 @@ test.describe("file explorer path in URL", () => {
     // survives the browser and is decoded by the router, which is
     // when our `.includes("..")` check fires.
     await page.goto("/files/..%2F..%2Fetc%2Fpasswd");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Guard redirects to /files (empty pathMatch).
     await expect(async () => {
@@ -132,7 +132,7 @@ test.describe("file explorer path in URL", () => {
 
   test("legacy ?path= with traversal is stripped by guard", async ({ page }) => {
     await page.goto("/files?path=../../../etc/passwd");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(async () => {
       const url = new URL(page.url());
       expect(url.pathname).toMatch(/^\/files\/?$/);
@@ -142,7 +142,7 @@ test.describe("file explorer path in URL", () => {
 
   test("absolute path attempt is stripped by guard", async ({ page }) => {
     await page.goto("/files//etc/passwd");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(async () => {
       const url = new URL(page.url());
       expect(url.pathname).toMatch(/^\/files\/?$/);

--- a/e2e/tests/files-path-url.spec.ts
+++ b/e2e/tests/files-path-url.spec.ts
@@ -188,7 +188,7 @@ test.describe("rejections", () => {
   for (const { label, url } of BAD_PATHS) {
     test(`rejects ${label}`, async ({ page }) => {
       await page.goto(url);
-      await expect(page.getByText("MulmoClaude")).toBeVisible();
+      await expect(page.getByTestId("app-title")).toBeVisible();
       await expect(async () => {
         const parsed = new URL(page.url());
         expect(parsed.searchParams.get("path")).toBeNull();

--- a/e2e/tests/health-check.spec.ts
+++ b/e2e/tests/health-check.spec.ts
@@ -25,7 +25,7 @@ test.describe("health check (useHealth)", () => {
   test("sandboxEnabled=true → lock button shows 'Sandbox enabled' tooltip", async ({ page }) => {
     await mockHealth(page, { geminiAvailable: true, sandboxEnabled: true });
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const lockBtn = page.getByTestId("sandbox-lock-button");
     await expect(lockBtn).toHaveAttribute("title", "Sandbox enabled (Docker)", {
@@ -36,7 +36,7 @@ test.describe("health check (useHealth)", () => {
   test("sandboxEnabled=false → lock button shows 'No sandbox' tooltip", async ({ page }) => {
     await mockHealth(page, { geminiAvailable: false, sandboxEnabled: false });
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const lockBtn = page.getByTestId("sandbox-lock-button");
     await expect(lockBtn).toHaveAttribute("title", "No sandbox (Docker not found)", { timeout: 3 * ONE_SECOND_MS });
@@ -47,7 +47,7 @@ test.describe("health check (useHealth)", () => {
     // branch (geminiAvailable → false, sandboxEnabled unchanged).
     await page.route(urlEndsWith("/api/health"), (route: Route) => route.fulfill({ status: 500 }));
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Page didn't crash — lock button still rendered.
     await expect(page.getByTestId("sandbox-lock-button")).toBeVisible();

--- a/e2e/tests/history-panel.spec.ts
+++ b/e2e/tests/history-panel.spec.ts
@@ -24,7 +24,7 @@ test.describe("session-history side panel", () => {
 
   test("toggling the button opens the panel with server sessions", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Panel is closed initially — session items should not be in DOM.
     await expect(page.getByTestId(`session-item-${SESSION_A.id}`)).toBeHidden();
@@ -38,7 +38,7 @@ test.describe("session-history side panel", () => {
 
   test("clicking a session navigates to /chat/:id and closes nothing", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await page.getByTestId("session-history-toggle-off").click();
     await page.getByTestId(`session-item-${SESSION_A.id}`).click();
@@ -64,7 +64,7 @@ test.describe("session-history side panel", () => {
     });
 
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // Wait for the onMount /api/sessions GET to land before snapshotting the baseline.
     await expect.poll(() => sessionFetchCount).toBeGreaterThan(0);
     const countAfterMount = sessionFetchCount;
@@ -78,7 +78,7 @@ test.describe("session-history side panel", () => {
 
   test("filter bar is visible with All/Unread/Human/Scheduler/Skill/Bridge buttons", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await page.getByTestId("session-history-toggle-off").click();
 

--- a/e2e/tests/image-plugins.spec.ts
+++ b/e2e/tests/image-plugins.spec.ts
@@ -89,7 +89,7 @@ test.describe("image plugin rendering", () => {
 
   test("image session loads without crashing", async ({ page }) => {
     await page.goto("/chat/img-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // The session has tool results — the tool-results panel renders a preview
     // per result. Scope to that panel — the session-tab bar now also surfaces
     // the preview text as a tab label, so an unscoped getByText would trip
@@ -99,7 +99,7 @@ test.describe("image plugin rendering", () => {
 
   test("empty imageData does not produce a broken <img> tag", async ({ page }) => {
     await page.goto("/chat/img-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // Wait for the tool-results to render before checking for broken images.
     await expect(page.getByTestId("tool-results-scroll").getByText("Generate an image")).toBeVisible();
     // No <img> with empty src should exist.
@@ -109,7 +109,7 @@ test.describe("image plugin rendering", () => {
 
   test("legacy data URI image renders as an actual <img>", async ({ page }) => {
     await page.goto("/chat/img-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // At least one <img> with a data: src should exist (the legacy entry).
     const dataImages = page.locator('img[src^="data:image"]');
     await expect(async () => {
@@ -119,7 +119,7 @@ test.describe("image plugin rendering", () => {
 
   test("file-path image uses /api/files/raw for src", async ({ page }) => {
     await page.goto("/chat/img-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // At least one <img> with a /api/files/raw src should exist.
     const fileImages = page.locator('img[src*="/api/files/raw"]');
     await expect(async () => {

--- a/e2e/tests/internal-link-navigation.spec.ts
+++ b/e2e/tests/internal-link-navigation.spec.ts
@@ -91,7 +91,7 @@ test.describe("internal link navigation", () => {
 
   test("sidebar preview link click selects result without navigating away", async ({ page }) => {
     await page.goto("/chat/link-test-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // The sidebar should show the text-response preview card.
     const previewCard = page.getByTestId("tool-results-scroll").locator("> div.cursor-pointer").nth(1);
@@ -106,7 +106,7 @@ test.describe("internal link navigation", () => {
 
   test("clicking workspace wiki link navigates to wiki view", async ({ page }) => {
     await page.goto("/chat/link-test-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Select the text-response result to show it in the canvas.
     const previewCard = page.getByTestId("tool-results-scroll").locator("> div.cursor-pointer").nth(1);
@@ -125,7 +125,7 @@ test.describe("internal link navigation", () => {
 
   test("clicking workspace file link navigates to files view", async ({ page }) => {
     await page.goto("/chat/link-test-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Select the text-response result.
     const previewCard = page.getByTestId("tool-results-scroll").locator("> div.cursor-pointer").nth(1);

--- a/e2e/tests/localstorage.spec.ts
+++ b/e2e/tests/localstorage.spec.ts
@@ -12,7 +12,7 @@ test.describe("localStorage state restoration", () => {
     await page.goto("/");
     await page.evaluate(() => localStorage.setItem("canvas_layout_mode", "stack"));
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(async () => {
       const stored = await page.evaluate(() => localStorage.getItem("canvas_layout_mode"));
       expect(stored).toBe("stack");
@@ -23,7 +23,7 @@ test.describe("localStorage state restoration", () => {
     await page.goto("/");
     await page.evaluate(() => localStorage.setItem("canvas_layout_mode", "single"));
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(async () => {
       const stored = await page.evaluate(() => localStorage.getItem("canvas_layout_mode"));
       expect(stored).toBe("single");
@@ -34,7 +34,7 @@ test.describe("localStorage state restoration", () => {
     await page.goto("/");
     await page.evaluate(() => localStorage.setItem("canvas_layout_mode", "<script>alert(1)</script>"));
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // Layout silently falls back to single; no URL param is written.
     await expect(page).toHaveURL(/\/chat/);
   });
@@ -43,7 +43,7 @@ test.describe("localStorage state restoration", () => {
     await page.goto("/");
     await page.evaluate(() => localStorage.setItem("canvas_view_mode", "files"));
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(async () => {
       const legacy = await page.evaluate(() => localStorage.getItem("canvas_view_mode"));
       expect(legacy).toBeNull();
@@ -58,7 +58,7 @@ test.describe("localStorage state restoration", () => {
     await page.reload();
     // The right sidebar should be visible (it contains tool call history).
     // We check for the build icon which toggles it.
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // The right sidebar state is a UI pref — just verify no crash.
   });
 
@@ -70,14 +70,14 @@ test.describe("localStorage state restoration", () => {
       localStorage.setItem("files_expanded_dirs", "not-json");
     });
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
   });
 
   test("files_expanded_dirs with valid JSON set is preserved", async ({ page }) => {
     await page.goto("/");
     await page.evaluate(() => localStorage.setItem("files_expanded_dirs", JSON.stringify(["", "wiki", "data"])));
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     const stored = await page.evaluate(() => localStorage.getItem("files_expanded_dirs"));
     expect(JSON.parse(stored ?? "[]")).toContain("wiki");
   });

--- a/e2e/tests/lock-status-popup.spec.ts
+++ b/e2e/tests/lock-status-popup.spec.ts
@@ -8,7 +8,7 @@ test.describe("LockStatusPopup", () => {
 
   test("clicking the lock button opens the popup", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const lockBtn = page.getByTestId("sandbox-lock-button");
     await expect(lockBtn).toBeVisible();
@@ -35,7 +35,7 @@ test.describe("LockStatusPopup", () => {
     );
 
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByTestId("sandbox-lock-button").click();
 
     const firstQuery = page.getByTestId("sandbox-test-query").first();
@@ -47,7 +47,7 @@ test.describe("LockStatusPopup", () => {
 
   test("clicking outside closes the popup", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByTestId("sandbox-lock-button").click();
 
     const firstQuery = page.getByTestId("sandbox-test-query").first();
@@ -81,7 +81,7 @@ test.describe("LockStatusPopup", () => {
     );
 
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByTestId("sandbox-lock-button").click();
 
     // The credential block only renders when sandbox is enabled,
@@ -104,7 +104,7 @@ test.describe("LockStatusPopup", () => {
     // exactly this branch. Nothing to override; the popup just opens
     // and the credential block should be absent.
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByTestId("sandbox-lock-button").click();
 
     // Query buttons appear (sandbox-off popup still has them)…

--- a/e2e/tests/queries-panel.spec.ts
+++ b/e2e/tests/queries-panel.spec.ts
@@ -35,7 +35,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
 
   test("Suggestions button toggles the query list", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const toggle = page.getByTestId("suggestions-btn");
     await expect(toggle).toBeVisible();
@@ -56,7 +56,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
   test("plain click on a query sends it as a message", async ({ page }) => {
     const captured = await captureAgentPost(page);
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await page.getByTestId("suggestions-btn").click();
     const query = page.getByRole("button", {
@@ -77,7 +77,7 @@ test.describe("queries panel (useQueriesPanel)", () => {
   test("Shift+click on a query fills the input without sending", async ({ page }) => {
     const captured = await captureAgentPost(page);
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await page.getByTestId("suggestions-btn").click();
     const query = page.getByRole("button", {

--- a/e2e/tests/right-sidebar-toggle.spec.ts
+++ b/e2e/tests/right-sidebar-toggle.spec.ts
@@ -13,7 +13,7 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
 
   test("clicking the header button shows/hides the sidebar", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // The sidebar has a unique heading "Tool Call History" (h2).
     const sidebarHeading = page.getByRole("heading", {
@@ -31,7 +31,7 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
 
   test("toggle state persists to localStorage", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await page.getByTitle("Tool call history", { exact: true }).click();
     await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
@@ -53,14 +53,14 @@ test.describe("right sidebar toggle (useRightSidebar)", () => {
     await page.addInitScript(() => localStorage.setItem("right_sidebar_visible", "true"));
 
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // Panel and toggle button both visible on chat.
     await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeVisible();
     await expect(page.getByTitle("Tool call history", { exact: true })).toBeVisible();
 
     for (const route of ["/wiki", "/automations", "/files"] as const) {
       await page.goto(route);
-      await expect(page.getByText("MulmoClaude")).toBeVisible();
+      await expect(page.getByTestId("app-title")).toBeVisible();
       // Panel content gone.
       await expect(page.getByRole("heading", { name: "Tool Call History" })).toBeHidden();
       // Toggle button gone (dead control suppression).

--- a/e2e/tests/router-guards.spec.ts
+++ b/e2e/tests/router-guards.spec.ts
@@ -18,7 +18,7 @@ test.describe("URL injection defence", () => {
     // Even with a garbage path, the app should not crash.
     // The catch-all redirect sends it to /chat.
     await page.goto("/chat/<script>alert(1)</script>");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // URL must resolve to a valid /chat path — no script tags in decoded pathname
     const pathname = decodeURIComponent(new URL(page.url()).pathname);
@@ -28,7 +28,7 @@ test.describe("URL injection defence", () => {
 
   test("path traversal → app renders normally", async ({ page }) => {
     await page.goto("/chat/..%2F..%2Fetc%2Fpasswd");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // URL must resolve to a valid /chat path, not a traversed location
     const { pathname } = new URL(page.url());
@@ -38,18 +38,18 @@ test.describe("URL injection defence", () => {
   test("extremely long path segment → app renders normally", async ({ page }) => {
     const longStr = "a".repeat(200);
     await page.goto(`/chat/${longStr}`);
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
   });
 
   test("unknown route → redirected to /chat, app loads", async ({ page }) => {
     await page.goto("/admin/secret");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     const { pathname } = new URL(page.url());
     expect(pathname).toMatch(VALID_CHAT_PATH);
   });
 
   test("special chars in path → app does not crash", async ({ page }) => {
     await page.goto('/chat/test"onmouseover="alert(1)');
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
   });
 });

--- a/e2e/tests/router-navigation.spec.ts
+++ b/e2e/tests/router-navigation.spec.ts
@@ -99,19 +99,19 @@ test.describe("session navigation via URL", () => {
 test.describe("page routing — direct page loads", () => {
   test("/files loads the files page", async ({ page }) => {
     await page.goto("/files");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/files");
   });
 
   test("/automations loads the automations page", async ({ page }) => {
     await page.goto("/automations");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/automations");
   });
 
   test("/wiki loads the wiki page", async ({ page }) => {
     await page.goto("/wiki");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     expect(new URL(page.url()).pathname).toBe("/wiki");
   });
 });

--- a/e2e/tests/session-history-side-panel.spec.ts
+++ b/e2e/tests/session-history-side-panel.spec.ts
@@ -24,7 +24,7 @@ test.describe("session-history side-panel toggle", () => {
 
   test("Single view: toggle button hidden → visible shows the left session-history column", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Off by default — side-panel DOM is absent.
     await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
@@ -51,7 +51,7 @@ test.describe("session-history side-panel toggle", () => {
     });
 
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Side panel off initially in Stack too.
     await expect(page.getByTestId("session-history-side-panel")).toBeHidden();
@@ -75,7 +75,7 @@ test.describe("session-history side-panel toggle", () => {
 
     // Reload — panel should still be visible without clicking again.
     await page.reload();
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(page.getByTestId("session-history-side-panel")).toBeVisible();
   });
 
@@ -93,7 +93,7 @@ test.describe("session-history side-panel toggle", () => {
 
   test("opening the side panel replaces the SessionTabBar entirely", async ({ page }) => {
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // SessionTabBar is present with its tabs and toggle when the panel is off.
     await expect(page.getByTestId(`session-tab-${SESSION_A.id}`)).toBeVisible();
@@ -160,7 +160,7 @@ test.describe("session tab bar — visible per-tab info", () => {
   test("shows a short label under the role icon on each tab", async ({ page }) => {
     await mockAllApis(page, { sessions: [SESSION_A, SESSION_B] });
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const tabA = page.getByTestId(`session-tab-${SESSION_A.id}`);
     const tabB = page.getByTestId(`session-tab-${SESSION_B.id}`);
@@ -185,7 +185,7 @@ test.describe("session tab bar — visible per-tab info", () => {
       ],
     });
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const tabA = page.getByTestId(`session-tab-${SESSION_A.id}`);
     const tabB = page.getByTestId(`session-tab-${SESSION_B.id}`);
@@ -203,7 +203,7 @@ test.describe("session tab bar — visible per-tab info", () => {
       ],
     });
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     const tabA = page.getByTestId(`session-tab-${SESSION_A.id}`);
     const tabB = page.getByTestId(`session-tab-${SESSION_B.id}`);
@@ -229,7 +229,7 @@ test.describe("session tab bar — visible per-tab info", () => {
 
     // On /chat, the Chat button already carries the unread badge.
     await page.goto("/chat");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await expect(chatBtn.getByTestId("session-count-unread")).toBeVisible();
 
     // Navigate off chat. The tab bar (and its per-tab dots) unmounts,

--- a/e2e/tests/shapescript-plugin.spec.ts
+++ b/e2e/tests/shapescript-plugin.spec.ts
@@ -58,7 +58,7 @@ test.describe("shapescript plugin rendering", () => {
 
   test("opens the 3D view from the sidebar preview", async ({ page }) => {
     await page.goto("/chat/shapescript-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     await expect(page.locator('[data-testid="shapescript-preview"]')).toBeVisible();
     await page.getByText("Cube Row").first().click();

--- a/e2e/tests/skills.spec.ts
+++ b/e2e/tests/skills.spec.ts
@@ -125,14 +125,14 @@ test.describe("manageSkills plugin", () => {
 
   test("sidebar preview renders the skill list count", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     // Preview renders "2 skills" somewhere in the sidebar.
     await expect(page.getByText("2 skills").first()).toBeVisible();
   });
 
   test("View renders the full skill list when selected", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Click the tool-result preview in the sidebar to open the View.
     await page.getByText("2 skills").first().click();
@@ -144,7 +144,7 @@ test.describe("manageSkills plugin", () => {
 
   test("selecting a skill loads its detail body from the API", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-ci_enable")).toBeVisible();
 
@@ -158,7 +158,7 @@ test.describe("manageSkills plugin", () => {
 
   test("skill body is rendered as formatted HTML, not raw markdown", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-ci_enable")).toBeVisible();
 
@@ -272,7 +272,7 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
 
   test("Delete button is hidden for user-scope skills", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
 
@@ -285,7 +285,7 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
 
   test("Delete button is visible for project-scope skills", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
 
@@ -312,7 +312,7 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
     );
 
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
 
@@ -344,7 +344,7 @@ test.describe("manageSkills plugin — delete (phase 1)", () => {
     );
 
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
     await expect(page.getByTestId("skill-item-user-only")).toBeVisible();
 
@@ -446,7 +446,7 @@ test.describe("manageSkills plugin — post-delete selection", () => {
 
   test("deleting the selected middle skill advances to the neighbour, not the first row", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("3 skills").first().click();
     await expect(page.getByTestId("skill-item-beta-skill")).toBeVisible();
 
@@ -467,7 +467,7 @@ test.describe("manageSkills plugin — post-delete selection", () => {
 
   test("deleting the selected last skill advances to the new last row", async ({ page }) => {
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("3 skills").first().click();
     await expect(page.getByTestId("skill-item-gamma-skill")).toBeVisible();
 
@@ -579,7 +579,7 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
     await setupExternalCatalog(page, calls);
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
 
     const repo = page.getByTestId("skill-catalog-repo-anthropics-skills");
@@ -611,7 +611,7 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
       return route.fulfill({ status: 500, json: { error: "repo registry corrupt" } });
     });
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
 
     // The catalog load resolving (presets render) is the very event that
@@ -625,7 +625,7 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
     await setupExternalCatalog(page, calls);
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
 
     await page.getByTestId("skill-catalog-item-anthropics-skills/pdf").click();
@@ -641,7 +641,7 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
     await setupExternalCatalog(page, calls);
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
 
     await page.getByTestId("skill-catalog-add-repo").click();
@@ -672,7 +672,7 @@ test.describe("manageSkills plugin — external catalog (#1383 PR-C2)", () => {
     const calls = { star: [] as StarCall[], install: [] as InstallCall[], deleted: [] as string[] };
     await setupExternalCatalog(page, calls);
     await page.goto("/chat/skills-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     await page.getByText("2 skills").first().click();
 
     await page.getByTestId("skill-catalog-repo-update-anthropics-skills").click();

--- a/e2e/tests/spreadsheet.spec.ts
+++ b/e2e/tests/spreadsheet.spec.ts
@@ -62,7 +62,7 @@ async function mockFileContent(page: Page, path: string, body: { kind?: string; 
 // View mounts. Returns only after the View is visible.
 async function openSpreadsheetView(page: Page, sessionId = "sheet-session", sidebarTitle = "Test Sheet") {
   await page.goto(`/chat/${sessionId}`);
-  await expect(page.getByText("MulmoClaude")).toBeVisible();
+  await expect(page.getByTestId("app-title")).toBeVisible();
   // Wait for the actual sidebar item rather than a fixed sleep —
   // page ready-state + element visibility is more reliable.
   const item = page.getByText(sidebarTitle).first();
@@ -110,7 +110,7 @@ test.describe("spreadsheet — rendering", () => {
     const sheets = [{ name: "Sheet1", data: [[{ v: "x" }]] }];
     await setupSpreadsheetSession(page, { sheets, title: "Q1 Revenue" });
     await page.goto("/chat/sheet-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
     const item = page.getByText("Q1 Revenue").first();
     await expect(item).toBeVisible({ timeout: 5 * ONE_SECOND_MS });
     await item.click();

--- a/e2e/tests/wiki-navigation.spec.ts
+++ b/e2e/tests/wiki-navigation.spec.ts
@@ -350,7 +350,7 @@ test.describe("wiki navigation — from manageWiki tool result", () => {
 
   test("clicking a page card in a tool-result index navigates to /wiki", async ({ page }) => {
     await page.goto("/chat/wiki-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Select the wiki index tool result in the right sidebar.
     await page.getByText(`Wiki Index`, { exact: false }).first().click();
@@ -370,7 +370,7 @@ test.describe("wiki navigation — from manageWiki tool result", () => {
 
   test("Chat button returns to /chat from /wiki (session-tab bar is chat-only)", async ({ page }) => {
     await page.goto("/chat/wiki-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Leave /chat for /wiki. The session-history chrome is now
     // chat-only, so the session-tab bar unmounts off /chat.

--- a/e2e/tests/wiki-plugin.spec.ts
+++ b/e2e/tests/wiki-plugin.spec.ts
@@ -71,7 +71,7 @@ test.describe("wiki plugin — rendering", () => {
 
   test("renders a relative image ref via /api/files/raw", async ({ page }) => {
     await page.goto("/chat/wiki-session");
-    await expect(page.getByText("MulmoClaude")).toBeVisible();
+    await expect(page.getByTestId("app-title")).toBeVisible();
 
     // Select the wiki tool result in the sidebar → mounts the wiki View.
     // Preview renders as "Wiki: <title>".


### PR DESCRIPTION
## Summary

PR #3110 の CI で `e2e/tests/session-history-side-panel.spec.ts:96` が落ちた。中身は **strict mode violation** で、その PR の変更とは無関係:

```
Error: strict mode violation: getByText('MulmoClaude') resolved to 5 elements:
  1) <span data-testid="app-title" ...>MulmoClaude</span>  aka getByTestId('app-home-btn')
  2) <button>Tell me about this app, Mulm…</button>
  3) <button>How do I access MulmoClaude …</button>
  4) <button>How do I use the Telegram br…</button>
  5) <button>Something about MulmoClaude …</button>
```

アプリ名は**空チャット時の role suggestion chip にも出る**（`src/config/roles.ts`）。つまり `page.getByText("MulmoClaude")` は「chip が描画された run でだけ」5 要素に一致して落ちる — テスト対象と無関係な理由で赤くなり、再現が run 依存になる。

**落ちた 1 行だけ直しても意味がない**: 同じ判定が **25 spec・88 箇所**にあり、どれも同じ条件で落ちる。安定形はリポジトリ内に既にあった（`smoke.spec.ts` / `router-navigation.spec.ts` / `backend-offline-banner.spec.ts` が使う `getByTestId("app-title")`。`SidebarHeader.vue` に 1 つだけ存在する testid）。

- tracked な **24 spec の 87 箇所**を `page.getByTestId("app-title")` に置換
- `docs/developer.md` の E2E 節に規則を 1 行追加（89 箇所目を作らないため）

## Items to Confirm / Review

1. **88 箇所すべて意図が同じことを確認した上での sweep です。** 全て `.toBeVisible()` 一種類で、79 箇所は直前が `page.goto(...)`、残り 9 箇所も同じ test 内の goto + fixture setup の直後 — つまり「shell が描画された」判定のみ。**アプリ名そのものを検証している箇所は 1 つも無い**（あれば sweep から外すべきなので、ここは見てほしい点）。
2. **`e2e/tests/session-history-summary.spec.ts` は触っていません** — 未追跡ファイル（作業中のもの）なので、sweep から元に戻しました。tracked になったら 1 箇所だけ同じ置換が必要です。
3. **根本原因は chip 側ではなくテスト側と判断しました。** chip にアプリ名が出るのは仕様（role の suggestion 文言）なので、変えるべきは曖昧な locator のほう。chip の文言を変える案は取っていません。

## 検証

| 検証 | 結果 |
|---|---|
| ローカル e2e **全件** | **526 passed**（7.1 分、exit 0） |
| 落ちていた spec 単体 | 11/11 |
| sweep 最多の `skills.spec.ts` + `smoke` + `router-navigation` | 39/39 |
| `check:doc-links` | OK |

再現について: 元の失敗は「空状態の chip が描画された run」でだけ起きるため、ローカルでは再現できません。**根拠は CI のログ自体**で、一致した 5 要素が列挙されており、うち 4 つが `roles.ts` の chip、1 つが `app-title` です。新しい locator は `SidebarHeader.vue` の唯一の testid を指すので、chip の描画有無に依存しません。

Refs #3110

## User Prompt

- https://github.com/receptron/mulmoclaude/issues/3084 これって対応できる？
- （確認に対して）スコープは PR-A と PR-B 両方、打ち間違いは警告して exit(1)、email / irc は含めない。
- merge / 緑になったら 3110 もマージして / **merge して e2e の失敗直して**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Leq3Uj4w5Jykheqop7Kcxa

work in mulmoclaude4

## Summary by Sourcery

Use the unique app-title test ID for E2E shell-render checks to eliminate run-dependent locator ambiguity.

Bug Fixes:
- Prevent intermittent Playwright strict-mode failures when checking that the application shell has rendered by replacing ambiguous app-name text locators with the unique app-title test ID across the tracked E2E suite.

Enhancements:
- Document the required app-title locator for shell-render assertions and explain why app-name text locators are unreliable.

Documentation:
- Add E2E guidance to use the unique app-title test ID instead of the application name text when asserting shell rendering.