### PR TITLE
fix(client): the shutdown-deadline test asked for a signal Windows cannot deliver (#3084)

### DIFF
--- a/packages/client/test/fixture-hanging-shutdown.ts
+++ b/packages/client/test/fixture-hanging-shutdown.ts
@@ -10,6 +10,17 @@
 // The handle also has to exist BEFORE the signal: `process.on` does not keep
 // Node alive, so without it this fixture exits on its own between printing
 // `ready` and the parent's `kill`, and the test passes or fails by luck.
+//
+// Shutdown can also be asked for over stdin, because on Windows it cannot be
+// asked for with a signal at all: `subprocess.kill()` there terminates the
+// target unconditionally whichever name you pass, so the handler never runs and
+// the child dies in ~14ms with an empty stderr. The line below reaches the SAME
+// handler `process.on("SIGTERM")` registered, so what the test observes after
+// the trigger is identical on every platform — only the door differs.
+//
+// `unref` is what keeps that door from changing the thing under test: this
+// fixture exists to leave the deadline timer as the ONLY referenced handle, and
+// a listened-to stdin would itself hold the loop open and hide a regression.
 
 import { installProcessGuards } from "../src/processGuards.ts";
 
@@ -17,6 +28,9 @@ const graceMs = Number(process.argv[2]);
 const HEARTBEAT_MS = 1_000;
 
 const whileRunning = setInterval(() => {}, HEARTBEAT_MS);
+
+process.stdin.on("data", () => process.emit("SIGTERM", "SIGTERM"));
+process.stdin.unref();
 
 installProcessGuards({
   name: "fixture",

--- a/packages/client/test/test_processGuards_deadline.ts
+++ b/packages/client/test/test_processGuards_deadline.ts
@@ -26,11 +26,27 @@ interface ChildResult {
   elapsedMs: number;
 }
 
+// Windows has no catchable SIGTERM: `subprocess.kill()` terminates the target
+// unconditionally whatever name it is given, so the child dies before its
+// handler runs and the deadline this test exists to measure never starts. The
+// fixture therefore also accepts the request on stdin, which lands in the same
+// `process.on("SIGTERM")` handler — so only the door changes, not what is
+// observed. POSIX keeps the real signal: nothing else in the repo proves an
+// actual OS signal reaches a bridge's handler (the sibling suite synthesises it
+// with `process.emit`), and that coverage is worth keeping where it is possible.
+const requestShutdown = (child: ReturnType<typeof spawn>): void => {
+  if (process.platform === "win32") child.stdin?.write("shutdown\n");
+  else child.kill("SIGTERM");
+};
+
 const runUntilShutdown = async (): Promise<ChildResult> =>
   new Promise<ChildResult>((resolve, reject) => {
     const child = spawn(process.execPath, ["--import", "tsx", FIXTURE, String(GRACE_MS)], {
       cwd: path.join(HERE, "..", "..", ".."),
-      stdio: ["ignore", "pipe", "pipe"],
+      // stdin is piped on every platform so the two trigger paths differ in one
+      // line rather than in the spawn shape; the fixture unrefs it, so it does
+      // not become a second referenced handle and mask what this test measures.
+      stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
     let stderr = "";
@@ -45,7 +61,7 @@ const runUntilShutdown = async (): Promise<ChildResult> =>
       // before it had a handler at all.
       if (startedAt === 0 && stdout.includes("ready")) {
         startedAt = Date.now();
-        child.kill("SIGTERM");
+        requestShutdown(child);
       }
     });
     child.stderr.on("data", (chunk: Buffer) => {


### PR DESCRIPTION
## Summary

`lint_test (Windows)` has been **red on main** since the shutdown-deadline test landed with #3084 — both `24.x` and `22.x`. The child process died in ~14ms with an empty stderr:

```
code=null signal=SIGTERM elapsed=14ms stdout="ready\n" stderr=""
```

**Windows has no catchable SIGTERM.** `subprocess.kill()` there terminates the target unconditionally whatever signal name it is given, so the fixture's handler never ran and the deadline the test exists to measure never started. `installProcessGuards` is fine — the *test* was asking the OS for something it does not do.

The fixture now also accepts the shutdown request on **stdin**, landing in the same `process.on("SIGTERM")` handler, so all five assertions observe the same thing through either door. POSIX keeps the real signal.

## Items to Confirm / Review

1. **Why not simply skip the test on Windows.** Skipping would have been one line, but the regression it guards (an `unref`ed deadline timer letting Node drain the loop and exit before the grace period) is platform-independent logic that Windows runs too. The stdin door keeps Windows actually covered instead of merely green.

2. **Why POSIX keeps the real signal instead of using the stdin door everywhere.** One door would be simpler, but it would leave **nothing in the repo** proving an actual OS signal reaches a bridge's handler — the sibling suite (`test_processGuards.ts`) synthesises signals with `process.emit`, which is why it passes on Windows today. The three-line platform branch buys real signal coverage where the platform allows it.

3. **`process.stdin.unref()` is load-bearing, not tidiness.** This fixture exists to leave the deadline timer as the ONLY referenced handle. A listened-to stdin would itself hold the event loop open and mask exactly the regression under test. Verified directly before writing the fix: with the trigger delivered over an unref'd stdin and the heartbeat interval cleared, the child still exits on its own at `code=0 signal=null elapsed=239ms` with the deadline having fired.

4. **No production code changed.** `packages/client/src/processGuards.ts` is untouched; this is test + fixture only.

## How it was verified

Both doors pass, and — more importantly — **both doors still catch the original bug**. Reintroducing `deadline.unref()` in `processGuards.ts`:

| door | with the fix | with `deadline.unref()` reintroduced |
|---|---|---|
| POSIX (real `SIGTERM`) | pass 1 / fail 0 (503ms) | **pass 0 / fail 1** |
| Windows (stdin trigger, forced locally) | pass 1 / fail 0 (290ms) | **pass 0 / fail 1** |

so the Windows path is real regression coverage rather than a green tick. The source was confirmed byte-pristine after the mutation (`git diff --quiet` clean).

Also green: `yarn format` / `yarn lint` (0 errors) / `yarn typecheck` / `yarn build` / `yarn test`, and the full `@mulmobridge/client` suite at **109/109** — the suite that was 108/1 on Windows CI.

**Not exercised locally: Windows itself.** This machine is macOS, so the `win32` branch was verified by forcing that code path against the real fixture and the real assertions, not by running on Windows.

**And `lint_test (Windows)` does NOT run automatically on this PR.** Its `pull_request` trigger is scoped to `server/utils/launcher/**`, `test/utils/launcher/**` and its own workflow file — `packages/client/**` is not in that list, so the job is absent from this PR's check list. It is triggered here manually via `workflow_dispatch` against this branch, and that run is the ground truth for the fix.

That gap is itself worth noting: this code went red on main precisely because nothing gated it on Windows before merge (the workflow runs on `push: main`, i.e. after the fact). Whether `packages/client/**` should join the Windows `paths` list is a cost/benefit call — it puts a Windows runner on every PR touching that package — and is deliberately NOT decided in this PR.

## User Prompt

> main 側 #3084 の POSIX問題直して

(Following the merge of #3107, where this pre-existing main-side failure was diagnosed: the file is byte-identical to `origin/main`'s and `lint_test (Windows)` was already failing at `626615d6a`, the commit before that merge.)

Refs #3084

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVEsUbvb5W4BeVxpXNzpuW

work in mulmoclaude
