### PR TITLE
fix(publish): drift ゲートの走査範囲と指標を直す (#3116)

### DIFF
--- a/.github/workflows/mulmoclaude_smoke.yaml
+++ b/.github/workflows/mulmoclaude_smoke.yaml
@@ -24,10 +24,12 @@ on:
     # actually changed. Docs-only PRs, e2e fixtures, etc. shouldn't
     # burn CI minutes packing + installing mulmoclaude.
     paths:
-      - "packages/mulmoclaude/**"
-      - "packages/protocol/**"
-      - "packages/client/**"
-      - "packages/chat-service/**"
+      # Every workspace the drift stage scans, which since #3116 is any
+      # publishable package another workspace declares — not just the four
+      # `@mulmobridge/*` deps of the launcher. Listing the four was how a PR that
+      # added `asInt` to `@mulmoclaude/common` never started this workflow at all:
+      # widening the scan set does nothing if the trigger stays narrow.
+      - "packages/**"
       - "server/**"
       - "src/**"
       - "scripts/mulmoclaude/**"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,50 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 
+#### The publish-drift gate was scanning 4 packages and counting the wrong thing (#3116)
+
+`scripts/mulmoclaude/drift.mjs` exists to refuse one specific state: a new runtime export shipped
+at an unchanged version, so npm keeps serving a tarball without it and consumers crash at runtime
+with "does not provide an export named …". It did catch that for `@mulmobridge/client` in #3110.
+It could not have caught it for the other two packages in the same change, and three separate
+reasons were measured rather than guessed:
+
+**Which packages.** It read the launcher's `dependencies` and kept the `@mulmobridge/*` ones —
+four packages: `chat-service`, `client`, `protocol`, `web-push`. That leaves out
+`@mulmoclaude/common` (declared by 32 other workspaces), `@mulmobridge/webhook-runtime` (9),
+`@mulmoclaude/core` (8), `@mulmoclaude/markdown-utils` (2) and `@receptron/task-scheduler` (1).
+#3109 added `asInt` / `PORT_RANGE` to common and `listenWebhook` to webhook-runtime at unchanged
+versions, and the gate passed. The set is now every publishable workspace another workspace
+declares — 20 today — discovered from the `workspaces` globs, so a bridge under
+`packages/bridges/<name>` or a package whose directory does not match its name
+(`@receptron/task-scheduler` lives in `packages/scheduler`) is no longer unreachable.
+
+**What to compare.** It compared the local `src/index.ts` against the published `dist`, which only
+holds when dist mirrors src one-to-one — a tsc build. For a vite-bundled package it is nonsense:
+`@mulmoclaude/x-plugin`'s src has 6 export lines and its dist has 1, so the old metric called it
+**drifted** while it was byte-identical to what npm serves, and `@mulmoclaude/core` came out 229
+against 30. The comparison is now local **built** dist against published dist, the same relative
+path on both sides, so the build system cannot skew it. The smoke workflow already runs
+`yarn build:packages && yarn build` first; a missing local dist is reported as `skipped`, never as
+clean.
+
+**What to count.** Lines cannot see a bundle's surface. `x-plugin`'s entire public API is one line —
+`export { extractTweetId, formatTweet, readUrlArg, readXPost, searchX, tweetBody };` — so a seventh
+name added there leaves the count at 1 and the gate passes. The unit is now the set of exported
+**names**, per `exports` subpath, which is also what lets the gate say WHICH export is new instead of
+"the count went up by one". A `export * from` entry cannot be enumerated without the published
+tarball, so it falls back to line counting and says so; a wildcard subpath (`"./*": "./dist/*.js"`)
+is skipped with a reason.
+
+Measured on this tree: 20 packages, 17 `ok`, 3 `pending-publish` (`common`, `webhook-runtime`,
+`client` — the three genuinely awaiting publish), 0 `drifted`. The three false positives the old
+metric produced are gone, and `client`'s report now names `resolvePublishedApiUrl` — a third
+unpublished export that #3115's review had to find by hand.
+
+The workflow trigger moved with it. `mulmoclaude_smoke.yaml` only ran for
+`packages/{mulmoclaude,protocol,client,chat-service}`, so a PR touching `@mulmoclaude/common` never
+started the job at all: widening the scan set does nothing while the trigger stays narrow.
+
 #### `@mulmoclaude/common@1.3.0`, `@mulmobridge/webhook-runtime@1.2.0`, `@mulmoclaude/core@4.9.1` — the versions catch up with #3084
 
 #3084 left shared packages carrying new exports at unchanged versions. That is the state

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,6 +54,32 @@ The workflow trigger moved with it. `mulmoclaude_smoke.yaml` only ran for
 `packages/{mulmoclaude,protocol,client,chat-service}`, so a PR touching `@mulmoclaude/common` never
 started the job at all: widening the scan set does nothing while the trigger stays narrow.
 
+Four more holes came out of the cross-review, each reproduced before it was fixed, and they share a
+shape: **a wrong or empty answer that reads as clean**. The parser now enumerates what it CAN model —
+a brace list without comments, `default`, a declaration, `type`/`interface` — and marks every other
+`export` statement opaque, because three consecutive findings were each "it silently drops one more
+shape" and a ban-list has no last case. Concretely:
+
+- **A published subpath that 404s is drift, not a skip.** Adding `{ "./new": "./dist/new.js" }` at an
+  unchanged version is a consumer-visible addition — `import "pkg/new"` fails after a plain install —
+  and the old code skipped that entry, so the package reported `ok` as long as `.` compared cleanly.
+  Transport failures (5xx, 429, timeouts) still skip: they say nothing about the package.
+- **A non-JS `exports` target no longer counts as a comparison.** Eight of the twenty scanned
+  packages export a `./style.css`, so an unbuilt package had its JS entry skipped, its stylesheet
+  "compared", and the whole package reported `ok`.
+- **The parser never guesses a name it cannot read exactly.** `export { a as "string name" }` (ES2022
+  arbitrary module namespace names) reported `a`, and `export { café }` reported `caf` under an
+  ASCII-only pattern — a name the package does not export is worse than a coarse comparison.
+- **An opaque entry still compares the names it could read.** The fallback used to replace the name
+  comparison with a line count, so `export * from "./x.js";export { newThing };` was clean against
+  `export * from "./x.js";` — one line on each side, the added name discarded.
+- **A subpath whose `exports` conditions resolve to no file is reported, not substituted.** A nested
+  `{ node: { import: … } }` block was dropped entirely, and a types-only entry fell back to the
+  package's `main` — comparing a different file's export surface.
+
+`test/scripts/mulmoclaude/test_drift.ts` pins all of it: 48 cases, including the near-misses that
+must come back opaque rather than empty.
+
 #### `@mulmoclaude/common@1.3.0`, `@mulmobridge/webhook-runtime@1.2.0`, `@mulmoclaude/core@4.9.1` — the versions catch up with #3084
 
 #3084 left shared packages carrying new exports at unchanged versions. That is the state

--- a/packages/client/test/fixture-hanging-shutdown.ts
+++ b/packages/client/test/fixture-hanging-shutdown.ts
@@ -10,6 +10,17 @@
 // The handle also has to exist BEFORE the signal: `process.on` does not keep
 // Node alive, so without it this fixture exits on its own between printing
 // `ready` and the parent's `kill`, and the test passes or fails by luck.
+//
+// Shutdown can also be asked for over stdin, because on Windows it cannot be
+// asked for with a signal at all: `subprocess.kill()` there terminates the
+// target unconditionally whichever name you pass, so the handler never runs and
+// the child dies in ~14ms with an empty stderr. The line below reaches the SAME
+// handler `process.on("SIGTERM")` registered, so what the test observes after
+// the trigger is identical on every platform — only the door differs.
+//
+// `unref` is what keeps that door from changing the thing under test: this
+// fixture exists to leave the deadline timer as the ONLY referenced handle, and
+// a listened-to stdin would itself hold the loop open and hide a regression.
 
 import { installProcessGuards } from "../src/processGuards.ts";
 
@@ -17,6 +28,9 @@ const graceMs = Number(process.argv[2]);
 const HEARTBEAT_MS = 1_000;
 
 const whileRunning = setInterval(() => {}, HEARTBEAT_MS);
+
+process.stdin.on("data", () => process.emit("SIGTERM", "SIGTERM"));
+process.stdin.unref();
 
 installProcessGuards({
   name: "fixture",

--- a/packages/client/test/test_processGuards_deadline.ts
+++ b/packages/client/test/test_processGuards_deadline.ts
@@ -26,11 +26,27 @@ interface ChildResult {
   elapsedMs: number;
 }
 
+// Windows has no catchable SIGTERM: `subprocess.kill()` terminates the target
+// unconditionally whatever name it is given, so the child dies before its
+// handler runs and the deadline this test exists to measure never starts. The
+// fixture therefore also accepts the request on stdin, which lands in the same
+// `process.on("SIGTERM")` handler — so only the door changes, not what is
+// observed. POSIX keeps the real signal: nothing else in the repo proves an
+// actual OS signal reaches a bridge's handler (the sibling suite synthesises it
+// with `process.emit`), and that coverage is worth keeping where it is possible.
+const requestShutdown = (child: ReturnType<typeof spawn>): void => {
+  if (process.platform === "win32") child.stdin?.write("shutdown\n");
+  else child.kill("SIGTERM");
+};
+
 const runUntilShutdown = async (): Promise<ChildResult> =>
   new Promise<ChildResult>((resolve, reject) => {
     const child = spawn(process.execPath, ["--import", "tsx", FIXTURE, String(GRACE_MS)], {
       cwd: path.join(HERE, "..", "..", ".."),
-      stdio: ["ignore", "pipe", "pipe"],
+      // stdin is piped on every platform so the two trigger paths differ in one
+      // line rather than in the spawn shape; the fixture unrefs it, so it does
+      // not become a second referenced handle and mask what this test measures.
+      stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
     let stderr = "";
@@ -45,7 +61,7 @@ const runUntilShutdown = async (): Promise<ChildResult> =>
       // before it had a handler at all.
       if (startedAt === 0 && stdout.includes("ready")) {
         startedAt = Date.now();
-        child.kill("SIGTERM");
+        requestShutdown(child);
       }
     });
     child.stderr.on("data", (chunk: Buffer) => {

--- a/plans/fix-3116-drift-gate-scope.md
+++ b/plans/fix-3116-drift-gate-scope.md
@@ -14,11 +14,11 @@ workspace が別の workspace を宣言しているものを数えると **20 �
 
 ### 2. 指標（src の export 行数）が bundle ビルドで壊れる
 
-| package | ビルド | local src 行 | local dist 行 | 公開 dist 行 | 現指標の判定 |
-|---|---|---|---|---|---|
-| `@mulmoclaude/common` | tsc | 19 | 17 | 16 | 正しく drift |
-| `@mulmoclaude/x-plugin` | **vite** | 6 | 1 | 1 | **DRIFTED（誤検知）** |
-| `@mulmoclaude/core` | **vite** | — | — | — | local 229 / 公開 30 の無意味な比較 |
+| package                 | ビルド   | local src 行 | local dist 行 | 公開 dist 行 | 現指標の判定                       |
+| ----------------------- | -------- | ------------ | ------------- | ------------ | ---------------------------------- |
+| `@mulmoclaude/common`   | tsc      | 19           | 17            | 16           | 正しく drift                       |
+| `@mulmoclaude/x-plugin` | **vite** | 6            | 1             | 1            | **DRIFTED（誤検知）**              |
+| `@mulmoclaude/core`     | **vite** | —            | —             | —            | local 229 / 公開 30 の無意味な比較 |
 
 現行の「local **src** の export 行数 vs 公開 **dist** の export 行数」は、dist が src を
 1:1 で写す tsc ビルドでしか成立しない。広げた状態で測ると google / spotify / x の 3 plugin が
@@ -60,3 +60,16 @@ x-plugin の dist: export { extractTweetId, formatTweet, readUrlArg, readXPost, 
   `export default` を名前に数えない、`export * from` は opaque として扱う）
 - 既存 `test/scripts/mulmoclaude/test_drift.ts` の fixture ベースのテストを新形に移す
 - local dist が無い場合は `skipped` + 理由（黙って pass しない）
+
+## cross-review で出た 4 つの追加穴（すべて再現してから修正）
+
+どれも形が同じ — **間違った / 空の答えが clean と読まれる**:
+
+1. **公開側 subpath の 404 が skip だった** → concrete target の 404 は drift（transport 失敗は skip のまま）
+2. **非 JS target（`./style.css`）が「比較成功」に数えられていた** → 走査 20 のうち 8 個が該当。JS 未ビルドでも `ok` になり得た
+3. **パーサが読めない名前を推測していた** → `export { a as "string name" }` が `a`、`export { café }` が `caf`
+4. **opaque の fallback が名前比較を置き換えていた** / **ネスト条件と types のみの subpath** → 前者は 1 行対 1 行で clean、後者は別ファイルを比較
+
+3 回続けて「もう 1 つの形を落としている」と指摘されたので、**ルールを ban-list から許可リストに反転**した（文 / 指定子 / 宣言名 / 条件解決の 4 段）。安全なコードの一部も粗い比較に落ちるが、リリースゲートとしてはその取引が正しい。
+
+テストは 48 件。実ゲートは 20 パッケージ / drifted 0 / exit 0。

--- a/plans/fix-3116-drift-gate-scope.md
+++ b/plans/fix-3116-drift-gate-scope.md
@@ -1,0 +1,62 @@
+# fix(publish): drift ゲートの走査範囲と指標を直す (#3116)
+
+## 測って分かったこと（設計はこれで決まった）
+
+### 1. 走査範囲が 4 パッケージだけ
+
+`detectMulmobridgeDeps()` は launcher の `dependencies` から `@mulmobridge/*` だけを拾う
+（`drift.mjs:228`）。実際に見られているのは **chat-service / client / protocol / web-push** の 4 つ。
+`@mulmoclaude/common`（他 32 workspace が依存）、`@mulmobridge/webhook-runtime`（9）、
+`@mulmoclaude/core`（8）、`@mulmoclaude/markdown-utils`（2）、`@receptron/task-scheduler`（1）は
+対象外。#3109 の export 追加 2 件が素通りしたのはこれ。
+
+workspace が別の workspace を宣言しているものを数えると **20 パッケージ**が候補。
+
+### 2. 指標（src の export 行数）が bundle ビルドで壊れる
+
+| package | ビルド | local src 行 | local dist 行 | 公開 dist 行 | 現指標の判定 |
+|---|---|---|---|---|---|
+| `@mulmoclaude/common` | tsc | 19 | 17 | 16 | 正しく drift |
+| `@mulmoclaude/x-plugin` | **vite** | 6 | 1 | 1 | **DRIFTED（誤検知）** |
+| `@mulmoclaude/core` | **vite** | — | — | — | local 229 / 公開 30 の無意味な比較 |
+
+現行の「local **src** の export 行数 vs 公開 **dist** の export 行数」は、dist が src を
+1:1 で写す tsc ビルドでしか成立しない。広げた状態で測ると google / spotify / x の 3 plugin が
+DRIFTED になるが、**3 件とも誤検知**（bundle 済み dist を src と比べている）。
+
+### 3. 行数では bundle の追加 export を取りこぼす
+
+```
+x-plugin の dist: export { extractTweetId, formatTweet, readUrlArg, readXPost, searchX, tweetBody };
+```
+
+**1 行に 6 名前**。7 つ目を足しても行数は 1 のままなので、行数比較は素通りする。
+
+## 決めたこと
+
+1. **走査範囲**: 「publish 対象 かつ 別の workspace が宣言している」workspace すべて（scope 非依存、
+   パス規約非依存）。launcher しか依存していない plugin も対象に含める — launcher の公開コードが
+   その export を呼ぶので、壊れ方は同じ。
+2. **比較対象**: **local の build 済み dist ↔ 公開 dist**。src とは比べない。
+   smoke ワークフローは `yarn build:packages && yarn build` の後に走る（`mulmoclaude_smoke.yaml:80,86`）ので
+   CI では dist は新鮮。
+3. **指標**: 行数ではなく **export される名前の集合**。`exports` map の各 subpath entry について、
+   同じ相対パスのファイルを local と公開で読み、名前集合の差を取る。
+4. **ワークフローの `paths:` も広げる**。今は `packages/{mulmoclaude,protocol,client,chat-service}` と
+   `server/` `src/` `scripts/mulmoclaude/` だけなので、**common に export を足す PR では smoke が起動すらしない**。
+   走査対象を増やしても trigger しなければ意味が無い。
+
+## やらないこと
+
+- `audit:releases` への一本化（案 c）。README だけの drift が 45 件出るので PR ゲートにならない。
+  役割分担はそのまま: drift.mjs = 「export を足して version を据え置いた」の検出、
+  audit:releases = tag 基準の棚卸し。
+- 既存の判定語彙（`ok` / `pending-publish` / `drifted` / `skipped`）は変えない。smoke.mjs が読む。
+
+## 検証
+
+- 20 パッケージを新指標で測り、**DRIFTED が 0 件**（= 赤いゲートを landing させない）ことを確認してから push
+- `parseExportedNames` を両方向でユニットテスト（`export {a, b as c} from`、`export const/function/class`、
+  `export default` を名前に数えない、`export * from` は opaque として扱う）
+- 既存 `test/scripts/mulmoclaude/test_drift.ts` の fixture ベースのテストを新形に移す
+- local dist が無い場合は `skipped` + 理由（黙って pass しない）

--- a/scripts/mulmoclaude/drift.d.mts
+++ b/scripts/mulmoclaude/drift.d.mts
@@ -1,82 +1,116 @@
 // Type declarations for drift.mjs. Sidecar keeps the script plain
-// JS (no build step for the CI/script path) while tests + the
-// future smoke driver still get a typed import surface.
+// JS (no build step for the CI/script path) while tests + the smoke
+// driver still get a typed import surface.
 
-/** One entry from a successful drift scan. `status` encodes the verdict. */
-export interface PackageDriftResult {
-  packageBaseName: string;
-  localVersion: string | null;
-  /** The version the `latest` dist-tag resolved to on the registry. Null when
-   * the fetch failed and we fell back to the local installed dist. */
-  publishedVersion?: string | null;
-  /** `pending-publish` means the src has new exports AND the local
-   *  package.json version is ahead of the registry — i.e. the bump
-   *  is already in place, the cascade publish just hasn't landed
-   *  yet. Smoke treats this as non-fatal. */
-  status: "ok" | "drifted" | "pending-publish" | "skipped";
-  /** Present when `status` is "ok", "drifted", or "pending-publish". */
-  localCount?: number;
-  /** Present when `status` is "ok", "drifted", or "pending-publish". */
-  distCount?: number;
-  /** Present when `status` is "skipped" — human-readable explanation. */
-  reason?: string;
-  /** Present when the registry was unreachable and we compared against
-   * the local installed dist instead. */
-  fallbackReason?: string;
+/** The runtime names a module exports. `opaque` is true when the file
+ *  re-exports a whole module (`export * from`), so the set is incomplete and
+ *  the caller falls back to line counting. */
+export interface ExportedNames {
+  names: Set<string>;
+  opaque: boolean;
 }
 
-/** Outcome of the registry fetch — raw source plus the resolved version. */
-export interface PublishedSource {
+export function parseExportedNames(source: string): ExportedNames;
+
+/** Line-count fallback, used only for an opaque entry. */
+export function countValueExportLines(source: string): number;
+
+/** Maps each `exports` subpath to the file it serves, relative to the package
+ *  directory. Falls back to `module` / `main` / `dist/index.js`. */
+export function entryTargets(pkg: unknown): Map<string, string>;
+
+export interface EntryComparison {
+  /** Runtime names present locally and absent from the published build. */
+  added: string[];
+  localCount: number;
+  distCount: number;
+  opaque: boolean;
+  drifted: boolean;
+}
+
+export function compareEntry(localSource: string, publishedSource: string): EntryComparison;
+
+/**
+ * Returns true when `local` (a semver-ish string) is strictly greater than
+ * `published`. Ignores prerelease / build suffixes. Returns false for any
+ * malformed / missing input.
+ */
+export function isLocalVersionAhead(local: string | null | undefined, published: string | null | undefined): boolean;
+
+/** One publishable workspace in the scan set. */
+export interface WorkspaceLibrary {
+  name: string;
+  /** Directory relative to the repo root — read from the workspace globs, never
+   *  guessed from the package name. */
+  dir: string;
+  pkg: Record<string, unknown>;
+  /** Other workspaces that declare this one, in any dependency field. */
+  consumers: string[];
+}
+
+export function discoverWorkspaceLibraries(options?: { root?: string }): Promise<WorkspaceLibrary[]>;
+
+export interface PublishedVersion {
   version: string | null;
+  reason: string | null;
+}
+
+export interface PublishedEntry {
   source: string | null;
   reason: string | null;
 }
 
-/** Injectable fetcher — tests supply a stub, real runs use the registry. */
-export type FetchPublishedSource = (args: { packageBaseName: string; timeoutMs?: number }) => Promise<PublishedSource>;
+export type FetchPublishedVersion = (args: { name: string; timeoutMs?: number }) => Promise<PublishedVersion>;
+export type FetchPublishedEntry = (args: { name: string; version: string; entryPath: string; timeoutMs?: number }) => Promise<PublishedEntry>;
 
-export function countValueExportLines(source: string): number;
+export function defaultFetchPublishedVersion(args: { name: string; timeoutMs?: number }): Promise<PublishedVersion>;
+export function defaultFetchPublishedEntry(args: { name: string; version: string; entryPath: string; timeoutMs?: number }): Promise<PublishedEntry>;
 
-/**
- * Returns true when `local` (a semver-ish string) is strictly
- * greater than `published`. Ignores prerelease / build suffixes.
- * Returns false for any malformed / missing input.
- */
-export function isLocalVersionAhead(local: string | null | undefined, published: string | null | undefined): boolean;
+/** One entry from a drift scan. `status` encodes the verdict. */
+export interface PackageDriftResult {
+  /** The full package name. (It held the scope-less base name before #3116, when
+   *  every scanned package was `@mulmobridge/*`.) */
+  packageBaseName: string;
+  localVersion: string | null;
+  publishedVersion?: string | null;
+  /** `pending-publish` means the local build has new exports AND the local
+   *  version is ahead of the registry — the bump is in place, the cascade
+   *  publish just has not landed. Smoke treats it as non-fatal. */
+  status: "ok" | "drifted" | "pending-publish" | "skipped";
+  /** Total exported names in the local build, summed over compared entries. */
+  localCount?: number;
+  /** Total exported names in the published build. */
+  distCount?: number;
+  /** `<subpath>:<name>` for each runtime name the local build adds. */
+  added?: string[];
+  entriesCompared?: number;
+  /** Present when some entries could not be compared (missing local build,
+   *  wildcard subpath, published file 404) — the rest still were. */
+  partialReason?: string;
+  /** Subpaths whose export set could not be enumerated (`export * from`), where
+   *  the weaker line-count comparison was used instead. */
+  opaqueEntries?: string[];
+  /** Present when `status` is "skipped" — human-readable explanation. */
+  reason?: string;
+}
 
 export interface CheckPackageDriftOptions {
   root?: string;
-  /** Required at runtime — throws if omitted. Typed as optional so
-   * tests can assert the throw without a `@ts-expect-error`. */
-  packageBaseName?: string;
-  srcRelative?: string;
-  distRelative?: string;
-  /** Override the `node_modules` path (used by fixtures that
-   * can't ship a real node_modules/ — globally gitignored). */
+  /** Required at runtime — throws if omitted. Typed optional so tests can assert
+   *  the throw without a `@ts-expect-error`. */
+  name?: string;
+  dir?: string;
+  pkg?: Record<string, unknown>;
   installedRoot?: string;
-  /** Injectable published-source fetcher. Defaults to the real
-   * registry+unpkg implementation; tests pass a stub. */
-  fetchPublishedSource?: FetchPublishedSource;
+  fetchPublishedVersion?: FetchPublishedVersion;
+  fetchPublishedEntry?: FetchPublishedEntry;
 }
 
 export function checkPackageDrift(options: CheckPackageDriftOptions): Promise<PackageDriftResult>;
 
-export interface DetectOptions {
-  root?: string;
-}
-
-export function detectMulmobridgeDeps(options?: DetectOptions): Promise<string[]>;
-
-export interface CheckWorkspaceDriftOptions {
-  root?: string;
-  /** Overrides auto-detection when provided. */
-  packageBaseNames?: string[];
-  /** Override the `node_modules` path — passed through to every
-   * per-package check. */
-  installedRoot?: string;
-  srcRelative?: string;
-  distRelative?: string;
-  fetchPublishedSource?: FetchPublishedSource;
+export interface CheckWorkspaceDriftOptions extends Omit<CheckPackageDriftOptions, "name" | "dir" | "pkg"> {
+  /** Restricts the discovered set to these package names. */
+  packageNames?: string[];
 }
 
 export function checkWorkspaceDrift(options?: CheckWorkspaceDriftOptions): Promise<PackageDriftResult[]>;
@@ -88,9 +122,9 @@ export function checkWorkspaceDrift(options?: CheckWorkspaceDriftOptions): Promi
  */
 export function formatLine(result: PackageDriftResult): string;
 
-/** Statuses that fail the run. `pending-publish` joins the list only at release time:
- *  non-fatal on an ordinary PR, fatal when publishing, because the declared range's lower
- *  bound is then missing from the registry (#3099). */
+/** Statuses that fail the run. `pending-publish` joins the list only at release
+ *  time: non-fatal on an ordinary PR, fatal when publishing, because the declared
+ *  range's lower bound is then missing from the registry (#3099). */
 export function failingStatuses(release: boolean): PackageDriftResult["status"][];
 
 /** CLI entry point. Returns 0 on clean, 1 if any package blocks publishing.

--- a/scripts/mulmoclaude/drift.d.mts
+++ b/scripts/mulmoclaude/drift.d.mts
@@ -7,7 +7,13 @@
  *  the caller falls back to line counting. */
 export interface ExportedNames {
   names: Set<string>;
+  /** True when a statement cannot be modelled at all — the caller falls back to
+   *  line counting. Barrels are NOT counted here; see `stars`. */
   opaque: boolean;
+  /** How many `export * from "…"` barrels the source has. A caller that can read
+   *  the re-exported file resolves them exactly; one that cannot must treat the
+   *  entry as opaque. */
+  stars: number;
 }
 
 /** Statements beginning with `export`, with a brace group's newlines flattened so
@@ -41,6 +47,24 @@ export interface EntryComparison {
 }
 
 export function compareEntry(localSource: string, publishedSource: string): EntryComparison;
+
+/** True when `text` holds a `,` outside every bracket, brace, paren and string. */
+export function hasTopLevelComma(text: string): boolean;
+
+/** The relative specifiers of every `export * from "…"` barrel in a source.
+ *  `export * as ns from` is excluded — that exports one namespace name. */
+export function starTargets(source: string): (string | null)[];
+
+/** Every runtime name an entry exposes, following `export *` into the files it
+ *  re-exports. `read` maps a package-relative path to source text or null; depth
+ *  and a visited set bound the walk, and anything unresolvable keeps the result
+ *  opaque rather than understating the surface. */
+export function collectEntryNames(args: {
+  entryPath: string;
+  read: (path: string) => Promise<string | null>;
+  depth?: number;
+  seen?: Set<string>;
+}): Promise<{ names: Set<string>; opaque: boolean }>;
 
 /**
  * Returns true when `local` (a semver-ish string) is strictly greater than

--- a/scripts/mulmoclaude/drift.d.mts
+++ b/scripts/mulmoclaude/drift.d.mts
@@ -20,9 +20,16 @@ export function parseExportedNames(source: string): ExportedNames;
 /** Line-count fallback, used only for an opaque entry. */
 export function countValueExportLines(source: string): number;
 
-/** Maps each `exports` subpath to the file it serves, relative to the package
- *  directory. Falls back to `module` / `main` / `dist/index.js`. */
-export function entryTargets(pkg: unknown): Map<string, string>;
+/** The runtime target behind one `exports` value, descending through condition
+ *  objects. Null when no string target resolves — reported as unresolved rather
+ *  than replaced with a guess. */
+export function resolveConditionTarget(value: unknown, depth?: number): string | null;
+
+/** Maps each `exports` subpath to the file it serves (relative to the package
+ *  directory), or to null when no runtime target resolves. A package with no
+ *  `exports` map at all falls back to `module` / `main` / `dist/index.js` for `.`;
+ *  that fallback never applies per subpath. */
+export function entryTargets(pkg: unknown): Map<string, string | null>;
 
 export interface EntryComparison {
   /** Runtime names present locally and absent from the published build. */

--- a/scripts/mulmoclaude/drift.d.mts
+++ b/scripts/mulmoclaude/drift.d.mts
@@ -10,6 +10,11 @@ export interface ExportedNames {
   opaque: boolean;
 }
 
+/** Statements beginning with `export`, with a brace group's newlines flattened so
+ *  a wrapped list is one statement, and `;`-separated statements split apart.
+ *  Column 0 only — an indented `export` in a built file is text, not an export. */
+export function exportStatements(source: string): string[];
+
 export function parseExportedNames(source: string): ExportedNames;
 
 /** Line-count fallback, used only for an opaque entry. */

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -43,6 +43,42 @@ const REGISTRY_BASE = "https://registry.npmjs.org";
 const UNPKG_BASE = "https://unpkg.com";
 const REGISTRY_TIMEOUT_MS = 15_000;
 
+/** True when `text` holds a `,` outside every bracket, brace, paren and string —
+ *  i.e. a second declarator rather than a comma inside an initialiser. */
+export function hasTopLevelComma(text) {
+  let depth = 0;
+  let quote = null;
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+    if (quote !== null) {
+      if (char === "\\") i += 1;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") quote = char;
+    else if (char === "(" || char === "[" || char === "{") depth += 1;
+    else if (char === ")" || char === "]" || char === "}") depth = depth > 0 ? depth - 1 : 0;
+    else if (char === "," && depth === 0) return true;
+  }
+  return false;
+}
+
+/** The relative specifiers of every `export * from "…"` in a source. A barrel's
+ *  public surface lives in those files, so comparing only the barrel line says
+ *  nothing: an export added to the target changes what consumers can import while
+ *  the barrel itself is byte-identical on both sides. */
+export function starTargets(source) {
+  const out = [];
+  for (const statement of exportStatements(source)) {
+    const rest = statement.slice("export".length).trim();
+    if (!rest.startsWith("*")) continue;
+    if (/^\*\s+as\s+/.test(rest)) continue; // a namespace export, not a barrel
+    const spec = /from\s*["']([^"']+)["']/.exec(rest);
+    out.push(spec === null ? null : spec[1]);
+  }
+  return out;
+}
+
 /** Statements that begin with `export`, with newlines inside a brace group
  *  flattened so a wrapped list is one statement, and `;`-separated statements on
  *  one line split apart. Parsing per LINE instead of per statement silently
@@ -82,6 +118,11 @@ export function exportStatements(source) {
 export function parseExportedNames(source) {
   const names = new Set();
   let opaque = false;
+  // Barrels are counted, not lumped into `opaque`: a caller that can READ the
+  // re-exported file (collectEntryNames) resolves them exactly, and one that
+  // cannot must treat them as opaque. Sharing one flag made the resolved case
+  // permanently coarse.
+  let stars = 0;
   const IDENT = /^[A-Za-z_$][\w$]*/;
   const DECLARERS = new Set(["function", "function*", "class", "const", "let", "var"]);
   const NO_NAME_FORMS = new Set(["type", "interface"]);
@@ -122,7 +163,12 @@ export function parseExportedNames(source) {
   for (const statement of exportStatements(source)) {
     let rest = statement.slice("export".length).trim();
     if (rest.startsWith("*")) {
-      opaque = true;
+      // `export * as ns from "./x.js"` exports one name — the namespace object —
+      // and is NOT a barrel: following the target would credit this entry with
+      // names consumers cannot import directly.
+      const named = /^\*\s+as\s+([A-Za-z_$][\w$]*)\b/.exec(rest);
+      if (named !== null) names.add(named[1]);
+      else stars += 1;
       continue;
     }
     if (rest.startsWith("{")) {
@@ -159,6 +205,13 @@ export function parseExportedNames(source) {
       continue;
     }
     const declared = rest.slice(head.length).trim();
+    // One declarator per statement is what this models. `export const a = 1, b = 2`
+    // used to yield `a` alone while claiming to be exact; a comma at depth 0 (not
+    // inside brackets, braces, parens or a string) means more than one name.
+    if (hasTopLevelComma(declared)) {
+      opaque = true;
+      continue;
+    }
     const match = IDENT.exec(declared);
     // The identifier must END where a declaration's name legitimately can — the
     // boundary is a permit-list for the same reason the statement shapes are. An
@@ -169,7 +222,7 @@ export function parseExportedNames(source) {
     if (match === null || !(after === "" || /^[\s=(;:,<{)]/.test(after))) opaque = true;
     else names.add(match[0]);
   }
-  return { names, opaque };
+  return { names, opaque, stars };
 }
 
 // Kept from the line-counting era: it is the fallback for an opaque entry, and
@@ -310,13 +363,53 @@ export async function defaultFetchPublishedEntry({ name, version, entryPath, tim
   }
 }
 
+/**
+ * Every runtime name an entry exposes, following `export * from "…"` into the
+ * files it re-exports. A barrel's own line is identical on both sides while the
+ * target gains an export, so comparing only the barrel reports clean on exactly
+ * the change this gate exists to catch — the largest hole the cross-review of
+ * #3116 found, live today in `@mulmoclaude/markdown-utils`.
+ *
+ * `read(path)` resolves a path relative to the package root to source text, or
+ * null. Depth and a visited set bound it; anything unresolvable keeps the entry
+ * opaque rather than pretending the surface is smaller than it is.
+ */
+export async function collectEntryNames({ entryPath, read, depth = 0, seen = new Set() }) {
+  const names = new Set();
+  if (depth > 4 || seen.has(entryPath)) return { names, opaque: true };
+  seen.add(entryPath);
+  const source = await read(entryPath);
+  if (source === null) return { names, opaque: true };
+  const { names: directNames, opaque: directOpaque } = parseExportedNames(source);
+  for (const name of directNames) names.add(name);
+  let opaque = directOpaque;
+  for (const target of starTargets(source)) {
+    if (target === null || !target.startsWith(".")) {
+      // `export * from "some-package"` re-exports a dependency's surface, which is
+      // not in this tarball at all. Not resolvable here; stay opaque.
+      opaque = true;
+      continue;
+    }
+    const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(entryPath), target));
+    const nested = await collectEntryNames({ entryPath: resolved, read, depth: depth + 1, seen });
+    for (const name of nested.names) names.add(name);
+    if (nested.opaque) opaque = true;
+  }
+  // A barrel whose targets all resolved is NOT opaque: the union is the surface.
+  // `opaque` above only ever comes from a shape the parser cannot model or a star
+  // that could not be followed.
+  return { names, opaque };
+}
+
 // Compare two module sources and say which runtime names the local one adds.
 // An opaque entry on either side falls back to line counting, and says so.
 export function compareEntry(localSource, publishedSource) {
   const local = parseExportedNames(localSource);
   const published = parseExportedNames(publishedSource);
   const added = [...local.names].filter((name) => !published.names.has(name)).sort();
-  if (local.opaque || published.opaque) {
+  // Without a reader this comparator cannot follow a barrel, so one makes the
+  // entry opaque here even though `collectEntryNames` would resolve it.
+  if (local.opaque || published.opaque || local.stars > 0 || published.stars > 0) {
     // The names this parser DID extract are still exact, so they are compared as
     // usual; the line count is an ADDITIONAL signal for the part it could not
     // name. Replacing the comparison with the line count alone let
@@ -442,13 +535,30 @@ export async function checkPackageDrift({
       skipped.push(`${subpath} (published ${entryPath}: ${remote.reason ?? "unavailable"})`);
       continue;
     }
-    const result = compareEntry(localSource, remote.source);
+    // Follow `export *` on BOTH sides, by the same relative paths, so a barrel
+    // whose target gained an export is compared on its real surface rather than on
+    // one identical line.
+    const localNames = await collectEntryNames({
+      entryPath,
+      read: async (rel) => readFile(path.join(root, dir ?? "", rel), "utf8").catch(() => null),
+    });
+    const publishedNames = await collectEntryNames({
+      entryPath,
+      read: async (rel) => (await fetchPublishedEntry({ name, version: published.version, entryPath: rel })).source,
+    });
+    const addedNames = [...localNames.names].filter((exportName) => !publishedNames.names.has(exportName)).sort();
+    const entryOpaque = localNames.opaque || publishedNames.opaque;
     compared += 1;
-    localCount += result.localCount;
-    distCount += result.distCount;
-    if (result.opaque) opaqueEntries.push(subpath);
-    for (const exportName of result.added) added.push(`${subpath}:${exportName}`);
-    if (result.opaque && result.drifted) added.push(`${subpath}:+${result.localCount - result.distCount} export line(s)`);
+    localCount += localNames.names.size;
+    distCount += publishedNames.names.size;
+    if (entryOpaque) opaqueEntries.push(subpath);
+    for (const exportName of addedNames) added.push(`${subpath}:${exportName}`);
+    if (entryOpaque) {
+      // The part that could not be named is still covered by the coarser signal.
+      const localLines = countValueExportLines(localSource);
+      const distLines = countValueExportLines(remote.source);
+      if (localLines > distLines) added.push(`${subpath}:+${localLines - distLines} unnamed export line(s)`);
+    }
   }
 
   if (compared === 0) {

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -352,6 +352,15 @@ export async function checkPackageDrift({
   let compared = 0;
 
   for (const [subpath, entryPath] of entries) {
+    if (!/\.(?:js|mjs|cjs)$/.test(entryPath)) {
+      // A `./style.css` or `./package.json` entry carries no export surface this
+      // metric can speak about, and counting it as a successful comparison is
+      // worse than useless: eight of the scanned packages export a stylesheet, so
+      // a package whose JS dist was never built would have had its `.` entry
+      // skipped, its CSS entry "compared", and the whole package reported `ok`.
+      skipped.push(`${subpath} (${entryPath} is not a JS module — no export surface to compare)`);
+      continue;
+    }
     if (subpath.includes("*") || entryPath.includes("*")) {
       // A wildcard subpath (`"./*": "./dist/*.js"`) names a family, not a file.
       // Enumerating it would mean walking the published tarball; say so rather

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -1,292 +1,389 @@
-// @mulmobridge/* drift check (§2 of publish-mulmoclaude skill).
+// Workspace publish-drift check (§2 of the publish-mulmoclaude skill).
 //
-// Problem: a local `packages/<name>/src/` file adds a new runtime
-// export without a version bump. The tarball a real user installs
-// from the registry ships the OLD dist/, so consumers crash with:
+// Problem: a local `packages/<x>/src/` file adds a new runtime export without a
+// version bump. The tarball a real user installs from the registry ships the OLD
+// dist, so consumers crash with:
 //   does not provide an export named X
-// at runtime — invisible to lint, typecheck, or local dev.
+// at runtime — invisible to lint, typecheck, or local dev, because in a yarn
+// workspace `node_modules/<name>` is a symlink into `packages/<x>/` and the local
+// dist is always freshly built.
 //
-// Detection strategy: count value-export LINES in src/index.ts and
-// in the currently-published dist (fetched from the npm registry),
-// flag when src > published.
+// Three things about the shape of this check were measured, not assumed (#3116):
 //
-// Why the registry and not `node_modules/.../dist`: in a yarn-
-// workspace repo, `node_modules/@mulmobridge/<name>` is a symlink
-// into `packages/<name>/`. `yarn build:packages` then rebuilds that
-// symlinked dist from the current src, making `src == dist` in CI
-// regardless of whether the published version lags behind — the
-// whole point of the check. Compare against the registry payload
-// instead so the drift picks up exactly what a fresh
-// `npm install mulmoclaude` would see at runtime.
+//  1. WHICH PACKAGES. It used to read the launcher's `dependencies` and keep the
+//     `@mulmobridge/*` ones, which is four packages: chat-service, client,
+//     protocol, web-push. That missed `@mulmoclaude/common` (declared by 32 other
+//     workspaces), `@mulmobridge/webhook-runtime` (9), `@mulmoclaude/core` (8),
+//     `@mulmoclaude/markdown-utils` (2) and `@receptron/task-scheduler` (1) — and
+//     #3109 shipped new exports in two of those with no version bump, past a green
+//     gate. The set is now every publishable workspace that another workspace
+//     declares, whatever its scope and wherever it sits in the tree.
 //
-// "Value export LINES" = every `^export …` line except ones that
-// are entirely type-only (`export type …`, `export interface …`,
-// `export { type … }`). Counting lines (not individual specifiers)
-// matches the original skill heuristic and has caught every real
-// drift we've seen.
+//  2. WHAT TO COMPARE. It used to compare the local `src/index.ts` against the
+//     published `dist`. That only holds when dist mirrors src one-to-one, i.e. a
+//     tsc build. For a vite-bundled package it is nonsense: `x-plugin`'s src has 6
+//     export lines and its dist has 1, so the old metric called it DRIFTED when it
+//     was identical to what npm serves; `core` came out 229 against 30. The
+//     comparison is now local BUILT dist against published dist — same relative
+//     path on both sides, so the build system cannot skew it. The smoke workflow
+//     runs `yarn build:packages && yarn build` first, so CI's dist is current; a
+//     missing local dist is reported as `skipped`, never as clean.
+//
+//  3. WHAT TO COUNT. Lines cannot see a bundle's exports. `x-plugin`'s whole
+//     public surface is one line — `export { extractTweetId, formatTweet,
+//     readUrlArg, readXPost, searchX, tweetBody };` — so a seventh name added there
+//     keeps the count at 1 and the old metric passes. The unit is now the set of
+//     exported NAMES, per `exports` subpath.
 
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const MULMOBRIDGE_SCOPE = "@mulmobridge/";
-const DEFAULT_INSTALLED_ROOT = "node_modules";
 const REGISTRY_BASE = "https://registry.npmjs.org";
 const UNPKG_BASE = "https://unpkg.com";
 const REGISTRY_TIMEOUT_MS = 15_000;
 
-// Returns how many `^export …` lines in `source` declare at least
-// one runtime (value) export. Type-only lines are filtered.
+// Names a module exports, or `opaque: true` when the file re-exports a whole
+// module (`export * from "./chunk.js"`) and the set cannot be enumerated without
+// resolving that file — which is not possible for the published side without
+// downloading the whole tarball. An opaque entry falls back to line counting,
+// which is weaker but still catches a new re-export line.
+export function parseExportedNames(source) {
+  const names = new Set();
+  let opaque = false;
+  const IDENT = /^[A-Za-z_$][\w$]*/;
+  const DECLARERS = new Set(["function", "function*", "class", "const", "let", "var"]);
+  const firstWord = (text) => {
+    const cut = text.search(/[^\w$*]/);
+    return cut === -1 ? text : text.slice(0, cut === 0 ? 1 : cut);
+  };
+  // One name from a brace specifier: `a` -> a, `a as b` -> b, `type T` -> none.
+  const specifierName = (raw) => {
+    const spec = raw.trim();
+    if (spec === "" || spec.startsWith("type ")) return null;
+    const parts = spec.split(/\s+/);
+    const picked = parts.length >= 3 && parts[parts.length - 2] === "as" ? parts[parts.length - 1] : parts[0];
+    const match = IDENT.exec(picked);
+    return match === null || match[0] === "default" ? null : match[0];
+  };
+
+  for (const line of source.split(/\r?\n/)) {
+    if (!line.startsWith("export")) continue;
+    let rest = line.slice("export".length);
+    if (rest !== "" && !/^[\s{*]/.test(rest)) continue; // `exported` etc., not a keyword
+    rest = rest.trim();
+    if (rest.startsWith("*")) {
+      opaque = true;
+      continue;
+    }
+    if (rest.startsWith("{")) {
+      const close = rest.indexOf("}");
+      const body = close === -1 ? rest.slice(1) : rest.slice(1, close);
+      for (const piece of body.split(",")) {
+        const name = specifierName(piece);
+        if (name !== null) names.add(name);
+      }
+      continue;
+    }
+    // Strip modifiers one word at a time — cheaper and safer than one regex with
+    // nested optional groups, which eslint's ReDoS rules reject outright.
+    let head = firstWord(rest);
+    while (head === "declare" || head === "async") {
+      rest = rest.slice(head.length).trim();
+      head = firstWord(rest);
+    }
+    if (head === "default" || head === "type" || head === "interface") continue;
+    if (!DECLARERS.has(head) && !(head === "function" || head === "function*")) continue;
+    const after = rest.slice(head.length).trim();
+    const match = IDENT.exec(after);
+    if (match !== null) names.add(match[0]);
+  }
+  return { names, opaque };
+}
+
+// Kept from the line-counting era: it is the fallback for an opaque entry, and
+// the only metric available when a `export * from` hides the real surface.
 //
-// Matches only when `export` is at column 0 (no leading whitespace)
-// to mirror the skill's `grep -E '^export'` exactly — indented
-// `export` tokens inside namespaces or conditional blocks aren't
-// module-level re-exports and shouldn't count.
+// "Value export LINES" = every `^export …` line except ones that are entirely
+// type-only (`export type …`, `export interface …`, `export { type … }`).
 export function countValueExportLines(source) {
   const lines = source.split(/\r?\n/);
   let count = 0;
   for (const line of lines) {
     if (!line.startsWith("export")) continue;
-    // `export type Foo = …` / `export interface Foo { … }`
     if (/^export\s+(?:type|interface)\b/.test(line)) continue;
-    // `export { type Foo, type Bar }` — brace starts with `type`.
-    // Matches the skill's heuristic even when the brace also has
-    // runtime bindings (rare in practice).
     if (/^export\s*\{\s*type\b/.test(line)) continue;
     count += 1;
   }
   return count;
 }
 
-// Read the local workspace package.json for `<packageBaseName>` to
-// surface its version string. Returns `null` if the file can't be
-// read — not every @mulmobridge/* dep has a local workspace twin.
-async function readLocalVersion(root, packageBaseName) {
-  const pkgPath = path.join(root, "packages", packageBaseName, "package.json");
+/** The `exports` subpaths of a manifest, mapped to the file each one serves.
+ *  Falls back to `module` / `main` / `dist/index.js` for a package with no
+ *  `exports` map, which is what the single-entry packages relied on. */
+export function entryTargets(pkg) {
+  const out = new Map();
+  const exp = pkg?.exports;
+  if (exp !== null && typeof exp === "object") {
+    for (const [subpath, value] of Object.entries(exp)) {
+      const target = typeof value === "string" ? value : (value?.import ?? value?.default ?? value?.require ?? null);
+      if (typeof target === "string") out.set(subpath, target.replace(/^\.\/+/, ""));
+    }
+  }
+  if (out.size === 0) {
+    const target = pkg?.module ?? pkg?.main ?? "dist/index.js";
+    out.set(".", String(target).replace(/^\.\/+/, ""));
+  }
+  return out;
+}
+
+async function readManifest(file) {
   try {
-    const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
-    return typeof pkg.version === "string" ? pkg.version : null;
+    return JSON.parse(await readFile(file, "utf8"));
   } catch {
     return null;
   }
 }
 
-// Default published-source fetcher: queries the npm registry for
-// the package's `latest` dist-tag version, then pulls the `main` /
-// `module` entry from unpkg. Returns `null` on any network / 404
-// failure so the caller can skip rather than crash.
-async function defaultFetchPublishedSource({ packageBaseName, timeoutMs = REGISTRY_TIMEOUT_MS } = {}) {
-  const fullName = MULMOBRIDGE_SCOPE + packageBaseName;
+// Every publishable workspace, by name, with the directory it lives in. Walks
+// the root manifest's `workspaces` globs rather than assuming `packages/<name>`:
+// the bridges sit under `packages/bridges/<name>` and the plugins under
+// `packages/plugins/<name>`, and `@receptron/task-scheduler` lives in
+// `packages/scheduler` — a name-to-path guess is wrong for most of the tree.
+async function readWorkspaces(root) {
+  const rootPkg = await readManifest(path.join(root, "package.json"));
+  const patterns = Array.isArray(rootPkg?.workspaces) ? rootPkg.workspaces : (rootPkg?.workspaces?.packages ?? []);
+  const { glob } = await import("node:fs/promises");
+  const found = new Map();
+  for (const pattern of patterns) {
+    for await (const dir of glob(pattern, { cwd: root })) {
+      const pkg = await readManifest(path.join(root, dir, "package.json"));
+      if (pkg === null || typeof pkg.name !== "string") continue;
+      if (pkg.private === true) continue;
+      found.set(pkg.name, { name: pkg.name, dir, pkg });
+    }
+  }
+  return found;
+}
+
+/** The scan set: publishable workspaces that at least one other workspace
+ *  declares, in any dependency field. A package nothing imports cannot break a
+ *  consumer by lacking an export; one the launcher alone imports can, because the
+ *  launcher's own published `server/` and `src/` call into it. */
+export async function discoverWorkspaceLibraries({ root = process.cwd() } = {}) {
+  const workspaces = await readWorkspaces(root);
+  const consumers = new Map();
+  for (const { name, pkg } of workspaces.values()) {
+    for (const field of ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"]) {
+      for (const dep of Object.keys(pkg[field] ?? {})) {
+        if (!workspaces.has(dep) || dep === name) continue;
+        const seen = consumers.get(dep) ?? new Set();
+        seen.add(name);
+        consumers.set(dep, seen);
+      }
+    }
+  }
+  return [...workspaces.values()]
+    .filter((entry) => (consumers.get(entry.name)?.size ?? 0) > 0)
+    .map((entry) => ({ ...entry, consumers: [...(consumers.get(entry.name) ?? [])].sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** The registry's `latest` version for a package, or null with a reason. */
+export async function defaultFetchPublishedVersion({ name, timeoutMs = REGISTRY_TIMEOUT_MS } = {}) {
   const controller = new AbortController();
   const killer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const metaRes = await fetch(`${REGISTRY_BASE}/${encodeURIComponent(fullName)}/latest`, {
-      signal: controller.signal,
-    });
-    if (!metaRes.ok) return { version: null, source: null, reason: `registry ${metaRes.status}` };
-    const meta = await metaRes.json();
+    const res = await fetch(`${REGISTRY_BASE}/${encodeURIComponent(name)}/latest`, { signal: controller.signal });
+    if (!res.ok) return { version: null, reason: `registry ${res.status}` };
+    const meta = await res.json();
     const version = typeof meta.version === "string" ? meta.version : null;
-    if (!version) return { version: null, source: null, reason: "registry meta missing version" };
-    // Prefer the package's declared `main` / `module` entry rather
-    // than assuming `dist/index.js` — a future refactor of the
-    // @mulmobridge/* packages could move the entry file.
-    const entry = typeof meta.module === "string" ? meta.module : typeof meta.main === "string" ? meta.main : "dist/index.js";
-    const distRes = await fetch(`${UNPKG_BASE}/${fullName}@${version}/${entry.replace(/^\.?\/+/, "")}`, {
-      signal: controller.signal,
-    });
-    if (!distRes.ok) return { version, source: null, reason: `unpkg ${distRes.status}` };
-    const source = await distRes.text();
-    return { version, source, reason: null };
+    return version === null ? { version: null, reason: "registry meta missing version" } : { version, reason: null };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { version: null, source: null, reason: `network: ${message}` };
+    return { version: null, reason: `network: ${err instanceof Error ? err.message : String(err)}` };
   } finally {
     clearTimeout(killer);
   }
 }
 
-// Read installed-dist source (the pre-registry behaviour). Kept as
-// a fallback so offline / registry-unreachable callers still get a
-// signal, and the existing fixture-based tests keep working.
-async function readInstalledDistSource({ root, packageBaseName, installedRoot, distRelative }) {
-  const distPath = path.join(root, installedRoot, MULMOBRIDGE_SCOPE + packageBaseName, distRelative);
+/** One published file, by the same relative path the local dist uses. */
+export async function defaultFetchPublishedEntry({ name, version, entryPath, timeoutMs = REGISTRY_TIMEOUT_MS } = {}) {
+  const controller = new AbortController();
+  const killer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await readFile(distPath, "utf8");
-  } catch {
-    return null;
+    const res = await fetch(`${UNPKG_BASE}/${name}@${version}/${entryPath}`, { signal: controller.signal });
+    if (!res.ok) return { source: null, reason: `unpkg ${res.status}` };
+    return { source: await res.text(), reason: null };
+  } catch (err) {
+    return { source: null, reason: `network: ${err instanceof Error ? err.message : String(err)}` };
+  } finally {
+    clearTimeout(killer);
   }
 }
 
-// Inspect one package: compare local src value-export count with
-// the currently-published dist (fetched from the registry). Returns
-// `{ status: "ok"|"drifted"|"skipped", ... }`.
-//
-// Options:
-//   fetchPublishedSource: override for the registry fetcher; must
-//     resolve to `{ version, source, reason }` shape. Tests pass a
-//     fake; real runs use defaultFetchPublishedSource.
-//   installedRoot / distRelative: legacy local-dist fallback, used
-//     when `fetchPublishedSource` returns no source (offline CI,
-//     package not on registry, etc.). Also kept so the existing
-//     fixture tests can exercise the local-dist path without hitting
-//     the network.
-export async function checkPackageDrift({
-  root = process.cwd(),
-  packageBaseName,
-  srcRelative = "src/index.ts",
-  distRelative = "dist/index.js",
-  installedRoot = DEFAULT_INSTALLED_ROOT,
-  fetchPublishedSource = defaultFetchPublishedSource,
-} = {}) {
-  if (!packageBaseName) {
-    throw new Error("checkPackageDrift: packageBaseName is required");
+// Compare two module sources and say which runtime names the local one adds.
+// An opaque entry on either side falls back to line counting, and says so.
+export function compareEntry(localSource, publishedSource) {
+  const local = parseExportedNames(localSource);
+  const published = parseExportedNames(publishedSource);
+  if (local.opaque || published.opaque) {
+    const localCount = countValueExportLines(localSource);
+    const distCount = countValueExportLines(publishedSource);
+    return { added: [], localCount, distCount, opaque: true, drifted: localCount > distCount };
   }
-  const srcPath = path.join(root, "packages", packageBaseName, srcRelative);
-  const localVersion = await readLocalVersion(root, packageBaseName);
-
-  let srcSource;
-  try {
-    srcSource = await readFile(srcPath, "utf8");
-  } catch {
-    return { packageBaseName, localVersion, status: "skipped", reason: `local src not found at ${srcRelative}` };
-  }
-
-  const published = await fetchPublishedSource({ packageBaseName });
-  let distSource = published.source;
-  const publishedVersion = published.version;
-  let fallbackReason = null;
-  if (distSource === null) {
-    distSource = await readInstalledDistSource({ root, packageBaseName, installedRoot, distRelative });
-    if (distSource !== null) {
-      fallbackReason = `registry unreachable (${published.reason ?? "unknown"}) — compared against local ${installedRoot}/.../${distRelative}`;
-    }
-  }
-
-  if (distSource === null) {
-    return {
-      packageBaseName,
-      localVersion,
-      status: "skipped",
-      reason: `no dist to compare — registry: ${published.reason ?? "unknown"}, local dist not found either`,
-    };
-  }
-
-  const localCount = countValueExportLines(srcSource);
-  const distCount = countValueExportLines(distSource);
-  const drifted = localCount > distCount;
-
-  // A bumped version is the developer's acknowledgement that the new
-  // exports land under a new release. The registry still ships the
-  // old dist, but consumers of the NEW version will get the new
-  // exports once it's published — so from the drift-check's POV this
-  // is "pending publish", not "broken". Downgrading to non-failing
-  // also unblocks PRs that add exports + bump version + await the
-  // cascade publish to land after merge.
-  const isBumped = drifted && isLocalVersionAhead(localVersion, publishedVersion);
-
-  const status = drifted ? (isBumped ? "pending-publish" : "drifted") : "ok";
-  return {
-    packageBaseName,
-    localVersion,
-    publishedVersion,
-    status,
-    localCount,
-    distCount,
-    ...(fallbackReason ? { fallbackReason } : {}),
-  };
+  const added = [...local.names].filter((name) => !published.names.has(name)).sort();
+  return { added, localCount: local.names.size, distCount: published.names.size, opaque: false, drifted: added.length > 0 };
 }
 
-// Compare two semver-ish version strings and return true when
-// `local` is strictly ahead of `published`. Ignores pre-release /
-// build suffixes — we only bump majors / minors / patches in this
-// monorepo, and a prerelease drift is still "intentional" anyway.
-// Returns false on any malformed input so the drift check errs on
-// the strict side (caller's old behaviour preserved).
+/**
+ * Compare two semver-ish version strings and return true when `local` is
+ * strictly ahead of `published`. Ignores pre-release / build suffixes — this
+ * monorepo only bumps majors / minors / patches, and a prerelease drift is
+ * intentional anyway. Returns false on malformed input so the check errs strict.
+ */
 export function isLocalVersionAhead(local, published) {
-  if (typeof local !== "string" || typeof published !== "string") return false;
-  const parse = (str) => {
-    const [cleaned] = str.split(/[-+]/);
-    const parts = cleaned.split(".").map((part) => Number.parseInt(part, 10));
-    if (parts.length < 3) return null;
-    if (parts.some((part) => !Number.isFinite(part))) return null;
-    return parts.slice(0, 3);
+  const parse = (value) => {
+    if (typeof value !== "string") return null;
+    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(value.trim());
+    return match === null ? null : [Number(match[1]), Number(match[2]), Number(match[3])];
   };
-  const localParts = parse(local);
-  const publishedParts = parse(published);
-  if (!localParts || !publishedParts) return false;
-  for (let idx = 0; idx < 3; idx++) {
-    if (localParts[idx] > publishedParts[idx]) return true;
-    if (localParts[idx] < publishedParts[idx]) return false;
+  const a = parse(local);
+  const b = parse(published);
+  if (a === null || b === null) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
   }
   return false;
 }
 
-// Auto-detect which @mulmobridge/* packages to check by reading the
-// launcher's package.json. Only packages that ALSO exist as a local
-// workspace (`packages/<name>/`) are returned — published-only deps
-// can't drift against themselves.
-export async function detectMulmobridgeDeps({ root = process.cwd() } = {}) {
-  const pkgPath = path.join(root, "packages", "mulmoclaude", "package.json");
-  const pkg = JSON.parse(await readFile(pkgPath, "utf8"));
-  const deps = Object.keys(pkg.dependencies ?? {});
-  const bridges = deps.filter((name) => name.startsWith(MULMOBRIDGE_SCOPE)).map((name) => name.slice(MULMOBRIDGE_SCOPE.length));
-  const out = [];
-  for (const name of bridges) {
-    const localVersion = await readLocalVersion(root, name);
-    if (localVersion !== null) out.push(name);
+/**
+ * Inspect one workspace: for every `exports` subpath, compare the local built
+ * dist against the published one. Returns
+ * `{ status: "ok" | "drifted" | "pending-publish" | "skipped", ... }`.
+ *
+ * A bumped version downgrades drift to `pending-publish`: the registry still
+ * serves the old dist, but consumers of the NEW version will get the new exports
+ * once it is published, so from here it is "pending publish", not broken. That is
+ * also what unblocks a PR that adds exports, bumps, and waits for the cascade.
+ */
+export async function checkPackageDrift({
+  root = process.cwd(),
+  name,
+  dir,
+  pkg,
+  fetchPublishedVersion = defaultFetchPublishedVersion,
+  fetchPublishedEntry = defaultFetchPublishedEntry,
+} = {}) {
+  if (typeof name !== "string" || name === "") throw new Error("checkPackageDrift: `name` is required");
+  const manifest = pkg ?? (await readManifest(path.join(root, dir ?? "", "package.json")));
+  if (manifest === null) return { packageBaseName: name, localVersion: null, status: "skipped", reason: `no manifest under ${dir}` };
+  const localVersion = typeof manifest.version === "string" ? manifest.version : null;
+
+  const published = await fetchPublishedVersion({ name });
+  if (published.version === null) {
+    return {
+      packageBaseName: name,
+      localVersion,
+      publishedVersion: null,
+      status: "skipped",
+      reason: `no published version — ${published.reason ?? "unknown"}`,
+    };
   }
-  return out;
+
+  const entries = entryTargets(manifest);
+  const added = [];
+  const opaqueEntries = [];
+  const skipped = [];
+  let localCount = 0;
+  let distCount = 0;
+  let compared = 0;
+
+  for (const [subpath, entryPath] of entries) {
+    if (subpath.includes("*") || entryPath.includes("*")) {
+      // A wildcard subpath (`"./*": "./dist/*.js"`) names a family, not a file.
+      // Enumerating it would mean walking the published tarball; say so rather
+      // than reporting the unresolvable path as a missing build.
+      skipped.push(`${subpath} (wildcard subpath — not enumerable)`);
+      continue;
+    }
+    let localSource;
+    try {
+      localSource = await readFile(path.join(root, dir ?? "", entryPath), "utf8");
+    } catch {
+      // The dist file the manifest promises is not there. Reported, never silent:
+      // a missing local build is the one state that could make drift look clean.
+      skipped.push(`${subpath} (local ${entryPath} missing — build first)`);
+      continue;
+    }
+    const remote = await fetchPublishedEntry({ name, version: published.version, entryPath });
+    if (remote.source === null) {
+      skipped.push(`${subpath} (published ${entryPath}: ${remote.reason ?? "unavailable"})`);
+      continue;
+    }
+    const result = compareEntry(localSource, remote.source);
+    compared += 1;
+    localCount += result.localCount;
+    distCount += result.distCount;
+    if (result.opaque) opaqueEntries.push(subpath);
+    for (const exportName of result.added) added.push(`${subpath}:${exportName}`);
+    if (result.opaque && result.drifted) added.push(`${subpath}:+${result.localCount - result.distCount} export line(s)`);
+  }
+
+  if (compared === 0) {
+    return {
+      packageBaseName: name,
+      localVersion,
+      publishedVersion: published.version,
+      status: "skipped",
+      reason: `no entry could be compared — ${skipped.join("; ") || "no exports"}`,
+    };
+  }
+
+  const drifted = added.length > 0;
+  const status = drifted ? (isLocalVersionAhead(localVersion, published.version) ? "pending-publish" : "drifted") : "ok";
+  return {
+    packageBaseName: name,
+    localVersion,
+    publishedVersion: published.version,
+    status,
+    localCount,
+    distCount,
+    added,
+    entriesCompared: compared,
+    ...(skipped.length > 0 ? { partialReason: skipped.join("; ") } : {}),
+    ...(opaqueEntries.length > 0 ? { opaqueEntries } : {}),
+  };
 }
 
-// Run checkPackageDrift against every auto-detected (or explicit)
-// @mulmobridge/* workspace dep. Returns one result per package.
-export async function checkWorkspaceDrift({
-  root = process.cwd(),
-  packageBaseNames,
-  installedRoot = DEFAULT_INSTALLED_ROOT,
-  srcRelative,
-  distRelative,
-  fetchPublishedSource,
-} = {}) {
-  const names = packageBaseNames ?? (await detectMulmobridgeDeps({ root }));
+/** Run `checkPackageDrift` across the discovered scan set (or an explicit list). */
+export async function checkWorkspaceDrift({ root = process.cwd(), packageNames, ...rest } = {}) {
+  const discovered = await discoverWorkspaceLibraries({ root });
+  const targets = packageNames === undefined ? discovered : discovered.filter((entry) => packageNames.includes(entry.name));
   const results = [];
-  for (const name of names) {
-    results.push(
-      await checkPackageDrift({
-        root,
-        packageBaseName: name,
-        installedRoot,
-        srcRelative,
-        distRelative,
-        ...(fetchPublishedSource ? { fetchPublishedSource } : {}),
-      }),
-    );
+  for (const target of targets) {
+    results.push(await checkPackageDrift({ root, name: target.name, dir: target.dir, pkg: target.pkg, ...rest }));
   }
   return results;
 }
 
-// One console line per result. Every status the audit can return needs its own
-// branch: `pending-publish` used to fall through to the `✓ … (src == published)`
-// line below, which says the opposite of what happened — the counts DIFFER, the
-// bump just means it is intentional. That line read as fully clean while
-// @mulmobridge/client sat bumped-but-unpublished, and the launcher release it
-// would have broken was caught by a hand-run loop instead (#3099).
 export function formatLine(result) {
-  const { packageBaseName, localVersion, publishedVersion, status, fallbackReason } = result;
+  const { packageBaseName, localVersion, publishedVersion, status } = result;
   const local = localVersion ? `v${localVersion}` : "(no local version)";
   const published = publishedVersion ? `→ published v${publishedVersion}` : "";
-  const fallback = fallbackReason ? ` [${fallbackReason}]` : "";
-  const counts = `src has ${result.localCount} value-export lines, published dist has ${result.distCount}`;
+  const partial = result.partialReason ? ` [partial: ${result.partialReason}]` : "";
+  const opaque = result.opaqueEntries ? ` [opaque: ${result.opaqueEntries.join(", ")}]` : "";
+  const counts = `local dist exports ${result.localCount} name(s), published ${result.distCount}`;
   if (status === "drifted") {
-    return `  ⚠ @mulmobridge/${packageBaseName} ${local} ${published}: ${counts}${fallback}`;
+    return `  ⚠ ${packageBaseName} ${local} ${published}: ${counts} — adds ${result.added.join(", ")}${partial}${opaque}`;
   }
   if (status === "pending-publish") {
-    return `  ⧗ @mulmobridge/${packageBaseName} ${local} ${published}: ${counts} — bumped but NOT published yet${fallback}`;
+    return `  ⧗ ${packageBaseName} ${local} ${published}: ${counts} — adds ${result.added.join(", ")}, bumped but NOT published yet${partial}${opaque}`;
   }
   if (status === "skipped") {
-    return `  · @mulmobridge/${packageBaseName} ${local}: skipped — ${result.reason}`;
+    return `  · ${packageBaseName} ${local}: skipped — ${result.reason}`;
   }
-  return `  ✓ @mulmobridge/${packageBaseName} ${local} ${published}: ${result.localCount} value-export lines (src == published)${fallback}`;
+  return `  ✓ ${packageBaseName} ${local} ${published}: ${result.localCount} export name(s) match across ${result.entriesCompared} entry(ies)${partial}${opaque}`;
 }
 
 /**
@@ -294,7 +391,7 @@ export function formatLine(result) {
  *
  * `pending-publish` is deliberately non-fatal on an ordinary PR — the version bump is the
  * developer's acknowledgement, and blocking would stop a PR that adds exports and bumps
- * correctly while the cascade publish is still pending (see the note on `isBumped` above).
+ * correctly while the cascade publish is still pending.
  *
  * At RELEASE time the same state is the blocker itself: a package bumped but not published
  * is a dependency range whose lower bound does not exist on the registry, so
@@ -309,14 +406,14 @@ export const failingStatuses = (release) => (release ? ["drifted", "pending-publ
 
 // CLI: exits 1 if any package drifted, 0 otherwise. "skipped"
 // results don't fail the check but are printed so the operator can
-// decide if they should retry after `yarn install`.
+// decide if they should retry after a build.
 export async function main({ release = false } = {}) {
   const results = await checkWorkspaceDrift();
   for (const result of results) console.log(formatLine(result));
   const fails = failingStatuses(release);
   const blocking = results.filter((result) => fails.includes(result.status));
   if (blocking.length === 0) {
-    console.log(`[mulmoclaude:drift] OK — no workspace drift detected${release ? ", and nothing is waiting to be published" : ""}.`);
+    console.log(`[mulmoclaude:drift] OK — no workspace drift across ${results.length} package(s)${release ? ", and nothing is waiting to be published" : ""}.`);
     return 0;
   }
   const pending = blocking.filter((result) => result.status === "pending-publish");

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -43,16 +43,48 @@ const REGISTRY_BASE = "https://registry.npmjs.org";
 const UNPKG_BASE = "https://unpkg.com";
 const REGISTRY_TIMEOUT_MS = 15_000;
 
-// Names a module exports, or `opaque: true` when the file re-exports a whole
-// module (`export * from "./chunk.js"`) and the set cannot be enumerated without
-// resolving that file — which is not possible for the published side without
-// downloading the whole tarball. An opaque entry falls back to line counting,
-// which is weaker but still catches a new re-export line.
+/** Statements that begin with `export`, with newlines inside a brace group
+ *  flattened so a wrapped list is one statement, and `;`-separated statements on
+ *  one line split apart. Parsing per LINE instead of per statement silently
+ *  returned zero names for both shapes, which reads as "nothing exported" and so
+ *  as "no drift" — the exact failure this gate exists to prevent. */
+export function exportStatements(source) {
+  const flattened = [];
+  let depth = 0;
+  for (const char of source) {
+    if (char === "{") depth += 1;
+    else if (char === "}") depth = depth > 0 ? depth - 1 : 0;
+    flattened.push(depth > 0 && (char === "\n" || char === "\r") ? " " : char);
+  }
+  const statements = [];
+  for (const line of flattened.join("").split("\n")) {
+    // Column 0 only. An indented `export` is not a module-level export in a built
+    // file — it is text inside a template literal, a comment, or a namespace — and
+    // counting it would invent names the package does not have.
+    if (!line.startsWith("export")) continue;
+    for (const piece of line.split(";")) {
+      const chunk = piece.trim();
+      // `export` must be a complete token — `exported = 1` is not an export — but
+      // anything else that IS one is kept even when it looks unparseable
+      // (`export/*c*/{a}`), because the parser marks what it cannot model opaque.
+      // Dropping it here instead would be a silent miss, which reads as "clean".
+      if (chunk.startsWith("export") && !/^export[\w$]/.test(chunk)) statements.push(chunk);
+    }
+  }
+  return statements;
+}
+
+// Names a module exports, or `opaque: true` when a statement re-exports a whole
+// module (`export * from "./chunk.js"`) or cannot be parsed at all. Opaque falls
+// back to line counting — weaker, but it FAILS CLOSED: an export shape nobody
+// anticipated shows up as a coarser comparison, never as an empty name set that
+// would pass as clean.
 export function parseExportedNames(source) {
   const names = new Set();
   let opaque = false;
   const IDENT = /^[A-Za-z_$][\w$]*/;
   const DECLARERS = new Set(["function", "function*", "class", "const", "let", "var"]);
+  const NO_NAME_FORMS = new Set(["type", "interface"]);
   const firstWord = (text) => {
     const cut = text.search(/[^\w$*]/);
     return cut === -1 ? text : text.slice(0, cut === 0 ? 1 : cut);
@@ -63,22 +95,34 @@ export function parseExportedNames(source) {
     if (spec === "" || spec.startsWith("type ")) return null;
     const parts = spec.split(/\s+/);
     const picked = parts.length >= 3 && parts[parts.length - 2] === "as" ? parts[parts.length - 1] : parts[0];
+    // `default` counts: a default-import consumer breaks the same way when the
+    // published tarball lacks it, which is the failure this gate exists for.
     const match = IDENT.exec(picked);
-    return match === null || match[0] === "default" ? null : match[0];
+    return match === null ? null : match[0];
   };
 
-  for (const line of source.split(/\r?\n/)) {
-    if (!line.startsWith("export")) continue;
-    let rest = line.slice("export".length);
-    if (rest !== "" && !/^[\s{*]/.test(rest)) continue; // `exported` etc., not a keyword
-    rest = rest.trim();
+  // The rule is INVERTED on purpose: these four shapes are what this parser claims
+  // to understand, and every other `export` statement is opaque. Three separate
+  // findings in one review were each "it silently drops <one more shape>" — a
+  // language always has one more way to say a thing than a ban-list will name, and
+  // a dropped statement reads as "nothing exported", i.e. as "no drift". This
+  // direction rejects some perfectly safe code into the coarser line-count
+  // comparison, which is the trade worth making for a release gate.
+  for (const statement of exportStatements(source)) {
+    let rest = statement.slice("export".length).trim();
     if (rest.startsWith("*")) {
       opaque = true;
       continue;
     }
     if (rest.startsWith("{")) {
       const close = rest.indexOf("}");
-      const body = close === -1 ? rest.slice(1) : rest.slice(1, close);
+      const body = close === -1 ? null : rest.slice(1, close);
+      // A brace that never closes, or one carrying a comment (whose text could hide
+      // or invent a name once newlines are flattened), is not a shape this models.
+      if (body === null || body.includes("//") || body.includes("/*")) {
+        opaque = true;
+        continue;
+      }
       for (const piece of body.split(",")) {
         const name = specifierName(piece);
         if (name !== null) names.add(name);
@@ -92,11 +136,19 @@ export function parseExportedNames(source) {
       rest = rest.slice(head.length).trim();
       head = firstWord(rest);
     }
-    if (head === "default" || head === "type" || head === "interface") continue;
-    if (!DECLARERS.has(head) && !(head === "function" || head === "function*")) continue;
-    const after = rest.slice(head.length).trim();
-    const match = IDENT.exec(after);
-    if (match !== null) names.add(match[0]);
+    if (head === "default") {
+      names.add("default");
+      continue;
+    }
+    if (NO_NAME_FORMS.has(head)) continue;
+    if (!DECLARERS.has(head)) {
+      // `export <something we do not model>` — fail closed rather than drop it.
+      opaque = true;
+      continue;
+    }
+    const match = IDENT.exec(rest.slice(head.length).trim());
+    if (match === null) opaque = true;
+    else names.add(match[0]);
   }
   return { names, opaque };
 }
@@ -318,6 +370,17 @@ export async function checkPackageDrift({
     }
     const remote = await fetchPublishedEntry({ name, version: published.version, entryPath });
     if (remote.source === null) {
+      // A 404 on a CONCRETE target means the published package does not serve this
+      // path at all — `import "pkg/new"` fails after a plain install. That is the
+      // drift, not a gap in the check, so it counts rather than being skipped.
+      // Transport failures (5xx, 429, timeouts) stay skipped: they say nothing
+      // about the package.
+      if ((remote.reason ?? "").includes("404")) {
+        added.push(`${subpath}:ENTIRE SUBPATH absent from the published package (${entryPath})`);
+        compared += 1;
+        localCount += parseExportedNames(localSource).names.size;
+        continue;
+      }
       skipped.push(`${subpath} (published ${entryPath}: ${remote.reason ?? "unavailable"})`);
       continue;
     }

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -89,16 +89,27 @@ export function parseExportedNames(source) {
     const cut = text.search(/[^\w$*]/);
     return cut === -1 ? text : text.slice(0, cut === 0 ? 1 : cut);
   };
-  // One name from a brace specifier: `a` -> a, `a as b` -> b, `type T` -> none.
-  const specifierName = (raw) => {
+  // One brace specifier. Three outcomes, because "no name" and "I cannot model
+  // this" must not look alike: `{ kind: "name" }`, `{ kind: "type" }` (skip, the
+  // set is still exact), `{ kind: "unmodelled" }` (the whole entry goes opaque).
+  //
+  // `default` counts as a name: a default-import consumer breaks the same way when
+  // the published tarball lacks it, which is the failure this gate exists for.
+  const specifierKind = (raw) => {
     const spec = raw.trim();
-    if (spec === "" || spec.startsWith("type ")) return null;
+    if (spec === "") return { kind: "type" };
+    if (spec.startsWith("type ")) return { kind: "type" };
+    // An arbitrary module namespace name (`a as "string name"`, ES2022) is a real
+    // export this parser cannot name, and a truncated guess would be worse than a
+    // coarse comparison.
+    if (spec.includes('"') || spec.includes("'")) return { kind: "unmodelled" };
     const parts = spec.split(/\s+/);
     const picked = parts.length >= 3 && parts[parts.length - 2] === "as" ? parts[parts.length - 1] : parts[0];
-    // `default` counts: a default-import consumer breaks the same way when the
-    // published tarball lacks it, which is the failure this gate exists for.
     const match = IDENT.exec(picked);
-    return match === null ? null : match[0];
+    // The identifier must be the WHOLE token. `café` matched `caf` under an
+    // ASCII-only pattern and reported a name the package does not export.
+    if (match === null || match[0] !== picked) return { kind: "unmodelled" };
+    return { kind: "name", name: match[0] };
   };
 
   // The rule is INVERTED on purpose: these four shapes are what this parser claims
@@ -124,8 +135,9 @@ export function parseExportedNames(source) {
         continue;
       }
       for (const piece of body.split(",")) {
-        const name = specifierName(piece);
-        if (name !== null) names.add(name);
+        const spec = specifierKind(piece);
+        if (spec.kind === "name") names.add(spec.name);
+        else if (spec.kind === "unmodelled") opaque = true;
       }
       continue;
     }
@@ -146,8 +158,15 @@ export function parseExportedNames(source) {
       opaque = true;
       continue;
     }
-    const match = IDENT.exec(rest.slice(head.length).trim());
-    if (match === null) opaque = true;
+    const declared = rest.slice(head.length).trim();
+    const match = IDENT.exec(declared);
+    // The identifier must END where a declaration's name legitimately can — the
+    // boundary is a permit-list for the same reason the statement shapes are. An
+    // ASCII-only pattern truncated `café` to `caf` and reported a name the package
+    // does not export; anything but one of these characters means "not a shape this
+    // models", so the entry goes opaque rather than carrying a guess.
+    const after = match === null ? "" : declared.slice(match[0].length);
+    if (match === null || !(after === "" || /^[\s=(;:,<{)]/.test(after))) opaque = true;
     else names.add(match[0]);
   }
   return { names, opaque };

--- a/scripts/mulmoclaude/drift.mjs
+++ b/scripts/mulmoclaude/drift.mjs
@@ -189,22 +189,40 @@ export function countValueExportLines(source) {
   return count;
 }
 
-/** The `exports` subpaths of a manifest, mapped to the file each one serves.
- *  Falls back to `module` / `main` / `dist/index.js` for a package with no
- *  `exports` map, which is what the single-entry packages relied on. */
+/** The runtime target of one `exports` value, descending through condition objects
+ *  (`{ node: { import: "./a.js" } }`) in the order a bundler would. Returns null
+ *  when no string target can be resolved — a types-only or unrecognised condition
+ *  block is reported as unresolved, never replaced with a guess: falling back to
+ *  `main` per subpath made a `{ types: "./x.d.ts" }` entry compare `dist/index.js`,
+ *  which is a different file's export surface. */
+export function resolveConditionTarget(value, depth = 0) {
+  if (typeof value === "string") return value.replace(/^\.\/+/, "");
+  if (depth >= 8 || value === null || typeof value !== "object") return null;
+  for (const condition of ["import", "module", "default", "require", "node", "browser"]) {
+    if (!(condition in value)) continue;
+    const resolved = resolveConditionTarget(value[condition], depth + 1);
+    if (resolved !== null) return resolved;
+  }
+  return null;
+}
+
+/** Every `exports` subpath mapped to its runtime target, or to null when the
+ *  target cannot be resolved. A package with no `exports` map at all falls back to
+ *  `module` / `main` / `dist/index.js` for `.` — that fallback is for the WHOLE
+ *  package, never for an individual subpath. */
 export function entryTargets(pkg) {
   const out = new Map();
   const exp = pkg?.exports;
   if (exp !== null && typeof exp === "object") {
-    for (const [subpath, value] of Object.entries(exp)) {
-      const target = typeof value === "string" ? value : (value?.import ?? value?.default ?? value?.require ?? null);
-      if (typeof target === "string") out.set(subpath, target.replace(/^\.\/+/, ""));
-    }
+    for (const [subpath, value] of Object.entries(exp)) out.set(subpath, resolveConditionTarget(value));
+    return out;
   }
-  if (out.size === 0) {
-    const target = pkg?.module ?? pkg?.main ?? "dist/index.js";
-    out.set(".", String(target).replace(/^\.\/+/, ""));
+  if (typeof exp === "string") {
+    out.set(".", exp.replace(/^\.\/+/, ""));
+    return out;
   }
+  const target = pkg?.module ?? pkg?.main ?? "dist/index.js";
+  out.set(".", String(target).replace(/^\.\/+/, ""));
   return out;
 }
 
@@ -297,12 +315,18 @@ export async function defaultFetchPublishedEntry({ name, version, entryPath, tim
 export function compareEntry(localSource, publishedSource) {
   const local = parseExportedNames(localSource);
   const published = parseExportedNames(publishedSource);
-  if (local.opaque || published.opaque) {
-    const localCount = countValueExportLines(localSource);
-    const distCount = countValueExportLines(publishedSource);
-    return { added: [], localCount, distCount, opaque: true, drifted: localCount > distCount };
-  }
   const added = [...local.names].filter((name) => !published.names.has(name)).sort();
+  if (local.opaque || published.opaque) {
+    // The names this parser DID extract are still exact, so they are compared as
+    // usual; the line count is an ADDITIONAL signal for the part it could not
+    // name. Replacing the comparison with the line count alone let
+    // `export * from "./x.js";export { newThing };` read as clean against
+    // `export * from "./x.js";` — one line on both sides, and the added name
+    // discarded.
+    const localLines = countValueExportLines(localSource);
+    const distLines = countValueExportLines(publishedSource);
+    return { added, localCount: localLines, distCount: distLines, opaque: true, drifted: added.length > 0 || localLines > distLines };
+  }
   return { added, localCount: local.names.size, distCount: published.names.size, opaque: false, drifted: added.length > 0 };
 }
 
@@ -371,6 +395,12 @@ export async function checkPackageDrift({
   let compared = 0;
 
   for (const [subpath, entryPath] of entries) {
+    if (entryPath === null) {
+      // No string target behind this subpath's condition block. Say so; do not
+      // substitute another file and compare that instead.
+      skipped.push(`${subpath} (no runtime target resolved from its exports conditions)`);
+      continue;
+    }
     if (!/\.(?:js|mjs|cjs)$/.test(entryPath)) {
       // A `./style.css` or `./package.json` entry carries no export surface this
       // metric can speak about, and counting it as a successful comparison is

--- a/test/scripts/mulmoclaude/fixtures/drift-clean/installed_packages/@mulmobridge/protocol/_dist/index.js
+++ b/test/scripts/mulmoclaude/fixtures/drift-clean/installed_packages/@mulmobridge/protocol/_dist/index.js
@@ -1,4 +1,0 @@
-// Published dist snapshot — 3 value-export lines. Same count as src.
-export { EVENT_TYPES, GENERATION_KINDS, generationKey } from "./events.js";
-export { CHAT_SOCKET_PATH, CHAT_SOCKET_EVENTS } from "./socket.js";
-export { CHAT_SERVICE_ROUTES } from "./routes.js";

--- a/test/scripts/mulmoclaude/fixtures/drift-clean/packages/mulmoclaude/package.json
+++ b/test/scripts/mulmoclaude/fixtures/drift-clean/packages/mulmoclaude/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "mulmoclaude-fixture-drift-clean",
-  "version": "0.0.0",
-  "dependencies": {
-    "@mulmobridge/protocol": "^0.1.0"
-  }
-}

--- a/test/scripts/mulmoclaude/fixtures/drift-clean/packages/protocol/package.json
+++ b/test/scripts/mulmoclaude/fixtures/drift-clean/packages/protocol/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@mulmobridge/protocol",
-  "version": "0.1.3"
-}

--- a/test/scripts/mulmoclaude/fixtures/drift-clean/packages/protocol/src/index.ts
+++ b/test/scripts/mulmoclaude/fixtures/drift-clean/packages/protocol/src/index.ts
@@ -1,8 +1,0 @@
-// 3 value-export lines, 1 type-only re-export, 1 `export type` line.
-// count should equal the published dist below: 3.
-
-export { EVENT_TYPES, type EventType, GENERATION_KINDS, type GenerationKind, generationKey } from "./events";
-export { CHAT_SOCKET_PATH, CHAT_SOCKET_EVENTS, type ChatSocketEvent } from "./socket";
-export { type Attachment } from "./attachment";
-export { CHAT_SERVICE_ROUTES } from "./routes";
-export type { ExtraType } from "./extra";

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/installed_packages/@mulmobridge/client/_dist/index.js
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/installed_packages/@mulmobridge/client/_dist/index.js
@@ -1,1 +1,0 @@
-export { createBridgeClient } from "./client.js";

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/installed_packages/@mulmobridge/protocol/_dist/index.js
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/installed_packages/@mulmobridge/protocol/_dist/index.js
@@ -1,3 +1,0 @@
-// Published dist snapshot — 2 value-export lines. Local src has 3.
-export { EVENT_TYPES, generationKey } from "./events.js";
-export { CHAT_SOCKET_PATH } from "./socket.js";

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/client/package.json
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/client/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@mulmobridge/client",
-  "version": "0.1.2"
-}

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/client/src/index.ts
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/client/src/index.ts
@@ -1,3 +1,0 @@
-// Non-drifted sibling: src and dist have the same count. The
-// multi-package test asserts we only flag the one that drifted.
-export { createBridgeClient } from "./client";

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/mulmoclaude/package.json
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/mulmoclaude/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "mulmoclaude-fixture-drift-drifted",
-  "version": "0.0.0",
-  "dependencies": {
-    "@mulmobridge/protocol": "^0.1.0",
-    "@mulmobridge/client": "^0.1.0",
-    "express": "^5.0.0"
-  }
-}

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/protocol/package.json
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/protocol/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@mulmobridge/protocol",
-  "version": "0.1.3"
-}

--- a/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/protocol/src/index.ts
+++ b/test/scripts/mulmoclaude/fixtures/drift-drifted/packages/protocol/src/index.ts
@@ -1,7 +1,0 @@
-// 3 value-export lines in src. Published dist (one file over in
-// node_modules/) only has 2 — the third line was added here without
-// a version bump. This is the DRIFT scenario.
-
-export { EVENT_TYPES, generationKey } from "./events";
-export { CHAT_SOCKET_PATH } from "./socket";
-export { BRAND_NEW_UNPUBLISHED } from "./newThing";

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -1,411 +1,277 @@
-// Unit tests for scripts/mulmoclaude/drift.mjs — the JS port of
-// SKILL.md §2 workspace-drift check. Covers the pure line counter,
-// the per-package audit against filesystem fixtures, and the
-// auto-detection step that reads packages/mulmoclaude/package.json.
+// Unit tests for scripts/mulmoclaude/drift.mjs — the publish-drift gate.
+//
+// The shape under test changed in #3116: the gate used to compare the local
+// `src/index.ts` against the published dist and count LINES, over the four
+// `@mulmobridge/*` packages the launcher depends on. Each of those three choices
+// was wrong in a way that let real drift through, so the tests below pin the new
+// ones: local BUILT dist vs published dist, counted as NAMES, over every
+// publishable workspace another workspace declares.
 
-import { describe, it } from "node:test";
+import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import * as drift from "../../../scripts/mulmoclaude/drift.mjs";
 
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-const FIXTURES = path.join(HERE, "fixtures");
-
-// Most tests want to exercise the local-fixture fallback rather
-// than the real registry. Pass this stub to force the fallback
-// branch (registry "unreachable") and let the existing fixtures
-// under installed_packages/.../\_dist/ drive the comparison.
-const offlineRegistry = async () => ({ version: null, source: null, reason: "test stub — skip registry" });
-
-// Stub returning a specific source, used by the new drifted-from-
-// published tests below.
-function registryReturning(source: string, version = "0.0.0-stub") {
-  return async () => ({ version, source, reason: null });
-}
-
-describe("countValueExportLines", () => {
-  it("counts plain re-export lines", () => {
-    const source = `export { foo } from "./foo";\nexport { bar } from "./bar";\n`;
-    assert.equal(drift.countValueExportLines(source), 2);
+describe("parseExportedNames", () => {
+  it("reads a brace re-export, including renames", () => {
+    const { names, opaque } = drift.parseExportedNames(`export { a, b as c } from "./x.js";\n`);
+    assert.deepEqual([...names].sort(), ["a", "c"]);
+    assert.equal(opaque, false);
   });
 
-  it("counts a mixed value+type brace as ONE line (value-bearing)", () => {
-    // `EVENT_TYPES` is a runtime binding, so the line counts even
-    // though it also lists some types. Matches the skill's shell
-    // regex behaviour exactly.
-    const source = `export { EVENT_TYPES, type EventType, generationKey } from "./events";\n`;
-    assert.equal(drift.countValueExportLines(source), 1);
+  it("reads declarations", () => {
+    const source = "export function f() {}\nexport const g = 1;\nexport class H {}\nexport async function i() {}\nexport let j;\n";
+    assert.deepEqual([...drift.parseExportedNames(source).names].sort(), ["f", "g", "H", "i", "j"].sort());
   });
 
-  it("excludes `export type` lines", () => {
-    const source = `export type Foo = number;\nexport type { Bar } from "./bar";\n`;
-    assert.equal(drift.countValueExportLines(source), 0);
+  it("counts every name on ONE line — the case line counting cannot see", () => {
+    // `@mulmoclaude/x-plugin`'s entire published surface is this single line, so
+    // a seventh name added here does not move a line count at all.
+    const source = "export { extractTweetId, formatTweet, readUrlArg, readXPost, searchX, tweetBody };\n";
+    assert.equal(drift.parseExportedNames(source).names.size, 6);
   });
 
-  it("excludes `export interface` lines", () => {
-    const source = `export interface Foo { x: number; }\n`;
-    assert.equal(drift.countValueExportLines(source), 0);
+  it("ignores type-only exports and `default`", () => {
+    const source = "export type Foo = string;\nexport interface Bar {}\nexport { type Baz } from './b.js';\nexport default thing;\n";
+    assert.deepEqual([...drift.parseExportedNames(source).names], []);
   });
 
-  it("excludes `export { type Foo }` brace-type-only lines", () => {
-    const source = `export { type Attachment } from "./attachment";\n`;
-    assert.equal(drift.countValueExportLines(source), 0);
+  it("marks `export * from` opaque — the set cannot be enumerated from this file alone", () => {
+    const { names, opaque } = drift.parseExportedNames(`export * from "./chunk.js";\nexport const visible = 1;\n`);
+    assert.equal(opaque, true);
+    assert.deepEqual([...names], ["visible"]);
   });
 
-  it("includes `export { type Foo }` when the brace also has runtime bindings", () => {
-    const source = `export { type Attachment, saveAttachment } from "./attachment";\n`;
-    // Brace starts with `type`, so the skill's heuristic strips it.
-    // We match the skill — this is an intentional false negative
-    // that favours consistency with the existing pipeline.
-    assert.equal(drift.countValueExportLines(source), 0);
-  });
-
-  it("handles CRLF line endings", () => {
-    const source = 'export { a } from "./a";\r\nexport { b } from "./b";\r\n';
-    assert.equal(drift.countValueExportLines(source), 2);
-  });
-
-  it("ignores indented `export` (only top-level counts)", () => {
-    // TypeScript namespaces and conditional blocks emit nested
-    // `export` tokens that aren't module-level exports.
-    const source = `namespace NS {\n  export const x = 1;\n}\n`;
-    assert.equal(drift.countValueExportLines(source), 0);
-  });
-
-  it("returns 0 for empty / no-export files", () => {
-    assert.equal(drift.countValueExportLines(""), 0);
-    assert.equal(drift.countValueExportLines("const x = 1;\n"), 0);
+  it("ignores indented exports (only module-level counts)", () => {
+    assert.equal(drift.parseExportedNames("  export const inner = 1;\n").names.size, 0);
   });
 });
 
-describe("checkPackageDrift", () => {
-  it("reports ok when src and dist line counts match", async () => {
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-clean"),
-      packageBaseName: "protocol",
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(result.status, "ok");
-    assert.equal(result.localCount, 3);
-    assert.equal(result.distCount, 3);
-    assert.equal(result.localVersion, "0.1.3");
+describe("entryTargets", () => {
+  it("maps every exports subpath to its file", () => {
+    const pkg = { exports: { ".": { import: "./dist/index.js" }, "./server": "./dist/server.js" } };
+    assert.deepEqual(
+      [...drift.entryTargets(pkg)],
+      [
+        [".", "dist/index.js"],
+        ["./server", "dist/server.js"],
+      ],
+    );
   });
 
-  it("flags drift when src has more value-export lines than dist", async () => {
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-drifted"),
-      packageBaseName: "protocol",
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(result.status, "drifted");
-    assert.equal(result.localCount, 3);
-    assert.equal(result.distCount, 2);
-  });
-
-  it("returns ok for a sibling package that didn't drift", async () => {
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-drifted"),
-      packageBaseName: "client",
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(result.status, "ok");
-    assert.equal(result.localCount, 1);
-    assert.equal(result.distCount, 1);
-  });
-
-  it("skips (not fails) when the installed dist is missing", async () => {
-    // drift-clean has protocol but not, say, chat-service. Missing
-    // node_modules entry must NOT be a hard error — tests run
-    // without a full yarn install on the fixture tree.
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-clean"),
-      packageBaseName: "chat-service",
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(result.status, "skipped");
-    assert.match(result.reason ?? "", /src not found|dist not found/);
-  });
-
-  it("throws when packageBaseName is missing", async () => {
-    await assert.rejects(drift.checkPackageDrift({ root: FIXTURES }), /packageBaseName is required/);
-  });
-
-  it("flags drift against the registry-published source (workspace-symlink aware)", async () => {
-    // drift-clean's protocol src has 3 value-export lines. The
-    // stub registry returns a dist with only 2 lines — what
-    // would ship to users after an install-from-registry. Drift
-    // must flag this even though the local workspace dist would
-    // otherwise match src.
-    const publishedOldDist = `export { a } from "./a.js";\nexport { b } from "./b.js";\n`;
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-clean"),
-      packageBaseName: "protocol",
-      // drift-clean/packages/protocol/package.json is 0.1.3 — match it
-      // so the version compare resolves to "equal" (= not bumped).
-      fetchPublishedSource: registryReturning(publishedOldDist, "0.1.3"),
-    });
-    assert.equal(result.status, "drifted");
-    assert.equal(result.localCount, 3);
-    assert.equal(result.distCount, 2);
-    assert.equal(result.publishedVersion, "0.1.3");
-    assert.equal(result.fallbackReason, undefined, "must not use local fallback when registry succeeded");
-  });
-
-  it("downgrades drift to 'pending-publish' when local version is ahead of registry", async () => {
-    // Same shape as the drifted test above, but the registry stub
-    // reports an OLDER version than what's in the local
-    // package.json. That means the developer has already bumped
-    // the workspace version to acknowledge the new exports — the
-    // cascade publish just hasn't landed yet. Smoke should let
-    // the PR through.
-    const publishedOldDist = `export { a } from "./a.js";\nexport { b } from "./b.js";\n`;
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-clean"),
-      packageBaseName: "protocol",
-      fetchPublishedSource: registryReturning(publishedOldDist, "0.1.2"),
-    });
-    assert.equal(result.status, "pending-publish");
-    assert.equal(result.localCount, 3);
-    assert.equal(result.distCount, 2);
-    assert.equal(result.localVersion, "0.1.3");
-    assert.equal(result.publishedVersion, "0.1.2");
-  });
-
-  it("falls back to local installed dist when the registry fetch returns no source", async () => {
-    const result = await drift.checkPackageDrift({
-      root: path.join(FIXTURES, "drift-clean"),
-      packageBaseName: "protocol",
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(result.status, "ok");
-    assert.match(result.fallbackReason ?? "", /registry unreachable/);
+  it("falls back to module / main when there is no exports map", () => {
+    assert.deepEqual([...drift.entryTargets({ main: "./dist/entry.js" })], [[".", "dist/entry.js"]]);
+    assert.deepEqual([...drift.entryTargets({})], [[".", "dist/index.js"]]);
   });
 });
 
-/**
- * What the operator actually reads.
- *
- * `pending-publish` used to fall through to the `✓ … (src == published)` branch,
- * so a package that was bumped but never published printed as fully clean — and
- * the one number it showed was the LOCAL count, so the published side never
- * appeared at all. That line was on screen during the 1.16.0 release while
- * `@mulmobridge/client` sat at 1.1.0 with 1.0.2 on npm (#3099).
- *
- * These assert the EXACT line, built from the fixture. That is the opposite of
- * where this started — the first version asserted properties, on the reasoning
- * that pinning the sentence goes red on a reword. Four review rounds then found
- * four different wrong formatters that satisfied properties: labels swapped, the
- * fixture pair hard-coded, a swap with the correct counts appended, and ` EXTRA`
- * on the two statuses checked loosely. Presence can always be satisfied by adding
- * text, so the property rule had no last case. Going red on a reword is the price,
- * and it is the right one here: these lines are what an operator reads to decide
- * whether publishing is safe.
- */
-describe("formatLine", () => {
-  const result = (status: drift.PackageDriftResult["status"], extra: Record<string, unknown> = {}) => ({
-    packageBaseName: "client",
-    localVersion: "1.1.0",
-    publishedVersion: "1.0.2",
-    status,
-    // Asymmetric, and neither digit appears in the versions above — so a regex can tie
-    // each count to its own side of the line without matching "v1.1.0" by accident.
-    localCount: 17,
-    distCount: 4,
-    ...extra,
+describe("compareEntry", () => {
+  it("reports the names the local build adds", () => {
+    const result = drift.compareEntry("export { a, b };\n", "export { a };\n");
+    assert.deepEqual(result.added, ["b"]);
+    assert.equal(result.drifted, true);
   });
 
-  it("renders every status the audit can return", () => {
-    const statuses: drift.PackageDriftResult["status"][] = ["ok", "drifted", "pending-publish", "skipped"];
-    statuses.forEach((status) => {
-      const line = drift.formatLine(result(status, { reason: "no dist" }));
-      assert.match(line, /client/, `${status} names the package`);
-    });
+  it("is clean when the same names are spelled differently", () => {
+    const result = drift.compareEntry("export const a = 1;\nexport const b = 2;\n", "export { a, b };\n");
+    assert.deepEqual(result.added, []);
+    assert.equal(result.drifted, false);
   });
 
-  it("renders EXACTLY these lines — every status, with and without the fallback note", () => {
-    // Four rounds, four wrong formatters that satisfied a presence-based property: labels
-    // swapped, the fixture pair hard-coded, a swap with the correct counts appended as a
-    // suffix, and ` EXTRA` tacked onto the two statuses this test used to check loosely.
-    // Presence can ALWAYS be satisfied by adding more text, so enumerating those is a
-    // queue rather than a rule. This states what is PERMITTED — the exact line, for every
-    // status, with the expected string BUILT FROM the fixture so a hard-coded formatter
-    // fails it too (#3101 rounds 1-4).
-    //
-    // It DELIBERATELY goes red on a reworded message. These are the lines an operator
-    // reads to decide whether publishing is safe; rewording one should be a decision, not
-    // a side effect of an unrelated edit.
-    // Two identities as well as three count pairs: varying only the counts left the
-    // package/version head hard-codeable, which is round 2's finding in a different field
-    // (#3101 round 5). Every field the line interpolates is now varied.
-    const identities = [
-      { packageBaseName: "client", localVersion: "1.1.0", publishedVersion: "1.0.2" },
-      { packageBaseName: "protocol", localVersion: "2.0.0", publishedVersion: "1.9.4" },
-    ];
-    const pairs = [
-      { localCount: 17, distCount: 4 },
-      { localCount: 9, distCount: 8 },
-      { localCount: 231, distCount: 5 },
-    ];
-    const note = "registry unreachable";
-    const cases = identities.flatMap((identity) => pairs.map((pair) => ({ ...identity, ...pair })));
-    cases.forEach(({ packageBaseName, localVersion, publishedVersion, localCount, distCount }) => {
-      const identity = { packageBaseName, localVersion, publishedVersion };
-      const head = `@mulmobridge/${packageBaseName} v${localVersion} → published v${publishedVersion}`;
-      const counts = `src has ${localCount} value-export lines, published dist has ${distCount}`;
-      const expected: Record<string, string> = {
-        "pending-publish": `  ⧗ ${head}: ${counts} — bumped but NOT published yet`,
-        drifted: `  ⚠ ${head}: ${counts}`,
-        ok: `  ✓ ${head}: ${localCount} value-export lines (src == published)`,
-      };
-      Object.entries(expected).forEach(([status, line]) => {
-        const shape = { ...identity, localCount, distCount };
-        assert.equal(drift.formatLine(result(status as drift.PackageDriftResult["status"], shape)), line, status);
-        assert.equal(
-          drift.formatLine(result(status as drift.PackageDriftResult["status"], { ...shape, fallbackReason: note })),
-          `${line} [${note}]`,
-          `${status} + fallback`,
-        );
-      });
-    });
-
-    // `skipped` is the odd one out by design: no counts, no published version, no
-    // fallback note — it is the branch that ran before any of those were resolved.
-    identities.forEach(({ packageBaseName, localVersion, publishedVersion }) => {
-      const skipped = result("skipped", { packageBaseName, localVersion, publishedVersion, reason: "local src not found" });
-      assert.equal(drift.formatLine(skipped), `  · @mulmobridge/${packageBaseName} v${localVersion}: skipped — local src not found`);
-    });
-  });
-});
-
-/**
- * Which verdicts stop the run, and when.
- *
- * `pending-publish` is deliberately non-fatal on an ordinary PR — the bump is the
- * developer's acknowledgement and blocking would stop a PR that did the right thing while
- * the cascade publish is still pending. At RELEASE time the same state is the blocker
- * itself: the declared range's lower bound is not on the registry, so
- * `npx mulmoclaude@<next>` fails with ETARGET. That is what happened on 1.16.0, and only a
- * hand-run shell loop caught it (#3099).
- *
- * So the property is not "pending-publish fails" or "pending-publish passes" — it is that
- * the SAME verdict answers differently depending on the flag.
- */
-describe("failingStatuses", () => {
-  it("fails only on drift for an ordinary run", () => {
-    assert.deepEqual(drift.failingStatuses(false), ["drifted"]);
+  it("does not call a REMOVED export drift — that is a different problem", () => {
+    const result = drift.compareEntry("export { a };\n", "export { a, b };\n");
+    assert.deepEqual(result.added, []);
+    assert.equal(result.drifted, false);
   });
 
-  it("also fails on pending-publish at release time", () => {
-    assert.deepEqual(drift.failingStatuses(true), ["drifted", "pending-publish"]);
-  });
-
-  it("treats pending-publish differently BETWEEN the two — the whole point of the flag", () => {
-    assert.equal(drift.failingStatuses(false).includes("pending-publish"), false);
-    assert.equal(drift.failingStatuses(true).includes("pending-publish"), true);
-  });
-
-  it("never lets a release run pass something an ordinary run would fail", () => {
-    const ordinary = drift.failingStatuses(false);
-    const release = drift.failingStatuses(true);
-    ordinary.forEach((status) => assert.ok(release.includes(status), `${status} must still fail at release time`));
-  });
-
-  it("leaves ok and skipped passing in both modes", () => {
-    [false, true].forEach((release) => {
-      const failing = drift.failingStatuses(release);
-      assert.equal(failing.includes("ok"), false, `ok passes (release=${release})`);
-      assert.equal(failing.includes("skipped"), false, `skipped passes (release=${release})`);
-    });
+  it("falls back to line counting when either side is opaque", () => {
+    const result = drift.compareEntry(`export * from "./x.js";\nexport { a };\n`, `export * from "./x.js";\n`);
+    assert.equal(result.opaque, true);
+    assert.equal(result.drifted, true);
   });
 });
 
 describe("isLocalVersionAhead", () => {
-  it("returns true when any component is strictly greater", () => {
-    assert.equal(drift.isLocalVersionAhead("0.1.3", "0.1.2"), true);
-    assert.equal(drift.isLocalVersionAhead("0.2.0", "0.1.99"), true);
-    assert.equal(drift.isLocalVersionAhead("1.0.0", "0.99.99"), true);
+  it("compares numerically, not lexically", () => {
+    assert.equal(drift.isLocalVersionAhead("1.10.0", "1.9.0"), true);
+    assert.equal(drift.isLocalVersionAhead("1.9.0", "1.10.0"), false);
+    assert.equal(drift.isLocalVersionAhead("1.2.3", "1.2.3"), false);
   });
 
-  it("returns false when versions are equal or local is behind", () => {
-    assert.equal(drift.isLocalVersionAhead("0.1.2", "0.1.2"), false);
-    assert.equal(drift.isLocalVersionAhead("0.1.2", "0.1.3"), false);
-    assert.equal(drift.isLocalVersionAhead("0.1.2", "0.2.0"), false);
-  });
-
-  it("ignores prerelease / build suffixes", () => {
-    // Treating "0.1.3-rc.1" as "0.1.3" is intentional — any
-    // prerelease of a bumped version still counts as a deliberate
-    // bump for the drift check.
-    assert.equal(drift.isLocalVersionAhead("0.1.3-rc.1", "0.1.2"), true);
-    assert.equal(drift.isLocalVersionAhead("0.1.3+build.5", "0.1.3"), false);
-  });
-
-  it("returns false for malformed / missing input", () => {
-    assert.equal(drift.isLocalVersionAhead("", "0.1.2"), false);
-    assert.equal(drift.isLocalVersionAhead("0.1", "0.1.2"), false);
-    assert.equal(drift.isLocalVersionAhead("abc", "0.1.2"), false);
-    assert.equal(drift.isLocalVersionAhead(null, "0.1.2"), false);
-    assert.equal(drift.isLocalVersionAhead("0.1.2", undefined), false);
+  it("errs strict on malformed input", () => {
+    assert.equal(drift.isLocalVersionAhead("next", "1.0.0"), false);
+    assert.equal(drift.isLocalVersionAhead(null, "1.0.0"), false);
+    assert.equal(drift.isLocalVersionAhead("1.0.0", undefined), false);
   });
 });
 
-describe("detectMulmobridgeDeps", () => {
-  it("returns only bridge deps that also have a local workspace", async () => {
-    // drift-drifted declares @mulmobridge/protocol + @mulmobridge/client
-    // + express. Only the first two have a packages/<name>/ dir, so
-    // only those two should be returned (express is not a bridge).
-    const names = await drift.detectMulmobridgeDeps({
-      root: path.join(FIXTURES, "drift-drifted"),
-    });
-    assert.deepEqual(names.sort(), ["client", "protocol"]);
+describe("checkPackageDrift — against a fake workspace and a stubbed registry", () => {
+  let root = "";
+
+  const writeWorkspace = (name: string, dir: string, version: string, distByPath: Record<string, string>, exportsMap?: unknown): void => {
+    mkdirSync(path.join(root, dir, "dist"), { recursive: true });
+    writeFileSync(
+      path.join(root, dir, "package.json"),
+      JSON.stringify({ name, version, ...(exportsMap === undefined ? { main: "./dist/index.js" } : { exports: exportsMap }) }),
+    );
+    for (const [rel, source] of Object.entries(distByPath)) {
+      mkdirSync(path.join(root, dir, path.dirname(rel)), { recursive: true });
+      writeFileSync(path.join(root, dir, rel), source);
+    }
+  };
+
+  const published = (version: string, byPath: Record<string, string>) => ({
+    fetchPublishedVersion: async () => ({ version, reason: null }),
+    fetchPublishedEntry: async ({ entryPath }: { entryPath: string }) => {
+      const source = byPath[entryPath];
+      return source === undefined ? { source: null, reason: "unpkg 404" } : { source, reason: null };
+    },
   });
 
-  it("returns empty when the launcher has no bridge deps", async () => {
-    // drift-clean only declares one bridge; assert that handle:
-    const names = await drift.detectMulmobridgeDeps({
-      root: path.join(FIXTURES, "drift-clean"),
+  before(() => {
+    root = mkdtempSync(path.join(tmpdir(), "drift-"));
+  });
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("flags a new export at an unchanged version", async () => {
+    writeWorkspace("@scope/a", "packages/a", "1.0.0", { "dist/index.js": "export { one, two };\n" });
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/a",
+      dir: "packages/a",
+      ...published("1.0.0", { "dist/index.js": "export { one };\n" }),
     });
-    assert.deepEqual(names, ["protocol"]);
+    assert.equal(result.status, "drifted");
+    assert.deepEqual(result.added, [".:two"]);
+  });
+
+  it("downgrades to pending-publish once the version is bumped", async () => {
+    writeWorkspace("@scope/b", "packages/b", "1.1.0", { "dist/index.js": "export { one, two };\n" });
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/b",
+      dir: "packages/b",
+      ...published("1.0.0", { "dist/index.js": "export { one };\n" }),
+    });
+    assert.equal(result.status, "pending-publish");
+  });
+
+  it("is clean when the built surfaces match, whatever the source looked like", async () => {
+    // The bundled case: one line locally, one line published, same six names.
+    const bundled = "export { a, b, c, d, e, f };\n";
+    writeWorkspace("@scope/c", "packages/c", "1.0.0", { "dist/index.js": bundled });
+    const result = await drift.checkPackageDrift({ root, name: "@scope/c", dir: "packages/c", ...published("1.0.0", { "dist/index.js": bundled }) });
+    assert.equal(result.status, "ok");
+    assert.equal(result.localCount, 6);
+  });
+
+  it("checks EVERY exports subpath, not just the root one", async () => {
+    writeWorkspace(
+      "@scope/d",
+      "packages/d",
+      "1.0.0",
+      { "dist/index.js": "export { root };\n", "dist/server.js": "export { server, extra };\n" },
+      { ".": "./dist/index.js", "./server": "./dist/server.js" },
+    );
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/d",
+      dir: "packages/d",
+      ...published("1.0.0", { "dist/index.js": "export { root };\n", "dist/server.js": "export { server };\n" }),
+    });
+    assert.equal(result.status, "drifted");
+    assert.deepEqual(result.added, ["./server:extra"]);
+    assert.equal(result.entriesCompared, 2);
+  });
+
+  it("skips — never passes — when the local dist is missing", async () => {
+    writeWorkspace("@scope/e", "packages/e", "1.0.0", {});
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/e",
+      dir: "packages/e",
+      ...published("1.0.0", { "dist/index.js": "export { one };\n" }),
+    });
+    assert.equal(result.status, "skipped");
+    assert.match(result.reason ?? "", /build first/);
+  });
+
+  it("skips a wildcard subpath with a reason rather than calling it a missing build", async () => {
+    writeWorkspace("@scope/f", "packages/f", "1.0.0", { "dist/index.js": "export { one };\n" }, { ".": "./dist/index.js", "./*": "./dist/*.js" });
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/f",
+      dir: "packages/f",
+      ...published("1.0.0", { "dist/index.js": "export { one };\n" }),
+    });
+    assert.equal(result.status, "ok");
+    assert.match(result.partialReason ?? "", /wildcard subpath/);
+  });
+
+  it("skips when the package is not on the registry", async () => {
+    writeWorkspace("@scope/g", "packages/g", "1.0.0", { "dist/index.js": "export { one };\n" });
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/g",
+      dir: "packages/g",
+      fetchPublishedVersion: async () => ({ version: null, reason: "registry 404" }),
+    });
+    assert.equal(result.status, "skipped");
+    assert.match(result.reason ?? "", /registry 404/);
+  });
+
+  it("throws when the name is missing", async () => {
+    await assert.rejects(() => drift.checkPackageDrift({ root, dir: "packages/a" }), /name` is required/);
   });
 });
 
-describe("checkWorkspaceDrift (auto-detection)", () => {
-  it("runs per-package checks across auto-detected deps", async () => {
-    const results = await drift.checkWorkspaceDrift({
-      root: path.join(FIXTURES, "drift-drifted"),
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(results.length, 2);
-    const protocolResult = results.find((row) => row.packageBaseName === "protocol");
-    const clientResult = results.find((row) => row.packageBaseName === "client");
-    assert.equal(protocolResult?.status, "drifted");
-    assert.equal(clientResult?.status, "ok");
+describe("discoverWorkspaceLibraries", () => {
+  let root = "";
+
+  before(() => {
+    root = mkdtempSync(path.join(tmpdir(), "drift-discover-"));
+    writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "root", private: true, workspaces: ["packages/*", "packages/nested/*"] }));
+    const write = (dir: string, pkg: unknown): void => {
+      mkdirSync(path.join(root, dir), { recursive: true });
+      writeFileSync(path.join(root, dir, "package.json"), JSON.stringify(pkg));
+    };
+    write("packages/lib", { name: "@scope/lib", version: "1.0.0" });
+    write("packages/nested/deep", { name: "@scope/deep", version: "1.0.0", dependencies: { "@scope/lib": "^1.0.0" } });
+    write("packages/host", { name: "host", version: "1.0.0", devDependencies: { "@scope/deep": "^1.0.0" } });
+    write("packages/lonely", { name: "@scope/lonely", version: "1.0.0" });
+    write("packages/secret", { name: "@scope/secret", version: "1.0.0", private: true, dependencies: { "@scope/lonely": "^1.0.0" } });
+  });
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
   });
 
-  it("accepts an explicit package list (skips auto-detection)", async () => {
-    const results = await drift.checkWorkspaceDrift({
-      root: path.join(FIXTURES, "drift-clean"),
-      packageBaseNames: ["protocol"],
-      installedRoot: "installed_packages",
-      distRelative: "_dist/index.js",
-      fetchPublishedSource: offlineRegistry,
-    });
-    assert.equal(results.length, 1);
-    const [onlyResult] = results;
-    assert.ok(onlyResult);
-    assert.equal(onlyResult.status, "ok");
+  it("finds packages another workspace declares, wherever they sit in the tree", async () => {
+    const found = await drift.discoverWorkspaceLibraries({ root });
+    const names = found.map((entry) => entry.name);
+    // `@scope/deep` lives under packages/nested/ — a `packages/<name>` path guess
+    // would miss it, which is how the bridges and plugins escaped the old gate.
+    assert.ok(names.includes("@scope/lib"), names.join(", "));
+    assert.ok(names.includes("@scope/deep"), names.join(", "));
+  });
+
+  it("leaves out a package nothing imports", async () => {
+    // `@scope/lonely` IS declared — but only by a private workspace, which ships
+    // nothing, so no consumer can break on its exports.
+    const names = (await drift.discoverWorkspaceLibraries({ root })).map((entry) => entry.name);
+    assert.ok(!names.includes("@scope/lonely"), names.join(", "));
+  });
+
+  it("leaves out private workspaces even when imported", async () => {
+    const names = (await drift.discoverWorkspaceLibraries({ root })).map((entry) => entry.name);
+    assert.ok(!names.includes("@scope/secret"), names.join(", "));
+  });
+
+  it("records who the consumers are", async () => {
+    const lib = (await drift.discoverWorkspaceLibraries({ root })).find((entry) => entry.name === "@scope/lib");
+    assert.deepEqual(lib?.consumers, ["@scope/deep"]);
   });
 });

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -51,10 +51,34 @@ describe("parseExportedNames", () => {
     assert.deepEqual([...drift.parseExportedNames('export { default as thing } from "./x.js";\n').names], ["thing"]);
   });
 
-  it("marks `export * from` opaque — the set cannot be enumerated from this file alone", () => {
-    const { names, opaque } = drift.parseExportedNames(`export * from "./chunk.js";\nexport const visible = 1;\n`);
-    assert.equal(opaque, true);
-    assert.deepEqual([...names], ["visible"]);
+  // A barrel is COUNTED, not lumped into `opaque`: a caller that can read the
+  // re-exported file resolves it exactly (`collectEntryNames`), and one that
+  // cannot must treat it as opaque (`compareEntry`). Sharing one flag kept a
+  // fully-resolved barrel permanently coarse.
+  it("counts `export * from` as a barrel rather than as an unmodelled shape", () => {
+    const parsed = drift.parseExportedNames(`export * from "./chunk.js";\nexport const visible = 1;\n`);
+    assert.equal(parsed.stars, 1);
+    assert.equal(parsed.opaque, false);
+    assert.deepEqual([...parsed.names], ["visible"]);
+  });
+
+  it("`export * as ns from` exports ONE name and is not a barrel", () => {
+    const parsed = drift.parseExportedNames(`export * as ns from "./x.js";\n`);
+    assert.deepEqual([...parsed.names], ["ns"]);
+    assert.equal(parsed.stars, 0);
+    assert.deepEqual(drift.starTargets(`export * as ns from "./x.js";\n`), []);
+  });
+
+  it("a multi-declarator statement is opaque rather than half-named", () => {
+    const parsed = drift.parseExportedNames("export const a = 1, b = 2;\n");
+    assert.equal(parsed.opaque, true);
+    assert.deepEqual([...parsed.names], []);
+  });
+
+  it("a comma inside an initialiser is not a second declarator", () => {
+    assert.deepEqual([...drift.parseExportedNames("export const f = fn(1, 2);\n").names], ["f"]);
+    assert.deepEqual([...drift.parseExportedNames("export const xs = [1, 2];\n").names], ["xs"]);
+    assert.deepEqual([...drift.parseExportedNames('export const s = "a,b";\n').names], ["s"]);
   });
 
   it("ignores indented exports (only module-level counts)", () => {
@@ -86,7 +110,6 @@ describe("parseExportedNames", () => {
       "export { a, /* x */ b };\n", // a block comment inside the brace
       "export { a,\n", // a brace that never closes
       "export enum Colour { Red }\n", // a form this parser does not model
-      'export * from "./chunk.js";\n', // enumerable only with the published tarball
     ];
     nearMisses.forEach((source) => {
       const { names, opaque } = drift.parseExportedNames(source);

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -329,6 +329,28 @@ describe("checkPackageDrift — against a fake workspace and a stubbed registry"
     assert.equal(result.status, "skipped");
   });
 
+  // Raised by Codex as a P2: eight of the twenty scanned packages export a
+  // `./style.css`, so a non-JS entry counting as a successful comparison meant an
+  // unbuilt package could report `ok` — its JS entry skipped, its stylesheet
+  // "compared", and the verdict clean.
+  it("does not let a non-JS entry stand in for a missing JS build", async () => {
+    writeWorkspace(
+      "@scope/j",
+      "packages/j",
+      "1.0.0",
+      { "dist/style.css": ".a { color: red }\n" }, // note: no dist/index.js
+      { ".": "./dist/index.js", "./style.css": "./dist/style.css" },
+    );
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/j",
+      dir: "packages/j",
+      ...published("1.0.0", { "dist/index.js": "export { one };\n", "dist/style.css": ".a { color: red }\n" }),
+    });
+    assert.equal(result.status, "skipped", `expected skipped, got ${result.status}`);
+    assert.match(result.reason ?? "", /not a JS module|build first/);
+  });
+
   it("skips when the package is not on the registry", async () => {
     writeWorkspace("@scope/g", "packages/g", "1.0.0", { "dist/index.js": "export { one };\n" });
     const result = await drift.checkPackageDrift({

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -180,9 +180,43 @@ describe("entryTargets", () => {
     );
   });
 
+  it("marks a subpath with no runtime target as null instead of borrowing `main`", () => {
+    const pkg = { exports: { ".": { import: "./dist/index.js" }, "./types": { types: "./dist/t.d.ts" } }, main: "./dist/index.js" };
+    assert.deepEqual(
+      [...drift.entryTargets(pkg)],
+      [
+        [".", "dist/index.js"],
+        ["./types", null],
+      ],
+    );
+  });
+
   it("falls back to module / main when there is no exports map", () => {
     assert.deepEqual([...drift.entryTargets({ main: "./dist/entry.js" })], [[".", "dist/entry.js"]]);
     assert.deepEqual([...drift.entryTargets({})], [[".", "dist/index.js"]]);
+  });
+});
+
+describe("resolveConditionTarget", () => {
+  it("descends through a condition block the way a bundler would", () => {
+    assert.equal(drift.resolveConditionTarget({ node: { import: "./dist/node.js" } }), "dist/node.js");
+    assert.equal(drift.resolveConditionTarget({ types: "./d.ts", import: "./dist/index.js" }), "dist/index.js");
+    assert.equal(drift.resolveConditionTarget("./dist/plain.js"), "dist/plain.js");
+  });
+
+  // Raised by Codex as a P2: a nested condition object bypassed the old
+  // string-only check, and the per-subpath `main` fallback then compared
+  // `dist/index.js` — a DIFFERENT file's export surface — for a types-only entry.
+  it("returns null rather than guessing when no runtime target exists", () => {
+    assert.equal(drift.resolveConditionTarget({ types: "./dist/index.d.ts" }), null);
+    assert.equal(drift.resolveConditionTarget(null), null);
+    assert.equal(drift.resolveConditionTarget(42), null);
+  });
+
+  it("stops descending instead of recursing forever", () => {
+    let deep: unknown = "./dist/x.js";
+    for (let i = 0; i < 12; i++) deep = { import: deep };
+    assert.equal(drift.resolveConditionTarget(deep), null);
   });
 });
 
@@ -208,6 +242,15 @@ describe("compareEntry", () => {
   it("falls back to line counting when either side is opaque", () => {
     const result = drift.compareEntry(`export * from "./x.js";\nexport { a };\n`, `export * from "./x.js";\n`);
     assert.equal(result.opaque, true);
+    assert.equal(result.drifted, true);
+  });
+
+  // Raised by Codex as a P1: the opaque branch used to REPLACE the name
+  // comparison with a line count, so a name added on the same line as the
+  // `export *` was discarded and both sides counted one line.
+  it("still compares the names it could read inside an opaque entry", () => {
+    const result = drift.compareEntry(`export * from "./x.js";export { newThing };\n`, `export * from "./x.js";\n`);
+    assert.deepEqual(result.added, ["newThing"]);
     assert.equal(result.drifted, true);
   });
 });

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -33,9 +33,22 @@ describe("parseExportedNames", () => {
     assert.equal(drift.parseExportedNames(source).names.size, 6);
   });
 
-  it("ignores type-only exports and `default`", () => {
-    const source = "export type Foo = string;\nexport interface Bar {}\nexport { type Baz } from './b.js';\nexport default thing;\n";
+  it("ignores type-only exports", () => {
+    const source = "export type Foo = string;\nexport interface Bar {}\nexport { type Baz } from './b.js';\n";
     assert.deepEqual([...drift.parseExportedNames(source).names], []);
+  });
+
+  // `default` is a runtime export: a default-import consumer breaks the same way
+  // when the published tarball lacks it. Raised by Codex as a P1.
+  it("counts `default` in every shape that exports it", () => {
+    const shapes = ["export default thing;\n", "export default function f() {}\n", "export { a as default };\n", 'export { default } from "./x.js";\n'];
+    shapes.forEach((source) => {
+      assert.deepEqual([...drift.parseExportedNames(source).names], ["default"], source);
+    });
+  });
+
+  it("`default as thing` exports `thing`, not `default`", () => {
+    assert.deepEqual([...drift.parseExportedNames('export { default as thing } from "./x.js";\n').names], ["thing"]);
   });
 
   it("marks `export * from` opaque — the set cannot be enumerated from this file alone", () => {
@@ -46,6 +59,76 @@ describe("parseExportedNames", () => {
 
   it("ignores indented exports (only module-level counts)", () => {
     assert.equal(drift.parseExportedNames("  export const inner = 1;\n").names.size, 0);
+  });
+
+  // Parsing per LINE returned zero names for both shapes below, and zero names
+  // reads as "nothing exported" — so a package whose build emits either one
+  // would have reported clean no matter what it exported. Found by Claude while
+  // reviewing this PR, not flagged by Codex.
+  it("reads a brace list wrapped across lines", () => {
+    const source = 'export {\n  mimeFromExtension,\n  isImageMime,\n} from "./mime.js";\n';
+    assert.deepEqual([...drift.parseExportedNames(source).names].sort(), ["isImageMime", "mimeFromExtension"]);
+  });
+
+  it("reads several statements sharing one line, as a minified bundle emits them", () => {
+    assert.deepEqual([...drift.parseExportedNames("export{a,b};export{c};\n").names].sort(), ["a", "b", "c"]);
+  });
+
+  // The rule is inverted: the four shapes above are what the parser claims to
+  // model, and EVERYTHING else is opaque. Three findings in one review were each
+  // "it silently drops one more shape", so the ban-list became a permit-list. The
+  // cases below are the near-misses — each one must come back opaque rather than
+  // as an empty name set, because empty reads as "nothing exported" = "no drift".
+  it("treats every unmodelled export statement as opaque, not as empty", () => {
+    const nearMisses = [
+      "export/*c*/{a};\n", // a comment where the brace should start
+      "export {\n  a, // keep\n  b\n};\n", // a line comment inside the brace
+      "export { a, /* x */ b };\n", // a block comment inside the brace
+      "export { a,\n", // a brace that never closes
+      "export enum Colour { Red }\n", // a form this parser does not model
+      'export * from "./chunk.js";\n', // enumerable only with the published tarball
+    ];
+    nearMisses.forEach((source) => {
+      const { names, opaque } = drift.parseExportedNames(source);
+      assert.equal(opaque, true, `expected opaque for ${JSON.stringify(source)}`);
+      assert.deepEqual([...names], [], `expected no invented names for ${JSON.stringify(source)}`);
+    });
+  });
+
+  it("still does not treat an identifier starting with `export` as an export", () => {
+    const { names, opaque } = drift.parseExportedNames("exported = 1;\nexportable();\n");
+    assert.deepEqual([...names], []);
+    assert.equal(opaque, false, "a lookalike must not push the whole entry into the coarse comparison");
+  });
+
+  it("marks an export form it does not model opaque — fails CLOSED, never silently empty", () => {
+    const { names, opaque } = drift.parseExportedNames("export enum Colour { Red }\n");
+    assert.equal(opaque, true);
+    assert.deepEqual([...names], []);
+  });
+
+  it("marks a brace that never closes opaque rather than guessing", () => {
+    assert.equal(drift.parseExportedNames("export { a,\n").opaque, true);
+  });
+});
+
+describe("exportStatements", () => {
+  it("flattens a brace group so a wrapped statement stays one statement", () => {
+    const statements = drift.exportStatements("export {\n a,\n b\n}\n");
+    assert.equal(statements.length, 1);
+    assert.match(statements[0] ?? "", /^export \{\s+a,\s+b\s*\}$/);
+  });
+
+  it("keeps ignoring an indented export — it is text, not a module-level export", () => {
+    assert.deepEqual(drift.exportStatements("  export const inner = 1;\n"), []);
+  });
+
+  it("splits statements that share a line", () => {
+    assert.deepEqual(drift.exportStatements("export{a};export{b}"), ["export{a}", "export{b}"]);
+  });
+
+  it("keeps out identifiers that merely start with `export`", () => {
+    assert.deepEqual(drift.exportStatements("exported = 1\nexportable()\n"), []);
   });
 });
 
@@ -210,6 +293,40 @@ describe("checkPackageDrift — against a fake workspace and a stubbed registry"
     });
     assert.equal(result.status, "ok");
     assert.match(result.partialReason ?? "", /wildcard subpath/);
+  });
+
+  // Raised by Codex as a P1: adding `{ "./new": "./dist/new.js" }` at an unchanged
+  // version is a consumer-visible addition — `import "pkg/new"` fails after a plain
+  // install — and the published file 404s, so treating that as a skip let the whole
+  // package report `ok` as long as `.` compared cleanly.
+  it("counts a concrete subpath the published package does not serve as DRIFT", async () => {
+    writeWorkspace(
+      "@scope/h",
+      "packages/h",
+      "1.0.0",
+      { "dist/index.js": "export { root };\n", "dist/new.js": "export { fresh };\n" },
+      { ".": "./dist/index.js", "./new": "./dist/new.js" },
+    );
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/h",
+      dir: "packages/h",
+      ...published("1.0.0", { "dist/index.js": "export { root };\n" }),
+    });
+    assert.equal(result.status, "drifted");
+    assert.match(result.added?.join(" ") ?? "", /ENTIRE SUBPATH absent/);
+  });
+
+  it("still SKIPS a transport failure — a 500 says nothing about the package", async () => {
+    writeWorkspace("@scope/i", "packages/i", "1.0.0", { "dist/index.js": "export { root };\n" });
+    const result = await drift.checkPackageDrift({
+      root,
+      name: "@scope/i",
+      dir: "packages/i",
+      fetchPublishedVersion: async () => ({ version: "1.0.0", reason: null }),
+      fetchPublishedEntry: async () => ({ source: null, reason: "unpkg 500" }),
+    });
+    assert.equal(result.status, "skipped");
   });
 
   it("skips when the package is not on the registry", async () => {

--- a/test/scripts/mulmoclaude/test_drift.ts
+++ b/test/scripts/mulmoclaude/test_drift.ts
@@ -95,6 +95,42 @@ describe("parseExportedNames", () => {
     });
   });
 
+  // The remaining hole class after the inversion is "a WRONG name set while opaque
+  // stays false". Both shapes below did exactly that: the first exports the name
+  // `string name` (ES2022 arbitrary module namespace names) and the parser reported
+  // `a`; the second exports `café` and an ASCII-only identifier pattern reported
+  // `caf`. A name the package does not export is worse than a coarse comparison.
+  it("goes opaque rather than guessing when it cannot name the export exactly", () => {
+    const unnameable = [
+      'export { a as "string name" };\n',
+      'export { "string name" as a } from "./x.js";\n',
+      "export { café };\n",
+      "export const café = 1;\n",
+      "export function café() {}\n",
+    ];
+    unnameable.forEach((source) => {
+      const { names, opaque } = drift.parseExportedNames(source);
+      assert.equal(opaque, true, `expected opaque for ${JSON.stringify(source)}`);
+      assert.deepEqual([...names], [], `expected no guessed name for ${JSON.stringify(source)}`);
+    });
+  });
+
+  it("still names every ASCII declaration shape exactly", () => {
+    const shapes: [string, string][] = [
+      ["export const a = 1;\n", "a"],
+      ["export let x;\n", "x"],
+      ["export var v = 1;\n", "v"],
+      ["export function f() {}\n", "f"],
+      ["export class C {}\n", "C"],
+      ["export const $d = 1;\n", "$d"],
+      ["export const _u = 1;\n", "_u"],
+      ["export async function g() {}\n", "g"],
+    ];
+    shapes.forEach(([source, name]) => {
+      assert.deepEqual([...drift.parseExportedNames(source).names], [name], source);
+    });
+  });
+
   it("still does not treat an identifier starting with `export` as an export", () => {
     const { names, opaque } = drift.parseExportedNames("exported = 1;\nexportable();\n");
     assert.deepEqual([...names], []);


### PR DESCRIPTION
## Summary

`scripts/mulmoclaude/drift.mjs` は「新しい runtime export を version 据え置きで出荷した」状態だけを落とすゲートです。#3110 の `@mulmobridge/client` では実際に機能しました。**同じ変更に含まれる残り 2 つは原理的に捕まえられませんでした。** 理由は 3 つあり、いずれも推測ではなく測って確かめています。

### 1. どのパッケージを見るか — 4 → 20

launcher の `dependencies` から `@mulmobridge/*` だけを拾っていたので、実際の対象は **chat-service / client / protocol / web-push の 4 つ**。#3109 が export を足した `@mulmoclaude/common`（他 32 workspace が宣言）と `@mulmobridge/webhook-runtime`（9）は**どちらも対象外**でした。

走査範囲を「**別の workspace が宣言している publish 対象すべて**」にしました（今日 20）。`workspaces` の glob から探すので、`packages/bridges/<name>` の下や、ディレクトリ名が package 名と違うもの（`@receptron/task-scheduler` は `packages/scheduler`）も届きます。

### 2. 何と比べるか — src ↔ 公開 dist から **local build 済み dist ↔ 公開 dist** へ

| package | ビルド | local src 行 | local dist 行 | 公開 dist 行 | 旧指標の判定 |
|---|---|---|---|---|---|
| `@mulmoclaude/common` | tsc | 19 | 17 | 16 | 正しく drift |
| `@mulmoclaude/x-plugin` | **vite** | 6 | 1 | 1 | **DRIFTED（誤検知）** |
| `@mulmoclaude/core` | **vite** | — | — | — | local 229 / 公開 30 の無意味な比較 |

src と公開 dist の比較は「dist が src を 1:1 で写す tsc ビルド」でしか成立しません。両側で**同じ相対パスのビルド済みファイル**を比べる形にしたので、ビルド方式が結果を歪めません。smoke ワークフローは `yarn build:packages && yarn build` の後に走るので CI の dist は新鮮で、local dist が無い場合は `skipped` + 理由（黙って clean にはしない）。

### 3. 何を数えるか — 行数から **名前集合** へ

```
x-plugin の公開 dist 全体:
export { extractTweetId, formatTweet, readUrlArg, readXPost, searchX, tweetBody };
```

**1 行に 6 名前**。7 つ目を足しても行数は 1 のままなので、行数比較は素通りします。単位を `exports` subpath ごとの**名前集合**にしました。副産物として「**どの export が新しいか**」を言えるようになります。

### 4. ワークフローの trigger も広げた

`mulmoclaude_smoke.yaml` は `packages/{mulmoclaude,protocol,client,chat-service}` にしか反応しないので、**`@mulmoclaude/common` を触る PR ではジョブが起動すらしませんでした**。走査範囲を広げても trigger が狭いままでは意味が無いので `packages/**` にしています。

## cross-review で塞いだ 14 の追加穴（`/codex-cross-review`、tier C、round 1-8）

いずれも**再現してから**修正し、形は共通です — **間違った / 空の答えが clean と読まれる**。

| # | 穴 | 発見 |
|---|---|---|
| 1 | **公開側 subpath の 404 が `skipped`** になり、他 entry が通れば全体 `ok`。`{"./new":"./dist/new.js"}` を version 据え置きで足すと `import "pkg/new"` が install 後に失敗するのに緑 | Codex P1 |
| 2 | **非 JS の `exports` target（`./style.css`）が「比較成功」に数えられ**、JS dist 未ビルドのパッケージが `ok` に。走査 20 のうち **8 個**が CSS を export | Codex P2 |
| 9 | **version を上げただけ（export 差分なし）が release blocker でなかった**。`pending-publish` は `added.length > 0` のときだけ付くので、API 変更の無い patch が `ok` になり `--release` を通っていた。consumer レンジは既に `^<local>` = npm に無い version = **ETARGET**。実際に `@mulmoclaude/core@4.9.1` が clean と出ていた | Codex P1 |
| 10 | **公開済みファイルを指す新 subpath が clean だった**。local の `exports` map だけを列挙するので `{"./new": "./dist/index.js"}` は同じファイルを 2 回比較して一致。公開 `package.json` に key が無いので `import "pkg/new"` は install 後に失敗する | Codex P1 |
| 11 | **同じ名前を出す barrel が 2 つあると union していた**。ESM は ambiguous な名前を公開しない（`import { x }` はエラー）ので、衝突が解消して importable になった変更を clean と言っていた | Codex P2 |
| 12 | **`require` の報告が nested 条件を見ていなかった**（`{ node: { import, require } }`）| Codex P2 |
| 13 | **ファイル全体の brace カウンタが実在の export 行を飲み込んでいた（実 entry 2 件）**。`@mulmoclaude/core` の `./plugin-vue` dist は列 0 の export 行が 1 本（10 名前）だけで、それが前の行に結合され **両側 0 名前 = 一致** と読まれていた。効果は合計に出る: `core` 676 → **686**、`shapescript-plugin` 47 → **62** | **Claude（ground truth ハーネス）** |
| 14 | **「manifest は読めたが `exports` map が無い」を「判定できない」と答えていた**。10 番の最初の実装が「読めない」と同じ null を返していたため、`main` → `exports` への移行で subpath を足しても version 据え置きで clean になり得た。後者は確定した答え（`main` 経由で `.` だけを serve）| Codex P1 |
| 3 | パーサが**読めない名前を推測**（`export { a as "string name" }` → `a`、`export { café }` → `caf`）| Codex P2 / Claude 同時 |
| 4 | **opaque の fallback が名前比較を置き換え**（`export * from "./x.js";export { newThing };` が 1 行対 1 行で clean）+ **ネスト条件 / types のみの subpath**が別ファイルを比較 | Codex P1+P2 |
| 5 | **`export * from` を列挙せず行数比較に落としていた** — bundle は公開 API 全体を barrel の裏に置けるので、そこに名前を足しても緑。両側で辿るようにした（深さ 4 / cycle guard）ので実ゲートの opaque entry は **0**、`core` の 33 entries も名前で比較される | Codex P1 |
| 6 | **CJS entry が「0 名前 vs 0 名前 = 一致」**。`require` だけの subpath は `export` 文を持たないので、何も比較せずに clean を出していた。skip + 理由に変更（dual package は `import` 条件で比較されるので損失なし）| Codex P1 |
| 7 | **文字列内の `;` が文を捏造**していた。`export const a = "x;export const b = 1"` が 2 文に割れ、存在しない `b` を「local だけにある export」= drift として報告。`;` split / `,` 判定 / bracket 追跡を 1 つの文字列対応スキャナに統合 + **barrel walk 中の到達不能ファイルが drift と読まれていた**（404 は粗い比較に降格、transport 失敗は skip）| Codex P2+P1 |
| 8 | **`require` 分岐が verdict に出ていなかった**。`exports` 条件は 1 subpath = 1 target で `import` が勝つため、走査対象の **48 subpath が持つ別の `.cjs`** は比較も言及もされず、部分的な verdict が全体の verdict として読めていた。各行に `N require branch(es) NOT compared` を出す（**パースはしない** — 下記 2 参照）| Codex P2 |

加えて **ルールを ban-list から許可リストへ反転**しました。`parseExportedNames` への指摘が 3 回続いたため（多行 brace / 1 行複数文 / `default`、さらに `export/*c*/{a}` と brace 内コメント）、**形を足すのをやめて**「理解できる 4 形以外はすべて `opaque`」にしています（文 / 指定子 / 宣言名 / 条件解決 / barrel 解決の 5 段）。安全なコードの一部も粗い比較に落ちますが、リリースゲートとしてはその取引が正しいと判断しました。

**私の重大なミスも 1 件ありました**: round 1 の修正が実は push されておらず（型エラー切り分けで `git stash` → `pop` したため index が空になり、`drift.d.mts` の 5 行だけが commit されていた）、Codex が round 2 で P1 として検出しました。以降は commit ごとに `git show --stat` と remote SHA 一致を確認しています。

テストは **83 件**（`test/scripts/mulmoclaude/test_drift.ts`）。実ゲートは **20 パッケージ / drifted 0 / PR exit 0**、`--release` は 4 件 block（client / webhook-runtime / common / core — 実際に未公開の 4 つ）。上のガードはそれぞれ **mutation で赤を確認**しています（11/11 — ガードを 1 つずつ外して、対応するケースだけが落ちる）。

### パーサは外部の ground truth で判定しています

13 番は**パーサを読んでも出ませんでした**。`scripts/mulmoclaude/drift-groundtruth.mjs` を追加し、走査対象の local dist entry を全部 `import()` して `Object.keys(namespace)`（Node が実際に公開する名前）とパーサの結果を比較します:

```
[drift:groundtruth] 67 entry(ies) imported, 67 exact, 1 could not be imported (side effects)
```

修正前はここが **65/67** で、`@mulmoclaude/core ./plugin-vue` と `@mulmoclaude/shapescript-plugin ./vue` が **MISSED 10 名前 / 6 名前・opaque=false** でした。`yarn test` には入れません（ビルド済みコードの import は副作用がある）ので、パーサを触ったら手で回す運用です。

**残す制約 1 つ（実測して残した）**: 複数行テンプレートリテラル**内部**の列 0 `export` 行は文として読まれるので名前を捏造します。塞ぐガード（直前の backtick が奇数なら行を落として opaque）は **実 entry 6 件・数百の実在名前**を名前比較から落とす一方、67 entry の実測ではその形は **0 件**。捏造名は sample 自体が変わらなければ両側同じなので、最悪 false `drifted` で **false `ok` にはなりません**。テストにも `KNOWN LIMITATION` として固定しています。

## Items to Confirm / Review

1. **走査範囲に plugin も入ります**（launcher だけが依存しているものも含む、20 のうち 11）。launcher の公開コード（`server/` / `src/`）がその export を呼ぶので壊れ方は同じ、という判断です。plugin を除くなら「launcher 以外の consumer がいるもの」= 7 つに絞る形になります（`discoverWorkspaceLibraries` の 1 行）
2. **`export * from` は両側で辿ります**（深さ 4 / cycle guard / 相対 specifier のみ）。bare specifier（`export * from "other-pkg"`）と読めなかったファイルだけが `opaqueEntries` として行数比較に落ちます。実ゲートでは現在 0 件で、`core` の 676 名前が 33 entries すべてで名前比較されています。フェッチは entry ごとに増えるので、コスト面の判断としてレビューしてほしい点です
3. **CJS 分岐はパースしない判断です**（#8）。理由は「reader の失敗形が名前 0 個」で、それは今回 6 round かけて潰した「両側 0 名前 = 一致」そのものだからです。判断の前に実測しました: 8 行の CJS reader を実ツリーに当てると **48 subpath のうち 10 が 0 名前**（rollup が `exports.x = ...` をカンマ連結するため）。部分集合しか読めない reader は逆に**存在する export を drift と誤報**します。一方 ESM 側の drift が強制する version bump は、1 ビルドが両形式を同じ entry から出すので両方を publish し直します。**ゲートは ESM 専用と明記し、verdict の行にその旨を出す**形にしました。CJS 側も比較すべきというレビュー判断なら、別 PR で CJS reader を「名前 0 個なら opaque」で fail-closed に書く形になります
4. **実行コストは 20 パッケージ × entries**（`core` は 33 entries）で、registry 1 + unpkg N フェッチ。手元で通しで数十秒〜1 分程度でした。CI で問題になるなら並列度を上げる余地があります
5. **旧 fixture ツリーを削除しました**（`fixtures/drift-{clean,drifted}/`）。新テストは tmpdir に fake workspace を組み立てるので、`installed_packages/.../_dist/` を repo に置く必要がありません
6. `pending-publish` / `drifted` / `skipped` の語彙と `smoke.mjs` の契約は変えていません。`packageBaseName` が **scope 込みのフルネーム**になったので、smoke のメッセージが `client@1.2.0` → `@mulmobridge/client@1.2.0` に変わります（改善方向の変化）

## 検証

| 検証 | 結果 |
|---|---|
| 新ゲートを実 registry に対して通し | **20 パッケージ / 17 `ok` / 3 `pending-publish` / `drifted` 0 / exit 0** |
| 旧指標の誤検知 | **消滅**（google / spotify / x plugin が `ok` に、`core` の 229 対 30 も解消） |
| 検出力の確認 | `client` の報告に **`resolvePublishedApiUrl`** が名前で出る — #3115 のレビューが手作業で見つけた 3 つ目の未公開 export |
| `test_drift.ts`（新形に書き換え） | **83 pass / 0 fail** |
| 新規ガードの mutation 検証 | 11 個のガードを 1 つずつ外し、**11/11 で対応ケースが赤** |
| ground truth（`drift-groundtruth.mjs`） | **67 entry / 67 完全一致**（修正前 65/67） |
| 実ゲート `--release` | exit 1、block は 4 件（client / webhook-runtime / common / core） |
| CJS 分岐の実測（パースしない判断の根拠） | 走査 20 のうち **48 subpath が別の `.cjs` を publish**。8 行の naive reader では **10/48 が 0 名前**（rollup のカンマ連結） |
| `yarn test`（リポジトリ全体） | **10054 tests / 0 fail** |
| `tsc -p test/tsconfig.json` | clean |
| eslint（`scripts/mulmoclaude/` + `test/scripts/mulmoclaude/`） | 私の変更分は 0（残る 5 warning は `deps.mjs` の既存分） |
| `check:changelog-ships` / `check:doc-links` | OK |

`parseExportedNames` は eslint の ReDoS ルール（`security/detect-unsafe-regex` / `sonarjs/super-linear-regex`）に引っかからないよう、**文字列操作ベース**に書いています（正規表現は identifier 抽出だけ）。最初の実装は 1 本の正規表現で modifier を optional group にしていて error になったので、抑制ではなく書き換えで解消しました。

Closes #3116

## User Prompt

- 「#3116 / #3117 含め進めよう。publish は必要なタイミングで」

## Plan

[`plans/fix-3116-drift-gate-scope.md`](plans/fix-3116-drift-gate-scope.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Leq3Uj4w5Jykheqop7Kcxa

work in mulmoclaude4

## Summary by Sourcery

Strengthen the publish-drift gate to scan all consumed workspaces and reliably compare their built runtime APIs with published packages.

Bug Fixes:
- Correct the publish-drift gate so it detects newly exposed runtime exports, missing published subpaths, and unpublished version bumps without treating incomplete or non-comparable results as clean.

Enhancements:
- Expand drift scanning to all publishable workspaces consumed by other workspaces and compare built local distributions with published distributions by export-name sets across package subpaths.
- Harden export analysis and verdict reporting for barrels, conditional exports, CommonJS branches, transport failures, opaque syntax, and ambiguous re-exports.
- Add runtime ground-truth validation for the export parser and improve diagnostics with affected export names, partial comparisons, and scan scope.

CI:
- Broaden the smoke workflow trigger to cover all package changes under packages/**.

Documentation:
- Document the expanded drift-gate scope, export-based comparison, failure handling, and validation procedures in the changelog and implementation plan.

Tests:
- Replace fixture-based drift tests with temporary-workspace coverage for parsing, workspace discovery, entry resolution, barrel traversal, failure modes, version gating, and package verdicts.

Chores:
- Remove obsolete drift fixture trees and update the drift module type declarations for the expanded API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved publish-drift checks by comparing built package exports with published packages more accurately.
  - Expanded validation across workspaces, package entry points, barrel files, subpaths, and conditional exports.
  - Reduced false drift reports and improved detection of added or missing exports.
  - Improved handling of pending publishes, missing builds, unsupported entries, and unmeasured CommonJS branches.
  - Smoke checks now run when any workspace package changes.

- **Tests**
  - Added ground-truth validation and expanded regression coverage for drift detection.

- **Documentation**
  - Updated changelog and planning documentation with expanded drift-check coverage and results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

