### PR TITLE
fix(deps): plugin の @mulmoclaude/common を peer + dev に揃える (#3117)

### DIFF
--- a/packages/plugins/accounting-plugin/package.json
+++ b/packages/plugins/accounting-plugin/package.json
@@ -36,10 +36,8 @@
     "test": "tsx --test test/test_*.ts test/accounting/test_*.ts",
     "lint": "eslint src test"
   },
-  "dependencies": {
-    "@mulmoclaude/common": "^1.3.0"
-  },
   "peerDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "express": "^5.2.1",
     "gui-chat-protocol": "^2.0.0",
@@ -61,6 +59,7 @@
     }
   },
   "devDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/express": "^5.0.6",

--- a/packages/plugins/html-plugin/package.json
+++ b/packages/plugins/html-plugin/package.json
@@ -34,10 +34,8 @@
     "lint": "eslint .",
     "test": "tsx --test test/test_*.ts"
   },
-  "dependencies": {
-    "@mulmoclaude/common": "^1.3.0"
-  },
   "peerDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"

--- a/packages/plugins/markdown-plugin/package.json
+++ b/packages/plugins/markdown-plugin/package.json
@@ -36,7 +36,6 @@
   },
   "dependencies": {
     "@marp-team/marp-core": "^4.4.0",
-    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/markdown-utils": "^2.2.0",
     "js-yaml": "^5.4.1",
     "marked": "^18.0.12",
@@ -44,12 +43,14 @@
     "mermaid": "^11.16.1"
   },
   "peerDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.4.1",

--- a/packages/plugins/mulmoscript-plugin/package.json
+++ b/packages/plugins/mulmoscript-plugin/package.json
@@ -42,12 +42,10 @@
     "lint": "eslint .",
     "test": "tsx --test test/test_*.ts"
   },
-  "dependencies": {
-    "@mulmoclaude/common": "^1.3.0"
-  },
   "peerDependencies": {
     "@mulmocast/beat-editor": "^1.1.1",
     "@mulmocast/types": "^2.9.0",
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "graphai": "^2.0.18",
     "gui-chat-protocol": "^2.0.0",
@@ -56,6 +54,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@mulmoclaude/common": "^1.3.0",
     "@mulmoclaude/core": "^4.9.1",
     "@tailwindcss/vite": "^4.3.2",
     "@types/node": "^26.4.1",

--- a/packages/plugins/spotify-plugin/package.json
+++ b/packages/plugins/spotify-plugin/package.json
@@ -27,15 +27,14 @@
     "test": "echo 'no in-package tests; covered by host tests under test/plugins/spotify/'",
     "lint": "eslint src"
   },
-  "dependencies": {
-    "@mulmoclaude/common": "^1.3.0"
-  },
   "peerDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "gui-chat-protocol": "^2.0.0",
     "vue": "^3.5.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^6.0.3",
     "vite": "^8.3.0",

--- a/packages/plugins/x-plugin/package.json
+++ b/packages/plugins/x-plugin/package.json
@@ -26,10 +26,11 @@
     "test": "tsx --test test/test_*.ts",
     "lint": "eslint src test"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@mulmoclaude/common": "^1.3.0"
   },
   "devDependencies": {
+    "@mulmoclaude/common": "^1.3.0",
     "@types/node": "^26.4.1",
     "tsx": "^4.23.13",
     "typescript": "^6.0.3",

--- a/plans/fix-3117-plugin-common-peer-dev.md
+++ b/plans/fix-3117-plugin-common-peer-dev.md
@@ -1,0 +1,41 @@
+# fix(deps): plugin の `@mulmoclaude/common` を peer + dev に揃える (#3117)
+
+`@mulmoclaude/core` は 8 plugin で `devDependencies` + `peerDependencies` に揃っているのに、
+`@mulmoclaude/common` は 6 plugin が `dependencies` で宣言していた。CLAUDE.md の規則:
+
+> A plugin declares host-provided packages as `peer` + `dev` — never `dependencies`.
+> `dependencies` makes npm install a **second copy nested under the plugin**, so the plugin
+> and the host each get their own module instance.
+
+launcher 自身が `@mulmoclaude/common` を宣言しているので common も host 提供 package。
+**方針 (a)**（ユーザー判断 2026-09-13）: 規則の文面は変えず、**6 つを core と同じ形に揃える**。
+
+## 現状 → 目標
+
+| plugin | 現状 | 目標 |
+|---|---|---|
+| `x-plugin` | `dependencies: ^1.3.0` | `peerDependencies` + `devDependencies` |
+| `accounting-plugin` | 同上 | 同上 |
+| `html-plugin` | `dependencies` **と** `devDependencies` の両方 | `dependencies` を削り peer を追加（dev は既にある） |
+| `mulmoscript-plugin` | `dependencies: ^1.3.0` | `peerDependencies` + `devDependencies` |
+| `spotify-plugin` | 同上 | 同上 |
+| `markdown-plugin` | 同上 | 同上 |
+
+**`dependencies` から消すだけでは駄目**（import しているものが未宣言になる）。CLAUDE.md が
+明記しているとおり、**peer への追加と dev への追加が対になる**。6 つとも実際に src から
+common を import している（3 / 9 / 2 / 10 / 3 / 2 ファイル）。
+
+## 検証すること
+
+- `check:launcher-sync` の "no peer-dep violations" — launcher は `@mulmoclaude/common: ^1.3.0` を
+  宣言しているので新しい peer（`^1.3.0`）を満たす。**これが唯一の機械的ゲート**
+- lockfile が変わらないこと（workspace 内部解決なので変わらない見込み。変わったら
+  クリーン install で検証する — 温かい `node_modules` は嘘をつく）
+- 6 plugin が standalone でビルド/テストできること（dev 宣言がそれを担保する）
+- 各 plugin の build + typecheck + test
+
+## この PR でやらないこと
+
+- **規則の文面は変えない**。判定基準（module state / singleton 要求）を書き足す案 (b) は採らない
+- **publish はしない**。配置変更は各 plugin の次の publish でユーザーに届く。
+  それまで npm 上の 6 つは `dependencies` のまま = 現状と同じ挙動


### PR DESCRIPTION
## Summary

`@mulmoclaude/core` は 8 plugin で `devDependencies` + `peerDependencies` に揃っているのに、**`@mulmoclaude/common` は 6 plugin が `dependencies` で宣言**していました。launcher 自身が common を宣言している以上 common も host 提供 package なので、CLAUDE.md の規則の対象です:

> A plugin declares host-provided packages as `peer` + `dev` — never `dependencies`. `dependencies` makes npm install a **second copy nested under the plugin**, so the plugin and the host each get their own module instance.

| plugin | before | after |
|---|---|---|
| `x-plugin` | `dependencies` | `peerDependencies` + `devDependencies` |
| `accounting-plugin` | `dependencies` | 同上 |
| `html-plugin` | `dependencies` **と** `devDependencies` | `dependencies` を削除、peer を追加 |
| `mulmoscript-plugin` | `dependencies` | `peerDependencies` + `devDependencies` |
| `spotify-plugin` | `dependencies` | 同上 |
| `markdown-plugin` | `dependencies` | 同上 |

**`dependencies` から消すだけにはしていません。** import しているものが未宣言になるので、CLAUDE.md が明記しているとおり **peer への追加と dev への追加が対**です。6 つとも実際に src から common を import しています（文字列を含むファイル数で 3 / 9 / 2 / 10 / 3 / 2、うち実 import 文を持つのは 2 / 9 / 2 / 10 / 2 / 2 — 残りはコメント言及）。

**逆方向も確認しました**: manifest を持つ 17 plugin を実 import パターン（`from` / `import` / `require(` + 文字列）で走査し、common を実 import しているのは**この 6 つだけ**で、宣言だけあって import が無いものもありません。`shapescript-plugin` は `src/core/contract.ts:9` の doc コメントで言及しているだけです。

## cross-review で出た論点（`/codex-cross-review`、tier C、round 1）

### 第二の host（`mulmoterminal`）は新しい peer を満たすのか — Codex P2

CLAUDE.md は host を **2 つ** 名指ししているのに、この PR が証明していたのは launcher 側だけ、という指摘です。実測:

| | |
|---|---|
| `receptron/mulmoterminal` の直接宣言 | 影響する 6 plugin のうち **5 つ**（accounting / html / markdown / mulmoscript / x）と `@mulmoclaude/core: ^4.9.0`。**`@mulmoclaude/common` の直接宣言は無い** |
| 公開版 `@mulmoclaude/core@4.9.0` の宣言 | `@mulmoclaude/common: ^1.2.0`（`dependencies`） |
| npm 上の `@mulmoclaude/common` 最新 | **1.2.0** |
| 公開中の 6 plugin の宣言 | `^1.2.0` / `^1.1.2` / `^1.1.1`（すべて `dependencies`） |

**結論: 解決します。** 理由は semver の 1 系キャレットで、`^1.2.0` は **1.3.0 を満たします**（`^0.23.0` が 0.24.0 を満たさないのとは逆 — CLAUDE.md の 0.x 固有の記述と混同しないこと）。`common@1.3.0` の publish 後は `mulmoterminal → core@^4.9.0 → common@^1.2.0` が 1.3.0 に解決し、hoist された 1 本が plugin 側の peer `^1.3.0` を満たします。

**publish 順は前提条件として明記します（round 2 で自分の主張を訂正しました）。** 最初「2 つのゲートが plugin の publish 自体を block する」と書きましたが、**これは言い過ぎ**でした。実際に読むと:

| ゲート | 実際の走査範囲 |
|---|---|
| `check:published-deps` | **launcher の manifest だけ**（`packages/mulmoclaude/package.json`）。今 exit 1 になるのは launcher が `common: ^1.3.0` を宣言しているからで、**plugin の peer 下限は見ていません** |
| `drift.mjs --release` | workspace 自身の export と version のずれを見るゲートで、**plugin の peer 下限が npm にあるかは見ていません** |
| `/publish` skill | 「dependency order で回す」という**手順の指示**であって機械的ゲートではありません |

つまり **plugin の publish は peer 下限の存在を機械的に検証されていません**。守っているのは CLAUDE.md の「Publish order — always bottom-up, launcher last」という順序規則です。

> **前提条件**: この 6 plugin のどれかを publish する前に、**`@mulmoclaude/common@1.3.0` を先に publish**してください。`^1.3.0` の peer は npm に 1.3.0 が無い限り満たせません。bottom-up の publish 順（common → plugins）そのものなので新しい制約ではありませんが、機械的に止まるものではないので手順として書いておきます。

**残る前提は明記します**: この解決は hoist される flat な tree（npm / yarn v1）か pnpm の `auto-install-peers`（v8 以降の既定 on）に依存しています。strict で非 hoist かつ auto-install-peers を切った構成では未充足になります。恒久的な対処は `mulmoterminal` 側で `@mulmoclaude/common` を直接宣言することで、**別リポジトリの変更**なので本 PR には含めず、フォローアップとして提案します。

### rule の rationale は common には効きません（測定済み）

CLAUDE.md が書く失敗形は「core が module state に持つもの（registries / watchers / caches）が二重に存在する」ですが、`@mulmoclaude/common` はそれに当たりません:

```
packages/common/src/logger.ts:0   index.ts:0   envCoerce.ts:0
envScan.ts:0   meta-webhook.ts:0  ssrf.ts:0     ← module-level let/var の件数
dependencies: {}   peerDependencies: {}
```

module-level のコレクションは `HTML_ESCAPES` / `ALLOWED_PROTOCOLS` / `BLOCKED_HOSTNAMES` の読み取り専用ルックアップだけです。純関数パッケージの二重コピーは実行時に無害なので、この PR の実際の利点は次の 3 点です:

1. `core` と同じ形に揃えて、配置の判断を per-package にしない
2. nested な二重コピーが消えて install が小さい
3. host が古いとき、nested コピーで silent に動くのではなく **loudly に壊れる**（`asInt` / `PORT_RANGE` は 1.3.0 で足したばかりなので実利があります）

## Items to Confirm / Review

1. **方針は (a)（実態を規則に合わせる）で、規則の文面は変えていません。** issue #3117 には (b)「規則の側に判定基準（module state / singleton 要求）を書く」案も並べてありましたが、採っていません。common は状態を持たない純 leaf なので (b) にも理があった点は記録しておきます
2. **npm への影響は次の publish 時。** マージ時点では npm 上の 6 つは `dependencies` のままなので、既存ユーザーの install 内容は変わりません。各 plugin が次に publish された時点で、その plugin の install は「common を自前で持つ」から「host のものを使う（無ければ npm 7+ が peer として入れる）」に変わります
3. **`accounting-plugin` はキー順を動かしていません。** 最初 `peerDependencies` を `peerDependenciesMeta` の後ろに動かしてしまったので、内容だけの変更に戻しました（`scripts → peerDependencies → peerDependenciesMeta → devDependencies` の順を維持）
4. **`x-plugin` だけは `peerDependencies` ブロックが新設**なので、他の plugin と同じ位置（`devDependencies` の直前）に置いています

## 検証

| 検証 | 結果 |
|---|---|
| `check:launcher-sync` | **OK — "no peer-dep violations"**（launcher は `@mulmoclaude/common: ^1.3.0` を宣言しており新しい peer を満たす）。**これが唯一の機械的ゲート** |
| 6 plugin の build | 6/6 成功 |
| テストのある 4 plugin（x / accounting / html / mulmoscript） | **776 pass / 0 fail**（189 suites） |
| `yarn.lock` | **不変**（workspace 内部解決なので field 移動では動かない） |
| `plugins:codegen:check` / `check:changelog-ships` | OK |

## 経緯

#3115 の `/codex-cross-review` 中に見つけ、**両レビュアー合意で #3115 はブロックしない**と判断して #3117 に切り出したものです。Codex の判定:

> the dependency-field placement predates #3115 … Moving those six entries between fields is behaviorally larger than the release chore because it changes what npm installs for six published plugins.

Closes #3117

## User Prompt

- （#3115 のレビュー中に見つけた件について）「#3116 / #3117 含め進めよう。publish は必要なタイミングで」
- （方針確認に対して）「(a) 6 つを peer + dev に移す」

## Plan

[`plans/fix-3117-plugin-common-peer-dev.md`](plans/fix-3117-plugin-common-peer-dev.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Leq3Uj4w5Jykheqop7Kcxa

work in mulmoclaude4

## Summary by Sourcery

Declare the host-provided @mulmoclaude/common package consistently as a peer and development dependency across the six affected plugins.

Bug Fixes:
- Align @mulmoclaude/common dependency declarations across six plugins by removing nested runtime dependencies and declaring the package as both a peer and development dependency.

Documentation:
- Add a plan documenting the dependency alignment, validation scope, and required publish ordering.

Tests:
- Validate the updated plugins through successful builds and existing test suites, with all 776 tests passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated six plugins to use the shared common package supplied by the host application instead of bundling it as a direct runtime dependency.
  - Standardized plugin package requirements by declaring the shared package for development and as a peer requirement where applicable.
  - Updated the HTML and MulmoScript plugins to support the newer core package version.
  - Plugin installation or validation may be affected if the host application lacks a compatible version.

- **Documentation**
  - Added planning and verification details for the plugin dependency alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->